### PR TITLE
feat(schema)!: enforce field-path regex at parse time (#120)

### DIFF
--- a/internal/schema/yaml.go
+++ b/internal/schema/yaml.go
@@ -21,6 +21,12 @@ const (
 // where each segment is [a-zA-Z0-9][a-zA-Z0-9._-]*
 var schemaURNPattern = regexp.MustCompile(`^urn:decree:schema:[a-zA-Z0-9][a-zA-Z0-9._-]*(?::[a-zA-Z0-9][a-zA-Z0-9._-]*)*$`)
 
+// fieldPathPattern is the grammar for map keys under `fields:`. Must start with
+// an ASCII letter or underscore; subsequent characters may be letters, digits,
+// underscore, dot, or hyphen. Enforced at parse time to catch pathological
+// keys (empty, leading digit, whitespace, special chars) early.
+var fieldPathPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.-]*$`)
+
 // SchemaYAML is the top-level YAML document for schema import/export.
 type SchemaYAML struct {
 	SpecVersion        string                     `yaml:"spec_version"`
@@ -122,8 +128,8 @@ func validateSchemaYAML(doc *SchemaYAML) error {
 		return fmt.Errorf("at least one field is required")
 	}
 	for path, f := range doc.Fields {
-		if path == "" {
-			return fmt.Errorf("field path cannot be empty")
+		if !fieldPathPattern.MatchString(path) {
+			return fmt.Errorf("invalid field path %q: must match %s", path, fieldPathPattern)
 		}
 		if _, ok := yamlTypeToProto(f.Type); !ok {
 			return fmt.Errorf("field %s: unknown type %q", path, f.Type)

--- a/internal/schema/yaml_test.go
+++ b/internal/schema/yaml_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -269,6 +270,43 @@ func TestYAMLValidation_SchemaAndID(t *testing.T) {
 	t.Run("$id rejects wrong namespace", func(t *testing.T) {
 		_, err := unmarshalSchemaYAML([]byte("spec_version: \"v1\"\n$id: urn:other:schema:test:v1" + validBody))
 		assert.ErrorContains(t, err, "$id")
+	})
+}
+
+func TestYAMLValidation_FieldPath(t *testing.T) {
+	mkYAML := func(path string) []byte {
+		return []byte(fmt.Sprintf("spec_version: \"v1\"\nname: test\nfields:\n  %q:\n    type: string\n", path))
+	}
+
+	t.Run("valid paths accepted", func(t *testing.T) {
+		for _, path := range []string{"x", "app.name", "app_name", "app-name", "a.b.c", "_leading_underscore", "x1", "x.y-z_2"} {
+			_, err := unmarshalSchemaYAML(mkYAML(path))
+			assert.NoError(t, err, "expected %q to be accepted", path)
+		}
+	})
+
+	t.Run("invalid paths rejected", func(t *testing.T) {
+		cases := []struct {
+			name string
+			path string
+		}{
+			{"empty", ""},
+			{"leading digit", "1app"},
+			{"leading dot", ".app"},
+			{"leading hyphen", "-app"},
+			{"whitespace", "app name"},
+			{"tab", "app\tname"},
+			{"special chars", "app@name"},
+			{"colon", "app:name"},
+			{"slash", "app/name"},
+			{"dollar", "$app"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := unmarshalSchemaYAML(mkYAML(tc.path))
+				assert.ErrorContains(t, err, "invalid field path")
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
Closes #120. Part of milestone [Schema Spec v0.1.0](https://github.com/opendecree/decree/milestone/10). Design brief: `.agents/context/schema-spec.md`.

## Summary
- Validate every map key under `fields:` against `^[a-zA-Z_][a-zA-Z0-9_.-]*$` at YAML parse time.
- Clear error message includes the offending path and the regex.
- Replaces the pre-existing "must be non-empty" check with the full pattern.

## Scope
- **Breaking.** Per no-backward-compat policy, schemas with out-of-pattern keys (empty, leading digit/dot/hyphen, whitespace, special chars) now fail at parse. No deprecation period.
- All checked-in fixtures (examples, e2e, docs) verified to conform — no migration needed.
- Meta-schema encoding of the same regex is scoped to #123.
- User-facing docs entry is scoped to #127.

## Test plan
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues
- [x] `make e2e` — pass with rebuilt service image
- [x] Unit tests cover valid patterns (`x`, `app.name`, `app_name`, `app-name`, `_leading_underscore`, `x.y-z_2`) and invalid ones (empty, leading digit, leading dot, leading hyphen, whitespace, tab, special chars, colon, slash, dollar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)