### PR TITLE
fix(cli): config set/set-many send typed values matching schema

### DIFF
--- a/cmd/decree/config.go
+++ b/cmd/decree/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/configclient"
 )
 
 var configCmd = &cobra.Command{
@@ -63,7 +65,18 @@ var configGetAllCmd = &cobra.Command{
 var configSetCmd = &cobra.Command{
 	Use:   "set <tenant-id> <field-path> <value>",
 	Short: "Set a single config value",
-	Args:  cobra.ExactArgs(3),
+	Long: `Set a single config value.
+
+Values are parsed according to the schema's field type:
+  string    -> as-is
+  integer   -> decimal integer (e.g. 42)
+  number    -> float (e.g. 3.14)
+  bool      -> true / false
+  time      -> RFC3339 (e.g. 2006-01-02T15:04:05Z)
+  duration  -> Go duration (e.g. 15s, 2h, 500ms)
+  url       -> as-is
+  json      -> must be valid JSON`,
+	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conn, err := dialServer()
 		if err != nil {
@@ -71,7 +84,7 @@ var configSetCmd = &cobra.Command{
 		}
 		defer func() { _ = conn.Close() }()
 
-		if err := newConfigClient(conn).Set(cmd.Context(), args[0], args[1], args[2]); err != nil {
+		if err := runConfigSet(cmd.Context(), newAdminClient(conn), newConfigClient(conn), args[0], args[1], args[2]); err != nil {
 			return err
 		}
 		fmt.Println("Set.")
@@ -79,19 +92,38 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
+// runConfigSet is the testable core of `decree config set`: fetch the tenant's
+// schema, coerce raw to the declared field type, and dispatch a typed write.
+func runConfigSet(ctx context.Context, admin *adminclient.Client, cfg *configclient.Client, tenantID, fieldPath, raw string) error {
+	types, err := tenantFieldTypes(ctx, admin, tenantID)
+	if err != nil {
+		return err
+	}
+	ft, err := lookupFieldType(types, fieldPath)
+	if err != nil {
+		return err
+	}
+	tv, err := parseTypedValue(ft, raw)
+	if err != nil {
+		return fmt.Errorf("field %s: %w", fieldPath, err)
+	}
+	return cfg.SetTyped(ctx, tenantID, fieldPath, tv)
+}
+
 var configSetManyCmd = &cobra.Command{
 	Use:   "set-many <tenant-id> <key=value>...",
 	Short: "Set multiple config values atomically",
+	Long:  "Set multiple config values atomically. Values are parsed according to each field's schema type (see `decree config set --help`).",
 	Args:  cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		tenantID := args[0]
-		values := make(map[string]string, len(args)-1)
+		rawValues := make(map[string]string, len(args)-1)
 		for _, kv := range args[1:] {
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) != 2 {
 				return fmt.Errorf("invalid key=value pair: %s", kv)
 			}
-			values[parts[0]] = parts[1]
+			rawValues[parts[0]] = parts[1]
 		}
 		desc, _ := cmd.Flags().GetString("description")
 
@@ -101,12 +133,39 @@ var configSetManyCmd = &cobra.Command{
 		}
 		defer func() { _ = conn.Close() }()
 
-		if err := newConfigClient(conn).SetMany(cmd.Context(), tenantID, values, desc); err != nil {
+		n, err := runConfigSetMany(cmd.Context(), newAdminClient(conn), newConfigClient(conn), tenantID, rawValues, desc)
+		if err != nil {
 			return err
 		}
-		fmt.Printf("Set %d values.\n", len(values))
+		fmt.Printf("Set %d values.\n", n)
 		return nil
 	},
+}
+
+// runConfigSetMany is the testable core of `decree config set-many`: fetch the
+// tenant's schema, coerce each raw value to its field type, and dispatch a
+// typed atomic batch write. Returns the number of fields written.
+func runConfigSetMany(ctx context.Context, admin *adminclient.Client, cfg *configclient.Client, tenantID string, rawValues map[string]string, description string) (int, error) {
+	types, err := tenantFieldTypes(ctx, admin, tenantID)
+	if err != nil {
+		return 0, err
+	}
+	typed := make(map[string]*configclient.TypedValue, len(rawValues))
+	for path, raw := range rawValues {
+		ft, err := lookupFieldType(types, path)
+		if err != nil {
+			return 0, err
+		}
+		tv, err := parseTypedValue(ft, raw)
+		if err != nil {
+			return 0, fmt.Errorf("field %s: %w", path, err)
+		}
+		typed[path] = tv
+	}
+	if err := cfg.SetManyTyped(ctx, tenantID, typed, description); err != nil {
+		return 0, err
+	}
+	return len(typed), nil
 }
 
 var configVersionsCmd = &cobra.Command{

--- a/cmd/decree/config_integration_test.go
+++ b/cmd/decree/config_integration_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+// fakeSchemaTransport stubs adminclient.SchemaTransport with just enough to
+// serve GetTenant + GetSchema. Any other method panics (nil receiver on the
+// embedded interface), which surfaces as a loud test failure if reached.
+type fakeSchemaTransport struct {
+	adminclient.SchemaTransport
+
+	tenant *adminclient.Tenant
+	schema *adminclient.Schema
+}
+
+func (f *fakeSchemaTransport) GetTenant(_ context.Context, id string) (*adminclient.Tenant, error) {
+	if f.tenant == nil || id != f.tenant.ID {
+		return nil, errors.New("tenant not found")
+	}
+	return f.tenant, nil
+}
+
+func (f *fakeSchemaTransport) GetSchema(_ context.Context, id string, _ *int32) (*adminclient.Schema, error) {
+	if f.schema == nil || id != f.schema.ID {
+		return nil, errors.New("schema not found")
+	}
+	return f.schema, nil
+}
+
+// fakeConfigTransport stubs configclient.Transport, capturing SetField /
+// SetFields requests for assertions. Other methods panic if called.
+type fakeConfigTransport struct {
+	configclient.Transport
+
+	setField  *configclient.SetFieldRequest
+	setFields *configclient.SetFieldsRequest
+}
+
+func (f *fakeConfigTransport) SetField(_ context.Context, req *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
+	f.setField = req
+	return &configclient.SetFieldResponse{}, nil
+}
+
+func (f *fakeConfigTransport) SetFields(_ context.Context, req *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
+	f.setFields = req
+	return &configclient.SetFieldsResponse{}, nil
+}
+
+func buildClients(t *testing.T, fields ...adminclient.Field) (*adminclient.Client, *configclient.Client, *fakeConfigTransport) {
+	t.Helper()
+	admin := adminclient.New(
+		&fakeSchemaTransport{
+			tenant: &adminclient.Tenant{ID: "t1", SchemaID: "s1", SchemaVersion: 1},
+			schema: &adminclient.Schema{ID: "s1", Version: 1, Fields: fields},
+		},
+		nil, nil, nil,
+	)
+	tr := &fakeConfigTransport{}
+	cfg := configclient.New(tr)
+	return admin, cfg, tr
+}
+
+func TestRunConfigSet_PicksTypedValueKindFromSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    adminclient.Field
+		raw      string
+		wantKind configclient.ValueKind
+		check    func(*configclient.TypedValue) bool
+	}{
+		{"bool", adminclient.Field{Path: "x", Type: "bool"}, "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.BoolValue() }},
+		{"integer", adminclient.Field{Path: "x", Type: "integer"}, "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == 42 }},
+		{"number", adminclient.Field{Path: "x", Type: "number"}, "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.FloatValue() == 3.14 }},
+		{"duration", adminclient.Field{Path: "x", Type: "duration"}, "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.DurationValue().Seconds() == 15 }},
+		{"string", adminclient.Field{Path: "x", Type: "string"}, "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			admin, cfg, tr := buildClients(t, tt.field)
+			if err := runConfigSet(context.Background(), admin, cfg, "t1", "x", tt.raw); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tr.setField == nil {
+				t.Fatal("SetField not called")
+			}
+			if tr.setField.Value == nil {
+				t.Fatal("SetField called with nil Value")
+			}
+			if got := tr.setField.Value.Kind(); got != tt.wantKind {
+				t.Fatalf("kind: got %v, want %v (CLI sent the wrong TypedValue kind for the schema's field type)", got, tt.wantKind)
+			}
+			if !tt.check(tr.setField.Value) {
+				t.Error("captured value failed type-specific check")
+			}
+		})
+	}
+}
+
+func TestRunConfigSet_UnknownFieldErrors(t *testing.T) {
+	admin, cfg, tr := buildClients(t, adminclient.Field{Path: "known", Type: "string"})
+	err := runConfigSet(context.Background(), admin, cfg, "t1", "unknown", "x")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if tr.setField != nil {
+		t.Error("SetField should not be called for unknown field")
+	}
+}
+
+func TestRunConfigSet_ParseErrorShortCircuits(t *testing.T) {
+	admin, cfg, tr := buildClients(t, adminclient.Field{Path: "x", Type: "bool"})
+	err := runConfigSet(context.Background(), admin, cfg, "t1", "x", "not-a-bool")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if tr.setField != nil {
+		t.Error("SetField should not be called when parsing fails")
+	}
+}
+
+func TestRunConfigSetMany_SendsTypedValuesMatchingSchema(t *testing.T) {
+	admin, cfg, tr := buildClients(t,
+		adminclient.Field{Path: "a", Type: "integer"},
+		adminclient.Field{Path: "b", Type: "bool"},
+		adminclient.Field{Path: "c", Type: "duration"},
+	)
+	n, err := runConfigSetMany(context.Background(), admin, cfg, "t1", map[string]string{
+		"a": "100",
+		"b": "true",
+		"c": "2m",
+	}, "batch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("wrote %d, want 3", n)
+	}
+	if tr.setFields == nil {
+		t.Fatal("SetFields not called")
+	}
+	if tr.setFields.Description != "batch" {
+		t.Errorf("description: got %q, want %q", tr.setFields.Description, "batch")
+	}
+	byPath := map[string]*configclient.TypedValue{}
+	for _, u := range tr.setFields.Updates {
+		byPath[u.FieldPath] = u.Value
+	}
+	if byPath["a"].Kind() != configclient.KindInteger || byPath["a"].IntValue() != 100 {
+		t.Errorf("a: got kind=%v int=%d", byPath["a"].Kind(), byPath["a"].IntValue())
+	}
+	if byPath["b"].Kind() != configclient.KindBool || !byPath["b"].BoolValue() {
+		t.Errorf("b: got kind=%v bool=%v", byPath["b"].Kind(), byPath["b"].BoolValue())
+	}
+	if byPath["c"].Kind() != configclient.KindDuration || byPath["c"].DurationValue().Minutes() != 2 {
+		t.Errorf("c: got kind=%v dur=%v", byPath["c"].Kind(), byPath["c"].DurationValue())
+	}
+}
+
+func TestRunConfigSetMany_OneBadValueFailsAtomically(t *testing.T) {
+	admin, cfg, tr := buildClients(t,
+		adminclient.Field{Path: "a", Type: "integer"},
+		adminclient.Field{Path: "b", Type: "bool"},
+	)
+	_, err := runConfigSetMany(context.Background(), admin, cfg, "t1", map[string]string{
+		"a": "100",
+		"b": "not-a-bool",
+	}, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if tr.setFields != nil {
+		t.Error("SetFields should not be called if any value fails to parse")
+	}
+}

--- a/cmd/decree/typed.go
+++ b/cmd/decree/typed.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+// parseTypedValue parses raw into a TypedValue matching the field type declared
+// in the schema. fieldType values match [domain.FieldType] strings: string,
+// integer, number, bool, time (RFC3339), duration (Go duration), url, json.
+func parseTypedValue(fieldType, raw string) (*configclient.TypedValue, error) {
+	switch fieldType {
+	case "", "string":
+		return configclient.StringVal(raw), nil
+	case "integer":
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid integer value %q: %w", raw, err)
+		}
+		return configclient.IntVal(v), nil
+	case "number":
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid number value %q: %w", raw, err)
+		}
+		return configclient.FloatVal(v), nil
+	case "bool":
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bool value %q (want true/false): %w", raw, err)
+		}
+		return configclient.BoolVal(v), nil
+	case "time":
+		v, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid time value %q (want RFC3339, e.g. 2006-01-02T15:04:05Z): %w", raw, err)
+		}
+		return configclient.TimeVal(v), nil
+	case "duration":
+		v, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid duration value %q (want Go duration, e.g. 15s, 2h): %w", raw, err)
+		}
+		return configclient.DurationVal(v), nil
+	case "url":
+		return configclient.URLVal(raw), nil
+	case "json":
+		var tmp any
+		if err := json.Unmarshal([]byte(raw), &tmp); err != nil {
+			return nil, fmt.Errorf("invalid json value: %w", err)
+		}
+		return configclient.JSONVal(raw), nil
+	default:
+		return nil, fmt.Errorf("unsupported field type %q", fieldType)
+	}
+}
+
+// tenantFieldTypes fetches the schema assigned to tenantID and returns a
+// map of field path → field type string.
+func tenantFieldTypes(ctx context.Context, admin *adminclient.Client, tenantID string) (map[string]string, error) {
+	t, err := admin.GetTenant(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("lookup tenant: %w", err)
+	}
+	s, err := admin.GetSchemaVersion(ctx, t.SchemaID, t.SchemaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("lookup schema %s v%d: %w", t.SchemaID, t.SchemaVersion, err)
+	}
+	types := make(map[string]string, len(s.Fields))
+	for _, f := range s.Fields {
+		types[f.Path] = f.Type
+	}
+	return types, nil
+}
+
+// lookupFieldType returns the declared type for fieldPath, erroring if the
+// field is unknown to the schema.
+func lookupFieldType(types map[string]string, fieldPath string) (string, error) {
+	ft, ok := types[fieldPath]
+	if !ok {
+		return "", fmt.Errorf("unknown field %q (not in schema)", fieldPath)
+	}
+	return ft, nil
+}

--- a/cmd/decree/typed_test.go
+++ b/cmd/decree/typed_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+func TestParseTypedValue_Success(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType string
+		raw       string
+		wantKind  configclient.ValueKind
+		check     func(*configclient.TypedValue) bool
+	}{
+		{"string", "string", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
+		{"empty field type defaults to string", "", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
+		{"integer", "integer", "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == 42 }},
+		{"integer negative", "integer", "-7", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == -7 }},
+		{"number", "number", "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.FloatValue() == 3.14 }},
+		{"bool true", "bool", "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.BoolValue() }},
+		{"bool false", "bool", "false", configclient.KindBool, func(v *configclient.TypedValue) bool { return !v.BoolValue() }},
+		{"time RFC3339", "time", "2026-03-30T12:00:00Z", configclient.KindTime, func(v *configclient.TypedValue) bool {
+			return v.TimeValue().Equal(time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC))
+		}},
+		{"duration", "duration", "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.DurationValue() == 15*time.Second }},
+		{"url", "url", "https://example.com", configclient.KindURL, func(v *configclient.TypedValue) bool { return v.URLValue() == "https://example.com" }},
+		{"json object", "json", `{"a":1}`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.JSONValue() == `{"a":1}` }},
+		{"json array", "json", `[1,2,3]`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.JSONValue() == `[1,2,3]` }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tv, err := parseTypedValue(tt.fieldType, tt.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tv.Kind() != tt.wantKind {
+				t.Errorf("kind: got %v, want %v", tv.Kind(), tt.wantKind)
+			}
+			if !tt.check(tv) {
+				t.Errorf("value check failed for %q -> %q", tt.fieldType, tt.raw)
+			}
+		})
+	}
+}
+
+func TestParseTypedValue_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType string
+		raw       string
+	}{
+		{"integer garbage", "integer", "abc"},
+		{"number garbage", "number", "abc"},
+		{"bool garbage", "bool", "yes-please"},
+		{"time wrong format", "time", "2026-03-30 12:00"},
+		{"duration garbage", "duration", "2 hours"},
+		{"json malformed", "json", `{"a":`},
+		{"unsupported type", "complex", "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseTypedValue(tt.fieldType, tt.raw); err == nil {
+				t.Errorf("expected error for %q -> %q", tt.fieldType, tt.raw)
+			}
+		})
+	}
+}
+
+func TestLookupFieldType(t *testing.T) {
+	types := map[string]string{"a": "integer", "b": "bool"}
+
+	if got, err := lookupFieldType(types, "a"); err != nil || got != "integer" {
+		t.Errorf("a: got (%q, %v), want (integer, nil)", got, err)
+	}
+	if _, err := lookupFieldType(types, "missing"); err == nil {
+		t.Error("expected error for missing field")
+	}
+}

