### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - /
+      - /api
+      - /cmd/decree
+      - /e2e
+      - /sdk/configclient
+      - /sdk/adminclient
+      - /sdk/configwatcher
+      - /sdk/grpctransport
+      - /sdk/tools
+      - /examples/quickstart
+      - /examples/setup
+      - /examples/schema-lifecycle
+      - /examples/feature-flags
+      - /examples/config-validation
+      - /examples/multi-tenant
+      - /examples/live-config
+      - /examples/environment-bootstrap
+      - /examples/optimistic-concurrency
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /build
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Enable weekly Dependabot version bump PRs across all ecosystems
- 18 Go modules covered (root + api + cmd/decree + e2e + 5 sdk + 9 examples)
- `github-actions` (root), `docker` (`/build` — 3 Dockerfiles)
- Minor + patch grouped per ecosystem; majors stay separate
- `open-pull-requests-limit: 5` per ecosystem; labels `dependencies`, `ci`

## Notes
- Issue says "8 modules" but actual count is 18; included all of them
- No `ignore` rules upfront for SDK Go-1.22 pin — will react if Dependabot proposes a Go-incompatible bump

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the file
- [ ] After merge: confirm Dependabot picks up config (Insights → Dependency graph → Dependabot)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)