### PR TITLE
fix(schema)!: rename top-level syntax → spec_version (#118)

### DIFF
--- a/api/centralconfig/v1/schema_service.pb.go
+++ b/api/centralconfig/v1/schema_service.pb.go
@@ -1483,7 +1483,7 @@ func (x *ExportSchemaRequest) GetVersion() int32 {
 
 type ExportSchemaResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// YAML-encoded schema (syntax v1). Includes schema name, description,
+	// YAML-encoded schema (spec_version v1). Includes schema name, description,
 	// version, and all field definitions with OAS-style constraint naming.
 	// Server-generated fields (id, checksum, published, created_at) are excluded.
 	YamlContent   []byte `protobuf:"bytes,1,opt,name=yaml_content,json=yamlContent,proto3" json:"yaml_content,omitempty"`
@@ -1530,7 +1530,7 @@ func (x *ExportSchemaResponse) GetYamlContent() []byte {
 
 type ImportSchemaRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// YAML-encoded schema (syntax v1). Must include `syntax`, `name`, and `fields`.
+	// YAML-encoded schema (spec_version v1). Must include `spec_version`, `name`, and `fields`.
 	//
 	// Import uses full-replace semantics:
 	// - If no schema with this name exists: creates a new schema with version 1.

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -93,7 +93,7 @@ func TestVersionOrEmpty(t *testing.T) {
 // --- parseConfigValues ---
 
 func TestParseConfigValues(t *testing.T) {
-	yaml := `syntax: v1
+	yaml := `spec_version: v1
 values:
   app.name:
     value: MyApp
@@ -125,7 +125,7 @@ func TestParseConfigValues_Invalid(t *testing.T) {
 }
 
 func TestParseConfigValues_Empty(t *testing.T) {
-	m := parseConfigValues([]byte("syntax: v1\n"))
+	m := parseConfigValues([]byte("spec_version: v1\n"))
 	if m == nil {
 		t.Fatal("expected non-nil")
 	}

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -1757,7 +1757,7 @@
         "yamlContent": {
           "type": "string",
           "format": "byte",
-          "description": "YAML-encoded schema (syntax v1). Includes schema name, description,\nversion, and all field definitions with OAS-style constraint naming.\nServer-generated fields (id, checksum, published, created_at) are excluded."
+          "description": "YAML-encoded schema (spec_version v1). Includes schema name, description,\nversion, and all field definitions with OAS-style constraint naming.\nServer-generated fields (id, checksum, published, created_at) are excluded."
         }
       }
     },
@@ -2034,7 +2034,7 @@
         "yamlContent": {
           "type": "string",
           "format": "byte",
-          "description": "YAML-encoded schema (syntax v1). Must include `syntax`, `name`, and `fields`.\n\nImport uses full-replace semantics:\n- If no schema with this name exists: creates a new schema with version 1.\n- If a schema exists and fields differ from latest: creates the next version.\n- If a schema exists and fields are identical: returns AlreadyExists error.\n\nImported versions are created as drafts (unpublished) unless auto_publish is true.\nThe `version` field in the YAML is informational \u2014 the server assigns\nthe next version number automatically."
+          "description": "YAML-encoded schema (spec_version v1). Must include `spec_version`, `name`, and `fields`.\n\nImport uses full-replace semantics:\n- If no schema with this name exists: creates a new schema with version 1.\n- If a schema exists and fields differ from latest: creates the next version.\n- If a schema exists and fields are identical: returns AlreadyExists error.\n\nImported versions are created as drafts (unpublished) unless auto_publish is true.\nThe `version` field in the YAML is informational \u2014 the server assigns\nthe next version number automatically."
         },
         "autoPublish": {
           "type": "boolean",

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1269,7 +1269,7 @@ bypasses the cache and reads directly from the database.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| yaml_content | [bytes](#bytes) |  | YAML-encoded schema (syntax v1). Includes schema name, description, version, and all field definitions with OAS-style constraint naming. Server-generated fields (id, checksum, published, created_at) are excluded. |
+| yaml_content | [bytes](#bytes) |  | YAML-encoded schema (spec_version v1). Includes schema name, description, version, and all field definitions with OAS-style constraint naming. Server-generated fields (id, checksum, published, created_at) are excluded. |
 
 
 
@@ -1345,7 +1345,7 @@ bypasses the cache and reads directly from the database.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| yaml_content | [bytes](#bytes) |  | YAML-encoded schema (syntax v1). Must include `syntax`, `name`, and `fields`.
+| yaml_content | [bytes](#bytes) |  | YAML-encoded schema (spec_version v1). Must include `spec_version`, `name`, and `fields`.
 
 Import uses full-replace semantics: - If no schema with this name exists: creates a new schema with version 1. - If a schema exists and fields differ from latest: creates the next version. - If a schema exists and fields are identical: returns AlreadyExists error.
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -1757,7 +1757,7 @@
         "yamlContent": {
           "type": "string",
           "format": "byte",
-          "description": "YAML-encoded schema (syntax v1). Includes schema name, description,\nversion, and all field definitions with OAS-style constraint naming.\nServer-generated fields (id, checksum, published, created_at) are excluded."
+          "description": "YAML-encoded schema (spec_version v1). Includes schema name, description,\nversion, and all field definitions with OAS-style constraint naming.\nServer-generated fields (id, checksum, published, created_at) are excluded."
         }
       }
     },
@@ -2034,7 +2034,7 @@
         "yamlContent": {
           "type": "string",
           "format": "byte",
-          "description": "YAML-encoded schema (syntax v1). Must include `syntax`, `name`, and `fields`.\n\nImport uses full-replace semantics:\n- If no schema with this name exists: creates a new schema with version 1.\n- If a schema exists and fields differ from latest: creates the next version.\n- If a schema exists and fields are identical: returns AlreadyExists error.\n\nImported versions are created as drafts (unpublished) unless auto_publish is true.\nThe `version` field in the YAML is informational \u2014 the server assigns\nthe next version number automatically."
+          "description": "YAML-encoded schema (spec_version v1). Must include `spec_version`, `name`, and `fields`.\n\nImport uses full-replace semantics:\n- If no schema with this name exists: creates a new schema with version 1.\n- If a schema exists and fields differ from latest: creates the next version.\n- If a schema exists and fields are identical: returns AlreadyExists error.\n\nImported versions are created as drafts (unpublished) unless auto_publish is true.\nThe `version` field in the YAML is informational \u2014 the server assigns\nthe next version number automatically."
         },
         "autoPublish": {
           "type": "boolean",

--- a/docs/concepts/schemas-and-fields.md
+++ b/docs/concepts/schemas-and-fields.md
@@ -27,7 +27,7 @@ Schemas are defined in YAML for import/export. The format uses syntax version `v
 
 ```yaml
 # yaml-language-server: $schema=../../schemas/schema-yaml.json
-syntax: "v1"
+spec_version: "v1"
 name: payments
 description: Payment processing configuration
 version_description: Add timeout field

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ export DECREE_SUBJECT=admin@example.com
 A schema defines the structure of your configuration — what fields exist, their types, and constraints. Create a file called `payments.yaml`:
 
 ```yaml
-syntax: "v1"
+spec_version: "v1"
 name: payments
 description: Payment processing configuration
 

--- a/docs/usecases/config-as-code.md
+++ b/docs/usecases/config-as-code.md
@@ -29,7 +29,7 @@ your-service/
 Define your config structure in `config/schema.yaml`:
 
 ```yaml
-syntax: "v1"
+spec_version: "v1"
 name: payments
 description: Payment processing configuration
 
@@ -71,7 +71,7 @@ Create a values file per environment. Only include values you want to set — fi
 
 `config/values.prod.yaml`:
 ```yaml
-syntax: "v1"
+spec_version: "v1"
 values:
   payments.enabled:
     value: true
@@ -87,7 +87,7 @@ values:
 
 `config/values.dev.yaml`:
 ```yaml
-syntax: "v1"
+spec_version: "v1"
 values:
   payments.enabled:
     value: true

--- a/e2e/bench_test.go
+++ b/e2e/bench_test.go
@@ -197,7 +197,7 @@ func benchImport(b *testing.B, name string, fieldCount int) {
 
 	// Build YAML with all fields.
 	var yamlBuilder []byte
-	yamlBuilder = append(yamlBuilder, "syntax: \"v1\"\nvalues:\n"...)
+	yamlBuilder = append(yamlBuilder, "spec_version: \"v1\"\nvalues:\n"...)
 	for i := 0; i < fieldCount; i++ {
 		yamlBuilder = append(yamlBuilder, fmt.Sprintf("  f.field_%d:\n    value: \"val-%d\"\n", i, i)...)
 	}

--- a/e2e/schema_test.go
+++ b/e2e/schema_test.go
@@ -96,7 +96,7 @@ func TestSchemaExportImport(t *testing.T) {
 
 	yamlStr := string(yamlContent)
 	t.Logf("Exported YAML:\n%s", yamlStr)
-	assert.Contains(t, yamlStr, "syntax:")
+	assert.Contains(t, yamlStr, "spec_version:")
 	assert.Contains(t, yamlStr, "name: export-e2e")
 	assert.Contains(t, yamlStr, "trade.fee")
 
@@ -122,7 +122,7 @@ func TestSchemaExportImport(t *testing.T) {
 	assert.Equal(t, int32(2), got.Version)
 
 	// 6. Import new schema by name.
-	newYAML := []byte(`syntax: "v1"
+	newYAML := []byte(`spec_version: "v1"
 name: brand-new-e2e
 description: Created via import
 fields:

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -120,7 +120,7 @@ func TestConstraintValidation(t *testing.T) {
 	// --- Import validation ---
 
 	t.Run("import valid YAML accepted", func(t *testing.T) {
-		validYAML := []byte(`syntax: "v1"
+		validYAML := []byte(`spec_version: "v1"
 values:
   app.retries:
     value: 5
@@ -134,7 +134,7 @@ values:
 	})
 
 	t.Run("import rejects constraint violation", func(t *testing.T) {
-		badYAML := []byte(`syntax: "v1"
+		badYAML := []byte(`spec_version: "v1"
 values:
   app.retries:
     value: 99
@@ -145,7 +145,7 @@ values:
 	})
 
 	t.Run("import rejects unknown field", func(t *testing.T) {
-		badYAML := []byte(`syntax: "v1"
+		badYAML := []byte(`spec_version: "v1"
 values:
   app.nonexistent:
     value: "hello"

--- a/examples/config-validation/config-invalid.yaml
+++ b/examples/config-validation/config-invalid.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 values:
   app.name:
     value: ""

--- a/examples/config-validation/config-valid.yaml
+++ b/examples/config-validation/config-valid.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 values:
   app.name:
     value: "My Application"

--- a/examples/config-validation/schema.yaml
+++ b/examples/config-validation/schema.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 name: validation-example
 description: Schema for validation example
 fields:

--- a/examples/environment-bootstrap/env.yaml
+++ b/examples/environment-bootstrap/env.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 schema:
   name: billing-service
   description: Billing service configuration

--- a/examples/seed.yaml
+++ b/examples/seed.yaml
@@ -1,4 +1,4 @@
-syntax: v1
+spec_version: v1
 schema:
   name: example-app
   description: Example application configuration schema

--- a/fixtures/billing.yaml
+++ b/fixtures/billing.yaml
@@ -13,7 +13,7 @@
 #
 # Load: decree seed fixtures/billing.yaml
 
-syntax: v1
+spec_version: v1
 
 schema:
   name: billing

--- a/fixtures/draft.yaml
+++ b/fixtures/draft.yaml
@@ -9,7 +9,7 @@
 #
 # Load: decree seed fixtures/draft.yaml
 
-syntax: v1
+spec_version: v1
 
 schema:
   name: draft-schema

--- a/fixtures/empty.yaml
+++ b/fixtures/empty.yaml
@@ -6,7 +6,7 @@
 #
 # Load: decree seed fixtures/empty.yaml
 
-syntax: v1
+spec_version: v1
 
 schema:
   name: blank

--- a/fixtures/minimal.yaml
+++ b/fixtures/minimal.yaml
@@ -5,7 +5,7 @@
 #
 # Load: decree seed fixtures/minimal.yaml
 
-syntax: v1
+spec_version: v1
 
 schema:
   name: simple

--- a/fixtures/showcase.yaml
+++ b/fixtures/showcase.yaml
@@ -24,7 +24,7 @@
 #
 # Load: decree seed fixtures/showcase.yaml
 
-syntax: v1
+spec_version: v1
 
 schema:
   name: showcase

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -305,7 +305,7 @@ func TestImportConfig_Success(t *testing.T) {
 	ctx := context.Background()
 
 	yamlContent := []byte(`
-syntax: "v1"
+spec_version: "v1"
 description: "imported config"
 values:
   payments.fee:
@@ -357,7 +357,7 @@ func TestImportConfig_ValidationRejectsUnknownField(t *testing.T) {
 	ctx := context.Background()
 
 	yamlContent := []byte(`
-syntax: "v1"
+spec_version: "v1"
 values:
   unknown.field:
     value: "hello"
@@ -390,7 +390,7 @@ func TestImportConfig_ValidationRejectsConstraintViolation(t *testing.T) {
 
 	// Import an integer value that exceeds max constraint.
 	yamlContent := []byte(`
-syntax: "v1"
+spec_version: "v1"
 values:
   app.retries:
     value: 99
@@ -431,7 +431,7 @@ func TestImportConfig_MergeMode_SkipsSameValues(t *testing.T) {
 	ctx := context.Background()
 
 	yamlContent := []byte(`
-syntax: "v1"
+spec_version: "v1"
 values:
   app.name:
     value: "same"
@@ -487,7 +487,7 @@ func TestImportConfig_DefaultsMode_SkipsExistingValues(t *testing.T) {
 	ctx := context.Background()
 
 	yamlContent := []byte(`
-syntax: "v1"
+spec_version: "v1"
 values:
   app.existing:
     value: "new-from-yaml"

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -11,11 +11,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const yamlSyntaxV1 = "v1"
+const yamlSpecVersionV1 = "v1"
 
 // ConfigYAML is the top-level YAML document for config import/export.
 type ConfigYAML struct {
-	Syntax      string                     `yaml:"syntax"`
+	SpecVersion string                     `yaml:"spec_version"`
 	Version     int32                      `yaml:"version,omitempty"`
 	Description string                     `yaml:"description,omitempty"`
 	Values      map[string]ConfigValueYAML `yaml:"values"`
@@ -37,11 +37,11 @@ type configValueImport struct {
 // --- Validation ---
 
 func validateConfigYAML(doc *ConfigYAML) error {
-	if doc.Syntax == "" {
-		return fmt.Errorf("syntax is required")
+	if doc.SpecVersion == "" {
+		return fmt.Errorf("spec_version is required")
 	}
-	if doc.Syntax != yamlSyntaxV1 {
-		return fmt.Errorf("unsupported syntax version: %s", doc.Syntax)
+	if doc.SpecVersion != yamlSpecVersionV1 {
+		return fmt.Errorf("unsupported spec_version: %s", doc.SpecVersion)
 	}
 	if len(doc.Values) == 0 {
 		return fmt.Errorf("at least one value is required")
@@ -60,7 +60,7 @@ func validateConfigYAML(doc *ConfigYAML) error {
 // for typed value representation.
 func configToYAML(version int32, description string, rows []configRow, fieldTypes map[string]domain.FieldType) *ConfigYAML {
 	doc := &ConfigYAML{
-		Syntax:      yamlSyntaxV1,
+		SpecVersion: yamlSpecVersionV1,
 		Version:     version,
 		Description: description,
 		Values:      make(map[string]ConfigValueYAML, len(rows)),

--- a/internal/config/yaml_bench_test.go
+++ b/internal/config/yaml_bench_test.go
@@ -8,8 +8,8 @@ import (
 
 func BenchmarkMarshalConfigYAML(b *testing.B) {
 	doc := &ConfigYAML{
-		Syntax:  yamlSyntaxV1,
-		Version: 3,
+		SpecVersion: yamlSpecVersionV1,
+		Version:     3,
 		Values: map[string]ConfigValueYAML{
 			"payments.fee":      {Value: 0.025},
 			"payments.currency": {Value: "USD"},
@@ -24,7 +24,7 @@ func BenchmarkMarshalConfigYAML(b *testing.B) {
 }
 
 func BenchmarkUnmarshalConfigYAML(b *testing.B) {
-	data := []byte(`syntax: "v1"
+	data := []byte(`spec_version: "v1"
 version: 3
 values:
   payments.fee:

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -30,7 +30,7 @@ func TestConfigYAML_Roundtrip(t *testing.T) {
 
 	// Export: rows -> YAML doc -> bytes
 	doc := configToYAML(5, "test export", rows, fieldTypes)
-	assert.Equal(t, yamlSyntaxV1, doc.Syntax)
+	assert.Equal(t, yamlSpecVersionV1, doc.SpecVersion)
 	assert.Equal(t, int32(5), doc.Version)
 	assert.Len(t, doc.Values, 6)
 
@@ -134,28 +134,28 @@ func TestConfigYAML_StringifyValue_Errors(t *testing.T) {
 }
 
 func TestConfigYAML_Validation(t *testing.T) {
-	t.Run("missing syntax", func(t *testing.T) {
+	t.Run("missing spec_version", func(t *testing.T) {
 		_, err := unmarshalConfigYAML([]byte(`
 values:
   x:
     value: "hello"
 `))
-		assert.ErrorContains(t, err, "syntax is required")
+		assert.ErrorContains(t, err, "spec_version is required")
 	})
 
-	t.Run("unsupported syntax", func(t *testing.T) {
+	t.Run("unsupported spec_version", func(t *testing.T) {
 		_, err := unmarshalConfigYAML([]byte(`
-syntax: "v99"
+spec_version: "v99"
 values:
   x:
     value: "hello"
 `))
-		assert.ErrorContains(t, err, "unsupported syntax version")
+		assert.ErrorContains(t, err, "unsupported spec_version")
 	})
 
 	t.Run("empty values", func(t *testing.T) {
 		_, err := unmarshalConfigYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 values: {}
 `))
 		assert.ErrorContains(t, err, "at least one value is required")
@@ -163,7 +163,7 @@ values: {}
 
 	t.Run("valid minimal", func(t *testing.T) {
 		doc, err := unmarshalConfigYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 values:
   x:
     value: "hello"

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -610,7 +610,7 @@ func TestExportSchema_InvalidID(t *testing.T) {
 // --- ImportSchema ---
 
 func validYAML(name string) []byte {
-	return []byte("syntax: v1\nname: " + name + "\nfields:\n  app.name:\n    type: string\n")
+	return []byte("spec_version: v1\nname: " + name + "\nfields:\n  app.name:\n    type: string\n")
 }
 
 func TestImportSchema_NewSchema(t *testing.T) {

--- a/internal/schema/yaml.go
+++ b/internal/schema/yaml.go
@@ -8,11 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const yamlSyntaxV1 = "v1"
+const yamlSpecVersionV1 = "v1"
 
 // SchemaYAML is the top-level YAML document for schema import/export.
 type SchemaYAML struct {
-	Syntax             string                     `yaml:"syntax"`
+	SpecVersion        string                     `yaml:"spec_version"`
 	Name               string                     `yaml:"name"`
 	Description        string                     `yaml:"description,omitempty"`
 	Version            int32                      `yaml:"version,omitempty"`
@@ -84,11 +84,11 @@ type ConstraintsYAML struct {
 // --- Validation ---
 
 func validateSchemaYAML(doc *SchemaYAML) error {
-	if doc.Syntax == "" {
-		return fmt.Errorf("syntax is required")
+	if doc.SpecVersion == "" {
+		return fmt.Errorf("spec_version is required")
 	}
-	if doc.Syntax != yamlSyntaxV1 {
-		return fmt.Errorf("unsupported syntax version: %s", doc.Syntax)
+	if doc.SpecVersion != yamlSpecVersionV1 {
+		return fmt.Errorf("unsupported spec_version: %s", doc.SpecVersion)
 	}
 	if doc.Name == "" {
 		return fmt.Errorf("name is required")
@@ -162,7 +162,7 @@ func protoTypeToYAML(t pb.FieldType) string {
 
 func schemaToYAML(s *pb.Schema) *SchemaYAML {
 	doc := &SchemaYAML{
-		Syntax:             yamlSyntaxV1,
+		SpecVersion:        yamlSpecVersionV1,
 		Name:               s.Name,
 		Description:        s.Description,
 		Version:            s.Version,

--- a/internal/schema/yaml_bench_test.go
+++ b/internal/schema/yaml_bench_test.go
@@ -8,8 +8,8 @@ import (
 
 func BenchmarkMarshalSchemaYAML(b *testing.B) {
 	doc := &SchemaYAML{
-		Syntax: yamlSyntaxV1,
-		Name:   "payments",
+		SpecVersion: yamlSpecVersionV1,
+		Name:        "payments",
 		Fields: map[string]SchemaFieldYAML{
 			"payments.fee":      {Type: "string", Description: "Fee percentage"},
 			"payments.currency": {Type: "string"},
@@ -24,7 +24,7 @@ func BenchmarkMarshalSchemaYAML(b *testing.B) {
 }
 
 func BenchmarkUnmarshalSchemaYAML(b *testing.B) {
-	data := []byte(`syntax: "v1"
+	data := []byte(`spec_version: "v1"
 name: payments
 fields:
   payments.fee:

--- a/internal/schema/yaml_test.go
+++ b/internal/schema/yaml_test.go
@@ -55,7 +55,7 @@ func TestYAMLRoundtrip(t *testing.T) {
 
 	// Proto → YAML
 	doc := schemaToYAML(original)
-	assert.Equal(t, yamlSyntaxV1, doc.Syntax)
+	assert.Equal(t, yamlSpecVersionV1, doc.SpecVersion)
 	assert.Equal(t, "payments", doc.Name)
 	assert.Equal(t, "Payment config", doc.Description)
 	assert.Equal(t, int32(3), doc.Version)
@@ -149,30 +149,30 @@ func TestYAMLTypeMapping(t *testing.T) {
 }
 
 func TestYAMLValidation(t *testing.T) {
-	t.Run("missing syntax", func(t *testing.T) {
+	t.Run("missing spec_version", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte(`
 name: test
 fields:
   x:
     type: string
 `))
-		assert.ErrorContains(t, err, "syntax is required")
+		assert.ErrorContains(t, err, "spec_version is required")
 	})
 
-	t.Run("unsupported syntax", func(t *testing.T) {
+	t.Run("unsupported spec_version", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte(`
-syntax: "v99"
+spec_version: "v99"
 name: test
 fields:
   x:
     type: string
 `))
-		assert.ErrorContains(t, err, "unsupported syntax version")
+		assert.ErrorContains(t, err, "unsupported spec_version")
 	})
 
 	t.Run("missing name", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 fields:
   x:
     type: string
@@ -182,7 +182,7 @@ fields:
 
 	t.Run("no fields", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 name: test
 fields: {}
 `))
@@ -191,7 +191,7 @@ fields: {}
 
 	t.Run("unknown field type", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 name: test
 fields:
   x:
@@ -202,7 +202,7 @@ fields:
 
 	t.Run("valid minimal", func(t *testing.T) {
 		doc, err := unmarshalSchemaYAML([]byte(`
-syntax: "v1"
+spec_version: "v1"
 name: test
 fields:
   x:
@@ -227,7 +227,7 @@ func TestYAMLValidation_InvalidSlug(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := unmarshalSchemaYAML([]byte("syntax: \"v1\"\nname: " + tc.slug + "\nfields:\n  x:\n    type: string\n"))
+			_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\nname: " + tc.slug + "\nfields:\n  x:\n    type: string\n"))
 			assert.ErrorContains(t, err, "slug")
 		})
 	}

--- a/proto/centralconfig/v1/schema_service.proto
+++ b/proto/centralconfig/v1/schema_service.proto
@@ -114,7 +114,7 @@ service SchemaService {
   }
 
   // Import/export.
-  // Schemas can be exported as YAML (syntax v1) for backup, review, or version control.
+  // Schemas can be exported as YAML (spec_version v1) for backup, review, or version control.
 
   // ExportSchema serializes a schema version to YAML.
   rpc ExportSchema(ExportSchemaRequest) returns (ExportSchemaResponse) {
@@ -339,14 +339,14 @@ message ExportSchemaRequest {
 }
 
 message ExportSchemaResponse {
-  // YAML-encoded schema (syntax v1). Includes schema name, description,
+  // YAML-encoded schema (spec_version v1). Includes schema name, description,
   // version, and all field definitions with OAS-style constraint naming.
   // Server-generated fields (id, checksum, published, created_at) are excluded.
   bytes yaml_content = 1;
 }
 
 message ImportSchemaRequest {
-  // YAML-encoded schema (syntax v1). Must include `syntax`, `name`, and `fields`.
+  // YAML-encoded schema (spec_version v1). Must include `spec_version`, `name`, and `fields`.
   //
   // Import uses full-replace semantics:
   // - If no schema with this name exists: creates a new schema with version 1.

--- a/schemas/schema-yaml.json
+++ b/schemas/schema-yaml.json
@@ -2,15 +2,15 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/opendecree/decree/schemas/schema-yaml.json",
   "title": "OpenDecree Schema YAML",
-  "description": "Schema definition format for the OpenDecree (syntax v1).",
+  "description": "Schema definition format for the OpenDecree (spec_version v1).",
   "type": "object",
-  "required": ["syntax", "name", "fields"],
+  "required": ["spec_version", "name", "fields"],
   "additionalProperties": false,
   "properties": {
-    "syntax": {
+    "spec_version": {
       "type": "string",
       "const": "v1",
-      "description": "Schema syntax version. Must be \"v1\"."
+      "description": "Decree schema spec version. Must be \"v1\"."
     },
     "name": {
       "type": "string",

--- a/sdk/adminclient/client_test.go
+++ b/sdk/adminclient/client_test.go
@@ -315,15 +315,15 @@ func TestExportImportConfig(t *testing.T) {
 	ctx := context.Background()
 
 	mc.exportConfigFn = func(_ context.Context, _ string, _ *int32) ([]byte, error) {
-		return []byte("syntax: v1\nvalues:\n  a:\n    value: x\n"), nil
+		return []byte("spec_version: v1\nvalues:\n  a:\n    value: x\n"), nil
 	}
 
 	data, err := client.ExportConfig(ctx, "t1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(data), "syntax") {
-		t.Errorf("expected %q to contain %q", string(data), "syntax")
+	if !strings.Contains(string(data), "spec_version") {
+		t.Errorf("expected %q to contain %q", string(data), "spec_version")
 	}
 
 	mc.importConfigFn = func(_ context.Context, req *ImportConfigRequest) (*Version, error) {

--- a/sdk/adminclient/operations_test.go
+++ b/sdk/adminclient/operations_test.go
@@ -102,15 +102,15 @@ func TestExportSchema_Success(t *testing.T) {
 	client := New(ms, nil, nil, nil)
 
 	ms.exportSchemaFn = func(_ context.Context, _ string, _ *int32) ([]byte, error) {
-		return []byte("syntax: v1"), nil
+		return []byte("spec_version: v1"), nil
 	}
 
 	data, err := client.ExportSchema(context.Background(), "s1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(data), "syntax") {
-		t.Errorf("expected %q to contain %q", string(data), "syntax")
+	if !strings.Contains(string(data), "spec_version") {
+		t.Errorf("expected %q to contain %q", string(data), "spec_version")
 	}
 }
 
@@ -122,7 +122,7 @@ func TestExportSchema_SpecificVersion(t *testing.T) {
 		if id != "s1" || version == nil || *version != int32(2) {
 			t.Fatalf("unexpected args: id=%v version=%v", id, version)
 		}
-		return []byte("syntax: v1"), nil
+		return []byte("spec_version: v1"), nil
 	}
 
 	v := int32(2)
@@ -143,7 +143,7 @@ func TestImportSchema_Success(t *testing.T) {
 		return &Schema{ID: "s1", Name: "imported", Version: 1, CreatedAt: time.Now()}, nil
 	}
 
-	s, err := client.ImportSchema(context.Background(), []byte("syntax: v1\nname: imported"))
+	s, err := client.ImportSchema(context.Background(), []byte("spec_version: v1\nname: imported"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -79,8 +79,8 @@ func Run(ctx context.Context, client Client, tenantID string, opts ...Option) (*
 
 	// 4. Build seed file.
 	file := &seed.File{
-		Syntax: "v1",
-		Schema: buildSchemaDef(schema),
+		SpecVersion: "v1",
+		Schema:      buildSchemaDef(schema),
 		Tenant: seed.TenantDef{Name: tenant.Name},
 		Config: seed.ConfigDef{Values: configDoc.Values},
 	}

--- a/sdk/tools/dump/dump_test.go
+++ b/sdk/tools/dump/dump_test.go
@@ -74,7 +74,7 @@ func baseMock() *mockClient {
 			}, nil
 		},
 		exportConfigFn: func(_ context.Context, _ string, _ *int32) ([]byte, error) {
-			return []byte(`syntax: "v1"
+			return []byte(`spec_version: "v1"
 values:
   rate:
     value: 42
@@ -100,8 +100,8 @@ func TestRun_FullDump(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if file.Syntax != "v1" {
-		t.Errorf("syntax = %q", file.Syntax)
+	if file.SpecVersion != "v1" {
+		t.Errorf("spec_version = %q", file.SpecVersion)
 	}
 	if file.Schema.Name != "payments" {
 		t.Errorf("schema.name = %q", file.Schema.Name)
@@ -210,7 +210,7 @@ func TestRun_WithConfigVersion(t *testing.T) {
 	var gotVersion *int32
 	mock.exportConfigFn = func(_ context.Context, _ string, version *int32) ([]byte, error) {
 		gotVersion = version
-		return []byte(`syntax: "v1"
+		return []byte(`spec_version: "v1"
 values:
   rate:
     value: 1
@@ -426,8 +426,8 @@ func TestConvertConstraints(t *testing.T) {
 
 func TestMarshal(t *testing.T) {
 	f := &seed.File{
-		Syntax: "v1",
-		Schema: seed.SchemaDef{
+		SpecVersion: "v1",
+		Schema:      seed.SchemaDef{
 			Name:   "test",
 			Fields: map[string]seed.FieldDef{"x": {Type: "string"}},
 		},

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -20,8 +20,8 @@ import (
 
 // File is the top-level YAML document for seed and dump operations.
 type File struct {
-	Syntax string    `yaml:"syntax"`
-	Schema SchemaDef `yaml:"schema"`
+	SpecVersion string    `yaml:"spec_version"`
+	Schema      SchemaDef `yaml:"schema"`
 	Tenant TenantDef `yaml:"tenant"`
 	Config ConfigDef `yaml:"config,omitempty"`
 	Locks  []LockDef `yaml:"locks,omitempty"`
@@ -139,8 +139,8 @@ func ParseFile(data []byte) (*File, error) {
 	if err := yaml.Unmarshal(data, &f); err != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", err)
 	}
-	if f.Syntax != "v1" {
-		return nil, fmt.Errorf("unsupported syntax version: %q (expected \"v1\")", f.Syntax)
+	if f.SpecVersion != "v1" {
+		return nil, fmt.Errorf("unsupported spec_version: %q (expected \"v1\")", f.SpecVersion)
 	}
 	if f.Schema.Name == "" {
 		return nil, fmt.Errorf("schema.name is required")
@@ -283,12 +283,12 @@ func Run(ctx context.Context, client Client, file *File, opts ...Option) (*Resul
 // marshalSchemaYAML extracts the schema section into the standard schema YAML format.
 func marshalSchemaYAML(f *File) ([]byte, error) {
 	doc := struct {
-		Syntax      string              `yaml:"syntax"`
+		SpecVersion string              `yaml:"spec_version"`
 		Name        string              `yaml:"name"`
 		Description string              `yaml:"description,omitempty"`
 		Fields      map[string]FieldDef `yaml:"fields"`
 	}{
-		Syntax:      "v1",
+		SpecVersion: "v1",
 		Name:        f.Schema.Name,
 		Description: f.Schema.Description,
 		Fields:      f.Schema.Fields,
@@ -299,11 +299,11 @@ func marshalSchemaYAML(f *File) ([]byte, error) {
 // marshalConfigYAML extracts the config section into the standard config YAML format.
 func marshalConfigYAML(f *File) ([]byte, error) {
 	doc := struct {
-		Syntax      string                    `yaml:"syntax"`
+		SpecVersion string                    `yaml:"spec_version"`
 		Description string                    `yaml:"description,omitempty"`
 		Values      map[string]ConfigValueDef `yaml:"values"`
 	}{
-		Syntax:      "v1",
+		SpecVersion: "v1",
 		Description: f.Config.Description,
 		Values:      f.Config.Values,
 	}

--- a/sdk/tools/seed/seed_test.go
+++ b/sdk/tools/seed/seed_test.go
@@ -47,7 +47,7 @@ func (m *mockClient) LockField(ctx context.Context, tenantID, fieldPath string, 
 
 func testFile() *File {
 	return &File{
-		Syntax: "v1",
+		SpecVersion: "v1",
 		Schema: SchemaDef{
 			Name: "test-schema",
 			Fields: map[string]FieldDef{
@@ -69,7 +69,7 @@ func testFile() *File {
 
 // --- Parse tests ---
 
-const validSeedYAML = `syntax: "v1"
+const validSeedYAML = `spec_version: "v1"
 schema:
   name: payment-config
   description: "Payment settings"
@@ -101,8 +101,8 @@ func TestParseFile_Valid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if f.Syntax != "v1" {
-		t.Errorf("syntax = %q, want v1", f.Syntax)
+	if f.SpecVersion != "v1" {
+		t.Errorf("spec_version = %q, want v1", f.SpecVersion)
 	}
 	if f.Schema.Name != "payment-config" {
 		t.Errorf("schema.name = %q, want payment-config", f.Schema.Name)
@@ -133,7 +133,7 @@ func TestParseFile_Errors(t *testing.T) {
 		data string
 	}{
 		{"invalid yaml", "{{bad"},
-		{"wrong syntax", `syntax: "v2"
+		{"wrong spec_version", `spec_version: "v2"
 schema:
   name: test
   fields:
@@ -141,20 +141,20 @@ schema:
       type: string
 tenant:
   name: t`},
-		{"no schema name", `syntax: "v1"
+		{"no schema name", `spec_version: "v1"
 schema:
   fields:
     a:
       type: string
 tenant:
   name: t`},
-		{"no fields", `syntax: "v1"
+		{"no fields", `spec_version: "v1"
 schema:
   name: test
   fields: {}
 tenant:
   name: t`},
-		{"no tenant name", `syntax: "v1"
+		{"no tenant name", `spec_version: "v1"
 schema:
   name: test
   fields:
@@ -175,7 +175,7 @@ tenant:
 }
 
 func TestParseFile_MinimalValid(t *testing.T) {
-	data := `syntax: "v1"
+	data := `spec_version: "v1"
 schema:
   name: minimal
   fields:
@@ -230,7 +230,7 @@ func TestMarshal_RoundTrip(t *testing.T) {
 }
 
 func TestParseFile_FieldConstraints(t *testing.T) {
-	data := `syntax: "v1"
+	data := `spec_version: "v1"
 schema:
   name: constrained
   fields:

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -22,7 +22,7 @@ import (
 
 // SchemaFile is the parsed representation of a schema YAML file.
 type SchemaFile struct {
-	Syntax      string              `yaml:"syntax"`
+	SpecVersion string              `yaml:"spec_version"`
 	Name        string              `yaml:"name"`
 	Description string              `yaml:"description,omitempty"`
 	Info        any                 `yaml:"info,omitempty"`
@@ -64,8 +64,8 @@ type ConstraintsDef struct {
 
 // ConfigFile is the parsed representation of a config YAML file.
 type ConfigFile struct {
-	Syntax string                    `yaml:"syntax"`
-	Values map[string]ConfigValueDef `yaml:"values"`
+	SpecVersion string                    `yaml:"spec_version"`
+	Values      map[string]ConfigValueDef `yaml:"values"`
 }
 
 // ConfigValueDef represents a single config value in the YAML format.
@@ -140,8 +140,8 @@ func ParseSchema(data []byte) (*SchemaFile, error) {
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", err)
 	}
-	if doc.Syntax != "v1" {
-		return nil, fmt.Errorf("unsupported syntax version: %q (expected \"v1\")", doc.Syntax)
+	if doc.SpecVersion != "v1" {
+		return nil, fmt.Errorf("unsupported spec_version: %q (expected \"v1\")", doc.SpecVersion)
 	}
 	if doc.Name == "" {
 		return nil, fmt.Errorf("schema name is required")
@@ -163,8 +163,8 @@ func ParseConfig(data []byte) (*ConfigFile, error) {
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("invalid YAML: %w", err)
 	}
-	if doc.Syntax != "v1" {
-		return nil, fmt.Errorf("unsupported syntax version: %q (expected \"v1\")", doc.Syntax)
+	if doc.SpecVersion != "v1" {
+		return nil, fmt.Errorf("unsupported spec_version: %q (expected \"v1\")", doc.SpecVersion)
 	}
 	if len(doc.Values) == 0 {
 		return nil, fmt.Errorf("at least one value is required")

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-const schemaYAML = `syntax: "v1"
+const schemaYAML = `spec_version: "v1"
 name: test-schema
 fields:
   rate:
@@ -38,7 +38,7 @@ fields:
 `
 
 func TestValidate_Valid(t *testing.T) {
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   rate:
     value: 50.5
@@ -75,31 +75,31 @@ func TestValidate_TypeMismatch(t *testing.T) {
 		field  string
 		msg    string
 	}{
-		{"integer gets string", `syntax: "v1"
+		{"integer gets string", `spec_version: "v1"
 values:
   count:
     value: "not-a-number"`, "count", "expected integer"},
-		{"number gets bool", `syntax: "v1"
+		{"number gets bool", `spec_version: "v1"
 values:
   rate:
     value: true`, "rate", "expected number"},
-		{"bool gets string", `syntax: "v1"
+		{"bool gets string", `spec_version: "v1"
 values:
   enabled:
     value: "yes"`, "enabled", "expected bool"},
-		{"string gets int", `syntax: "v1"
+		{"string gets int", `spec_version: "v1"
 values:
   name:
     value: 42`, "name", "expected string"},
-		{"url gets int", `syntax: "v1"
+		{"url gets int", `spec_version: "v1"
 values:
   endpoint:
     value: 42`, "endpoint", "expected url"},
-		{"time gets int", `syntax: "v1"
+		{"time gets int", `spec_version: "v1"
 values:
   start_time:
     value: 123`, "start_time", "expected time"},
-		{"duration gets int", `syntax: "v1"
+		{"duration gets int", `spec_version: "v1"
 values:
   timeout:
     value: 123`, "timeout", "expected duration"},
@@ -122,11 +122,11 @@ func TestValidate_NumericConstraints(t *testing.T) {
 		config string
 		msg    string
 	}{
-		{"below minimum", `syntax: "v1"
+		{"below minimum", `spec_version: "v1"
 values:
   rate:
     value: -1`, "less than minimum"},
-		{"above maximum", `syntax: "v1"
+		{"above maximum", `spec_version: "v1"
 values:
   rate:
     value: 101`, "exceeds maximum"},
@@ -144,7 +144,7 @@ values:
 }
 
 func TestValidate_ExclusiveMinMax(t *testing.T) {
-	schema := `syntax: "v1"
+	schema := `spec_version: "v1"
 name: test
 fields:
   val:
@@ -158,15 +158,15 @@ fields:
 		value string
 		valid bool
 	}{
-		{"at exclusive min", `syntax: "v1"
+		{"at exclusive min", `spec_version: "v1"
 values:
   val:
     value: 0`, false},
-		{"at exclusive max", `syntax: "v1"
+		{"at exclusive max", `spec_version: "v1"
 values:
   val:
     value: 10`, false},
-		{"within range", `syntax: "v1"
+		{"within range", `spec_version: "v1"
 values:
   val:
     value: 5`, true},
@@ -194,15 +194,15 @@ func TestValidate_StringConstraints(t *testing.T) {
 		config string
 		msg    string
 	}{
-		{"too short", `syntax: "v1"
+		{"too short", `spec_version: "v1"
 values:
   name:
     value: ""`, "less than minLength"},
-		{"too long", `syntax: "v1"
+		{"too long", `spec_version: "v1"
 values:
   name:
     value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"`, "exceeds maxLength"},
-		{"bad pattern", `syntax: "v1"
+		{"bad pattern", `spec_version: "v1"
 values:
   name:
     value: "hello123"`, "does not match pattern"},
@@ -220,7 +220,7 @@ values:
 }
 
 func TestValidate_Enum(t *testing.T) {
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   tags:
     value: "invalid"
@@ -233,7 +233,7 @@ values:
 }
 
 func TestValidate_EnumWithNumericTypes(t *testing.T) {
-	schema := `syntax: "v1"
+	schema := `spec_version: "v1"
 name: test
 fields:
   level:
@@ -254,19 +254,19 @@ fields:
 		config string
 		valid  bool
 	}{
-		{"int enum match", `syntax: "v1"
+		{"int enum match", `spec_version: "v1"
 values:
   level:
     value: 1`, true},
-		{"int enum miss", `syntax: "v1"
+		{"int enum miss", `spec_version: "v1"
 values:
   level:
     value: 4`, false},
-		{"float enum match", `syntax: "v1"
+		{"float enum match", `spec_version: "v1"
 values:
   ratio:
     value: 1.5`, true},
-		{"bool enum match", `syntax: "v1"
+		{"bool enum match", `spec_version: "v1"
 values:
   flag:
     value: true`, true},
@@ -290,7 +290,7 @@ values:
 
 func TestValidate_Nullable(t *testing.T) {
 	t.Run("nullable field allows null", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   tags:
     value: null
@@ -305,7 +305,7 @@ values:
 	})
 
 	t.Run("non-nullable rejects null", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   count:
     value: null
@@ -319,7 +319,7 @@ values:
 }
 
 func TestValidate_Strict(t *testing.T) {
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   unknown_field:
     value: "hello"
@@ -345,7 +345,7 @@ values:
 
 func TestValidate_URL(t *testing.T) {
 	t.Run("invalid url", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   endpoint:
     value: "not-a-url"
@@ -358,7 +358,7 @@ values:
 	})
 
 	t.Run("relative url rejected", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   endpoint:
     value: "/relative/path"
@@ -373,7 +373,7 @@ values:
 
 func TestValidate_JSON(t *testing.T) {
 	t.Run("structured YAML is valid JSON", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   payload:
     value:
@@ -391,7 +391,7 @@ values:
 	})
 
 	t.Run("JSON array is valid", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   payload:
     value: [1, 2, 3]
@@ -406,7 +406,7 @@ values:
 	})
 
 	t.Run("invalid JSON string", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   payload:
     value: "{bad json"
@@ -419,7 +419,7 @@ values:
 	})
 
 	t.Run("non-string non-structured rejects", func(t *testing.T) {
-		config := `syntax: "v1"
+		config := `spec_version: "v1"
 values:
   payload:
     value: 42
@@ -433,7 +433,7 @@ values:
 }
 
 func TestValidate_IntegerRejectsFloat(t *testing.T) {
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   count:
     value: 3.14
@@ -446,7 +446,7 @@ values:
 }
 
 func TestValidate_IntegerAcceptsWholeFloat(t *testing.T) {
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   count:
     value: 3.0
@@ -461,7 +461,7 @@ values:
 }
 
 func TestValidate_InvalidPattern(t *testing.T) {
-	schema := `syntax: "v1"
+	schema := `spec_version: "v1"
 name: test
 fields:
   x:
@@ -469,7 +469,7 @@ fields:
     constraints:
       pattern: "[invalid"
 `
-	config := `syntax: "v1"
+	config := `spec_version: "v1"
 values:
   x:
     value: "test"
@@ -483,14 +483,14 @@ values:
 
 func TestValidateParsed(t *testing.T) {
 	schema := &SchemaFile{
-		Syntax: "v1",
-		Name:   "test",
+		SpecVersion: "v1",
+		Name:        "test",
 		Fields: map[string]FieldDef{
 			"x": {Type: "integer"},
 		},
 	}
 	config := &ConfigFile{
-		Syntax: "v1",
+		SpecVersion: "v1",
 		Values: map[string]ConfigValueDef{
 			"x": {Value: 42},
 		},
@@ -503,7 +503,7 @@ func TestValidateParsed(t *testing.T) {
 }
 
 func TestValidate_SchemaParseError(t *testing.T) {
-	_, err := Validate([]byte("{{bad"), []byte(`syntax: "v1"
+	_, err := Validate([]byte("{{bad"), []byte(`spec_version: "v1"
 values:
   x:
     value: 1`))
@@ -525,19 +525,19 @@ func TestParseSchema_Errors(t *testing.T) {
 		data string
 	}{
 		{"invalid yaml", "{{bad"},
-		{"wrong syntax", `syntax: "v2"
+		{"wrong spec_version", `spec_version: "v2"
 name: test
 fields:
   a:
     type: string`},
-		{"no name", `syntax: "v1"
+		{"no name", `spec_version: "v1"
 fields:
   a:
     type: string`},
-		{"no fields", `syntax: "v1"
+		{"no fields", `spec_version: "v1"
 name: test
 fields: {}`},
-		{"bad type", `syntax: "v1"
+		{"bad type", `spec_version: "v1"
 name: test
 fields:
   a:
@@ -560,11 +560,11 @@ func TestParseConfig_Errors(t *testing.T) {
 		data string
 	}{
 		{"invalid yaml", "{{bad"},
-		{"wrong syntax", `syntax: "v2"
+		{"wrong spec_version", `spec_version: "v2"
 values:
   a:
     value: 1`},
-		{"no values", `syntax: "v1"
+		{"no values", `spec_version: "v1"
 values: {}`},
 	}
 


### PR DESCRIPTION
Closes #118. Part of milestone [Schema Spec v0.1.0](https://github.com/opendecree/decree/milestone/10). Design brief: `.agents/context/schema-spec.md` (landing in #128).

## Summary
- Rename top-level `syntax:` → `spec_version:` in both **schema** YAML and **config** YAML formats.
- Applied across parsers (`internal/schema`, `internal/config`), SDK tools (`sdk/tools/{validate,seed,dump}`), fixtures, examples, docs, and proto doc comments.
- Error messages now reference `spec_version` (e.g. `spec_version is required`, `unsupported spec_version`).

## Scope
- **Breaking.** No backward-compat shim, no legacy-key migration helper — per the pre-production no-backward-compat policy.
- Config YAML is renamed in the same PR to keep both top-level formats in sync.
- `schemas/schema-yaml.json` (preliminary meta-schema) updated for consistency; full rewrite comes with #123.

## Test plan
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues
- [x] `make e2e` — all tests pass after rebuilding the service image
- [x] `make generate` — proto doc comments → regenerated `.pb.go` + `docs/api/*.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)