--- a/docs/cli/decree_config_set-many.md
+++ b/docs/cli/decree_config_set-many.md
@@ -6,6 +6,10 @@ title: decree config set-many
 
 Set multiple config values atomically
 
+### Synopsis
+
+Set multiple config values atomically. Values are parsed according to each field's schema type (see `decree config set --help`).
+
 ```
 decree config set-many <tenant-id> <key=value>... [flags]
 ```

--- a/docs/cli/decree_config_set.md
+++ b/docs/cli/decree_config_set.md
@@ -6,6 +6,20 @@ title: decree config set
 
 Set a single config value
 
+### Synopsis
+
+Set a single config value.
+
+Values are parsed according to the schema's field type:
+  string    -> as-is
+  integer   -> decimal integer (e.g. 42)
+  number    -> float (e.g. 3.14)
+  bool      -> true / false
+  time      -> RFC3339 (e.g. 2006-01-02T15:04:05Z)
+  duration  -> Go duration (e.g. 15s, 2h, 500ms)
+  url       -> as-is
+  json      -> must be valid JSON
+
 ```
 decree config set <tenant-id> <field-path> <value> [flags]
 ```

--- a/docs/man/decree-config-set-many.1
+++ b/docs/man/decree-config-set-many.1
@@ -10,7 +10,7 @@ decree-config-set-many - Set multiple config values atomically
 
 
 .SH DESCRIPTION
