### PR TITLE
fix(release): tag sdk/grpctransport alongside peer SDK submodules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           go install golang.org/x/exp/cmd/apidiff@latest
           NOTES=""
-          for mod in sdk/configclient sdk/adminclient sdk/configwatcher sdk/tools; do
+          for mod in sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools; do
             MOD_TAG="${mod}/$(echo $GITHUB_REF_NAME)"
             PREV_TAG="${mod}/${{ steps.prev.outputs.tag }}"
             # Check if both tags exist
@@ -128,8 +128,8 @@ jobs:
           # CLI
           go install github.com/opendecree/decree/cmd/decree@${TAG}
 
-          # SDK
-          go get github.com/opendecree/decree/sdk/configclient@${TAG}
+          # SDK (grpctransport pulls in configclient + configwatcher)
+          go get github.com/opendecree/decree/sdk/grpctransport@${TAG}
           go get github.com/opendecree/decree/sdk/adminclient@${TAG}
 
           # Docker

--- a/docs/development/checklists.md
+++ b/docs/development/checklists.md
@@ -64,6 +64,7 @@ Standard development workflow checklists.
    git tag -a sdk/configclient/v{X.Y.Z} -m "sdk/configclient v{X.Y.Z}"
    git tag -a sdk/adminclient/v{X.Y.Z} -m "sdk/adminclient v{X.Y.Z}"
    git tag -a sdk/configwatcher/v{X.Y.Z} -m "sdk/configwatcher v{X.Y.Z}"
+   git tag -a sdk/grpctransport/v{X.Y.Z} -m "sdk/grpctransport v{X.Y.Z}"
    git tag -a sdk/tools/v{X.Y.Z} -m "sdk/tools v{X.Y.Z}"
    git tag -a cmd/decree/v{X.Y.Z} -m "cmd/decree v{X.Y.Z}"
    ```


### PR DESCRIPTION
## Summary

Closes #165.

- Release process omitted `sdk/grpctransport` from the per-module tag list, so `go get .../sdk/grpctransport@latest` resolved to a pseudo-version instead of a stable semver — README recommends grpctransport as the default transport, so users hit this first.
- Update `docs/development/checklists.md` tag list + `.github/workflows/release.yml` apidiff loop + release-notes install block to include grpctransport.

Follow-ups (separate PRs/tasks):
- Org-level `.github/RELEASING.md` has the same omission.
- Backfill `sdk/grpctransport/v{X.Y.Z}` tags for past releases (v0.5.0 → v0.9.0-alpha.1) — pending user decision on scope.

## Test plan

- [x] `make pre-commit` — all green
- [x] `make lint-proto` — clean
- [ ] Next release (post-merge) produces `sdk/grpctransport/v{X.Y.Z}` tag and pkg.go.dev reflects a semver version