### PR TITLE
Auth: resolve tenant slugs in x-tenant-id header

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -160,7 +160,7 @@ func run() int {
 		authInterceptor = jwtInterceptor
 		logger.InfoContext(ctx, "JWT auth enabled", "jwks_url", cfg.JWTJWKSURL)
 	} else {
-		authInterceptor = auth.NewMetadataInterceptor()
+		authInterceptor = auth.NewMetadataInterceptor(tenantResolver(schemaStoreVal))
 		logger.InfoContext(ctx, "metadata auth enabled — pass x-subject, x-role, x-tenant-id headers")
 	}
 
@@ -267,6 +267,21 @@ type serverConfig struct {
 	JWTIssuer      string
 	JWTJWKSURL     string
 	LogLevel       string
+}
+
+// tenantResolver creates an auth.TenantResolver from a schema store.
+// Resolves tenant name slugs to UUIDs so x-tenant-id headers accept both.
+func tenantResolver(store schema.Store) auth.TenantResolver {
+	return func(ctx context.Context, idOrName string) (string, error) {
+		if domain.IsUUID(idOrName) {
+			return idOrName, nil
+		}
+		tenant, err := store.GetTenantByName(ctx, idOrName)
+		if err != nil {
+			return "", err
+		}
+		return tenant.ID, nil
+	}
 }
 
 func loadConfig() serverConfig {

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -17,13 +17,21 @@ const (
 	headerTenantID = "x-tenant-id"
 )
 
+// TenantResolver resolves a tenant identifier (UUID or name slug) to a UUID.
+// Used by MetadataInterceptor to normalize x-tenant-id header values.
+type TenantResolver func(ctx context.Context, idOrName string) (string, error)
+
 // MetadataInterceptor extracts identity from gRPC metadata headers
 // instead of JWT tokens. Used when JWT auth is disabled.
-type MetadataInterceptor struct{}
+type MetadataInterceptor struct {
+	resolveTenant TenantResolver
+}
 
 // NewMetadataInterceptor creates a new metadata-based auth interceptor.
-func NewMetadataInterceptor() *MetadataInterceptor {
-	return &MetadataInterceptor{}
+// If resolver is non-nil, tenant IDs in x-tenant-id headers are resolved
+// from name slugs to UUIDs before storing in the auth context.
+func NewMetadataInterceptor(resolver TenantResolver) *MetadataInterceptor {
+	return &MetadataInterceptor{resolveTenant: resolver}
 }
 
 // UnaryInterceptor returns a gRPC unary server interceptor.
@@ -70,14 +78,23 @@ func (m *MetadataInterceptor) extractClaims(ctx context.Context) (context.Contex
 	}
 
 	// Parse tenant IDs — comma-separated in x-tenant-id header.
+	// If a resolver is configured, slugs are resolved to UUIDs.
 	var tenantIDs []string
 	rawTenantID := firstMetadataValue(md, headerTenantID)
 	if rawTenantID != "" {
 		for _, id := range strings.Split(rawTenantID, ",") {
 			id = strings.TrimSpace(id)
-			if id != "" {
-				tenantIDs = append(tenantIDs, id)
+			if id == "" {
+				continue
 			}
+			if m.resolveTenant != nil {
+				resolved, err := m.resolveTenant(ctx, id)
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "failed to resolve tenant %q: %v", id, err)
+				}
+				id = resolved
+			}
+			tenantIDs = append(tenantIDs, id)
 		}
 	}
 	if role != RoleSuperAdmin && len(tenantIDs) == 0 {

--- a/internal/auth/metadata_test.go
+++ b/internal/auth/metadata_test.go
@@ -19,7 +19,7 @@ func ctxWithMetadata(kvs map[string]string) context.Context {
 // --- UnaryInterceptor ---
 
 func TestMetadata_ValidSuperadmin(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{"x-subject": "admin@example.com"})
@@ -30,7 +30,7 @@ func TestMetadata_ValidSuperadmin(t *testing.T) {
 }
 
 func TestMetadata_DefaultsToSuperadmin(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{"x-subject": "user@example.com"})
@@ -50,7 +50,7 @@ func TestMetadata_DefaultsToSuperadmin(t *testing.T) {
 }
 
 func TestMetadata_AdminWithTenant(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{
@@ -74,7 +74,7 @@ func TestMetadata_AdminWithTenant(t *testing.T) {
 }
 
 func TestMetadata_UserWithTenant(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{
@@ -96,7 +96,7 @@ func TestMetadata_UserWithTenant(t *testing.T) {
 }
 
 func TestMetadata_MissingSubject(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{"x-role": "admin"})
@@ -108,7 +108,7 @@ func TestMetadata_MissingSubject(t *testing.T) {
 }
 
 func TestMetadata_NoMetadata(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := context.Background()
@@ -119,7 +119,7 @@ func TestMetadata_NoMetadata(t *testing.T) {
 }
 
 func TestMetadata_UnknownRole(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{
@@ -134,7 +134,7 @@ func TestMetadata_UnknownRole(t *testing.T) {
 }
 
 func TestMetadata_AdminMissingTenant(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{
@@ -149,7 +149,7 @@ func TestMetadata_AdminMissingTenant(t *testing.T) {
 }
 
 func TestMetadata_UserMissingTenant(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{
@@ -163,7 +163,7 @@ func TestMetadata_UserMissingTenant(t *testing.T) {
 }
 
 func TestMetadata_HealthCheckBypass(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
 	// No headers at all — health checks skip auth.
@@ -175,7 +175,7 @@ func TestMetadata_HealthCheckBypass(t *testing.T) {
 }
 
 func TestMetadata_StreamInterceptor(t *testing.T) {
-	interceptor := NewMetadataInterceptor()
+	interceptor := NewMetadataInterceptor(nil)
 	stream := interceptor.StreamInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{


### PR DESCRIPTION
## Summary

The metadata auth interceptor now resolves tenant name slugs to UUIDs in the `x-tenant-id` header. This enables non-superadmin roles to use human-readable tenant names:

```
x-tenant-id: demo-company    # resolved to UUID before access check
```

**The bug:** Admin UI in the demo sends `x-tenant-id: demo-company` (slug) but `CheckTenantAccess` compares against the resolved UUID → mismatch → "x-tenant-id required for non-superadmin".

**The fix:** `MetadataInterceptor` accepts an optional `TenantResolver` function. When present, slugs in `x-tenant-id` are resolved to UUIDs at extraction time, before they're stored in the auth context.

Changes:
- `MetadataInterceptor` now takes an optional `TenantResolver` parameter
- Server wires in a resolver from the schema store
- Existing tests pass `nil` (no resolution needed)

## Test plan

- [x] `make test` — all 20 modules pass
- [x] Existing auth tests unchanged (pass nil resolver)
- [ ] E2E: admin UI with `x-tenant-id: demo-company` + role=admin can edit config

🤖 Generated with [Claude Code](https://claude.com/claude-code)