### PR TITLE
cleanup: remove dead GetFieldLock sqlc query

### DIFF
--- a/db/queries/tenants.sql
+++ b/db/queries/tenants.sql
@@ -58,7 +58,3 @@ WHERE tenant_id = $1 AND field_path = $2;
 SELECT * FROM tenant_field_locks
 WHERE tenant_id = $1
 ORDER BY field_path;
-
--- name: GetFieldLock :one
-SELECT * FROM tenant_field_locks
-WHERE tenant_id = $1 AND field_path = $2;

--- a/internal/storage/dbstore/tenants.sql.gen.go
+++ b/internal/storage/dbstore/tenants.sql.gen.go
@@ -78,23 +78,6 @@ func (q *Queries) DeleteTenant(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
-const getFieldLock = `-- name: GetFieldLock :one
-SELECT tenant_id, field_path, locked_values FROM tenant_field_locks
-WHERE tenant_id = $1 AND field_path = $2
-`
-
-type GetFieldLockParams struct {
-	TenantID  pgtype.UUID `json:"tenant_id"`
-	FieldPath string      `json:"field_path"`
-}
-
-func (q *Queries) GetFieldLock(ctx context.Context, arg GetFieldLockParams) (TenantFieldLock, error) {
-	row := q.db.QueryRow(ctx, getFieldLock, arg.TenantID, arg.FieldPath)
-	var i TenantFieldLock
-	err := row.Scan(&i.TenantID, &i.FieldPath, &i.LockedValues)
-	return i, err
-}
-
 const getFieldLocks = `-- name: GetFieldLocks :many
 SELECT tenant_id, field_path, locked_values FROM tenant_field_locks
 WHERE tenant_id = $1


### PR DESCRIPTION
## Summary

Remove `-- name: GetFieldLock :one` (singular) from `db/queries/tenants.sql`. Zero non-generated callers — `internal/schema` uses the plural `GetFieldLocks` instead. Regenerated `tenants.sql.gen.go` drops `GetFieldLock` + `GetFieldLockParams`.

Flagged at 0% coverage in the tenants.sql.gen.go audit from PR #111 follow-up.

Closes #112

## Test plan

- [x] `make generate` regenerates dbstore without the symbol
- [x] `make pre-commit` clean (build, lint, format, test, coverage)
- [x] `make e2e` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)