### PR TITLE
feat(server): cursor-based pagination for list endpoints

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
   "cmd/decree": 85.0,
-  "internal": 61.0,
+  "internal": 61.4,
   "sdk/adminclient": 97.2,
   "sdk/configclient": 86.8,
   "sdk/configwatcher": 90.9,

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/pagination"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
 
@@ -51,14 +52,16 @@ func (s *Service) resolveTenantID(ctx context.Context, idOrName string) (string,
 }
 
 func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogRequest) (*pb.QueryWriteLogResponse, error) {
-	pageSize := req.PageSize
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 50
+	pageSize := pagination.ClampPageSize(req.PageSize, 50, 500)
+
+	offset, err := pagination.DecodePageToken(req.PageToken)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid page token")
 	}
 
 	params := QueryWriteLogParams{
-		Limit:  pageSize,
-		Offset: 0,
+		Limit:  pageSize + 1,
+		Offset: offset,
 	}
 	if req.TenantId != nil {
 		resolved, err := s.resolveTenantID(ctx, *req.TenantId)
@@ -88,12 +91,20 @@ func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogReques
 		return nil, status.Error(codes.Internal, "failed to query audit log")
 	}
 
+	nextToken := pagination.NextPageToken(pageSize, int32(len(entries)), offset)
+	if int32(len(entries)) > pageSize {
+		entries = entries[:pageSize]
+	}
+
 	pbEntries := make([]*pb.AuditEntry, 0, len(entries))
 	for _, e := range entries {
 		pbEntries = append(pbEntries, auditEntryToProto(e))
 	}
 
