### PR TITLE
fix(ci): use underscore input names for first-interaction@v3

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue! We'll take a look soon.
 
             In the meantime:
             - Check [CONTRIBUTING.md](https://github.com/opendecree/decree/blob/main/CONTRIBUTING.md) for development setup
             - Search [Discussions](https://github.com/opendecree/decree/discussions) for related topics
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request! We appreciate the contribution.
 
             Before review, please make sure:


### PR DESCRIPTION
## Summary
- v3 of `actions/first-interaction` renamed inputs from hyphens to underscores (`repo_token`, `issue_message`, `pr_message`).
- The v1→v3 bump in #178 left the workflow with the old hyphenated names, so every PR since then errors:
  ```
  Error: Input required and not supplied: issue_message
  ```
- Same fix needed in `decree-python`, `decree-typescript`, `decree-ui`, `demos` — separate PRs after this lands.

## Test plan
- [x] Verified `action.yml` of v3 expects underscore inputs.
- [ ] Welcome job passes on this PR (first-interaction skips since I am not a first-time contributor — but step itself should not error now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)