### PR TITLE
chore: SDK Go 1.22 compat CI + README update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,38 @@ jobs:
       - name: Coverage ratchet
         run: ./scripts/check-coverage.sh
 
+  sdk-compat:
+    name: SDK compat (Go ${{ matrix.go }})
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go: ["1.22", "1.23"]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+          cache-dependency-path: "**/go.sum"
+
+      - name: Build SDK core modules
+        run: |
+          cd sdk/configclient && go build ./...
+          cd ../adminclient && go build ./...
+          cd ../configwatcher && go build ./...
+
+      - name: Test SDK core modules
+        run: |
+          cd sdk/configclient && go test ./... -count=1 &
+          cd sdk/adminclient && go test ./... -count=1 &
+          cd sdk/configwatcher && go test ./... -count=1 &
+          wait
+
   docs:
     name: Docs check
     runs-on: ubuntu-latest
@@ -314,11 +346,11 @@ jobs:
   check:
     name: CI check
     if: always()
-    needs: [lint, test, docs, e2e, examples]
+    needs: [lint, test, sdk-compat, docs, e2e, examples]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, e2e, examples
+          allowed-skips: lint, test, sdk-compat, e2e, examples

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/opendecree/decree/actions/workflows/ci.yml"><img src="https://github.com/opendecree/decree/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/opendecree/decree/releases"><img src="https://img.shields.io/github/v/release/opendecree/decree" alt="Release"></a>
-  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.24-00ADD8?logo=go" alt="Go"></a>
+  <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.22+-00ADD8?logo=go" alt="Go"></a>
   <a href="https://goreportcard.com/report/github.com/opendecree/decree"><img src="https://goreportcard.com/badge/github.com/opendecree/decree" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
 </p>
@@ -59,23 +59,26 @@ No existing open-source tool combines a schema-first approach to typed configura
 
 ### Go
 
+The core SDK modules require **Go 1.22+** and have zero external dependencies. The `grpctransport` module (default transport) requires Go 1.24+.
+
 ```go
 // configclient — application runtime reads and writes
-client := configclient.New(rpc, configclient.WithSubject("myapp"))
+client := grpctransport.NewConfigClient(conn, grpctransport.WithSubject("myapp"))
 val, _ := client.GetInt(ctx, tenantID, "payments.retries")
 
 // configwatcher — live typed values with auto-reconnect
-w := configwatcher.New(conn, tenantID)
+w := grpctransport.NewWatcher(conn, tenantID, grpctransport.WithSubject("myapp"))
 fee := w.Float("payments.fee", 0.01)
 w.Start(ctx)
 fmt.Println(fee.Get()) // always fresh
 ```
 
 ```bash
-go get github.com/opendecree/decree/sdk/configclient@latest
-go get github.com/opendecree/decree/sdk/adminclient@latest
-go get github.com/opendecree/decree/sdk/configwatcher@latest
-go get github.com/opendecree/decree/sdk/tools@latest         # diff, docgen, validate, seed, dump
+go get github.com/opendecree/decree/sdk/grpctransport@latest  # gRPC transport (pulls in configclient, etc.)
+go get github.com/opendecree/decree/sdk/configclient@latest   # core client (no gRPC dependency)
+go get github.com/opendecree/decree/sdk/adminclient@latest    # admin operations
+go get github.com/opendecree/decree/sdk/configwatcher@latest  # live config watcher
+go get github.com/opendecree/decree/sdk/tools@latest          # diff, docgen, validate, seed, dump
 ```
 
 ### Python


### PR DESCRIPTION
## Summary

- Add `sdk-compat` CI job that tests core SDK modules (configclient, adminclient, configwatcher) against Go 1.22 and 1.23
- Update README badge to show Go 1.22+ and SDK examples to use grpctransport API
- Documents zero-dependency core SDK vs Go 1.24 grpctransport split

Closes #42

## Test plan

- [x] Core SDK modules verified to build and test on Go 1.22.0 locally (`GOTOOLCHAIN=go1.22.0 go build/test`)
- [x] CI will validate the new sdk-compat matrix job

🤖 Generated with [Claude Code](https://claude.com/claude-code)