-	return &pb.QueryWriteLogResponse{Entries: pbEntries}, nil
+	return &pb.QueryWriteLogResponse{
+		Entries:       pbEntries,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (s *Service) GetFieldUsage(ctx context.Context, req *pb.GetFieldUsageRequest) (*pb.GetFieldUsageResponse, error) {

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -106,11 +106,19 @@ func TestQueryWriteLog_DefaultPageSize(t *testing.T) {
 	ctx := context.Background()
 
 	store.On("QueryAuditWriteLog", ctx, mock.MatchedBy(func(p QueryWriteLogParams) bool {
-		return p.Limit == 50
+		return p.Limit == 51 // 50 (default page size) + 1 (to detect next page)
 	})).Return([]domain.AuditWriteLog{}, nil)
 
 	_, err := svc.QueryWriteLog(ctx, &pb.QueryWriteLogRequest{})
 	require.NoError(t, err)
+}
+
+func TestQueryWriteLog_InvalidPageToken(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := context.Background()
+
+	_, err := svc.QueryWriteLog(ctx, &pb.QueryWriteLogRequest{PageToken: "garbage"})
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // --- GetFieldUsage ---

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/cache"
+	"github.com/opendecree/decree/internal/pagination"
 	"github.com/opendecree/decree/internal/pubsub"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/telemetry"
@@ -460,18 +461,25 @@ func (s *Service) ListVersions(ctx context.Context, req *pb.ListVersionsRequest)
 		return nil, err
 	}
 
-	pageSize := req.PageSize
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 50
+	pageSize := pagination.ClampPageSize(req.PageSize, 50, 500)
+
+	offset, err := pagination.DecodePageToken(req.PageToken)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid page token")
 	}
 
 	versions, err := s.store.ListConfigVersions(ctx, ListConfigVersionsParams{
 		TenantID: tenantID,
-		Limit:    pageSize,
-		Offset:   0,
+		Limit:    pageSize + 1,
+		Offset:   offset,
 	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list versions")
+	}
+
+	nextToken := pagination.NextPageToken(pageSize, int32(len(versions)), offset)
+	if int32(len(versions)) > pageSize {
+		versions = versions[:pageSize]
 	}
 
 	pbVersions := make([]*pb.ConfigVersion, 0, len(versions))
@@ -479,7 +487,10 @@ func (s *Service) ListVersions(ctx context.Context, req *pb.ListVersionsRequest)
 		pbVersions = append(pbVersions, configVersionToProto(v))
 	}
 
-	return &pb.ListVersionsResponse{Versions: pbVersions}, nil
+	return &pb.ListVersionsResponse{
+		Versions:      pbVersions,
+		NextPageToken: nextToken,
+	}, nil
 }
 
 func (s *Service) GetVersion(ctx context.Context, req *pb.GetVersionRequest) (*pb.GetVersionResponse, error) {

--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,0 +1,66 @@
+// Package pagination provides opaque page-token encoding for list RPCs.
+//
+// Tokens are versioned to allow future migration from offset-based to
+// keyset-based pagination without breaking existing clients.
+package pagination
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const tokenVersion = "v1"
+
+// ClampPageSize returns a page size within [1, maxSize], defaulting to
+// defaultSize when the requested size is zero or negative.
+func ClampPageSize(requested, defaultSize, maxSize int32) int32 {
+	if requested <= 0 {
+		return defaultSize
+	}
+	if requested > maxSize {
+		return maxSize
+	}
+	return requested
+}
+
+// DecodePageToken decodes an opaque page token into an offset.
+// An empty token returns offset 0 (first page).
+func DecodePageToken(token string) (int32, error) {
+	if token == "" {
+		return 0, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	parts := strings.SplitN(string(raw), ":", 2)
+	if len(parts) != 2 || parts[0] != tokenVersion {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	offset, err := strconv.ParseInt(parts[1], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	if offset < 0 {
+		return 0, fmt.Errorf("invalid page token")
+	}
+	return int32(offset), nil
+}
+
+// EncodePageToken encodes an offset into an opaque page token.
+func EncodePageToken(offset int32) string {
+	raw := fmt.Sprintf("%s:%d", tokenVersion, offset)
+	return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// NextPageToken returns the token for the next page, or empty string if
+// there are no more results. Call this after fetching pageSize+1 rows
+// from the database.
+func NextPageToken(pageSize, resultCount, currentOffset int32) string {
+	if resultCount <= pageSize {
+		return ""
+	}
+	return EncodePageToken(currentOffset + pageSize)
+}

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -1,0 +1,104 @@
+package pagination
+
+import "testing"
+
+func TestDecodePageToken_Empty(t *testing.T) {
+	offset, err := DecodePageToken("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if offset != 0 {
+		t.Errorf("got %d, want 0", offset)
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	for _, offset := range []int32{0, 1, 50, 100, 999} {
+		token := EncodePageToken(offset)
+		got, err := DecodePageToken(token)
+		if err != nil {
+			t.Fatalf("DecodePageToken(%q): %v", token, err)
+		}
+		if got != offset {
+			t.Errorf("round-trip offset %d: got %d", offset, got)
+		}
+	}
+}
+
+func TestDecodePageToken_Invalid(t *testing.T) {
+	tests := []string{
+		"not-base64!!!",
+		"aW52YWxpZA==", // "invalid" (no version prefix)
+		"djI6NTA=",     // "v2:50" (wrong version)
+		"djE6LTE=",     // "v1:-1" (negative offset)
+		"djE6YWJj",     // "v1:abc" (non-numeric)
+	}
+	for _, token := range tests {
+		_, err := DecodePageToken(token)
+		if err == nil {
+			t.Errorf("DecodePageToken(%q): expected error, got nil", token)
+		}
+	}
+}
+
+func TestClampPageSize(t *testing.T) {
+	// Zero/negative → default
+	if got := ClampPageSize(0, 50, 100); got != 50 {
+		t.Errorf("got %d, want 50", got)
+	}
+	if got := ClampPageSize(-1, 50, 100); got != 50 {
+		t.Errorf("got %d, want 50", got)
+	}
+	// Within range → as-is
+	if got := ClampPageSize(25, 50, 100); got != 25 {
+		t.Errorf("got %d, want 25", got)
+	}
+	// Over max → capped
+	if got := ClampPageSize(200, 50, 100); got != 100 {
+		t.Errorf("got %d, want 100", got)
+	}
+	// Different max for lightweight resources
+	if got := ClampPageSize(300, 50, 500); got != 300 {
+		t.Errorf("got %d, want 300", got)
+	}
+	if got := ClampPageSize(600, 50, 500); got != 500 {
+		t.Errorf("got %d, want 500", got)
+	}
+}
+
+func TestNextPageToken(t *testing.T) {
+	// Full page → has next
+	if token := NextPageToken(50, 51, 0); token == "" {
+		t.Error("expected non-empty token for full page")
+	}
+
+	// Partial page → no next
+	if token := NextPageToken(50, 30, 0); token != "" {
+		t.Errorf("expected empty token for partial page, got %q", token)
+	}
+
+	// Exact page → no next
+	if token := NextPageToken(50, 50, 0); token != "" {
+		t.Errorf("expected empty token for exact page, got %q", token)
+	}
+
+	// Second page token encodes correct offset
+	token := NextPageToken(50, 51, 0)
+	offset, err := DecodePageToken(token)
+	if err != nil {
+		t.Fatalf("DecodePageToken: %v", err)
+	}
+	if offset != 50 {
+		t.Errorf("got offset %d, want 50", offset)
+	}
+
+	// Third page from offset 50
+	token = NextPageToken(50, 51, 50)
+	offset, err = DecodePageToken(token)
+	if err != nil {
+		t.Fatalf("DecodePageToken: %v", err)
+	}
+	if offset != 100 {
+		t.Errorf("got offset %d, want 100", offset)
+	}
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -12,6 +12,7 @@ import (
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/pagination"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/telemetry"
 	"github.com/opendecree/decree/internal/validation"
@@ -170,20 +171,24 @@ func (s *Service) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (*pb.
 }
 
 func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (*pb.ListSchemasResponse, error) {
-	pageSize := req.PageSize
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 50
+	pageSize := pagination.ClampPageSize(req.PageSize, 50, 100)
+
+	offset, err := pagination.DecodePageToken(req.PageToken)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid page token")
 	}
 
-	var offset int32
-	// TODO: implement cursor-based pagination using req.PageToken.
-
 	schemas, err := s.store.ListSchemas(ctx, ListSchemasParams{
-		Limit:  pageSize,
+		Limit:  pageSize + 1,
 		Offset: offset,
 	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list schemas")
+	}
+
+	nextToken := pagination.NextPageToken(pageSize, int32(len(schemas)), offset)
+	if int32(len(schemas)) > pageSize {
+		schemas = schemas[:pageSize]
 	}
 
 	// Fetch latest version for each schema.
@@ -201,7 +206,8 @@ func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (
 	}
 
 	return &pb.ListSchemasResponse{
-		Schemas: pbSchemas,
+		Schemas:       pbSchemas,
+		NextPageToken: nextToken,
 	}, nil
 }
 
@@ -381,16 +387,17 @@ func (s *Service) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (*pb.
 }
 
 func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (*pb.ListTenantsResponse, error) {
-	pageSize := req.PageSize
-	if pageSize <= 0 || pageSize > 100 {
-		pageSize = 50
+	pageSize := pagination.ClampPageSize(req.PageSize, 50, 500)
+
+	offset, err := pagination.DecodePageToken(req.PageToken)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid page token")
 	}
 
 	// Push tenant access filtering into the store so pagination is correct.
 	allowedIDs := auth.AllowedTenantIDs(ctx)
 
 	var tenants []domain.Tenant
-	var err error
 
 	if req.SchemaId != nil && *req.SchemaId != "" {
 		if !validUUID(*req.SchemaId) {
@@ -398,19 +405,24 @@ func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (
 		}
 		tenants, err = s.store.ListTenantsBySchema(ctx, ListTenantsBySchemaParams{
 			SchemaID:         *req.SchemaId,
-			Limit:            pageSize,
-			Offset:           0,
+			Limit:            pageSize + 1,
+			Offset:           offset,
 			AllowedTenantIDs: allowedIDs,
 		})
 	} else {
 		tenants, err = s.store.ListTenants(ctx, ListTenantsParams{
-			Limit:            pageSize,
-			Offset:           0,
+			Limit:            pageSize + 1,
+			Offset:           offset,
 			AllowedTenantIDs: allowedIDs,
 		})
 	}
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list tenants")
+	}
+
+	nextToken := pagination.NextPageToken(pageSize, int32(len(tenants)), offset)
+	if int32(len(tenants)) > pageSize {
+		tenants = tenants[:pageSize]
 	}
 
 	pbTenants := make([]*pb.Tenant, 0, len(tenants))
@@ -419,7 +431,8 @@ func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (
 	}
 
 	return &pb.ListTenantsResponse{
-		Tenants: pbTenants,
+		Tenants:       pbTenants,
+		NextPageToken: nextToken,
 	}, nil
 }
 

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -23,9 +23,9 @@ func testSchema() domain.Schema {
 	return domain.Schema{ID: testSchemaID, Name: "test-schema", CreatedAt: now, UpdatedAt: now}
 }
 
-func testVersion(v int32) domain.SchemaVersion {
+func testVersion() domain.SchemaVersion {
 	return domain.SchemaVersion{
-		ID: testVersionID, SchemaID: testSchemaID, Version: v,
+		ID: testVersionID, SchemaID: testSchemaID, Version: 1,
 		Checksum: "abc", CreatedAt: now,
 	}
 }
@@ -46,12 +46,60 @@ func TestListSchemas_Success(t *testing.T) {
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{
 		testSchema(),
 	}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(1), nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
 	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageSize: 10})
 	require.NoError(t, err)
 	assert.Len(t, resp.Schemas, 1)
+}
+
+func TestListSchemas_Pagination(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, testLogger, nil, nil)
+
+	s1 := testSchema()
+	s2 := testSchema()
+	s2.ID = "22222222-2222-2222-2222-222222222222"
+	s2.Name = "schema-2"
+
+	v1 := testVersion()
+	v2 := testVersion()
+	v2.ID = "33333333-3333-3333-3333-333333333333"
+
+	// Page 1: returns 2 results (pageSize+1) → has next page
+	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
+		return p.Offset == 0 && p.Limit == 2
+	})).Return([]domain.Schema{s1, s2}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, s1.ID).Return(v1, nil)
+	store.On("GetSchemaFields", mock.Anything, v1.ID).Return([]domain.SchemaField{}, nil)
+
+	resp, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageSize: 1})
+	require.NoError(t, err)
+	assert.Len(t, resp.Schemas, 1)
+	assert.NotEmpty(t, resp.NextPageToken, "expected next_page_token for full page")
+
+	// Page 2: returns 1 result (< pageSize+1) → no next page
+	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
+		return p.Offset == 1 && p.Limit == 2
+	})).Return([]domain.Schema{s2}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, s2.ID).Return(v2, nil)
+	store.On("GetSchemaFields", mock.Anything, v2.ID).Return([]domain.SchemaField{}, nil)
+
+	resp, err = svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{
+		PageSize:  1,
+		PageToken: resp.NextPageToken,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Schemas, 1)
+	assert.Empty(t, resp.NextPageToken, "expected no next_page_token for last page")
+}
+
+func TestListSchemas_InvalidPageToken(t *testing.T) {
+	svc := NewService(&mockStore{}, testLogger, nil, nil)
+
+	_, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageToken: "garbage"})
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // --- DeleteSchema ---
@@ -396,7 +444,7 @@ func TestGetSchema_ByName(t *testing.T) {
 	svc := NewService(store, testLogger, nil, nil)
 
 	store.On("GetSchemaByName", mock.Anything, "test-schema").Return(testSchema(), nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(1), nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
 	store.On("GetSchemaFields", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.GetSchema(context.Background(), &pb.GetSchemaRequest{Id: "test-schema"})
@@ -417,7 +465,7 @@ func TestListTenants_SuperadminSeesAll(t *testing.T) {
 	})
 
 	store.On("ListTenants", ctx, ListTenantsParams{
-		Limit: 50, AllowedTenantIDs: nil,
+		Limit: 51, AllowedTenantIDs: nil,
 	}).Return([]domain.Tenant{testTenant()}, nil)
 
 	resp, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{})
@@ -438,7 +486,7 @@ func TestListTenants_NonSuperadminFiltered(t *testing.T) {
 
 	// Store should receive AllowedTenantIDs — filtering happens at store level.
 	store.On("ListTenants", ctx, ListTenantsParams{
-		Limit: 50, AllowedTenantIDs: allowedIDs,
+		Limit: 51, AllowedTenantIDs: allowedIDs,
 	}).Return([]domain.Tenant{testTenant()}, nil)
 
 	resp, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{})
@@ -460,7 +508,7 @@ func TestListTenants_BySchemaFiltered(t *testing.T) {
 
 	schemaID := testSchemaID
 	store.On("ListTenantsBySchema", ctx, ListTenantsBySchemaParams{
-		SchemaID: schemaID, Limit: 50, AllowedTenantIDs: allowedIDs,
+		SchemaID: schemaID, Limit: 51, AllowedTenantIDs: allowedIDs,
 	}).Return([]domain.Tenant{testTenant()}, nil)
 
 	resp, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{SchemaId: &schemaID})
@@ -475,13 +523,21 @@ func TestListTenants_NoAuthContext_SeesAll(t *testing.T) {
 	ctx := context.Background() // No auth claims — permissive.
 
 	store.On("ListTenants", ctx, ListTenantsParams{
-		Limit: 50, AllowedTenantIDs: nil,
+		Limit: 51, AllowedTenantIDs: nil,
 	}).Return([]domain.Tenant{testTenant()}, nil)
 
 	resp, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{})
 	require.NoError(t, err)
 	assert.Len(t, resp.Tenants, 1)
 	store.AssertExpectations(t)
+}
+
+func TestListTenants_InvalidPageToken(t *testing.T) {
+	svc := NewService(&mockStore{}, testLogger, nil, nil)
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
+
+	_, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{PageToken: "garbage"})
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // --- ExportSchema ---


### PR DESCRIPTION
## Summary

- Add `internal/pagination` package with versioned opaque page tokens (base64 of `v1:<offset>`)
- Wire pagination into all 4 list RPCs: ListSchemas, ListTenants, ListVersions, QueryWriteLog
- Services request `pageSize+1` rows to detect next page without COUNT queries

Closes #13

## Test plan

- [x] `make pre-commit` passes (build, vet, format, lint, 23 test suites with `-race`, coverage)
- [x] Pagination helper: encode/decode round-trip, invalid tokens, next page detection
- [x] ListSchemas: multi-page traversal test, invalid token test
- [x] ListTenants: invalid token test, existing access control tests updated
- [x] QueryWriteLog: invalid token test, default page size test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)