### PR TITLE
ci: cut tools image build time with layer split + registry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@
 #
 # Jobs: changes ──┬── tools → lint, docs, e2e, examples ──→ check (alls-green gate)
 #                 └── test ─────────────────────────────────┘
-# The changes job runs dorny/paths-filter; lint, test, e2e, examples skip on docs-only PRs.
-# The tools job builds/caches the Docker image used by lint, docs, e2e, examples.
-# The check job aggregates all results for branch protection (skipped jobs are allowed).
+# The changes job runs dorny/paths-filter; all downstream jobs (tools, lint, test,
+# docs, e2e, examples) skip on docs-only PRs — zero-cost CI for top-level Markdown.
+# The tools job builds/caches the Docker image used by lint, docs, e2e, examples,
+# with a registry-backed buildx cache (:buildcache tag) so unchanged layers are
+# pulled from ghcr and only modified layers rebuild.
+# The check job aggregates all results for branch protection (skipped jobs allowed).
 
 name: CI
 
@@ -57,6 +60,8 @@ jobs:
   tools:
     name: Tools image
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -78,6 +83,10 @@ jobs:
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
 
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to ghcr.io
         if: steps.check.outputs.exists == 'false'
         uses: docker/login-action@v4
@@ -94,6 +103,8 @@ jobs:
           file: build/Dockerfile.tools
           push: true
           tags: ${{ env.TOOLS_IMAGE }}:${{ steps.hash.outputs.tag }}
+          cache-from: type=registry,ref=${{ env.TOOLS_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.TOOLS_IMAGE }}:buildcache,mode=max
 
     outputs:
       image: ${{ env.TOOLS_IMAGE }}:${{ steps.hash.outputs.tag }}
@@ -211,7 +222,8 @@ jobs:
   docs:
     name: Docs check
     runs-on: ubuntu-latest
-    needs: tools
+    needs: [tools, changes]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -353,4 +365,4 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, e2e, examples
+          allowed-skips: lint, test, sdk-compat, docs, e2e, examples

--- a/build/Dockerfile.tools
+++ b/build/Dockerfile.tools
@@ -1,15 +1,27 @@
 FROM golang:1.25-bookworm
 
-# Install all tools in a single layer with cached module and build dirs.
+# Tools are grouped by purpose so bumping one pin rebuilds only its layer.
+# Cache mounts persist Go module downloads and build artifacts within a build;
+# the CI buildx registry cache (:buildcache tag) persists layers across runs.
+
+# Proto toolchain
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go install github.com/bufbuild/buf/cmd/buf@v1.66.1 && \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1 && \
     go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.27.3 && \
-    go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.27.3 && \
+    go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.27.3
+
+# DB toolchain
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0 && \
-    go install github.com/pressly/goose/v3/cmd/goose@v3.27.0 && \
+    go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
+
+# Docs toolchain
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
     go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Tools image was the longest CI job (~4 min) and gated lint/docs/e2e/examples; docs-only PRs still paid the full cost.
- Registry-backed buildx cache (`:buildcache` tag on ghcr) means unchanged layers pull from registry instead of rebuilding cold — complements the new layer split so a single pin bump rebuilds only one of three layers.
- Gating tools + docs on the existing `code` path filter makes docs-only PRs zero-cost.

Closes #81

## Test plan
- [x] Local `docker build -f build/Dockerfile.tools` succeeds (~19s with warm mod cache)
- [x] ci.yml parses as valid YAML
- [ ] CI: verify tools job uses registry cache on first run (cache miss), writes `:buildcache`
- [ ] CI: verify subsequent Dockerfile change rebuilds only the touched layer
- [ ] CI: verify docs-only PR (top-level .md) skips tools + docs + downstream jobs and `check` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)