### PR TITLE
build: bump server/CLI Go toolchain to 1.25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: false
 
       - name: Find previous tag
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Schema-driven business configuration management service. Multi-tenant, gRPC API,
 
 | Concern | Tool | Version |
 |---------|------|---------|
-| Language | Go | 1.24 (server/CLI), 1.22 (SDK) |
+| Language | Go | 1.25 (server/CLI), 1.22 (SDK) |
 | API | gRPC (Protocol Buffers) | — |
 | Proto tooling | buf (local plugins) | v1.66.1 |
 | DB | PostgreSQL | 17 |
@@ -24,7 +24,7 @@ Schema-driven business configuration management service. Multi-tenant, gRPC API,
 
 ### Prerequisites
 
-Go 1.24+, Docker, Make. All generators run in Docker.
+Go 1.25+, Docker, Make. All generators run in Docker.
 
 ### Key Commands
 
@@ -99,6 +99,6 @@ Single Go binary, three gRPC services (SchemaService, ConfigService, AuditServic
 
 ### Go version policy
 
-- **Server, CLI, tools, api** — Go 1.24+ (our build environment)
+- **Server, CLI, tools, api** — Go 1.25+ (our build environment)
 - **SDK core modules** (configclient, adminclient, configwatcher) — Go 1.22 (lowest stable common ground for consumers who install the SDK)
 - **SDK grpctransport** — Go 1.24 (requires gRPC, which pins Go version)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # OpenDecree Makefile
 #
-# Prerequisites: Go 1.24+, Docker, Make. All code generators run in Docker.
+# Prerequisites: Go 1.25+, Docker, Make. All code generators run in Docker.
 # Run `make help` to see available targets.
 #
 # Workflow: modify specs → make generate → make pre-commit → commit

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 WORKDIR /app
 

--- a/build/Dockerfile.decree
+++ b/build/Dockerfile.decree
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Dependabot PR #97 pulled in deps that require Go >= 1.25, which breaks the server/CLI Docker builds that were still pinned to golang:1.24.
- Bumps `build/Dockerfile`, `build/Dockerfile.decree`, the release.yml goreleaser jobs, the Makefile prereq note, and the CLAUDE.md Go version policy.
- SDK core (configclient/adminclient/configwatcher) stays at Go 1.22 for consumer compatibility. SDK grpctransport stays at 1.24 (gRPC pin).

## Test plan
- [x] `make pre-commit` passes locally
- [x] `docker build -f build/Dockerfile` succeeds with golang:1.25 base
- [x] `make lint-proto` passes
- [ ] CI: full suite green on this PR (build env change only)
- [ ] After merge: Dependabot rebases #97 and its CI turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)