### PR TITLE
ci: enforce gofumpt formatting + fix drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,9 @@ jobs:
         with:
           version: v2.11.4
 
+      - name: Go format check
+        run: golangci-lint fmt --diff
+
       - name: Log in to ghcr.io
         uses: docker/login-action@v4
         with:

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -81,8 +81,8 @@ func Run(ctx context.Context, client Client, tenantID string, opts ...Option) (*
 	file := &seed.File{
 		SpecVersion: "v1",
 		Schema:      buildSchemaDef(schema),
-		Tenant: seed.TenantDef{Name: tenant.Name},
-		Config: seed.ConfigDef{Values: configDoc.Values},
+		Tenant:      seed.TenantDef{Name: tenant.Name},
+		Config:      seed.ConfigDef{Values: configDoc.Values},
 	}
 
 	// 5. Export locks.

--- a/sdk/tools/dump/dump_test.go
+++ b/sdk/tools/dump/dump_test.go
@@ -427,7 +427,7 @@ func TestConvertConstraints(t *testing.T) {
 func TestMarshal(t *testing.T) {
 	f := &seed.File{
 		SpecVersion: "v1",
-		Schema:      seed.SchemaDef{
+		Schema: seed.SchemaDef{
 			Name:   "test",
 			Fields: map[string]seed.FieldDef{"x": {Type: "string"}},
 		},

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -22,9 +22,9 @@ import (
 type File struct {
 	SpecVersion string    `yaml:"spec_version"`
 	Schema      SchemaDef `yaml:"schema"`
-	Tenant TenantDef `yaml:"tenant"`
-	Config ConfigDef `yaml:"config,omitempty"`
-	Locks  []LockDef `yaml:"locks,omitempty"`
+	Tenant      TenantDef `yaml:"tenant"`
+	Config      ConfigDef `yaml:"config,omitempty"`
+	Locks       []LockDef `yaml:"locks,omitempty"`
 }
 
 // SchemaDef defines a schema within a seed file.


### PR DESCRIPTION
## Summary

- Add `golangci-lint fmt --diff` step to the Lint CI job so gofumpt drift fails CI
- Fix pre-existing drift in `sdk/tools/{dump,seed}` (whitespace alignment only)

## Why

`.golangci.yml` declares `gofumpt` under `formatters:` — which `golangci-lint run` doesn't check (only `golangci-lint fmt` does). Result: `make pre-commit` caught drift locally but CI let it through. This closed the gap.

## Test plan

- [ ] CI `Lint` job runs the new format step and passes
- [ ] Locally: `make pre-commit` → all checks pass
- [ ] Locally: `golangci-lint fmt --diff` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)