### PR TITLE
Add demos section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,10 @@ Coverage badges reflect **business logic only** — infrastructure wrappers that
 
 Run `./scripts/coverage.sh` to calculate the server coverage, or `./scripts/coverage.sh -v` for a per-function breakdown.
 
+## Demos
+
+Want to see OpenDecree in action without reading docs? The [demos repo](https://github.com/opendecree/demos) has self-contained, runnable examples — from a 5-minute quickstart to production patterns. Each demo runs with a single `docker compose up`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, build instructions, and contribution guidelines.


### PR DESCRIPTION
## Summary

- Add "Demos" section to README pointing to the new `opendecree/demos` repo
- Placed before Contributing section for visibility

New repo: https://github.com/opendecree/demos

## Test plan

- [x] Links are correct
- [x] Section reads well in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)