### PR TITLE
chore(deps): ignore otel >=1.43 (Go 1.25 floor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,15 @@ updates:
           - minor
           - patch
     ignore:
-      # grpc-gateway 2.29+ requires Go 1.25; we hold the SDK transport floor at 1.24.
+      # The Go ecosystem is moving its floor to Go 1.25 in lockstep. We hold the
+      # SDK transport floor at 1.24, so any dep version that requires Go 1.25 is
+      # ignored until we revisit the floor. Re-evaluate periodically.
       - dependency-name: "github.com/grpc-ecosystem/grpc-gateway/v2"
         versions: [">=2.29.0"]
+      - dependency-name: "go.opentelemetry.io/otel"
+        versions: [">=1.43.0"]
+      - dependency-name: "go.opentelemetry.io/otel/sdk/metric"
+        versions: [">=1.43.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Add `go.opentelemetry.io/otel` and `go.opentelemetry.io/otel/sdk/metric` `>=1.43.0` to the Dependabot ignore list, alongside the existing grpc-gateway 2.29 ignore.

## Why

#181 holds the SDK transport floor at Go 1.24. `otel v1.43.0` hard-requires Go 1.25 in its `go.mod`, same pattern as `grpc-gateway 2.29.0` — so the otel-only Dependabot PR (#182) reopened today still tried to push `api/go.mod` from 1.24 → 1.25.

Reworded the ignore comment to flag this as a broader pattern: the Go ecosystem is moving its floor to 1.25 in lockstep. Each new ignore is tech debt, so we should revisit periodically instead of stacking ignores forever.

## Follow-up

- #182 will be closed once this lands (Dependabot will re-open with the remaining safe bumps next cycle).

## Test plan

- [x] YAML parses (no schema validator in repo, but Dependabot will accept on next push)
- [ ] Verify on next Dependabot run that otel 1.43 isn't proposed