### PR TITLE
CLI: add --wait flag for server readiness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,13 @@ decree docgen <schema-id>                          # generate markdown docs
 decree validate --schema s.yaml --config c.yaml   # offline validation
 ```
 
-Global flags: `--server`, `--subject`, `--role`, `--output table|json|yaml`
+Global flags: `--server`, `--subject`, `--role`, `--output table|json|yaml`, `--wait`, `--wait-timeout`
+
+Use `--wait` in Docker/Kubernetes init containers to wait for the server to be ready:
+
+```bash
+decree seed config.yaml --server decree:9090 --wait --wait-timeout 60s
+```
 
 ## Quick Start
 

--- a/cmd/decree/main.go
+++ b/cmd/decree/main.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	flagServer   string
-	flagSubject  string
-	flagRole     string
-	flagTenantID string
-	flagToken    string
-	flagOutput   string
-	flagInsecure bool
+	flagServer      string
+	flagSubject     string
+	flagRole        string
+	flagTenantID    string
+	flagToken       string
+	flagOutput      string
+	flagInsecure    bool
+	flagWait        bool
+	flagWaitTimeout string
 )
 
 func main() {
@@ -26,6 +30,26 @@ var rootCmd = &cobra.Command{
 	Use:   "decree",
 	Short: "OpenDecree CLI",
 	Long:  "Command-line tool for managing schemas, tenants, and configuration values in OpenDecree.",
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		if !flagWait {
+			return nil
+		}
+		timeout, err := time.ParseDuration(flagWaitTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid --wait-timeout: %w", err)
+		}
+		conn, err := dialServer()
+		if err != nil {
+			return err
+		}
+		defer conn.Close()
+		fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for server %s (timeout %s)...\n", flagServer, timeout)
+		if err := waitForServer(conn, timeout); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "Server ready.\n")
+		return nil
+	},
 }
 
 func init() {
@@ -37,6 +61,8 @@ func init() {
 	pf.StringVar(&flagToken, "token", envOrDefault("DECREE_TOKEN", ""), "JWT bearer token")
 	pf.StringVarP(&flagOutput, "output", "o", "table", "output format: table, json, yaml")
 	pf.BoolVar(&flagInsecure, "insecure", envOrDefault("DECREE_INSECURE", "true") == "true", "skip TLS verification")
+	pf.BoolVar(&flagWait, "wait", false, "wait for the server to be ready before executing the command")
+	pf.StringVar(&flagWaitTimeout, "wait-timeout", envOrDefault("DECREE_WAIT_TIMEOUT", "60s"), "maximum time to wait for server readiness")
 
 	// Flag completions.
 	_ = rootCmd.RegisterFlagCompletionFunc("output", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/decree/version.go
+++ b/cmd/decree/version.go
@@ -16,7 +16,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the CLI version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("ccs %s (commit %s)\n", cliVersion, cliCommit)
+		fmt.Printf("decree %s (commit %s)\n", cliVersion, cliCommit)
 	},
 }
 

--- a/cmd/decree/wait.go
+++ b/cmd/decree/wait.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// waitForServer polls the gRPC health check endpoint until the server is
+// ready or the timeout expires. Uses exponential backoff starting at 500ms.
+func waitForServer(conn *grpc.ClientConn, timeout time.Duration) error {
+	client := healthpb.NewHealthClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	backoff := 500 * time.Millisecond
+	maxBackoff := 5 * time.Second
+
+	for {
+		resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+		if err == nil && resp.Status == healthpb.HealthCheckResponse_SERVING {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			if err != nil {
+				return fmt.Errorf("server not ready after %s: %w", timeout, err)
+			}
+			return fmt.Errorf("server not ready after %s: status %s", timeout, resp.Status)
+		case <-time.After(backoff):
+		}
+
+		backoff = min(backoff*2, maxBackoff)
+	}
+}

--- a/cmd/decree/wait_test.go
+++ b/cmd/decree/wait_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestWaitForServer_Healthy(t *testing.T) {
+	// Start a gRPC server with health check.
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := grpc.NewServer()
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(srv, hs)
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := waitForServer(conn, 5*time.Second); err != nil {
+		t.Fatalf("expected healthy server, got: %v", err)
+	}
+}
+
+func TestWaitForServer_Timeout(t *testing.T) {
+	// Connect to a port that's not listening.
+	conn, err := grpc.NewClient("localhost:19999",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	err = waitForServer(conn, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}

--- a/docs/cli/decree.md
+++ b/docs/cli/decree.md
@@ -13,14 +13,16 @@ Command-line tool for managing schemas, tenants, and configuration values in Ope
 ### Options
 
 ```
