### PR TITLE
docs(go): align version policy with dep chain reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Single Go binary, three gRPC services (SchemaService, ConfigService, AuditServic
 
 ### Go version policy
 
-- **Server, CLI, tools, api** — Go 1.25+ (our build environment)
+- **Server (root module)** — Go 1.25+ (our build environment)
+- **CLI (`cmd/decree`)** — Go 1.25+ (standalone binary, no SDK consumers)
 - **SDK core modules** (configclient, adminclient, configwatcher) — Go 1.22 (lowest stable common ground for consumers who install the SDK)
-- **SDK grpctransport** — Go 1.24 (requires gRPC, which pins Go version)
+- **`api`, `sdk/tools`, `sdk/grpctransport`** — Go 1.24 (downstream of the gRPC pin on grpctransport; api is consumed by grpctransport and sdk/tools depends on api)

--- a/cmd/decree/go.mod
+++ b/cmd/decree/go.mod
@@ -1,8 +1,6 @@
 module github.com/opendecree/decree/cmd/decree
 
-go 1.24.0
-
-toolchain go1.24.11
+go 1.25.0
 
 require (
 	github.com/opendecree/decree/api v0.1.2


### PR DESCRIPTION
## Summary
- After #98 bumped the build env to Go 1.25, the per-module `go` directives were inconsistent with the stated CLAUDE.md policy.
- Dependency chain `sdk/tools → api → (shared by) sdk/grpctransport @ 1.24 (gRPC pin)` blocks a full 1.25 migration — only `cmd/decree` can bump safely (standalone binary, no SDK consumers).
- Rewrites the Go version policy in CLAUDE.md to match the actual chain instead of aspirational "Server, CLI, tools, api at 1.25+".

## Test plan
- [x] `cmd/decree` builds with Go 1.25
- [x] `make pre-commit` passes (coverage ratchet: internal bumped 61.4% → 69.3% as a side effect of the rebuild)
- [ ] CI green on this PR