### PR TITLE
ci: move remaining Docker caches from GHA to ghcr registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@
 # with a registry-backed buildx cache (:buildcache tag) so unchanged layers are
 # pulled from ghcr and only modified layers rebuild.
 # The check job aggregates all results for branch protection (skipped jobs allowed).
+#
+# Cache budget: all Docker layer caches live on ghcr.io as `:buildcache` tags on
+# their respective image repos (no 10GB GHA cache limit). Writers:
+#   - main.yml  → ghcr.io/<owner>/decree:buildcache, decree-cli:buildcache
+#   - release.yml → same refs (shared with main.yml, mode=max)
+#   - tools job → ghcr.io/<owner>/decree-tools:buildcache
+# ci.yml e2e/examples are read-only consumers.
 
 name: CI
 
@@ -297,8 +304,8 @@ jobs:
           file: build/Dockerfile
           load: true
           tags: decree-service
-          cache-from: type=gha,scope=e2e-server
-          cache-to: type=gha,mode=max,scope=e2e-server
+          # Read-only: main.yml is the canonical writer for this cache.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
 
       - name: Run E2E tests
         run: |
@@ -347,8 +354,8 @@ jobs:
           file: build/Dockerfile
           load: true
           tags: decree-service
-          cache-from: type=gha,scope=e2e-server
-          cache-to: type=gha,mode=max,scope=e2e-server
+          # Read-only: main.yml is the canonical writer for this cache.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
 
       - name: Run examples
         run: make examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
             VERSION=main
             COMMIT=${{ github.sha }}
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:main
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
 
   docs:
     name: Deploy docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,5 +216,5 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:latest
-          cache-from: type=gha,scope=${{ matrix.image }}-release
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-release
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max


### PR DESCRIPTION
## Summary
- Four `type=gha` Docker caches still shared the 10GB per-repo GHA cache budget (ci.yml e2e-server, main.yml decree + decree-cli, release.yml decree + decree-cli). Preempts the fallback plan in #10 — no size cap, no branch isolation, shared across workflows.
- main.yml and release.yml are the canonical writers (`mode=max`, multi-platform). ci.yml e2e/examples read-only to avoid single-platform writes stomping the multi-platform manifest.
- Added cache-budget comment to ci.yml header documenting all `:buildcache` refs.

Closes #10

## Test plan
- [x] ci.yml / main.yml / release.yml all parse as valid YAML
- [x] No `type=gha` cache refs remain in any workflow
- [ ] CI: verify e2e + examples read from ghcr cache (will be empty on first run until main.yml populates)
- [ ] After merge: verify main.yml's image push writes `decree:buildcache` and `decree-cli:buildcache`
- [ ] Next release tag: verify release.yml reuses main's cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)