-Set multiple config values atomically
+Set multiple config values atomically. Values are parsed according to each field's schema type (see \fBdecree config set --help\fR).
 
 
 .SH OPTIONS

--- a/docs/man/decree-config-set.1
+++ b/docs/man/decree-config-set.1
@@ -10,7 +10,18 @@ decree-config-set - Set a single config value
 
 
 .SH DESCRIPTION
-Set a single config value
+Set a single config value.
+
+.PP
+Values are parsed according to the schema's field type:
+  string    -> as-is
+  integer   -> decimal integer (e.g. 42)
+  number    -> float (e.g. 3.14)
+  bool      -> true / false
+  time      -> RFC3339 (e.g. 2006-01-02T15:04:05Z)
+  duration  -> Go duration (e.g. 15s, 2h, 500ms)
+  url       -> as-is
+  json      -> must be valid JSON
 
 
 .SH OPTIONS

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -207,6 +207,36 @@ func TestSetMany_Success(t *testing.T) {
 	}
 }
 
+func TestSetManyTyped_Success(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		if r.TenantID != "t1" || r.Description != "typed bulk" || len(r.Updates) != 2 {
+			return false
+		}
+		byPath := map[string]*TypedValue{}
+		for _, u := range r.Updates {
+			byPath[u.FieldPath] = u.Value
+		}
+		return byPath["count"] != nil && byPath["count"].Kind() == KindInteger && byPath["count"].IntValue() == 42 &&
+			byPath["enabled"] != nil && byPath["enabled"].Kind() == KindBool && byPath["enabled"].BoolValue()
+	}, &SetFieldsResponse{}, nil)
+
+	err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{
+		"count":   IntVal(42),
+		"enabled": BoolVal(true),
+	}, "typed bulk")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := tr.called("SetFields"); n != 1 {
+		t.Errorf("expected SetFields to be called once, got %d", n)
+	}
+}
+
 // --- Snapshot ---
 
 func TestSnapshot_PinnedVersion(t *testing.T) {

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -68,6 +68,27 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 	})
 }
 
