### PR TITLE
test(e2e): cover UpdateTenant RPC + restricted-claim tenant filtering

### DIFF
--- a/e2e/tenant_test.go
+++ b/e2e/tenant_test.go
@@ -1,0 +1,212 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/grpctransport"
+)
+
+// newRestrictedAdminClient builds an adminclient with x-role=admin and an
+// x-tenant-id header restricted to the given tenant IDs (comma-joined).
+// This exercises the non-superadmin code paths in ListTenants.
+func newRestrictedAdminClient(conn *grpc.ClientConn, tenantIDs []string) *adminclient.Client {
+	return grpctransport.NewAdminClient(conn,
+		grpctransport.WithSubject("e2e-restricted"),
+		grpctransport.WithRole("admin"),
+		grpctransport.WithTenantID(strings.Join(tenantIDs, ",")),
+	)
+}
+
+// --- UpdateTenant: rename only ---
+
+func TestUpdateTenantName(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	s, err := admin.CreateSchema(ctx, "rename-tenant-e2e", []adminclient.Field{
+		{Path: "x", Type: "FIELD_TYPE_STRING"},
+	}, "")
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, s.ID, 1)
+	require.NoError(t, err)
+
+	tenant, err := admin.CreateTenant(ctx, "tenant-rename-before", s.ID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = admin.DeleteTenant(ctx, tenant.ID)
+		_ = admin.DeleteSchema(ctx, s.ID)
+	})
+
+	updated, err := admin.UpdateTenantName(ctx, tenant.ID, "tenant-rename-after")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-rename-after", updated.Name)
+	assert.Equal(t, tenant.ID, updated.ID)
+
+	got, err := admin.GetTenant(ctx, tenant.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-rename-after", got.Name)
+}
+
+// --- UpdateTenant: schema version upgrade invalidates the validator cache ---
+
+func TestUpdateTenantSchemaVersion(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	cfg := newConfigClient(conn)
+	ctx := context.Background()
+
+	// v1 has only `app.value` (string).
+	s, err := admin.CreateSchema(ctx, "tenant-upgrade-e2e", []adminclient.Field{
+		{Path: "app.value", Type: "FIELD_TYPE_STRING"},
+	}, "")
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, s.ID, 1)
+	require.NoError(t, err)
+
+	// v2 drops `app.value`, adds `app.count`.
+	_, err = admin.UpdateSchema(ctx, s.ID,
+		[]adminclient.Field{{Path: "app.count", Type: "FIELD_TYPE_INT"}},
+		[]string{"app.value"},
+		"v2: swap fields",
+	)
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, s.ID, 2)
+	require.NoError(t, err)
+
+	// Tenant on v1, set the v1-only field — populates the validator cache.
+	tenant, err := admin.CreateTenant(ctx, "tenant-upgrade", s.ID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = admin.DeleteTenant(ctx, tenant.ID)
+		_ = admin.DeleteSchema(ctx, s.ID)
+	})
+	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.value", "v1"))
+
+	// Upgrade to v2.
+	updated, err := admin.UpdateTenantSchema(ctx, tenant.ID, 2)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), updated.SchemaVersion)
+
+	// Validator cache must reflect v2: setting v1's `app.value` now fails;
+	// setting v2's `app.count` succeeds.
+	err = cfg.Set(ctx, tenant.ID, "app.value", "still-v1")
+	require.Error(t, err, "setting dropped field on upgraded tenant must fail")
+
+	require.NoError(t, cfg.SetInt(ctx, tenant.ID, "app.count", 7))
+	count, err := cfg.GetInt(ctx, tenant.ID, "app.count")
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), count)
+}
+
+// --- UpdateTenant: rename + upgrade in a single call ---
+
+func TestUpdateTenantBothFields(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	s, err := admin.CreateSchema(ctx, "tenant-both-e2e", []adminclient.Field{
+		{Path: "k", Type: "FIELD_TYPE_STRING"},
+	}, "")
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, s.ID, 1)
+	require.NoError(t, err)
+
+	_, err = admin.UpdateSchema(ctx, s.ID,
+		[]adminclient.Field{{Path: "k2", Type: "FIELD_TYPE_STRING"}},
+		nil,
+		"v2: add k2",
+	)
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, s.ID, 2)
+	require.NoError(t, err)
+
+	tenant, err := admin.CreateTenant(ctx, "tenant-both-before", s.ID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = admin.DeleteTenant(ctx, tenant.ID)
+		_ = admin.DeleteSchema(ctx, s.ID)
+	})
+
+	newName := "tenant-both-after"
+	newVersion := int32(2)
+	updated, err := admin.UpdateTenant(ctx, tenant.ID, &newName, &newVersion)
+	require.NoError(t, err)
+	assert.Equal(t, newName, updated.Name)
+	assert.Equal(t, newVersion, updated.SchemaVersion)
+}
+
+// --- ListTenants restricted-claim filtering (with and without SchemaId) ---
+
+func TestListTenantsWithAccessFiltering(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	// Two schemas so we can also test the SchemaId-filtered path.
+	sA, err := admin.CreateSchema(ctx, "tenant-filter-a", []adminclient.Field{
+		{Path: "f", Type: "FIELD_TYPE_STRING"},
+	}, "")
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, sA.ID, 1)
+	require.NoError(t, err)
+
+	sB, err := admin.CreateSchema(ctx, "tenant-filter-b", []adminclient.Field{
+		{Path: "f", Type: "FIELD_TYPE_STRING"},
+	}, "")
+	require.NoError(t, err)
+	_, err = admin.PublishSchema(ctx, sB.ID, 1)
+	require.NoError(t, err)
+
+	tA1, err := admin.CreateTenant(ctx, "filter-a-1", sA.ID, 1)
+	require.NoError(t, err)
+	tA2, err := admin.CreateTenant(ctx, "filter-a-2", sA.ID, 1)
+	require.NoError(t, err)
+	tB1, err := admin.CreateTenant(ctx, "filter-b-1", sB.ID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = admin.DeleteTenant(ctx, tA1.ID)
+		_ = admin.DeleteTenant(ctx, tA2.ID)
+		_ = admin.DeleteTenant(ctx, tB1.ID)
+		_ = admin.DeleteSchema(ctx, sA.ID)
+		_ = admin.DeleteSchema(ctx, sB.ID)
+	})
+
+	// Restrict the caller to {tA1, tB1}: tA2 must be filtered out.
+	allowed := []string{tA1.ID, tB1.ID}
+	restricted := newRestrictedAdminClient(conn, allowed)
+
+	// No schema filter → exercises ListTenantsByIDs path.
+	all, err := restricted.ListTenants(ctx, "")
+	require.NoError(t, err)
+	gotAll := tenantIDSet(all)
+	assert.Contains(t, gotAll, tA1.ID)
+	assert.Contains(t, gotAll, tB1.ID)
+	assert.NotContains(t, gotAll, tA2.ID, "tA2 was not in the allowed set")
+
+	// Schema filter → exercises ListTenantsBySchemaAndIDs path.
+	bySchemaA, err := restricted.ListTenants(ctx, sA.ID)
+	require.NoError(t, err)
+	gotA := tenantIDSet(bySchemaA)
+	assert.Contains(t, gotA, tA1.ID)
+	assert.NotContains(t, gotA, tA2.ID, "tA2 was not in the allowed set")
+	assert.NotContains(t, gotA, tB1.ID, "tB1 belongs to schema B")
+}
+
+func tenantIDSet(tenants []*adminclient.Tenant) map[string]struct{} {
+	out := make(map[string]struct{}, len(tenants))
+	for _, t := range tenants {
+		out[t.ID] = struct{}{}
+	}
+	return out
+}

