### PR TITLE
feat(schema): add optional $schema and $id top-level fields (#119)

### DIFF
--- a/internal/schema/yaml.go
+++ b/internal/schema/yaml.go
@@ -2,17 +2,30 @@ package schema
 
 import (
 	"fmt"
+	"net/url"
+	"regexp"
 	"sort"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"gopkg.in/yaml.v3"
 )
 
-const yamlSpecVersionV1 = "v1"
+const (
+	yamlSpecVersionV1 = "v1"
+	// metaSchemaURL is the canonical URL of the meta-schema that validates
+	// decree.schema.yaml documents at this spec version. Emitted on export.
+	metaSchemaURL = "https://schemas.opendecree.io/schema/v0.1.0/decree.json"
+)
+
+// schemaURNPattern matches decree schema URNs: urn:decree:schema:<segment>(:<segment>)*
+// where each segment is [a-zA-Z0-9][a-zA-Z0-9._-]*
+var schemaURNPattern = regexp.MustCompile(`^urn:decree:schema:[a-zA-Z0-9][a-zA-Z0-9._-]*(?::[a-zA-Z0-9][a-zA-Z0-9._-]*)*$`)
 
 // SchemaYAML is the top-level YAML document for schema import/export.
 type SchemaYAML struct {
 	SpecVersion        string                     `yaml:"spec_version"`
+	Schema             string                     `yaml:"$schema,omitempty"`
+	ID                 string                     `yaml:"$id,omitempty"`
 	Name               string                     `yaml:"name"`
 	Description        string                     `yaml:"description,omitempty"`
 	Version            int32                      `yaml:"version,omitempty"`
@@ -90,6 +103,15 @@ func validateSchemaYAML(doc *SchemaYAML) error {
 	if doc.SpecVersion != yamlSpecVersionV1 {
 		return fmt.Errorf("unsupported spec_version: %s", doc.SpecVersion)
 	}
+	if doc.Schema != "" {
+		u, err := url.Parse(doc.Schema)
+		if err != nil || u.Scheme != "https" || u.Host == "" {
+			return fmt.Errorf("$schema must be an HTTPS URL, got %q", doc.Schema)
+		}
+	}
+	if doc.ID != "" && !schemaURNPattern.MatchString(doc.ID) {
+		return fmt.Errorf("$id must match urn:decree:schema:<segment>(:<segment>)*, got %q", doc.ID)
+	}
 	if doc.Name == "" {
 		return fmt.Errorf("name is required")
 	}
@@ -163,6 +185,8 @@ func protoTypeToYAML(t pb.FieldType) string {
 func schemaToYAML(s *pb.Schema) *SchemaYAML {
 	doc := &SchemaYAML{
 		SpecVersion:        yamlSpecVersionV1,
+		Schema:             metaSchemaURL,
+		ID:                 fmt.Sprintf("urn:decree:schema:%s:v%d", s.Name, s.Version),
 		Name:               s.Name,
 		Description:        s.Description,
 		Version:            s.Version,

--- a/internal/schema/yaml_test.go
+++ b/internal/schema/yaml_test.go
@@ -56,6 +56,8 @@ func TestYAMLRoundtrip(t *testing.T) {
 	// Proto → YAML
 	doc := schemaToYAML(original)
 	assert.Equal(t, yamlSpecVersionV1, doc.SpecVersion)
+	assert.Equal(t, metaSchemaURL, doc.Schema)
+	assert.Equal(t, "urn:decree:schema:payments:v3", doc.ID)
 	assert.Equal(t, "payments", doc.Name)
 	assert.Equal(t, "Payment config", doc.Description)
 	assert.Equal(t, int32(3), doc.Version)
@@ -231,6 +233,56 @@ func TestYAMLValidation_InvalidSlug(t *testing.T) {
 			assert.ErrorContains(t, err, "slug")
 		})
 	}
+}
+
+func TestYAMLValidation_SchemaAndID(t *testing.T) {
+	validBody := "\nname: test\nfields:\n  x:\n    type: string\n"
+
+	t.Run("both absent (optional)", func(t *testing.T) {
+		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"" + validBody))
+		require.NoError(t, err)
+	})
+
+	t.Run("both accepted when well-formed", func(t *testing.T) {
+		doc, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$schema: https://schemas.opendecree.io/schema/v0.1.0/decree.json\n$id: urn:decree:schema:test:v1" + validBody))
+		require.NoError(t, err)
+		assert.Equal(t, "https://schemas.opendecree.io/schema/v0.1.0/decree.json", doc.Schema)
+		assert.Equal(t, "urn:decree:schema:test:v1", doc.ID)
+	})
+
+	t.Run("$schema must be HTTPS", func(t *testing.T) {
+		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$schema: http://example.com/decree.json" + validBody))
+		assert.ErrorContains(t, err, "$schema")
+		assert.ErrorContains(t, err, "HTTPS")
+	})
+
+	t.Run("$schema must have host", func(t *testing.T) {
+		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$schema: not-a-url" + validBody))
+		assert.ErrorContains(t, err, "$schema")
+	})
+
+	t.Run("$id must be decree schema URN", func(t *testing.T) {
+		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$id: not-a-urn" + validBody))
+		assert.ErrorContains(t, err, "$id")
+	})
+
+	t.Run("$id rejects wrong namespace", func(t *testing.T) {
+		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$id: urn:other:schema:test:v1" + validBody))
+		assert.ErrorContains(t, err, "$id")
+	})
+}
+
+func TestSchemaToYAML_EmitsSchemaAndID(t *testing.T) {
+	doc := schemaToYAML(&pb.Schema{
+		Name:    "billing",
+		Version: 7,
+		Fields:  []*pb.SchemaField{{Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING}},
+	})
+	assert.Equal(t, metaSchemaURL, doc.Schema)
+	assert.Equal(t, "urn:decree:schema:billing:v7", doc.ID)
+
+	// Synthesized $id must satisfy the same pattern the parser enforces.
+	assert.Regexp(t, schemaURNPattern, doc.ID)
 }
 
 func TestConstraintsNilWhenEmpty(t *testing.T) {

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -23,6 +23,8 @@ import (
 // SchemaFile is the parsed representation of a schema YAML file.
 type SchemaFile struct {
 	SpecVersion string              `yaml:"spec_version"`
+	Schema      string              `yaml:"$schema,omitempty"`
+	ID          string              `yaml:"$id,omitempty"`
 	Name        string              `yaml:"name"`
 	Description string              `yaml:"description,omitempty"`
 	Info        any                 `yaml:"info,omitempty"`


### PR DESCRIPTION
Closes #119. Part of milestone [Schema Spec v0.1.0](https://github.com/opendecree/decree/milestone/10). Design brief: `.agents/context/schema-spec.md`.

## Summary
- Two optional top-level fields on the schema YAML format: `$schema` (HTTPS URL of the meta-schema), `$id` (URN).
- **Synthesize-on-export**, OAS-style: import validates format if present, does not persist; export emits server-determined values.
- `$schema` export value: canonical `https://schemas.opendecree.io/schema/v0.1.0/decree.json`.
- `$id` export value: `urn:decree:schema:{name}:v{version}` — deterministic from server state.
- Parser validations: `$schema` must be a well-formed HTTPS URL with a host; `$id` must match `^urn:decree:schema:<segment>(:<segment>)*$`.
- `sdk/tools/validate` — preemptively adds the two fields on `SchemaFile` so the local offline validator accepts YAMLs containing them (protects against follow-up breakage when #121 lands strict-unknown-keys).

## Persistence decision (see issue discussion)
Chose **synthesize-on-export (option C)** over persisted-via-proto (option A). Reasoning matches OpenAPI/JSON Schema: `$id` is a document identifier the spec owner determines, not user-submitted data. Deterministic URN from name + version is more useful than a user-chosen string (stable, predictable, federatable) and avoids a proto/DB migration for a metadata field.

## Not in scope (deferred)
- User-facing docs (schema-format.md, meta-schema.md) — #127
- Hosting `schemas.opendecree.io` — #125 (URL is reserved; not yet live)
- CLI export-time flag for opt-out `$schema` injection — #127 discussion, not needed yet

## Test plan
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues
- [x] `make e2e` — pass with rebuilt service image
- [x] New unit tests: both fields absent (valid), both accepted when well-formed, `$schema` rejects non-HTTPS + missing host, `$id` rejects non-URN + wrong namespace, export emits canonical `$schema` + deterministic `$id` matching the parser's URN pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)