### PR TITLE
chore(go): hold CLI + SDK transport at Go 1.24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # grpc-gateway 2.29+ requires Go 1.25; we hold the SDK transport floor at 1.24.
+      - dependency-name: "github.com/grpc-ecosystem/grpc-gateway/v2"
+        versions: [">=2.29.0"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Schema-driven business configuration management service. Multi-tenant, gRPC API,
 
 | Concern | Tool | Version |
 |---------|------|---------|
-| Language | Go | 1.25 (server/CLI), 1.22 (SDK) |
+| Language | Go | 1.25 (server), 1.24 (CLI + SDK transport), 1.22 (SDK core) |
 | API | gRPC (Protocol Buffers) | — |
 | Proto tooling | buf (local plugins) | v1.66.1 |
 | DB | PostgreSQL | 17 |
@@ -100,6 +100,6 @@ Single Go binary, three gRPC services (SchemaService, ConfigService, AuditServic
 ### Go version policy
 
 - **Server (root module)** — Go 1.25+ (our build environment)
-- **CLI (`cmd/decree`)** — Go 1.25+ (standalone binary, no SDK consumers)
+- **CLI (`cmd/decree`)** — Go 1.24 (matches the SDK transport floor; users installing via `go install` may be on the same version as their SDK consumers)
 - **SDK core modules** (configclient, adminclient, configwatcher) — Go 1.22 (lowest stable common ground for consumers who install the SDK)
 - **`api`, `sdk/tools`, `sdk/grpctransport`** — Go 1.24 (downstream of the gRPC pin on grpctransport; api is consumed by grpctransport and sdk/tools depends on api)

--- a/cmd/decree/go.mod
+++ b/cmd/decree/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendecree/decree/cmd/decree
 
-go 1.25.0
+go 1.24.0
 
 require (
 	github.com/opendecree/decree/api v0.1.2


### PR DESCRIPTION
## Summary

- Pin `cmd/decree/go.mod` back to `go 1.24.0` (was 1.25.0)
- Add Dependabot ignore for `grpc-gateway/v2 >= 2.29.0` to prevent re-bumping the SDK transport floor
- Sync CLAUDE.md Go version policy table

## Why

Dependabot PR #180 tried to bump `grpc-gateway/v2` to 2.29.0, which hard-requires Go 1.25 in its own `go.mod`. That cascades through `api` → `sdk/grpctransport` → CLI and shifts the SDK transport floor from 1.24 to 1.25. We're holding 1.24 for SDK consumers using transport.

Final policy:

| Module | Go |
|---|---|
| Server (root) | 1.25 |
| CLI (`cmd/decree`) | **1.24** (was 1.25) |
| `api`, `sdk/tools`, `sdk/grpctransport` | 1.24 |
| SDK core (`configclient`, `adminclient`, `configwatcher`) | 1.22 |

#180 closed; once 2.29 is ignored, Dependabot will re-open with just the otel bumps.

## Test plan

- [x] `make pre-commit` — build, vet, format, lint, test, coverage all pass
- [x] `cmd/decree` builds + tests at Go 1.24.0
- [ ] CI green (build + SDK compat 1.22 + 1.23 matrix)