### PR TITLE
feat(schema,config)!: reject unknown keys + reserve x-* extensions (#121)

### DIFF
--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 
@@ -13,18 +14,24 @@ import (
 
 const yamlSpecVersionV1 = "v1"
 
+// extensionKeyPattern is the grammar for OAS-style vendor extension keys.
+// Unknown YAML keys that do not match this pattern are rejected at parse time.
+var extensionKeyPattern = regexp.MustCompile(`^x-.+$`)
+
 // ConfigYAML is the top-level YAML document for config import/export.
 type ConfigYAML struct {
 	SpecVersion string                     `yaml:"spec_version"`
 	Version     int32                      `yaml:"version,omitempty"`
 	Description string                     `yaml:"description,omitempty"`
 	Values      map[string]ConfigValueYAML `yaml:"values"`
+	Extensions  map[string]any             `yaml:",inline"`
 }
 
 // ConfigValueYAML represents a single config value in the YAML format.
 type ConfigValueYAML struct {
-	Value       interface{} `yaml:"value"`
-	Description string      `yaml:"description,omitempty"`
+	Value       interface{}    `yaml:"value"`
+	Description string         `yaml:"description,omitempty"`
+	Extensions  map[string]any `yaml:",inline"`
 }
 
 // configValueImport is the parsed result of a YAML config value, ready for DB storage.
@@ -43,12 +50,34 @@ func validateConfigYAML(doc *ConfigYAML) error {
 	if doc.SpecVersion != yamlSpecVersionV1 {
 		return fmt.Errorf("unsupported spec_version: %s", doc.SpecVersion)
 	}
+	if err := validateExtensions("", doc.Extensions); err != nil {
+		return err
+	}
 	if len(doc.Values) == 0 {
 		return fmt.Errorf("at least one value is required")
 	}
-	for path := range doc.Values {
+	for path, v := range doc.Values {
 		if path == "" {
 			return fmt.Errorf("field path cannot be empty")
+		}
+		if err := validateExtensions("values."+path, v.Extensions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateExtensions rejects any keys in the inline-extension map that do not
+// match the x-* vendor-extension pattern. The path prefix is included in the
+// error so users can locate the offending key in large documents.
+func validateExtensions(pathPrefix string, ext map[string]any) error {
+	for key := range ext {
+		if !extensionKeyPattern.MatchString(key) {
+			loc := "top level"
+			if pathPrefix != "" {
+				loc = pathPrefix
+			}
+			return fmt.Errorf("unknown key %q at %s: only known fields or x-* vendor extensions are allowed", key, loc)
 		}
 	}
 	return nil

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -171,6 +171,44 @@ values:
 		require.NoError(t, err)
 		assert.Equal(t, "hello", doc.Values["x"].Value)
 	})
+
+	t.Run("unknown top-level key rejected", func(t *testing.T) {
+		_, err := unmarshalConfigYAML([]byte(`
+spec_version: "v1"
+typo_top: 1
+values:
+  x:
+    value: "hello"
+`))
+		assert.ErrorContains(t, err, "unknown key")
+		assert.ErrorContains(t, err, "top level")
+	})
+
+	t.Run("unknown key under a value rejected", func(t *testing.T) {
+		_, err := unmarshalConfigYAML([]byte(`
+spec_version: "v1"
+values:
+  x:
+    value: "hello"
+    typo_val: 1
+`))
+		assert.ErrorContains(t, err, "unknown key")
+		assert.ErrorContains(t, err, "values.x")
+	})
+
+	t.Run("x-* extensions accepted", func(t *testing.T) {
+		doc, err := unmarshalConfigYAML([]byte(`
+spec_version: "v1"
+x-owner: platform
+values:
+  x:
+    value: "hello"
+    x-reviewed-by: alice
+`))
+		require.NoError(t, err)
+		assert.Equal(t, "platform", doc.Extensions["x-owner"])
+		assert.Equal(t, "alice", doc.Values["x"].Extensions["x-reviewed-by"])
+	})
 }
 
 func TestConfigYAML_Description(t *testing.T) {

--- a/internal/schema/yaml.go
+++ b/internal/schema/yaml.go
@@ -27,6 +27,11 @@ var schemaURNPattern = regexp.MustCompile(`^urn:decree:schema:[a-zA-Z0-9][a-zA-Z
 // keys (empty, leading digit, whitespace, special chars) early.
 var fieldPathPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.-]*$`)
 
+// extensionKeyPattern is the grammar for OAS-style vendor extension keys.
+// Any YAML key not matching a known struct field must match this pattern,
+// otherwise the parser rejects the document as containing an unknown key.
+var extensionKeyPattern = regexp.MustCompile(`^x-.+$`)
+
 // SchemaYAML is the top-level YAML document for schema import/export.
 type SchemaYAML struct {
 	SpecVersion        string                     `yaml:"spec_version"`
@@ -38,21 +43,24 @@ type SchemaYAML struct {
 	VersionDescription string                     `yaml:"version_description,omitempty"`
 	Info               *SchemaInfoYAML            `yaml:"info,omitempty"`
 	Fields             map[string]SchemaFieldYAML `yaml:"fields"`
+	Extensions         map[string]any             `yaml:",inline"`
 }
 
 // SchemaInfoYAML contains optional schema-level metadata.
 type SchemaInfoYAML struct {
-	Title   string             `yaml:"title,omitempty"`
-	Author  string             `yaml:"author,omitempty"`
-	Contact *SchemaContactYAML `yaml:"contact,omitempty"`
-	Labels  map[string]string  `yaml:"labels,omitempty"`
+	Title      string             `yaml:"title,omitempty"`
+	Author     string             `yaml:"author,omitempty"`
+	Contact    *SchemaContactYAML `yaml:"contact,omitempty"`
+	Labels     map[string]string  `yaml:"labels,omitempty"`
+	Extensions map[string]any     `yaml:",inline"`
 }
 
 // SchemaContactYAML contains contact information for a schema owner.
 type SchemaContactYAML struct {
-	Name  string `yaml:"name,omitempty"`
-	Email string `yaml:"email,omitempty"`
-	URL   string `yaml:"url,omitempty"`
+	Name       string         `yaml:"name,omitempty"`
+	Email      string         `yaml:"email,omitempty"`
+	URL        string         `yaml:"url,omitempty"`
+	Extensions map[string]any `yaml:",inline"`
 }
 
 // SchemaFieldYAML represents a single field in the YAML format.
@@ -73,31 +81,35 @@ type SchemaFieldYAML struct {
 	ReadOnly     bool                   `yaml:"readOnly,omitempty"`
 	WriteOnce    bool                   `yaml:"writeOnce,omitempty"`
 	Sensitive    bool                   `yaml:"sensitive,omitempty"`
+	Extensions   map[string]any         `yaml:",inline"`
 }
 
 // ExampleYAML represents a named example value.
 type ExampleYAML struct {
-	Value   string `yaml:"value"`
-	Summary string `yaml:"summary,omitempty"`
+	Value      string         `yaml:"value"`
+	Summary    string         `yaml:"summary,omitempty"`
+	Extensions map[string]any `yaml:",inline"`
 }
 
 // ExternalDocsYAML links to external documentation.
 type ExternalDocsYAML struct {
-	Description string `yaml:"description,omitempty"`
-	URL         string `yaml:"url"`
+	Description string         `yaml:"description,omitempty"`
+	URL         string         `yaml:"url"`
+	Extensions  map[string]any `yaml:",inline"`
 }
 
 // ConstraintsYAML uses OAS-style naming for field constraints.
 type ConstraintsYAML struct {
-	Minimum          *float64 `yaml:"minimum,omitempty"`
-	Maximum          *float64 `yaml:"maximum,omitempty"`
-	ExclusiveMinimum *float64 `yaml:"exclusiveMinimum,omitempty"`
-	ExclusiveMaximum *float64 `yaml:"exclusiveMaximum,omitempty"`
-	MinLength        *int32   `yaml:"minLength,omitempty"`
-	MaxLength        *int32   `yaml:"maxLength,omitempty"`
-	Pattern          string   `yaml:"pattern,omitempty"`
-	Enum             []string `yaml:"enum,omitempty"`
-	JSONSchema       string   `yaml:"json_schema,omitempty"`
+	Minimum          *float64       `yaml:"minimum,omitempty"`
+	Maximum          *float64       `yaml:"maximum,omitempty"`
+	ExclusiveMinimum *float64       `yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum *float64       `yaml:"exclusiveMaximum,omitempty"`
+	MinLength        *int32         `yaml:"minLength,omitempty"`
+	MaxLength        *int32         `yaml:"maxLength,omitempty"`
+	Pattern          string         `yaml:"pattern,omitempty"`
+	Enum             []string       `yaml:"enum,omitempty"`
+	JSONSchema       string         `yaml:"json_schema,omitempty"`
+	Extensions       map[string]any `yaml:",inline"`
 }
 
 // --- Validation ---
@@ -118,6 +130,19 @@ func validateSchemaYAML(doc *SchemaYAML) error {
 	if doc.ID != "" && !schemaURNPattern.MatchString(doc.ID) {
 		return fmt.Errorf("$id must match urn:decree:schema:<segment>(:<segment>)*, got %q", doc.ID)
 	}
+	if err := validateExtensions("", doc.Extensions); err != nil {
+		return err
+	}
+	if doc.Info != nil {
+		if err := validateExtensions("info", doc.Info.Extensions); err != nil {
+			return err
+		}
+		if doc.Info.Contact != nil {
+			if err := validateExtensions("info.contact", doc.Info.Contact.Extensions); err != nil {
+				return err
+			}
+		}
+	}
 	if doc.Name == "" {
 		return fmt.Errorf("name is required")
 	}
@@ -133,6 +158,40 @@ func validateSchemaYAML(doc *SchemaYAML) error {
 		}
 		if _, ok := yamlTypeToProto(f.Type); !ok {
 			return fmt.Errorf("field %s: unknown type %q", path, f.Type)
+		}
+		if err := validateExtensions("fields."+path, f.Extensions); err != nil {
+			return err
+		}
+		if f.Constraints != nil {
+			if err := validateExtensions("fields."+path+".constraints", f.Constraints.Extensions); err != nil {
+				return err
+			}
+		}
+		if f.ExternalDocs != nil {
+			if err := validateExtensions("fields."+path+".externalDocs", f.ExternalDocs.Extensions); err != nil {
+				return err
+			}
+		}
+		for exName, ex := range f.Examples {
+			if err := validateExtensions("fields."+path+".examples."+exName, ex.Extensions); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateExtensions rejects any keys in the inline-extension map that do not
+// match the x-* vendor-extension pattern. The path prefix is included in the
+// error so users can locate the offending key in large documents.
+func validateExtensions(pathPrefix string, ext map[string]any) error {
+	for key := range ext {
+		if !extensionKeyPattern.MatchString(key) {
+			loc := "top level"
+			if pathPrefix != "" {
+				loc = pathPrefix
+			}
+			return fmt.Errorf("unknown key %q at %s: only known fields or x-* vendor extensions are allowed", key, loc)
 		}
 	}
 	return nil

--- a/internal/schema/yaml_test.go
+++ b/internal/schema/yaml_test.go
@@ -310,6 +310,170 @@ func TestYAMLValidation_FieldPath(t *testing.T) {
 	})
 }
 
+func TestYAMLValidation_RejectsUnknownKeys(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		locHint string // substring expected in error
+	}{
+		{
+			name: "unknown top-level key",
+			yaml: `spec_version: "v1"
+typo_top: 1
+name: test
+fields:
+  x:
+    type: string
+`,
+			locHint: "top level",
+		},
+		{
+			name: "unknown key under info",
+			yaml: `spec_version: "v1"
+name: test
+info:
+  typo_info: hi
+fields:
+  x:
+    type: string
+`,
+			locHint: "info",
+		},
+		{
+			name: "unknown key under info.contact",
+			yaml: `spec_version: "v1"
+name: test
+info:
+  contact:
+    typo_contact: hi
+fields:
+  x:
+    type: string
+`,
+			locHint: "info.contact",
+		},
+		{
+			name: "unknown key under a field",
+			yaml: `spec_version: "v1"
+name: test
+fields:
+  x:
+    type: string
+    typ: string
+`,
+			locHint: "fields.x",
+		},
+		{
+			name: "unknown key under constraints",
+			yaml: `spec_version: "v1"
+name: test
+fields:
+  x:
+    type: string
+    constraints:
+      minimun: 1
+`,
+			locHint: "fields.x.constraints",
+		},
+		{
+			name: "unknown key under externalDocs",
+			yaml: `spec_version: "v1"
+name: test
+fields:
+  x:
+    type: string
+    externalDocs:
+      url: https://example.com
+      typo_docs: hi
+`,
+			locHint: "fields.x.externalDocs",
+		},
+		{
+			name: "unknown key under an example",
+			yaml: `spec_version: "v1"
+name: test
+fields:
+  x:
+    type: string
+    examples:
+      ok:
+        value: hi
+        typo_ex: 1
+`,
+			locHint: "fields.x.examples.ok",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := unmarshalSchemaYAML([]byte(tc.yaml))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "unknown key")
+			assert.ErrorContains(t, err, tc.locHint)
+		})
+	}
+}
+
+func TestYAMLValidation_AcceptsXExtensions(t *testing.T) {
+	input := []byte(`spec_version: "v1"
+x-owner: platform
+name: test
+info:
+  title: Test
+  x-info-ext: info-val
+  contact:
+    name: a
+    x-contact-ext: c-val
+fields:
+  x:
+    type: string
+    x-field-ext: field-val
+    constraints:
+      minLength: 1
+      x-constraint-ext: cn-val
+    externalDocs:
+      url: https://example.com
+      x-docs-ext: d-val
+    examples:
+      ok:
+        value: hi
+        x-example-ext: e-val
+`)
+	doc, err := unmarshalSchemaYAML(input)
+	require.NoError(t, err)
+
+	assert.Equal(t, "platform", doc.Extensions["x-owner"])
+	assert.Equal(t, "info-val", doc.Info.Extensions["x-info-ext"])
+	assert.Equal(t, "c-val", doc.Info.Contact.Extensions["x-contact-ext"])
+	f := doc.Fields["x"]
+	assert.Equal(t, "field-val", f.Extensions["x-field-ext"])
+	assert.Equal(t, "cn-val", f.Constraints.Extensions["x-constraint-ext"])
+	assert.Equal(t, "d-val", f.ExternalDocs.Extensions["x-docs-ext"])
+	assert.Equal(t, "e-val", f.Examples["ok"].Extensions["x-example-ext"])
+}
+
+func TestYAML_XExtensionsRoundTrip(t *testing.T) {
+	input := []byte(`spec_version: "v1"
+x-owner: platform
+name: test
+fields:
+  a:
+    type: string
+    x-field-ext: field-val
+`)
+	doc, err := unmarshalSchemaYAML(input)
+	require.NoError(t, err)
+
+	out, err := marshalSchemaYAML(doc)
+	require.NoError(t, err)
+	outStr := string(out)
+	assert.Contains(t, outStr, "x-owner: platform")
+	assert.Contains(t, outStr, "x-field-ext: field-val")
+
+	// Re-parse — round-trip must succeed.
+	_, err = unmarshalSchemaYAML(out)
+	require.NoError(t, err)
+}
+
 func TestSchemaToYAML_EmitsSchemaAndID(t *testing.T) {
 	doc := schemaToYAML(&pb.Schema{
 		Name:    "billing",


### PR DESCRIPTION
Closes #121. Part of milestone [Schema Spec v0.1.0](https://github.com/opendecree/decree/milestone/10). Design brief: `.agents/context/schema-spec.md`.

## Summary
- Every object level in **both** the schema YAML and config YAML formats rejects unknown keys at parse time with a clear error pointing at the offending path.
- The `x-*` prefix is reserved for vendor extensions — accepted verbatim, preserved on export, round-trippable.
- Matches OAS 3.1's `unevaluatedProperties: false` + `patternProperties: "^x-": {}` model.

## Implementation
- Inline `Extensions map[string]any \`yaml:",inline"\`` field on each struct:
  - `internal/schema/yaml.go`: `SchemaYAML`, `SchemaInfoYAML`, `SchemaContactYAML`, `SchemaFieldYAML`, `ConstraintsYAML`, `ExampleYAML`, `ExternalDocsYAML`
  - `internal/config/yaml.go`: `ConfigYAML`, `ConfigValueYAML`
- Post-unmarshal, `validateExtensions` walks the captured inline keys at every level and rejects anything not matching `^x-.+$` with a location-prefixed error.
- `yaml.v3` round-trips inline maps naturally — no marshal changes required.

## Scope
- **Breaking.** Typos like `typ:` instead of `type:` or `minimun:` instead of `minimum:` that the lenient parser previously dropped silently now fail. Per no-backward-compat policy, no deprecation period.
- Meta-schema encoding (`unevaluatedProperties: false` + `patternProperties`) is scoped to #123.
- Docs entry (`docs/concepts/schema-format.md` explaining the `x-*` convention) is scoped to #127.

## Test plan
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues
- [x] `make e2e` — pass with rebuilt service image
- [x] Schema YAML unit tests:
  - Unknown keys rejected at top level, under `info`, `info.contact`, inside a field, inside `constraints`, inside `externalDocs`, inside an `examples` entry — each error contains the correct location hint
  - `x-*` keys accepted at every level and captured in the corresponding `Extensions` map
  - Round-trip: YAML with `x-*` keys at multiple levels → marshal → unmarshal preserves all extensions
- [x] Config YAML unit tests:
  - Unknown top-level and per-value keys rejected with location hints
  - `x-*` keys accepted at top level and per-value (e.g. `x-owner`, `x-reviewed-by`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)