### PR TITLE
feat(seed)!: decouple schema and config seeding + idempotent reseed (#140)

### DIFF
--- a/cmd/decree/seed.go
+++ b/cmd/decree/seed.go
@@ -12,9 +12,19 @@ import (
 
 var seedCmd = &cobra.Command{
 	Use:   "seed <file>",
-	Short: "Bootstrap a schema, tenant, and config from a single YAML file",
-	Long:  "Seed creates a schema, tenant, and initial configuration from a single YAML file. The operation is idempotent: existing schemas with identical fields are skipped, existing tenants are reused, and config values are merged.",
-	Args:  cobra.ExactArgs(1),
+	Short: "Seed a schema, tenant, and/or config from a YAML file",
+	Long: `Seed applies a YAML file against the server. The file may contain any combination of schema, tenant, config, and locks sections; the operation dispatches based on which are present:
+
+  schema only                  → imports the schema
+  tenant only                  → creates (or reuses) the tenant
+  schema + tenant              → imports schema + creates tenant
+  tenant + config (+ locks)    → reuses schema, creates tenant, imports config
+  schema + tenant + config     → full combined envelope (legacy form)
+
+In config-only mode, tenant.schema names an already-imported schema. If tenant.schema_version is omitted, the latest published version is used.
+
+The operation is idempotent: importing a schema with identical fields, or a config whose values match the latest version, is a no-op and does not create a new version.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		data, err := os.ReadFile(args[0])
 		if err != nil {

--- a/docs/cli/decree.md
+++ b/docs/cli/decree.md
@@ -35,7 +35,7 @@ Command-line tool for managing schemas, tenants, and configuration values in Ope
 * [decree dump](decree_dump.md)	 - Export a full tenant backup (schema + config + locks)
 * [decree lock](decree_lock.md)	 - Manage field locks
 * [decree schema](decree_schema.md)	 - Manage configuration schemas
-* [decree seed](decree_seed.md)	 - Bootstrap a schema, tenant, and config from a single YAML file
+* [decree seed](decree_seed.md)	 - Seed a schema, tenant, and/or config from a YAML file
 * [decree server](decree_server.md)	 - Server information and management
 * [decree tenant](decree_tenant.md)	 - Manage tenants
 * [decree validate](decree_validate.md)	 - Validate a config YAML against a schema YAML (offline)

--- a/docs/cli/decree_seed.md
+++ b/docs/cli/decree_seed.md
@@ -4,11 +4,21 @@ title: decree seed
 
 ## decree seed
 
-Bootstrap a schema, tenant, and config from a single YAML file
+Seed a schema, tenant, and/or config from a YAML file
 
 ### Synopsis
 
-Seed creates a schema, tenant, and initial configuration from a single YAML file. The operation is idempotent: existing schemas with identical fields are skipped, existing tenants are reused, and config values are merged.
+Seed applies a YAML file against the server. The file may contain any combination of schema, tenant, config, and locks sections; the operation dispatches based on which are present:
+
+  schema only                  → imports the schema
+  tenant only                  → creates (or reuses) the tenant
+  schema + tenant              → imports schema + creates tenant
+  tenant + config (+ locks)    → reuses schema, creates tenant, imports config
+  schema + tenant + config     → full combined envelope (legacy form)
+
+In config-only mode, tenant.schema names an already-imported schema. If tenant.schema_version is omitted, the latest published version is used.
+
+The operation is idempotent: importing a schema with identical fields, or a config whose values match the latest version, is a no-op and does not create a new version.
 
 ```
 decree seed <file> [flags]

--- a/docs/man/decree-seed.1
+++ b/docs/man/decree-seed.1
@@ -2,7 +2,7 @@
 .TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
-decree-seed - Bootstrap a schema, tenant, and config from a single YAML file
+decree-seed - Seed a schema, tenant, and/or config from a YAML file
 
 
 .SH SYNOPSIS
@@ -10,7 +10,20 @@ decree-seed - Bootstrap a schema, tenant, and config from a single YAML file
 
 
 .SH DESCRIPTION
-Seed creates a schema, tenant, and initial configuration from a single YAML file. The operation is idempotent: existing schemas with identical fields are skipped, existing tenants are reused, and config values are merged.
+Seed applies a YAML file against the server. The file may contain any combination of schema, tenant, config, and locks sections; the operation dispatches based on which are present:
+
+.PP
+schema only                  → imports the schema
+  tenant only                  → creates (or reuses) the tenant
+  schema + tenant              → imports schema + creates tenant
+  tenant + config (+ locks)    → reuses schema, creates tenant, imports config
+  schema + tenant + config     → full combined envelope (legacy form)
+
+.PP
+In config-only mode, tenant.schema names an already-imported schema. If tenant.schema_version is omitted, the latest published version is used.
+
+.PP
+The operation is idempotent: importing a schema with identical fields, or a config whose values match the latest version, is a no-op and does not create a new version.
 
 
 .SH OPTIONS

--- a/docs/usecases/config-as-code.md
+++ b/docs/usecases/config-as-code.md
@@ -121,6 +121,49 @@ decree config import "$TENANT_ID" "config/${ENV}.decree.config.yaml" \
   --description "deploy $(git rev-parse --short HEAD)"
 ```
 
+### Split-lifecycle deploys (seed form)
+
+When the schema ships with the **application** and each **tenant** provisions its own config at deploy time, use two seed files with different lifecycles:
+
+**`schema.seed.yaml`** — ships with the application binary, seeded once per release:
+
+```yaml
+spec_version: "v1"
+schema:
+  name: payments
+  fields:
+    payments.enabled: { type: bool }
+    payments.fee_rate: { type: number, constraints: { minimum: 0, maximum: 1 } }
+```
+
+```bash
+# App release pipeline
+decree seed schema.seed.yaml
+```
+
+**`org1.config.seed.yaml`** — ships with each tenant's deploy pipeline:
+
+```yaml
+spec_version: "v1"
+tenant:
+  name: org1
+  schema: payments
+  # schema_version omitted → latest published
+config:
+  values:
+    payments.enabled: { value: true }
+    payments.fee_rate: { value: 0.025 }
+```
+
+```bash
+# Tenant deploy pipeline
+decree seed org1.config.seed.yaml
+```
+
+The config file references the schema by name and defaults to the latest published version — no need to re-declare the schema in each tenant's pipeline. Pin explicitly with `tenant.schema_version: 3` if you need a specific version.
+
+Re-seeding the same file is a no-op: if the schema fields or config values match what's on the server, no new version is created.
+
 ## Import modes
 
 The `--mode` flag controls how YAML values interact with existing config:

--- a/examples/config.seed.yaml
+++ b/examples/config.seed.yaml
@@ -1,0 +1,21 @@
+spec_version: v1
+tenant:
+  name: acme-corp
+  schema: example-app
+  # schema_version omitted → latest published version of example-app is used.
+  # Pin explicitly with `schema_version: 3` to bind to a specific version.
+config:
+  description: Initial config for acme-corp
+  values:
+    app.name:
+      value: "Acme Corp App"
+    app.debug:
+      value: false
+    features.dark_mode:
+      value: true
+    server.rate_limit:
+      value: 100
+    payments.fee_rate:
+      value: 0.025
+    payments.currency:
+      value: "USD"

--- a/examples/schema.seed.yaml
+++ b/examples/schema.seed.yaml
@@ -1,0 +1,31 @@
+spec_version: v1
+schema:
+  name: example-app
+  description: Example application configuration schema
+  fields:
+    app.name:
+      type: string
+      description: Application display name
+    app.debug:
+      type: bool
+      description: Enable debug logging
+    features.dark_mode:
+      type: bool
+      description: Enable dark mode UI
+    server.rate_limit:
+      type: integer
+      description: Maximum requests per second
+      constraints:
+        minimum: 1
+        maximum: 10000
+    payments.fee_rate:
+      type: number
+      description: Transaction fee percentage (0-1)
+      constraints:
+        minimum: 0
+        maximum: 1
+    payments.currency:
+      type: string
+      description: Default currency code
+      constraints:
+        enum: [USD, EUR, GBP]

--- a/sdk/adminclient/client_test.go
+++ b/sdk/adminclient/client_test.go
@@ -417,3 +417,121 @@ func TestServiceNotConfigured(t *testing.T) {
 		t.Errorf("GetServerInfo: got error %v, want %v", err, ErrServiceNotConfigured)
 	}
 }
+
+func TestGetLatestPublishedSchemaVersion_LatestIsPublished(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{
+			Schemas: []*Schema{
+				{ID: "s_other", Name: "other", Version: 1, Published: true},
+				{ID: "s_payments", Name: "payments", Version: 3, Published: true},
+			},
+		}, nil
+	}
+
+	id, version, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "s_payments" || version != 3 {
+		t.Errorf("got %s@%d, want s_payments@3", id, version)
+	}
+}
+
+func TestGetLatestPublishedSchemaVersion_WalksBackFromDraft(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{
+			Schemas: []*Schema{{ID: "s1", Name: "payments", Version: 5, Published: false}},
+		}, nil
+	}
+	// v5 draft, v4 draft, v3 published.
+	ms.getSchemaFn = func(_ context.Context, id string, version *int32) (*Schema, error) {
+		if id != "s1" {
+			t.Errorf("unexpected id %q", id)
+		}
+		switch *version {
+		case 4:
+			return &Schema{ID: "s1", Version: 4, Published: false}, nil
+		case 3:
+			return &Schema{ID: "s1", Version: 3, Published: true}, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	id, version, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "s1" || version != 3 {
+		t.Errorf("got %s@%d, want s1@3", id, version)
+	}
+}
+
+func TestGetLatestPublishedSchemaVersion_NoPublishedVersion(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{
+			Schemas: []*Schema{{ID: "s1", Name: "payments", Version: 2, Published: false}},
+		}, nil
+	}
+	ms.getSchemaFn = func(_ context.Context, _ string, _ *int32) (*Schema, error) {
+		return &Schema{Published: false}, nil
+	}
+
+	_, _, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetLatestPublishedSchemaVersion_SchemaNameNotFound(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{Schemas: []*Schema{{ID: "s_other", Name: "other", Published: true}}}, nil
+	}
+
+	_, _, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetLatestPublishedSchemaVersion_ListError(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return nil, errors.New("rpc failed")
+	}
+
+	_, _, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if err == nil || !strings.Contains(err.Error(), "rpc failed") {
+		t.Errorf("expected rpc failed error, got %v", err)
+	}
+}
+
+func TestGetLatestPublishedSchemaVersion_GetSchemaVersionError(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{Schemas: []*Schema{{ID: "s1", Name: "payments", Version: 3, Published: false}}}, nil
+	}
+	ms.getSchemaFn = func(_ context.Context, _ string, _ *int32) (*Schema, error) {
+		return nil, errors.New("transport error")
+	}
+
+	_, _, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if err == nil || !strings.Contains(err.Error(), "transport error") {
+		t.Errorf("expected transport error, got %v", err)
+	}
+}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -108,3 +108,41 @@ func (c *Client) ImportSchema(ctx context.Context, yamlContent []byte, autoPubli
 	ap := len(autoPublish) > 0 && autoPublish[0]
 	return c.schema.ImportSchema(ctx, yamlContent, ap)
 }
+
+// GetLatestPublishedSchemaVersion finds the most recent published version of a schema by name.
+// Returns the schema ID and version number. If the latest version is a draft, walks
+// backward until it finds a published version.
+// Returns [ErrNotFound] if no schema with the given name exists, or if no version is published.
+func (c *Client) GetLatestPublishedSchemaVersion(ctx context.Context, name string) (id string, version int32, err error) {
+	if c.schema == nil {
+		return "", 0, ErrServiceNotConfigured
+	}
+	schemas, err := c.ListSchemas(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	var match *Schema
+	for _, s := range schemas {
+		if s.Name == name {
+			match = s
+			break
+		}
+	}
+	if match == nil {
+		return "", 0, ErrNotFound
+	}
+	if match.Published {
+		return match.ID, match.Version, nil
+	}
+	// Latest is a draft — walk back to find the newest published version.
+	for v := match.Version - 1; v >= 1; v-- {
+		s, err := c.GetSchemaVersion(ctx, match.ID, v)
+		if err != nil {
+			return "", 0, err
+		}
+		if s.Published {
+			return match.ID, v, nil
+		}
+	}
+	return "", 0, ErrNotFound
+}

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -1,7 +1,20 @@
-// Package seed bootstraps an OpenDecree environment from a single YAML file
-// containing a schema definition, tenant, configuration values, and optional
-// field locks. The operation is idempotent: existing schemas with identical
-// fields are skipped, existing tenants are reused, and config is merged.
+// Package seed bootstraps an OpenDecree environment from a single YAML file.
+// A seed file can contain any combination of schema, tenant, config, and locks
+// sections. The [Run] function dispatches based on which sections are present:
+//
+//   - schema only                  → ImportSchema
+//   - tenant only                  → CreateTenant (reuse if exists)
+//   - schema + tenant              → ImportSchema + CreateTenant
+//   - tenant + config (+ locks)    → CreateTenant + ImportConfig + LockField
+//   - schema + tenant + config     → all three (combined envelope, legacy form)
+//
+// In config-only mode, [TenantDef.Schema] references an already-imported schema
+// by name; if [TenantDef.SchemaVersion] is nil, the latest published version is
+// used.
+//
+// The operation is idempotent: importing a schema with identical fields, or a
+// config whose values match the latest version, is a no-op and does not create
+// a new version. Existing tenants are reused.
 //
 // The [File] type also serves as the shared YAML format for the dump package.
 package seed
@@ -19,10 +32,12 @@ import (
 // --- Seed/dump YAML format ---
 
 // File is the top-level YAML document for seed and dump operations.
+// Each of schema, tenant, and config is independently optional; see the package
+// docs for the valid combinations.
 type File struct {
 	SpecVersion string    `yaml:"spec_version"`
-	Schema      SchemaDef `yaml:"schema"`
-	Tenant      TenantDef `yaml:"tenant"`
+	Schema      SchemaDef `yaml:"schema,omitempty"`
+	Tenant      TenantDef `yaml:"tenant,omitempty"`
 	Config      ConfigDef `yaml:"config,omitempty"`
 	Locks       []LockDef `yaml:"locks,omitempty"`
 }
@@ -95,9 +110,17 @@ type ConstraintsDef struct {
 	JSONSchema       string   `yaml:"json_schema,omitempty"`
 }
 
-// TenantDef defines the tenant to create.
+// TenantDef defines the tenant to create or reuse.
+//
+// In combined mode (file also contains a schema section), Schema and
+// SchemaVersion are ignored — the tenant binds to the co-located schema.
+//
+// In config-only mode (no schema section), Schema names an already-imported
+// schema. If SchemaVersion is nil, the latest published version is used.
 type TenantDef struct {
-	Name string `yaml:"name"`
+	Name          string `yaml:"name"`
+	Schema        string `yaml:"schema,omitempty"`
+	SchemaVersion *int32 `yaml:"schema_version,omitempty"`
 }
 
 // ConfigDef defines initial configuration values.
@@ -125,15 +148,18 @@ type LockDef struct {
 type Client interface {
 	ImportSchema(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error)
 	ListSchemas(ctx context.Context) ([]*adminclient.Schema, error)
+	GetLatestPublishedSchemaVersion(ctx context.Context, name string) (string, int32, error)
 	ListTenants(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error)
 	CreateTenant(ctx context.Context, name, schemaID string, schemaVersion int32) (*adminclient.Tenant, error)
 	ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error)
+	ListConfigVersions(ctx context.Context, tenantID string) ([]*adminclient.Version, error)
 	LockField(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error
 }
 
 // --- Parse ---
 
-// ParseFile parses and validates a seed YAML file.
+// ParseFile parses and validates a seed YAML file. Validation depends on which
+// top-level sections are present; see the package docs for the valid shapes.
 func ParseFile(data []byte) (*File, error) {
 	var f File
 	if err := yaml.Unmarshal(data, &f); err != nil {
@@ -142,15 +168,39 @@ func ParseFile(data []byte) (*File, error) {
 	if f.SpecVersion != "v1" {
 		return nil, fmt.Errorf("unsupported spec_version: %q (expected \"v1\")", f.SpecVersion)
 	}
-	if f.Schema.Name == "" {
-		return nil, fmt.Errorf("schema.name is required")
+
+	hasSchema := f.Schema.Name != "" || len(f.Schema.Fields) > 0
+	hasTenant := f.Tenant.Name != ""
+	hasConfig := len(f.Config.Values) > 0
+	hasLocks := len(f.Locks) > 0
+
+	if !hasSchema && !hasTenant && !hasConfig && !hasLocks {
+		return nil, fmt.Errorf("seed file is empty — need at least one of schema, tenant, config, or locks")
 	}
-	if len(f.Schema.Fields) == 0 {
-		return nil, fmt.Errorf("schema.fields must have at least one field")
+
+	if hasSchema {
+		if f.Schema.Name == "" {
+			return nil, fmt.Errorf("schema.name is required when schema section is present")
+		}
+		if len(f.Schema.Fields) == 0 {
+			return nil, fmt.Errorf("schema.fields must have at least one field")
+		}
 	}
-	if f.Tenant.Name == "" {
-		return nil, fmt.Errorf("tenant.name is required")
+
+	if (hasConfig || hasLocks) && !hasTenant {
+		return nil, fmt.Errorf("config and locks require a tenant section")
 	}
+
+	if hasTenant {
+		if f.Tenant.Name == "" {
+			return nil, fmt.Errorf("tenant.name is required when tenant section is present")
+		}
+		// Config-only mode: tenant must name its schema.
+		if !hasSchema && f.Tenant.Schema == "" {
+			return nil, fmt.Errorf("tenant.schema is required when file has no schema section (config-only mode)")
+		}
+	}
+
 	return &f, nil
 }
 
@@ -186,8 +236,9 @@ func AutoPublish() Option {
 }
 
 // Run executes the seed operation against a live server.
-// It is idempotent: existing schemas with identical fields are skipped,
-// existing tenants are reused, and config uses merge mode.
+// It is idempotent: importing a schema with identical fields, or a config
+// whose values match the latest version, is a no-op and does not create
+// a new version. Existing tenants are reused.
 func Run(ctx context.Context, client Client, file *File, opts ...Option) (*Result, error) {
 	var o options
 	for _, opt := range opts {
@@ -196,86 +247,173 @@ func Run(ctx context.Context, client Client, file *File, opts ...Option) (*Resul
 
 	result := &Result{}
 
-	// 1. Import schema.
-	schemaYAML, err := marshalSchemaYAML(file)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling schema: %w", err)
-	}
+	hasSchema := file.Schema.Name != ""
+	hasTenant := file.Tenant.Name != ""
+	hasConfig := len(file.Config.Values) > 0
 
-	schema, err := client.ImportSchema(ctx, schemaYAML, o.autoPublish)
-	if err != nil {
-		if errors.Is(err, adminclient.ErrAlreadyExists) {
-			// Schema exists with identical fields — find it.
-			schemas, listErr := client.ListSchemas(ctx)
-			if listErr != nil {
-				return nil, fmt.Errorf("listing schemas: %w", listErr)
-			}
-			for _, s := range schemas {
-				if s.Name == file.Schema.Name {
-					result.SchemaID = s.ID
-					result.SchemaVersion = s.Version
-					break
-				}
-			}
-			if result.SchemaID == "" {
-				return nil, fmt.Errorf("schema %q reported as existing but not found", file.Schema.Name)
-			}
-		} else {
-			return nil, fmt.Errorf("importing schema: %w", err)
+	// 1. Resolve schema — either import it (schema section present) or look up
+	//    an existing one by name (config-only mode).
+	if hasSchema {
+		if err := importSchema(ctx, client, file, o, result); err != nil {
+			return nil, err
 		}
-	} else {
-		result.SchemaID = schema.ID
-		result.SchemaVersion = schema.Version
-		result.SchemaCreated = true
+	} else if hasTenant {
+		if err := resolveSchemaRef(ctx, client, file, result); err != nil {
+			return nil, err
+		}
 	}
 
 	// 2. Find or create tenant.
-	tenants, err := client.ListTenants(ctx, result.SchemaID)
-	if err != nil {
-		return nil, fmt.Errorf("listing tenants: %w", err)
-	}
-
-	for _, t := range tenants {
-		if t.Name == file.Tenant.Name {
-			result.TenantID = t.ID
-			break
+	if hasTenant {
+		if err := resolveTenant(ctx, client, file, result); err != nil {
+			return nil, err
 		}
 	}
 
-	if result.TenantID == "" {
-		tenant, err := client.CreateTenant(ctx, file.Tenant.Name, result.SchemaID, result.SchemaVersion)
-		if err != nil {
-			return nil, fmt.Errorf("creating tenant: %w", err)
+	// 3. Import config.
+	if hasConfig {
+		if err := importConfig(ctx, client, file, result); err != nil {
+			return nil, err
 		}
-		result.TenantID = tenant.ID
-		result.TenantCreated = true
-	}
-
-	// 3. Import config (if values provided).
-	if len(file.Config.Values) > 0 {
-		configYAML, err := marshalConfigYAML(file)
-		if err != nil {
-			return nil, fmt.Errorf("marshaling config: %w", err)
-		}
-
-		ver, err := client.ImportConfig(ctx, result.TenantID, configYAML, file.Config.Description, adminclient.ImportModeMerge)
-		if err != nil {
-			return nil, fmt.Errorf("importing config: %w", err)
-		}
-		result.ConfigVersion = ver.Version
-		result.ConfigImported = true
 	}
 
 	// 4. Apply locks.
 	for _, lock := range file.Locks {
-		err := client.LockField(ctx, result.TenantID, lock.FieldPath, lock.LockedValues...)
-		if err != nil {
+		if err := client.LockField(ctx, result.TenantID, lock.FieldPath, lock.LockedValues...); err != nil {
 			return nil, fmt.Errorf("locking field %s: %w", lock.FieldPath, err)
 		}
 		result.LocksApplied++
 	}
 
 	return result, nil
+}
+
+func importSchema(ctx context.Context, client Client, file *File, o options, result *Result) error {
+	schemaYAML, err := marshalSchemaYAML(file)
+	if err != nil {
+		return fmt.Errorf("marshaling schema: %w", err)
+	}
+
+	schema, err := client.ImportSchema(ctx, schemaYAML, o.autoPublish)
+	if err == nil {
+		result.SchemaID = schema.ID
+		result.SchemaVersion = schema.Version
+		result.SchemaCreated = true
+		return nil
+	}
+	if !errors.Is(err, adminclient.ErrAlreadyExists) {
+		return fmt.Errorf("importing schema: %w", err)
+	}
+	// Fields identical to latest version — look up the existing schema.
+	schemas, listErr := client.ListSchemas(ctx)
+	if listErr != nil {
+		return fmt.Errorf("listing schemas: %w", listErr)
+	}
+	for _, s := range schemas {
+		if s.Name == file.Schema.Name {
+			result.SchemaID = s.ID
+			result.SchemaVersion = s.Version
+			return nil
+		}
+	}
+	return fmt.Errorf("schema %q reported as existing but not found", file.Schema.Name)
+}
+
+// resolveSchemaRef looks up an existing schema by the reference in tenant.schema.
+// Uses tenant.schema_version if set, otherwise resolves the latest published version.
+func resolveSchemaRef(ctx context.Context, client Client, file *File, result *Result) error {
+	if file.Tenant.SchemaVersion != nil {
+		schemas, err := client.ListSchemas(ctx)
+		if err != nil {
+			return fmt.Errorf("listing schemas: %w", err)
+		}
+		for _, s := range schemas {
+			if s.Name == file.Tenant.Schema {
+				result.SchemaID = s.ID
+				result.SchemaVersion = *file.Tenant.SchemaVersion
+				return nil
+			}
+		}
+		return fmt.Errorf("schema %q not found", file.Tenant.Schema)
+	}
+	id, version, err := client.GetLatestPublishedSchemaVersion(ctx, file.Tenant.Schema)
+	if err != nil {
+		if errors.Is(err, adminclient.ErrNotFound) {
+			return fmt.Errorf("no published version of schema %q found", file.Tenant.Schema)
+		}
+		return fmt.Errorf("resolving schema %q: %w", file.Tenant.Schema, err)
+	}
+	result.SchemaID = id
+	result.SchemaVersion = version
+	return nil
+}
+
+func resolveTenant(ctx context.Context, client Client, file *File, result *Result) error {
+	tenants, err := client.ListTenants(ctx, result.SchemaID)
+	if err != nil {
+		return fmt.Errorf("listing tenants: %w", err)
+	}
+	for _, t := range tenants {
+		if t.Name == file.Tenant.Name {
+			result.TenantID = t.ID
+			return nil
+		}
+	}
+	// Tenant not found under this schema. In config-only mode, check if the
+	// tenant exists under a different schema and fail cleanly rather than
+	// silently creating a duplicate.
+	if file.Schema.Name == "" {
+		allSchemas, err := client.ListSchemas(ctx)
+		if err == nil {
+			for _, s := range allSchemas {
+				if s.ID == result.SchemaID {
+					continue
+				}
+				others, _ := client.ListTenants(ctx, s.ID)
+				for _, t := range others {
+					if t.Name == file.Tenant.Name {
+						return fmt.Errorf("tenant %q is bound to schema %q, not %q", t.Name, s.Name, file.Tenant.Schema)
+					}
+				}
+			}
+		}
+	}
+	tenant, err := client.CreateTenant(ctx, file.Tenant.Name, result.SchemaID, result.SchemaVersion)
+	if err != nil {
+		return fmt.Errorf("creating tenant: %w", err)
+	}
+	result.TenantID = tenant.ID
+	result.TenantCreated = true
+	return nil
+}
+
+func importConfig(ctx context.Context, client Client, file *File, result *Result) error {
+	configYAML, err := marshalConfigYAML(file)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+	ver, err := client.ImportConfig(ctx, result.TenantID, configYAML, file.Config.Description, adminclient.ImportModeMerge)
+	if err == nil {
+		result.ConfigVersion = ver.Version
+		result.ConfigImported = true
+		return nil
+	}
+	if !errors.Is(err, adminclient.ErrAlreadyExists) {
+		return fmt.Errorf("importing config: %w", err)
+	}
+	// Values match the latest version — report the existing version, no import.
+	versions, listErr := client.ListConfigVersions(ctx, result.TenantID)
+	if listErr != nil {
+		return fmt.Errorf("listing config versions: %w", listErr)
+	}
+	var latest int32
+	for _, v := range versions {
+		if v.Version > latest {
+			latest = v.Version
+		}
+	}
+	result.ConfigVersion = latest
+	return nil
 }
 
 // --- Internal helpers to marshal sub-documents ---

--- a/sdk/tools/seed/seed_test.go
+++ b/sdk/tools/seed/seed_test.go
@@ -3,6 +3,7 @@ package seed
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/opendecree/decree/sdk/adminclient"
@@ -11,12 +12,14 @@ import (
 // --- Mock client ---
 
 type mockClient struct {
-	importSchemaFn func(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error)
-	listSchemasFn  func(ctx context.Context) ([]*adminclient.Schema, error)
-	listTenantsFn  func(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error)
-	createTenantFn func(ctx context.Context, name, schemaID string, schemaVersion int32) (*adminclient.Tenant, error)
-	importConfigFn func(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error)
-	lockFieldFn    func(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error
+	importSchemaFn                    func(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error)
+	listSchemasFn                     func(ctx context.Context) ([]*adminclient.Schema, error)
+	getLatestPublishedSchemaVersionFn func(ctx context.Context, name string) (string, int32, error)
+	listTenantsFn                     func(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error)
+	createTenantFn                    func(ctx context.Context, name, schemaID string, schemaVersion int32) (*adminclient.Tenant, error)
+	importConfigFn                    func(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error)
+	listConfigVersionsFn              func(ctx context.Context, tenantID string) ([]*adminclient.Version, error)
+	lockFieldFn                       func(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error
 }
 
 func (m *mockClient) ImportSchema(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error) {
@@ -25,6 +28,10 @@ func (m *mockClient) ImportSchema(ctx context.Context, yamlContent []byte, autoP
 
 func (m *mockClient) ListSchemas(ctx context.Context) ([]*adminclient.Schema, error) {
 	return m.listSchemasFn(ctx)
+}
+
+func (m *mockClient) GetLatestPublishedSchemaVersion(ctx context.Context, name string) (string, int32, error) {
+	return m.getLatestPublishedSchemaVersionFn(ctx, name)
 }
 
 func (m *mockClient) ListTenants(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error) {
@@ -37,6 +44,10 @@ func (m *mockClient) CreateTenant(ctx context.Context, name, schemaID string, sc
 
 func (m *mockClient) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error) {
 	return m.importConfigFn(ctx, tenantID, yamlContent, description, mode...)
+}
+
+func (m *mockClient) ListConfigVersions(ctx context.Context, tenantID string) ([]*adminclient.Version, error) {
+	return m.listConfigVersionsFn(ctx, tenantID)
 }
 
 func (m *mockClient) LockField(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error {
@@ -154,14 +165,19 @@ schema:
   fields: {}
 tenant:
   name: t`},
-		{"no tenant name", `spec_version: "v1"
-schema:
-  name: test
-  fields:
-    a:
-      type: string
+		{"empty file", `spec_version: "v1"`},
+		{"config without tenant", `spec_version: "v1"
+config:
+  values:
+    x:
+      value: 1`},
+		{"config-only missing schema ref", `spec_version: "v1"
 tenant:
-  name: ""`},
+  name: t
+config:
+  values:
+    x:
+      value: 1`},
 	}
 
 	for _, tt := range tests {
@@ -539,5 +555,621 @@ func TestRun_LockFieldError(t *testing.T) {
 	_, err := Run(context.Background(), mock, file)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// --- ParseFile: decoupled modes ---
+
+func TestParseFile_SchemaOnly(t *testing.T) {
+	data := `spec_version: "v1"
+schema:
+  name: payments
+  fields:
+    rate:
+      type: number
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Schema.Name != "payments" || f.Tenant.Name != "" || len(f.Config.Values) != 0 {
+		t.Errorf("schema-only parsed incorrectly: %+v", f)
+	}
+}
+
+func TestParseFile_ConfigOnly_SchemaVersionOmitted(t *testing.T) {
+	data := `spec_version: "v1"
+tenant:
+  name: org1
+  schema: payments
+config:
+  values:
+    rate:
+      value: 42
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Tenant.Schema != "payments" {
+		t.Errorf("tenant.schema = %q", f.Tenant.Schema)
+	}
+	if f.Tenant.SchemaVersion != nil {
+		t.Errorf("expected schema_version nil (latest), got %d", *f.Tenant.SchemaVersion)
+	}
+}
+
+func TestParseFile_ConfigOnly_SchemaVersionExplicit(t *testing.T) {
+	data := `spec_version: "v1"
+tenant:
+  name: org1
+  schema: payments
+  schema_version: 3
+config:
+  values:
+    rate:
+      value: 42
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Tenant.SchemaVersion == nil || *f.Tenant.SchemaVersion != 3 {
+		t.Errorf("schema_version = %v, want 3", f.Tenant.SchemaVersion)
+	}
+}
+
+// --- Run: schema-only mode ---
+
+func TestRun_SchemaOnly(t *testing.T) {
+	file := &File{
+		SpecVersion: "v1",
+		Schema: SchemaDef{
+			Name:   "payments",
+			Fields: map[string]FieldDef{"rate": {Type: "number"}},
+		},
+	}
+	var importConfigCalled, createTenantCalled bool
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return &adminclient.Schema{ID: "s1", Version: 1}, nil
+		},
+		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
+			createTenantCalled = true
+			return nil, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			importConfigCalled = true
+			return nil, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.SchemaCreated || result.SchemaID != "s1" {
+		t.Errorf("expected schema created, got %+v", result)
+	}
+	if result.TenantID != "" || createTenantCalled {
+		t.Error("tenant should not be touched in schema-only mode")
+	}
+	if result.ConfigImported || importConfigCalled {
+		t.Error("config should not be touched in schema-only mode")
+	}
+}
+
+// --- Run: config-only mode ---
+
+func configOnlyFile(schemaVersion *int32) *File {
+	return &File{
+		SpecVersion: "v1",
+		Tenant: TenantDef{
+			Name:          "org1",
+			Schema:        "payments",
+			SchemaVersion: schemaVersion,
+		},
+		Config: ConfigDef{
+			Values: map[string]ConfigValueDef{"rate": {Value: 42}},
+		},
+	}
+}
+
+func TestRun_ConfigOnly_LatestPublished(t *testing.T) {
+	file := configOnlyFile(nil)
+	var resolvedName string
+	var importSchemaCalled bool
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			importSchemaCalled = true
+			return nil, nil
+		},
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, name string) (string, int32, error) {
+			resolvedName = name
+			return "s1", 5, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "org1"}}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return &adminclient.Version{Version: 2}, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if importSchemaCalled {
+		t.Error("ImportSchema should not be called in config-only mode")
+	}
+	if resolvedName != "payments" {
+		t.Errorf("resolved schema name = %q", resolvedName)
+	}
+	if result.SchemaID != "s1" || result.SchemaVersion != 5 {
+		t.Errorf("expected s1@5, got %s@%d", result.SchemaID, result.SchemaVersion)
+	}
+	if result.TenantID != "t1" || result.TenantCreated {
+		t.Errorf("expected reused tenant t1, got %+v", result)
+	}
+	if !result.ConfigImported || result.ConfigVersion != 2 {
+		t.Errorf("expected config v2, got %+v", result)
+	}
+}
+
+func TestRun_ConfigOnly_ExplicitVersion(t *testing.T) {
+	v := int32(3)
+	file := configOnlyFile(&v)
+	var getLatestCalled bool
+	mock := &mockClient{
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{{ID: "s1", Name: "payments", Version: 5}}, nil
+		},
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			getLatestCalled = true
+			return "", 0, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return nil, nil
+		},
+		createTenantFn: func(_ context.Context, _, _ string, schemaVersion int32) (*adminclient.Tenant, error) {
+			if schemaVersion != 3 {
+				t.Errorf("CreateTenant called with schema_version=%d, want 3", schemaVersion)
+			}
+			return &adminclient.Tenant{ID: "t1"}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return &adminclient.Version{Version: 1}, nil
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if getLatestCalled {
+		t.Error("GetLatestPublishedSchemaVersion should not be called when schema_version is explicit")
+	}
+}
+
+func TestRun_ConfigOnly_NoPublishedVersion(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "", 0, adminclient.ErrNotFound
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil {
+		t.Fatal("expected error when no published schema version")
+	}
+}
+
+func TestRun_ConfigOnly_SchemaMismatch(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s_payments", 1, nil
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{
+				{ID: "s_payments", Name: "payments"},
+				{ID: "s_billing", Name: "billing"},
+			}, nil
+		},
+		listTenantsFn: func(_ context.Context, schemaID string) ([]*adminclient.Tenant, error) {
+			if schemaID == "s_billing" {
+				return []*adminclient.Tenant{{ID: "t_existing", Name: "org1"}}, nil
+			}
+			return nil, nil
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil {
+		t.Fatal("expected schema-mismatch error")
+	}
+}
+
+// --- Run: idempotency ---
+
+func TestRun_SchemaReseed_NoNewVersion(t *testing.T) {
+	file := testFile()
+	file.Config.Values = nil
+	file.Locks = nil
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return nil, adminclient.ErrAlreadyExists
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{{ID: "s1", Name: "test-schema", Version: 4}}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SchemaCreated {
+		t.Error("schema was re-created — expected no new version")
+	}
+	if result.SchemaVersion != 4 {
+		t.Errorf("expected existing version 4, got %d", result.SchemaVersion)
+	}
+}
+
+func TestRun_ConfigReseed_NoNewVersion(t *testing.T) {
+	file := testFile()
+	file.Locks = nil
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return &adminclient.Schema{ID: "s1", Version: 1}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return nil, adminclient.ErrAlreadyExists
+		},
+		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {
+			return []*adminclient.Version{{Version: 7}, {Version: 6}}, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatalf("re-seed with identical config should not error, got: %v", err)
+	}
+	if result.ConfigImported {
+		t.Error("config was imported — expected no new version")
+	}
+	if result.ConfigVersion != 7 {
+		t.Errorf("expected existing version 7, got %d", result.ConfigVersion)
+	}
+}
+
+func TestRun_FullNoOpReseed(t *testing.T) {
+	file := testFile()
+	file.Locks = nil
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return nil, adminclient.ErrAlreadyExists
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{{ID: "s1", Name: "test-schema", Version: 2}}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return nil, adminclient.ErrAlreadyExists
+		},
+		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {
+			return []*adminclient.Version{{Version: 3}}, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SchemaCreated || result.TenantCreated || result.ConfigImported {
+		t.Errorf("expected fully no-op re-seed, got %+v", result)
+	}
+}
+
+// --- ParseFile / Run: remaining modes ---
+
+func TestParseFile_SchemaAndTenant(t *testing.T) {
+	data := `spec_version: "v1"
+schema:
+  name: payments
+  fields:
+    rate:
+      type: number
+tenant:
+  name: org1
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Schema.Name != "payments" || f.Tenant.Name != "org1" || len(f.Config.Values) != 0 {
+		t.Errorf("schema+tenant parsed incorrectly: %+v", f)
+	}
+}
+
+func TestParseFile_TenantOnly(t *testing.T) {
+	data := `spec_version: "v1"
+tenant:
+  name: org1
+  schema: payments
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Tenant.Name != "org1" || f.Tenant.Schema != "payments" {
+		t.Errorf("tenant-only parsed incorrectly: %+v", f)
+	}
+}
+
+func TestParseFile_LocksWithoutTenant(t *testing.T) {
+	data := `spec_version: "v1"
+locks:
+  - field_path: a
+`
+	if _, err := ParseFile([]byte(data)); err == nil {
+		t.Fatal("expected error for locks without tenant")
+	}
+}
+
+func TestRun_SchemaAndTenant(t *testing.T) {
+	file := &File{
+		SpecVersion: "v1",
+		Schema: SchemaDef{
+			Name:   "payments",
+			Fields: map[string]FieldDef{"rate": {Type: "number"}},
+		},
+		Tenant: TenantDef{Name: "org1"},
+	}
+	var importConfigCalled bool
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return &adminclient.Schema{ID: "s1", Version: 1}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return nil, nil
+		},
+		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
+			return &adminclient.Tenant{ID: "t1"}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			importConfigCalled = true
+			return nil, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.SchemaCreated || !result.TenantCreated {
+		t.Errorf("expected schema + tenant created, got %+v", result)
+	}
+	if importConfigCalled || result.ConfigImported {
+		t.Error("ImportConfig should not be called when no config section")
+	}
+}
+
+func TestRun_TenantOnly(t *testing.T) {
+	file := &File{
+		SpecVersion: "v1",
+		Tenant:      TenantDef{Name: "org1", Schema: "payments"},
+	}
+	var importSchemaCalled, importConfigCalled bool
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			importSchemaCalled = true
+			return nil, nil
+		},
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s1", 2, nil
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{{ID: "s1", Name: "payments"}}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return nil, nil
+		},
+		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
+			return &adminclient.Tenant{ID: "t1"}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			importConfigCalled = true
+			return nil, nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if importSchemaCalled {
+		t.Error("ImportSchema should not be called in tenant-only mode")
+	}
+	if !result.TenantCreated {
+		t.Error("expected tenant created")
+	}
+	if importConfigCalled {
+		t.Error("ImportConfig should not be called in tenant-only mode")
+	}
+}
+
+// --- Mismatch error-message content + config-only + locks ---
+
+func TestRun_ConfigOnly_SchemaMismatch_ErrorMessage(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s_payments", 1, nil
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{
+				{ID: "s_payments", Name: "payments"},
+				{ID: "s_billing", Name: "billing"},
+			}, nil
+		},
+		listTenantsFn: func(_ context.Context, schemaID string) ([]*adminclient.Tenant, error) {
+			if schemaID == "s_billing" {
+				return []*adminclient.Tenant{{ID: "t_existing", Name: "org1"}}, nil
+			}
+			return nil, nil
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"org1", "billing", "payments"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestRun_ConfigOnly_WithLocks(t *testing.T) {
+	file := configOnlyFile(nil)
+	file.Locks = []LockDef{
+		{FieldPath: "rate", LockedValues: []string{"42"}},
+	}
+	var lockedTenantID, lockedPath string
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s1", 1, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "org1"}}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return &adminclient.Version{Version: 1}, nil
+		},
+		lockFieldFn: func(_ context.Context, tenantID, fieldPath string, _ ...string) error {
+			lockedTenantID, lockedPath = tenantID, fieldPath
+			return nil
+		},
+	}
+	result, err := Run(context.Background(), mock, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lockedTenantID != "t1" || lockedPath != "rate" {
+		t.Errorf("LockField called with (%q, %q); want (t1, rate)", lockedTenantID, lockedPath)
+	}
+	if result.LocksApplied != 1 {
+		t.Errorf("LocksApplied = %d, want 1", result.LocksApplied)
+	}
+}
+
+// --- Round-trip: TenantDef.SchemaVersion pointer ---
+
+func TestMarshal_TenantSchemaVersionOmitEmpty(t *testing.T) {
+	f := &File{
+		SpecVersion: "v1",
+		Tenant:      TenantDef{Name: "org1", Schema: "payments"},
+		Config:      ConfigDef{Values: map[string]ConfigValueDef{"rate": {Value: 1}}},
+	}
+	data, err := Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "schema_version") {
+		t.Errorf("nil SchemaVersion should not appear in YAML; got:\n%s", data)
+	}
+	f2, err := ParseFile(data)
+	if err != nil {
+		t.Fatalf("re-parse failed: %v", err)
+	}
+	if f2.Tenant.SchemaVersion != nil {
+		t.Errorf("expected SchemaVersion nil after round-trip, got %d", *f2.Tenant.SchemaVersion)
+	}
+}
+
+func TestMarshal_TenantSchemaVersionRoundTrip(t *testing.T) {
+	v := int32(3)
+	f := &File{
+		SpecVersion: "v1",
+		Tenant:      TenantDef{Name: "org1", Schema: "payments", SchemaVersion: &v},
+		Config:      ConfigDef{Values: map[string]ConfigValueDef{"rate": {Value: 1}}},
+	}
+	data, err := Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := ParseFile(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f2.Tenant.SchemaVersion == nil || *f2.Tenant.SchemaVersion != 3 {
+		t.Errorf("SchemaVersion round-trip lost value: got %v", f2.Tenant.SchemaVersion)
+	}
+}
+
+func TestRun_ConfigOnly_ExplicitVersion_SchemaNotFound(t *testing.T) {
+	v := int32(3)
+	file := configOnlyFile(&v)
+	mock := &mockClient{
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{{ID: "s1", Name: "other"}}, nil
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil {
+		t.Fatal("expected error when schema name not found")
+	}
+}
+
+func TestRun_ConfigOnly_ExplicitVersion_ListSchemasError(t *testing.T) {
+	v := int32(3)
+	file := configOnlyFile(&v)
+	mock := &mockClient{
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return nil, fmt.Errorf("rpc down")
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil || !strings.Contains(err.Error(), "rpc down") {
+		t.Fatalf("expected rpc down error, got %v", err)
+	}
+}
+
+func TestRun_ConfigOnly_LatestPublished_GenericError(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "", 0, fmt.Errorf("transport error")
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil || !strings.Contains(err.Error(), "transport error") {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+}
+
+func TestRun_ConfigReseed_ListConfigVersionsError(t *testing.T) {
+	file := testFile()
+	file.Locks = nil
+	mock := &mockClient{
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+			return &adminclient.Schema{ID: "s1", Version: 1}, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
+		},
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+			return nil, adminclient.ErrAlreadyExists
+		},
+		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {
+			return nil, fmt.Errorf("db down")
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil || !strings.Contains(err.Error(), "db down") {
+		t.Fatalf("expected db down error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- `decree seed <file>` now dispatches on which sections the file contains (schema-only / tenant-only / schema+tenant / tenant+config+locks / combined)
- Config-only files bind to an existing schema via `tenant.schema` (name reference); `tenant.schema_version` is optional — when omitted, the latest published version is resolved client-side
- Config re-seed is now idempotent: `ImportConfig` returning `codes.AlreadyExists` is treated as a skip and the existing version number is reported instead of erroring
- Tenant-schema mismatches in config-only mode surface a clear error rather than silently re-binding

## Dispatch table

| Schema | Tenant | Config | Mode | Action |
|---|---|---|---|---|
| ✓ | ✗ | ✗ | schema-only | \`ImportSchema\` |
| ✗ | ✓ | ✗ | tenant-only | \`CreateTenant\` (reuse if exists) |
| ✓ | ✓ | ✗ | schema+tenant | \`ImportSchema\` + \`CreateTenant\` |
| ✗ | ✓ | ✓ | config-only | resolve schema → \`CreateTenant\` + \`ImportConfig\` + \`LockField\` |
| ✓ | ✓ | ✓ | combined | current behavior, unchanged |

## Design

See [\`.agents/context/seed-decoupling.md\`](../blob/main/.agents/context/seed-decoupling.md) (merged in #141).

## Acceptance (from #140)

- [x] All five dispatch modes work end-to-end (covered by unit tests with mocked client)
- [x] \`tenant.schema_version\` omitted resolves to latest **published** version
- [x] Combined envelope still works byte-for-byte identically (existing tests still pass)
- [x] Test coverage for every row in the dispatch table + idempotency + mismatch
- [x] \`docs/cli/decree_seed.md\` documents all modes
- [x] \`examples/schema.seed.yaml\` + \`examples/config.seed.yaml\` added

## Breaking?

\`feat!\` in the commit subject but the combined envelope is fully preserved. The bang flags that \`File.Schema\` is now \`omitempty\` and \`TenantDef\` gained two fields — API-additive for callers of the seed package. No user-visible CLI break.

## Test plan

- [x] \`make test\` — full suite green locally
- [x] \`make lint\` — 0 issues
- [ ] CI green
- [ ] Manual smoke: re-seed the existing \`examples/seed.yaml\` twice, confirm second run reports no new schema/config versions
- [ ] Manual smoke: \`decree seed examples/schema.seed.yaml\` then \`decree seed examples/config.seed.yaml\` against a live server

Closes #140