### PR TITLE
docs(context): archive seed decoupling effort (#137, #140)

### DIFF
--- a/.agents/context/completed.md
+++ b/.agents/context/completed.md
@@ -127,3 +127,7 @@ New Claude Code skills: `/before-pr` (PR checklist), `/merge` (merge + cleanup),
 ## Cross-Repo Alignment
 
 Labels aligned across decree, decree-python, decree-typescript, decree-ui (14 common labels, size S/M/L with descriptions). `admin-gui` label renamed to `decree-ui`. Project auto-add workflow (`project.yml`) added to all 4 repos — new issues/PRs auto-appear on OpenDecree Roadmap board. Admin GUI issues #131, #128, #126 moved from decree to decree-ui. CI improvement issues created (12 total: hardening, performance, readability × 4 repos).
+
+## Seed Decoupling (#137, #140)
+
+`decree seed <file>` dispatches on which top-level sections are present (schema-only / tenant-only / schema+tenant / config-only / combined). Config-only files name the target schema via `tenant.schema`; `tenant.schema_version` omitted → latest published version resolved client-side via new `adminclient.GetLatestPublishedSchemaVersion` (walks backward past drafts). Re-seeding identical content is now a no-op on both axes — `ImportConfig` returning `AlreadyExists` is treated as a skip instead of erroring. Tenant-schema mismatches in config-only mode error out rather than silently re-binding. Combined envelope preserved byte-for-byte. Design brief: `.agents/context/seed-decoupling.md`.


### PR DESCRIPTION
## Summary

- Archive the seed decoupling effort in \`.agents/context/completed.md\`
- One-paragraph entry pointing at the design brief (\`.agents/context/seed-decoupling.md\`) and the two issues (#137 discovery, #140 impl)

## Test plan

- [x] No code changes — docs only
- [ ] CI green