+// SetManyTyped writes multiple typed configuration values atomically in a single
+// version. The description is optional — pass an empty string to omit it.
+// Returns [ErrLocked] if any of the fields are locked.
+func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string) error {
+	return retryDo(ctx, c, func(ctx context.Context) error {
+		updates := make([]FieldUpdate, 0, len(values))
+		for path, v := range values {
+			updates = append(updates, FieldUpdate{
+				FieldPath: path,
+				Value:     v,
+			})
+		}
+		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
+			TenantID:    tenantID,
+			Updates:     updates,
+			Description: description,
+		})
+		return err
+	})
+}
+
 // LockedValue holds a field's current value and checksum for optimistic concurrency.
 // Use [Client.GetForUpdate] to obtain one, then call [LockedValue.Set] to write
 // a new value only if the field hasn't been modified since the read.


### PR DESCRIPTION
## Summary
- `decree config set` always wrapped values as `StringVal`, so every non-string field type (bool, number, integer, time, duration, url, json) was rejected by the server validator with errors like `expected bool value`. Same bug in `config set-many`. The CLI was effectively string-only.
- CLI now fetches the tenant's schema, parses each raw value according to its declared field type, and dispatches a typed write. No user-facing syntax change — `decree config set $T features.beta_access true` just works.

Also adds SDK `Client.SetManyTyped`, the typed counterpart to `SetMany` (same atomic batch semantics).

Closes #102

## Test plan
- [x] `TestParseTypedValue_Success / _Errors` — every field type parses correctly, bad inputs error cleanly (unit)
- [x] `TestRunConfigSet_PicksTypedValueKindFromSchema` — asserts the outgoing `SetField` request carries the correct `TypedValue.Kind` for each schema type (bool/int/number/duration/string). Verified by injecting the original bug (swap `SetTyped`→`Set`): tests fail with "CLI sent the wrong TypedValue kind for the schema's field type".
- [x] `TestRunConfigSet_UnknownFieldErrors` — field not in schema → error, no transport call
- [x] `TestRunConfigSet_ParseErrorShortCircuits` — bad value → error, no transport call
- [x] `TestRunConfigSetMany_SendsTypedValuesMatchingSchema` — each entry typed independently
- [x] `TestRunConfigSetMany_OneBadValueFailsAtomically` — single parse failure aborts the whole batch
- [x] `TestSetManyTyped_Success` — SDK transport test
- [x] `make pre-commit` clean, coverage ratcheted (cmd/decree 85.1→86.6, configclient 86.8→87.1)
- [x] `make docs` regenerated CLI reference + man pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)