-  -h, --help               help for decree
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+  -h, --help                  help for decree
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_audit.md
+++ b/docs/cli/decree_audit.md
@@ -19,13 +19,15 @@ Query the configuration change history and field read usage statistics. Useful f
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_audit_query.md
+++ b/docs/cli/decree_audit_query.md
@@ -23,13 +23,15 @@ decree audit query [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_audit_unused.md
+++ b/docs/cli/decree_audit_unused.md
@@ -19,13 +19,15 @@ decree audit unused <tenant-id> <since-duration> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_audit_usage.md
+++ b/docs/cli/decree_audit_usage.md
@@ -19,13 +19,15 @@ decree audit usage <tenant-id> <field-path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_completion.md
+++ b/docs/cli/decree_completion.md
@@ -21,13 +21,15 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_completion_bash.md
+++ b/docs/cli/decree_completion_bash.md
@@ -44,13 +44,15 @@ decree completion bash
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_completion_fish.md
+++ b/docs/cli/decree_completion_fish.md
@@ -35,13 +35,15 @@ decree completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_completion_powershell.md
+++ b/docs/cli/decree_completion_powershell.md
@@ -32,13 +32,15 @@ decree completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_completion_zsh.md
+++ b/docs/cli/decree_completion_zsh.md
@@ -46,13 +46,15 @@ decree completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config.md
+++ b/docs/cli/decree_config.md
@@ -19,13 +19,15 @@ Get and set typed configuration values for tenants. Supports single and batch op
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_export.md
+++ b/docs/cli/decree_config_export.md
@@ -20,13 +20,15 @@ decree config export <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_get-all.md
+++ b/docs/cli/decree_config_get-all.md
@@ -19,13 +19,15 @@ decree config get-all <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_get.md
+++ b/docs/cli/decree_config_get.md
@@ -19,13 +19,15 @@ decree config get <tenant-id> <field-path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_import.md
+++ b/docs/cli/decree_config_import.md
@@ -21,13 +21,15 @@ decree config import <tenant-id> <file> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_rollback.md
+++ b/docs/cli/decree_config_rollback.md
@@ -20,13 +20,15 @@ decree config rollback <tenant-id> <version> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_set-many.md
+++ b/docs/cli/decree_config_set-many.md
@@ -20,13 +20,15 @@ decree config set-many <tenant-id> <key=value>... [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_set.md
+++ b/docs/cli/decree_config_set.md
@@ -19,13 +19,15 @@ decree config set <tenant-id> <field-path> <value> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_config_versions.md
+++ b/docs/cli/decree_config_versions.md
@@ -19,13 +19,15 @@ decree config versions <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_diff.md
+++ b/docs/cli/decree_diff.md
@@ -31,13 +31,15 @@ decree diff [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_docgen.md
+++ b/docs/cli/decree_docgen.md
@@ -29,13 +29,15 @@ decree docgen [schema-id] [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_dump.md
+++ b/docs/cli/decree_dump.md
@@ -26,13 +26,15 @@ decree dump <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_lock.md
+++ b/docs/cli/decree_lock.md
@@ -19,13 +19,15 @@ Lock and unlock configuration fields. Locked fields cannot be modified by admin 
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_lock_list.md
+++ b/docs/cli/decree_lock_list.md
@@ -19,13 +19,15 @@ decree lock list <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_lock_remove.md
+++ b/docs/cli/decree_lock_remove.md
@@ -19,13 +19,15 @@ decree lock remove <tenant-id> <field-path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_lock_set.md
+++ b/docs/cli/decree_lock_set.md
@@ -19,13 +19,15 @@ decree lock set <tenant-id> <field-path> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema.md
+++ b/docs/cli/decree_schema.md
@@ -19,13 +19,15 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_create.md
+++ b/docs/cli/decree_schema_create.md
@@ -20,13 +20,15 @@ decree schema create [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_delete.md
+++ b/docs/cli/decree_schema_delete.md
@@ -19,13 +19,15 @@ decree schema delete <schema-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_export.md
+++ b/docs/cli/decree_schema_export.md
@@ -20,13 +20,15 @@ decree schema export <schema-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_get.md
+++ b/docs/cli/decree_schema_get.md
@@ -20,13 +20,15 @@ decree schema get <schema-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_import.md
+++ b/docs/cli/decree_schema_import.md
@@ -20,13 +20,15 @@ decree schema import <file> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_list.md
+++ b/docs/cli/decree_schema_list.md
@@ -19,13 +19,15 @@ decree schema list [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_schema_publish.md
+++ b/docs/cli/decree_schema_publish.md
@@ -19,13 +19,15 @@ decree schema publish <schema-id> <version> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_seed.md
+++ b/docs/cli/decree_seed.md
@@ -24,13 +24,15 @@ decree seed <file> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_tenant.md
+++ b/docs/cli/decree_tenant.md
@@ -19,13 +19,15 @@ Create, list, and delete tenants. Each tenant is assigned a published schema ver
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_tenant_create.md
+++ b/docs/cli/decree_tenant_create.md
@@ -22,13 +22,15 @@ decree tenant create [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_tenant_delete.md
+++ b/docs/cli/decree_tenant_delete.md
@@ -19,13 +19,15 @@ decree tenant delete <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_tenant_get.md
+++ b/docs/cli/decree_tenant_get.md
@@ -19,13 +19,15 @@ decree tenant get <tenant-id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_tenant_list.md
+++ b/docs/cli/decree_tenant_list.md
@@ -20,13 +20,15 @@ decree tenant list [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_validate.md
+++ b/docs/cli/decree_validate.md
@@ -22,13 +22,15 @@ decree validate [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_version.md
+++ b/docs/cli/decree_version.md
@@ -19,13 +19,15 @@ decree version [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/cli/decree_watch.md
+++ b/docs/cli/decree_watch.md
@@ -19,13 +19,15 @@ decree watch <tenant-id> [field-paths...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --insecure           skip TLS verification (default true)
-  -o, --output string      output format: table, json, yaml (default "table")
-      --role string        actor role (x-role header) (default "superadmin")
-      --server string      gRPC server address (default "localhost:9090")
-      --subject string     actor identity (x-subject header)
-      --tenant-id string   auth tenant ID (x-tenant-id header)
-      --token string       JWT bearer token
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```
 
 ### SEE ALSO

--- a/docs/man/decree-audit-query.1
+++ b/docs/man/decree-audit-query.1
@@ -62,6 +62,14 @@ Query the config change audit log
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-audit(1)\fP

--- a/docs/man/decree-audit-unused.1
+++ b/docs/man/decree-audit-unused.1
@@ -46,6 +46,14 @@ Find fields not read since the given duration (e.g. 7d, 24h)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-audit(1)\fP

--- a/docs/man/decree-audit-usage.1
+++ b/docs/man/decree-audit-usage.1
@@ -46,6 +46,14 @@ Show read usage statistics for a field
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-audit(1)\fP

--- a/docs/man/decree-audit.1
+++ b/docs/man/decree-audit.1
@@ -46,6 +46,14 @@ Query the configuration change history and field read usage statistics. Useful f
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-audit-query(1)\fP, \fBdecree-audit-unused(1)\fP, \fBdecree-audit-usage(1)\fP

--- a/docs/man/decree-completion-bash.1
+++ b/docs/man/decree-completion-bash.1
@@ -77,6 +77,14 @@ You will need to start a new shell for this setup to take effect.
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-completion(1)\fP

--- a/docs/man/decree-completion-fish.1
+++ b/docs/man/decree-completion-fish.1
@@ -67,6 +67,14 @@ You will need to start a new shell for this setup to take effect.
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-completion(1)\fP

--- a/docs/man/decree-completion-powershell.1
+++ b/docs/man/decree-completion-powershell.1
@@ -61,6 +61,14 @@ to your powershell profile.
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-completion(1)\fP

--- a/docs/man/decree-completion-zsh.1
+++ b/docs/man/decree-completion-zsh.1
@@ -81,6 +81,14 @@ You will need to start a new shell for this setup to take effect.
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-completion(1)\fP

--- a/docs/man/decree-completion.1
+++ b/docs/man/decree-completion.1
@@ -47,6 +47,14 @@ See each sub-command's help for details on how to use the generated script.
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-completion-bash(1)\fP, \fBdecree-completion-fish(1)\fP, \fBdecree-completion-powershell(1)\fP, \fBdecree-completion-zsh(1)\fP

--- a/docs/man/decree-config-export.1
+++ b/docs/man/decree-config-export.1
@@ -50,6 +50,14 @@ Export config to YAML
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-get-all.1
+++ b/docs/man/decree-config-get-all.1
@@ -46,6 +46,14 @@ Get all config values for a tenant
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-get.1
+++ b/docs/man/decree-config-get.1
@@ -46,6 +46,14 @@ Get a single config value
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-import.1
+++ b/docs/man/decree-config-import.1
@@ -54,6 +54,14 @@ Import config from a YAML file
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-rollback.1
+++ b/docs/man/decree-config-rollback.1
@@ -50,6 +50,14 @@ Rollback config to a previous version
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-set-many.1
+++ b/docs/man/decree-config-set-many.1
@@ -50,6 +50,14 @@ Set multiple config values atomically
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-set.1
+++ b/docs/man/decree-config-set.1
@@ -46,6 +46,14 @@ Set a single config value
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config-versions.1
+++ b/docs/man/decree-config-versions.1
@@ -46,6 +46,14 @@ List config versions
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-config(1)\fP

--- a/docs/man/decree-config.1
+++ b/docs/man/decree-config.1
@@ -46,6 +46,14 @@ Get and set typed configuration values for tenants. Supports single and batch op
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-config-export(1)\fP, \fBdecree-config-get(1)\fP, \fBdecree-config-get-all(1)\fP, \fBdecree-config-import(1)\fP, \fBdecree-config-rollback(1)\fP, \fBdecree-config-set(1)\fP, \fBdecree-config-set-many(1)\fP, \fBdecree-config-versions(1)\fP

--- a/docs/man/decree-diff.1
+++ b/docs/man/decree-diff.1
@@ -62,6 +62,14 @@ File mode (compare two local config YAML files):
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-docgen.1
+++ b/docs/man/decree-docgen.1
@@ -70,6 +70,14 @@ Generate markdown documentation from a schema. Provide a schema-id to fetch from
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-dump.1
+++ b/docs/man/decree-dump.1
@@ -58,6 +58,14 @@ Dump exports a tenant's schema, configuration, and field locks as a single YAML 
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-lock-list.1
+++ b/docs/man/decree-lock-list.1
@@ -46,6 +46,14 @@ List field locks for a tenant
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-lock(1)\fP

--- a/docs/man/decree-lock-remove.1
+++ b/docs/man/decree-lock-remove.1
@@ -46,6 +46,14 @@ Unlock a field
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-lock(1)\fP

--- a/docs/man/decree-lock-set.1
+++ b/docs/man/decree-lock-set.1
@@ -46,6 +46,14 @@ Lock a field (prevents modification by non-superadmin)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-lock(1)\fP

--- a/docs/man/decree-lock.1
+++ b/docs/man/decree-lock.1
@@ -46,6 +46,14 @@ Lock and unlock configuration fields. Locked fields cannot be modified by admin 
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-lock-list(1)\fP, \fBdecree-lock-remove(1)\fP, \fBdecree-lock-set(1)\fP

--- a/docs/man/decree-schema-create.1
+++ b/docs/man/decree-schema-create.1
@@ -50,6 +50,14 @@ Create a new schema from a YAML file
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-delete.1
+++ b/docs/man/decree-schema-delete.1
@@ -46,6 +46,14 @@ Delete a schema and all its versions (cascades to tenants)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-export.1
+++ b/docs/man/decree-schema-export.1
@@ -50,6 +50,14 @@ Export a schema to YAML
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-get.1
+++ b/docs/man/decree-schema-get.1
@@ -50,6 +50,14 @@ Show a schema
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-import.1
+++ b/docs/man/decree-schema-import.1
@@ -50,6 +50,14 @@ Import a schema from a YAML file
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-list.1
+++ b/docs/man/decree-schema-list.1
@@ -46,6 +46,14 @@ List all schemas
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema-publish.1
+++ b/docs/man/decree-schema-publish.1
@@ -46,6 +46,14 @@ Publish a schema version (makes it immutable and assignable to tenants)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-schema(1)\fP

--- a/docs/man/decree-schema.1
+++ b/docs/man/decree-schema.1
@@ -46,6 +46,14 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-schema-create(1)\fP, \fBdecree-schema-delete(1)\fP, \fBdecree-schema-export(1)\fP, \fBdecree-schema-get(1)\fP, \fBdecree-schema-import(1)\fP, \fBdecree-schema-list(1)\fP, \fBdecree-schema-publish(1)\fP

--- a/docs/man/decree-seed.1
+++ b/docs/man/decree-seed.1
@@ -50,6 +50,14 @@ Seed creates a schema, tenant, and initial configuration from a single YAML file
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-tenant-create.1
+++ b/docs/man/decree-tenant-create.1
@@ -58,6 +58,14 @@ Create a new tenant on a published schema version
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-tenant(1)\fP

--- a/docs/man/decree-tenant-delete.1
+++ b/docs/man/decree-tenant-delete.1
@@ -46,6 +46,14 @@ Delete a tenant and all its configuration data
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-tenant(1)\fP

--- a/docs/man/decree-tenant-get.1
+++ b/docs/man/decree-tenant-get.1
@@ -46,6 +46,14 @@ Show a tenant
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-tenant(1)\fP

--- a/docs/man/decree-tenant-list.1
+++ b/docs/man/decree-tenant-list.1
@@ -50,6 +50,14 @@ List tenants
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-tenant(1)\fP

--- a/docs/man/decree-tenant.1
+++ b/docs/man/decree-tenant.1
@@ -46,6 +46,14 @@ Create, list, and delete tenants. Each tenant is assigned a published schema ver
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP, \fBdecree-tenant-create(1)\fP, \fBdecree-tenant-delete(1)\fP, \fBdecree-tenant-get(1)\fP, \fBdecree-tenant-list(1)\fP

--- a/docs/man/decree-validate.1
+++ b/docs/man/decree-validate.1
@@ -58,6 +58,14 @@ Validate a config YAML against a schema YAML (offline)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-version.1
+++ b/docs/man/decree-version.1
@@ -46,6 +46,14 @@ Print the CLI version
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree-watch.1
+++ b/docs/man/decree-watch.1
@@ -46,6 +46,14 @@ Stream live config changes (like tail -f)
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree(1)\fP

--- a/docs/man/decree.1
+++ b/docs/man/decree.1
@@ -45,6 +45,14 @@ Command-line tool for managing schemas, tenants, and configuration values in Ope
 \fB--token\fP=""
 	JWT bearer token
 
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
 
 .SH SEE ALSO
 \fBdecree-audit(1)\fP, \fBdecree-completion(1)\fP, \fBdecree-config(1)\fP, \fBdecree-diff(1)\fP, \fBdecree-docgen(1)\fP, \fBdecree-dump(1)\fP, \fBdecree-lock(1)\fP, \fBdecree-schema(1)\fP, \fBdecree-seed(1)\fP, \fBdecree-tenant(1)\fP, \fBdecree-validate(1)\fP, \fBdecree-version(1)\fP, \fBdecree-watch(1)\fP


### PR DESCRIPTION
## Summary

- Add global `--wait` and `--wait-timeout` flags that health-check the server (gRPC health protocol) before executing any command
- Exponential backoff (500ms → 5s) with clear timeout error
- Fix stale "ccs" in version output → "decree"
- Regenerated CLI docs and man pages

**Use case:** Docker/Kubernetes init containers where the server may not be ready yet. Eliminates shell scripting wait loops.

```bash
# Before (15 lines of shell)
for i in $(seq 1 60); do
  decree schema list --server decree:9090 >/dev/null 2>&1 && break
  sleep 1
done
decree seed config.yaml --server decree:9090

# After (1 line)
decree seed config.yaml --server decree:9090 --wait --wait-timeout 60s
```

Closes #68.

## Test plan

- [x] `make test` passes (all modules)
- [x] New unit tests: healthy server (instant pass), unreachable server (timeout)
- [x] Manual test: `--wait --wait-timeout 3s` against unreachable port → clear error
- [x] Manual test: without `--wait` → no behavior change
- [x] CLI docs and man pages regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)