### PR TITLE
ci: migrate CodeQL to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,73 @@
+# CodeQL advanced setup. Replaces default-setup once disabled in repo settings.
+# Advanced unlocks paths-ignore (skip generated code) and Go module caching
+# across runs — projected ~1-2 min faster vs default-setup.
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "api/centralconfig/v1/**"
+      - "internal/storage/dbstore/*.gen.go"
+      - "**/*.md"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 7 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+              - api/centralconfig/v1/**
+              - internal/storage/dbstore/*.gen.go
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/codeql.yml` with explicit Analyze jobs for go / actions / python
- `paths-ignore` for generated code: `api/centralconfig/v1/**`, `internal/storage/dbstore/*.gen.go`
- `actions/setup-go` with module cache before CodeQL init for Go runs
- Matches default-setup's `default` query suite + `remote` threat model for findings parity

Projected ~1-2 min faster CI per PR vs default-setup (CodeQL Analyze (go) was the long pole at ~5m 40s).

## Activation steps (post-merge, ordering: b)
1. Merge this PR — workflow uploads fail while default-setup is still enabled
2. Disable default-setup: `gh api -X DELETE repos/opendecree/decree/code-scanning/default-setup` (or Settings → Code scanning → CodeQL → Switch to advanced)
3. Re-trigger workflow on main; verify uploads succeed
4. Compare findings against the last default-setup run for parity

Branch protection currently requires only `CI check` — no required-status-check rename needed.

## Test plan
- [ ] PR's CodeQL run kicks off (uploads will fail this round — expected, default-setup still active)
- [ ] After merge + default-setup disable, next run uploads cleanly
- [ ] Findings on parity commit equivalent to last default-setup run
- [ ] Wall-clock time reduced vs ~5m 40s baseline

Closes #183 (decree only — follow-up issues to be filed for decree-python, decree-typescript, decree-ui)

🤖 Generated with [Claude Code](https://claude.com/claude-code)