### PR TITLE
fix(ci): remove broken workflow_dispatch + update pre-commit skill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,16 +15,12 @@ env:
 jobs:
   test:
     name: Validate
-    # Skip CI on workflow_dispatch — reusable workflow refs can't resolve from
-    # a tag ref, and we run the full pre-release checklist before tagging anyway.
-    if: github.event_name != 'workflow_dispatch'
     uses: ./.github/workflows/ci.yml
 
   release-notes:
     name: Release notes
     runs-on: ubuntu-latest
     needs: test
-    if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Remove `workflow_dispatch` trigger from release.yml — it triggered on branch refs (not tags), causing startup_failure every time. Releases are always triggered by tag pushes.
- Clean up the `if` guards that existed only to handle workflow_dispatch
- Update `/pre-commit` skill to support `--update-thresholds` flag for coverage regression during refactors

## Test plan

- [x] Release workflow still triggers on `push: tags: v*` (unchanged)
- [x] No more accidental manual dispatch failures
- [x] CI passes (workflow change is docs-only for the CI pipeline itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)