--- a/sdk/adminclient/operations_test.go
+++ b/sdk/adminclient/operations_test.go
@@ -354,6 +354,31 @@ func TestUpdateTenantSchema(t *testing.T) {
 	}
 }
 
+func TestUpdateTenant_BothFields(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(ms, nil, nil, nil)
+
+	ms.updateTenantFn = func(_ context.Context, req *UpdateTenantRequest) (*Tenant, error) {
+		if req.Name == nil || *req.Name != "renamed" {
+			t.Fatalf("expected Name renamed, got %v", req.Name)
+		}
+		if req.SchemaVersion == nil || *req.SchemaVersion != int32(2) {
+			t.Fatalf("expected SchemaVersion 2, got %v", req.SchemaVersion)
+		}
+		return &Tenant{ID: "t1", Name: "renamed", SchemaVersion: 2, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
+	}
+
+	name := "renamed"
+	v := int32(2)
+	tenant, err := client.UpdateTenant(context.Background(), "t1", &name, &v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tenant.Name != "renamed" || tenant.SchemaVersion != 2 {
+		t.Errorf("got %+v, want renamed/v2", tenant)
+	}
+}
+
 func TestDeleteTenant_Success(t *testing.T) {
 	ms := &mockSchemaTransport{}
 	client := New(ms, nil, nil, nil)
@@ -722,6 +747,11 @@ func TestServiceNotConfigured_AllMethods(t *testing.T) {
 	_, err = client.UpdateTenantSchema(ctx, "t1", 2)
 	if !errors.Is(err, ErrServiceNotConfigured) {
 		t.Errorf("UpdateTenantSchema: got error %v, want %v", err, ErrServiceNotConfigured)
+	}
+
+	_, err = client.UpdateTenant(ctx, "t1", nil, nil)
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("UpdateTenant: got error %v, want %v", err, ErrServiceNotConfigured)
 	}
 
 	err = client.DeleteTenant(ctx, "t1")

--- a/sdk/adminclient/tenant.go
+++ b/sdk/adminclient/tenant.go
@@ -76,6 +76,19 @@ func (c *Client) UpdateTenantSchema(ctx context.Context, id string, schemaVersio
 	})
 }
 
+// UpdateTenant updates a tenant's name and/or schema version in a single call.
+// Pass nil for fields that should be left unchanged. At least one field must be non-nil.
+func (c *Client) UpdateTenant(ctx context.Context, id string, name *string, schemaVersion *int32) (*Tenant, error) {
+	if c.schema == nil {
+		return nil, ErrServiceNotConfigured
+	}
+	return c.schema.UpdateTenant(ctx, &UpdateTenantRequest{
+		ID:            id,
+		Name:          name,
+		SchemaVersion: schemaVersion,
+	})
+}
+
 // DeleteTenant permanently deletes a tenant and all its configuration data.
 func (c *Client) DeleteTenant(ctx context.Context, id string) error {
 	if c.schema == nil {


### PR DESCRIPTION
## Summary
- Adds e2e tests for `UpdateTenantName`, `UpdateTenantSchemaVersion`, single-call rename+upgrade, and `ListTenants` access filtering (admin role with restricted `x-tenant-id`).
- Adds `adminclient.UpdateTenant(id, name, schemaVersion)` so the SDK exposes the combined-update path the server already supports.
- Closes the gaps surfaced by the PR #111 coverage audit: previously `UpdateTenantName` / `UpdateTenantSchemaVersion` had 0% e2e coverage, and `ListTenantsByIDs` / `ListTenantsBySchemaAndIDs` were unreachable because e2e only ran as superadmin.

## Coverage after this change
| Function | Before | After |
| --- | --- | --- |
| `dbstore.UpdateTenantName` | 0% | 100% |
| `dbstore.UpdateTenantSchemaVersion` | 0% | 100% |
| `store_pg.UpdateTenantName` | 0% | 71.4% |
| `store_pg.UpdateTenantSchemaVersion` | 0% | 71.4% |
| `dbstore.ListTenantsByIDs` | 0% | 76.9% |
| `dbstore.ListTenantsBySchemaAndIDs` | 0% | 76.9% |

`TestUpdateTenantSchemaVersion` also exercises the validator-cache invalidation path: it sets a v1-only field, upgrades to v2 (which drops that field), and expects a subsequent set on the dropped field to fail.

## Test plan
- [x] `make pre-commit` (build, vet, lint, test, coverage)
- [x] `make e2e` (all four new tests pass)
- [x] `make e2e-coverage` (verifies the four target functions now have >0% coverage)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)