### PR TITLE
docs: add pkg.go.dev badge + SDK package docs (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://github.com/opendecree/decree/actions/workflows/ci.yml"><img src="https://github.com/opendecree/decree/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/opendecree/decree/releases"><img src="https://img.shields.io/github/v/release/opendecree/decree?include_prereleases" alt="Release"></a>
   <a href="https://go.dev/"><img src="https://img.shields.io/badge/Go-1.22+-00ADD8?logo=go" alt="Go"></a>
+  <a href="https://pkg.go.dev/github.com/opendecree/decree"><img src="https://pkg.go.dev/badge/github.com/opendecree/decree.svg" alt="Go Reference"></a>
   <a href="https://goreportcard.com/report/github.com/opendecree/decree"><img src="https://goreportcard.com/badge/github.com/opendecree/decree" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
 </p>
@@ -85,6 +86,13 @@ go get github.com/opendecree/decree/sdk/adminclient@latest    # admin operations
 go get github.com/opendecree/decree/sdk/configwatcher@latest  # live config watcher
 go get github.com/opendecree/decree/sdk/tools@latest          # diff, docgen, validate, seed, dump
 ```
+
+Go API docs on pkg.go.dev:
+[grpctransport](https://pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport) ·
+[configclient](https://pkg.go.dev/github.com/opendecree/decree/sdk/configclient) ·
+[adminclient](https://pkg.go.dev/github.com/opendecree/decree/sdk/adminclient) ·
+[configwatcher](https://pkg.go.dev/github.com/opendecree/decree/sdk/configwatcher) ·
+[tools](https://pkg.go.dev/github.com/opendecree/decree/sdk/tools)
 
 ### Python
 

--- a/sdk/configclient/client.go
+++ b/sdk/configclient/client.go
@@ -1,3 +1,11 @@
+// Package configclient provides an ergonomic Go client for reading and
+// writing OpenDecree configuration values at application runtime.
+//
+// The client wraps a pluggable [Transport] (see the sibling grpctransport
+// module for the gRPC implementation) with typed accessors and optimistic
+// concurrency helpers. For administrative operations such as schema and
+// tenant management, see the adminclient package. For a live, auto-refreshing
+// view over configuration, see configwatcher.
 package configclient
 
 // Client wraps a [Transport] with an ergonomic API for reading and writing

--- a/sdk/grpctransport/doc.go
+++ b/sdk/grpctransport/doc.go
@@ -1,0 +1,12 @@
+// Package grpctransport provides gRPC [Transport] implementations for the
+// OpenDecree SDK clients (configclient, adminclient) and a gRPC-backed
+// [configwatcher.Watcher].
+//
+// Convenience constructors [NewConfigClient], [NewAdminClient], and
+// [NewWatcher] wire a [grpc.ClientConnInterface] directly to the high-level
+// SDK types. Lower-level transport types (ConfigTransport, SchemaTransport,
+// AuditTransport, ServerTransport, AdminConfigTransport) are available for
+// custom wiring.
+//
+// This module pins Go 1.24 because google.golang.org/grpc does.
+package grpctransport


### PR DESCRIPTION
## Summary

Closes #163.

- README: add pkg.go.dev Go Reference badge to header; add per-submodule pkg.go.dev links under the Go install block (grpctransport, configclient, adminclient, configwatcher, tools).
- `sdk/configclient`: add missing package doc so godoc renders on pkg.go.dev.
- `sdk/grpctransport`: add `doc.go` with package overview.

Go Report Card badge was already present. Verified all tagged main-module versions (`v0.5.0` → `v0.9.0-alpha.1`) + SDK submodules are indexed on pkg.go.dev. Triggered fetch for `sdk/grpctransport`, which had never been requested.

## Follow-up (out of scope, flagging here)

`sdk/grpctransport` has **no semver tags** — peer SDK submodules (configclient, adminclient, configwatcher, tools) are all tagged per release but grpctransport is not. `go get .../grpctransport@latest` therefore resolves to a pseudo-version. Likely a release-process gap — will file separately.

## Test plan

- [x] `make test` — all green
- [x] `make lint` — 0 issues
- [ ] Verify pkg.go.dev badge renders in rendered README on PR