### PR TITLE
fix(cache): skip HSET when values map is empty

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -42,6 +42,11 @@ func (c *RedisCache) Get(ctx context.Context, tenantID string, version int32) (m
 }
 
 func (c *RedisCache) Set(ctx context.Context, tenantID string, version int32, values map[string]string, ttl time.Duration) error {
+	// Redis HSET rejects zero field/value pairs; skip the call. There is nothing
+	// to cache, and a subsequent Get will correctly report a miss.
+	if len(values) == 0 {
+		return nil
+	}
 	key := c.key(tenantID, version)
 	pipe := c.client.Pipeline()
 	pipe.HSet(ctx, key, values)

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -1,0 +1,24 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedisCache_SetEmptyValuesIsNoOp verifies that Set returns nil without
+// touching the Redis client when values is empty. go-redis' HSET rejects zero
+// field/value pairs ("ERR wrong number of arguments for 'hset' command"), so
+// we must skip the call. A nil client would panic on any pipeline use; the
+// test passes only when we take the early-return path.
+func TestRedisCache_SetEmptyValuesIsNoOp(t *testing.T) {
+	c := &RedisCache{client: nil, prefix: "config:"}
+
+	err := c.Set(context.Background(), "t1", 1, map[string]string{}, time.Minute)
+	require.NoError(t, err)
+
+	err = c.Set(context.Background(), "t1", 1, nil, time.Minute)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- `RedisCache.Set` now early-returns when `len(values) == 0`, avoiding the `HSET key` call that Redis rejects with `ERR wrong number of arguments for 'hset' command`.
- Adds a regression test that exercises the empty-map and nil-map paths against a `nil` client — only safe if the early-return triggers.

## Root cause
`ConfigService.GetConfig` builds `cacheMap` from DB rows (`internal/config/service.go:145–157`). When a tenant has no stored values at the requested version (new tenant pre-`SetField`, or a fresh version with nothing written), `cacheMap` is empty. `go-redis` unpacks an empty `map[string]string` into zero field/value pairs, so Redis refuses the command. The error was swallowed as a WARN ("failed to populate cache") and the response still succeeded, so the bug was latent but noisy in e2e logs.

Closes #110

## Test plan
- [x] `make test` — `internal/cache` passes, full suite green
- [x] `make lint` — 0 issues
- [ ] e2e WARN "failed to populate cache: ERR wrong number of arguments for 'hset' command" no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)