### PR TITLE
Add discussion templates for Q&A and Ideas

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,27 @@
+title: "[Idea] "
+labels:
+  - discovery
+body:
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I searched existing discussions and issues for this idea
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem does this solve, or what use case does it enable?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How do you envision this working? Include examples if possible.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, existing tools, or workarounds you've thought about.

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,34 @@
+title: "[Q&A] "
+labels: []
+body:
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I searched existing discussions and issues
+          required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Server
+        - CLI
+        - Go SDK
+        - Python SDK
+        - TypeScript SDK
+        - Admin GUI
+        - Deployment
+        - Other
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Environment details, what you've tried, relevant config or code snippets.


### PR DESCRIPTION
## Summary
- Q&A template: search checkbox, area dropdown, context field
- Ideas template: search checkbox, problem/proposal/alternatives

Closes #59

## Test plan
- [ ] Discussions → New discussion → Q&A shows form template
- [ ] Discussions → New discussion → Ideas shows form template

🤖 Generated with [Claude Code](https://claude.com/claude-code)