### PR TITLE
feat(schema,config): pluggable parser registry (#129)

### DIFF
--- a/.agents/context/schema-spec.md
+++ b/.agents/context/schema-spec.md
@@ -200,7 +200,7 @@ Meta-schema encodes this via `allOf` with 4 `if/then` branches keyed on `type`.
 
 ### Cross-cutting
 
-- #129 — Pluggable schema parser: extract v1 parser behind an interface so future spec versions register as a single package + init(). Unblocks v2 without branches across the codebase.
+- #129 — Pluggable schema parser. `Parser` interface + package-level registry in `internal/schema/parser.go` (and symmetric in `internal/config/parser.go`). Each spec version is a single sibling file (`parser_v1.go`, future `parser_v2.go`) that declares a parser struct and registers it via `init()`. The service layer dispatches through `schema.Dispatch(yaml)` on import and `schema.MarshalSchemaAt(s, version)` on export; layer-2 semantic checks run on the proto value after dispatch so they're shared across versions. Adding v2 means landing one new file; nothing else in the codebase changes.
 - #76 (Phase 1) — Reserve `validations:` and `dependentRequired:` keys in meta-schema + parser. No engine; rules round-trip through ImportSchema/GetSchema unevaluated. See [cel-validation.md](cel-validation.md). Must land in v0.1.0 to lock the schema shape.
 
 ## Open questions

--- a/api/centralconfig/v1/config_service.pb.go
+++ b/api/centralconfig/v1/config_service.pb.go
@@ -1181,7 +1181,11 @@ type ExportConfigRequest struct {
 	// Tenant ID (UUID).
 	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	// Config version to export. If omitted, exports the latest version.
-	Version       *int32 `protobuf:"varint,2,opt,name=version,proto3,oneof" json:"version,omitempty"`
+	Version *int32 `protobuf:"varint,2,opt,name=version,proto3,oneof" json:"version,omitempty"`
+	// Config-format spec version to emit (e.g. "v1"). When omitted, defaults
+	// to the highest version the server supports. The server returns
+	// InvalidArgument if the requested version is not registered.
+	SpecVersion   *string `protobuf:"bytes,3,opt,name=spec_version,json=specVersion,proto3,oneof" json:"spec_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1228,6 +1232,13 @@ func (x *ExportConfigRequest) GetVersion() int32 {
 		return *x.Version
 	}
 	return 0
+}
+
+func (x *ExportConfigRequest) GetSpecVersion() string {
+	if x != nil && x.SpecVersion != nil {
+		return *x.SpecVersion
+	}
+	return ""
 }
 
 type ExportConfigResponse struct {
@@ -1478,12 +1489,14 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\vfield_paths\x18\x02 \x03(\tR\n" +
 	"fieldPaths\"K\n" +
 	"\x11SubscribeResponse\x126\n" +
-	"\x06change\x18\x01 \x01(\v2\x1e.centralconfig.v1.ConfigChangeR\x06change\"]\n" +
+	"\x06change\x18\x01 \x01(\v2\x1e.centralconfig.v1.ConfigChangeR\x06change\"\x96\x01\n" +
 	"\x13ExportConfigRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1d\n" +
-	"\aversion\x18\x02 \x01(\x05H\x00R\aversion\x88\x01\x01B\n" +
+	"\aversion\x18\x02 \x01(\x05H\x00R\aversion\x88\x01\x01\x12&\n" +
+	"\fspec_version\x18\x03 \x01(\tH\x01R\vspecVersion\x88\x01\x01B\n" +
 	"\n" +
-	"\b_version\"9\n" +
+	"\b_versionB\x0f\n" +
+	"\r_spec_version\"9\n" +
 	"\x14ExportConfigResponse\x12!\n" +
 	"\fyaml_content\x18\x01 \x01(\fR\vyamlContent\"\xbe\x01\n" +
 	"\x13ImportConfigRequest\x12\x1b\n" +

--- a/api/centralconfig/v1/schema_service.pb.go
+++ b/api/centralconfig/v1/schema_service.pb.go
@@ -1432,7 +1432,11 @@ type ExportSchemaRequest struct {
 	// Schema ID (UUID).
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Schema version to export. If omitted, exports the latest version.
-	Version       *int32 `protobuf:"varint,2,opt,name=version,proto3,oneof" json:"version,omitempty"`
+	Version *int32 `protobuf:"varint,2,opt,name=version,proto3,oneof" json:"version,omitempty"`
+	// Schema-format spec version to emit (e.g. "v1"). When omitted, defaults
+	// to the highest version the server supports. The server returns
+	// InvalidArgument if the requested version is not registered.
+	SpecVersion   *string `protobuf:"bytes,3,opt,name=spec_version,json=specVersion,proto3,oneof" json:"spec_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1479,6 +1483,13 @@ func (x *ExportSchemaRequest) GetVersion() int32 {
 		return *x.Version
 	}
 	return 0
+}
+
+func (x *ExportSchemaRequest) GetSpecVersion() string {
+	if x != nil && x.SpecVersion != nil {
+		return *x.SpecVersion
+	}
+	return ""
 }
 
 type ExportSchemaResponse struct {
@@ -1727,12 +1738,14 @@ const file_centralconfig_v1_schema_service_proto_rawDesc = "" +
 	"\x15ListFieldLocksRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\"K\n" +
 	"\x16ListFieldLocksResponse\x121\n" +
-	"\x05locks\x18\x01 \x03(\v2\x1b.centralconfig.v1.FieldLockR\x05locks\"P\n" +
+	"\x05locks\x18\x01 \x03(\v2\x1b.centralconfig.v1.FieldLockR\x05locks\"\x89\x01\n" +
 	"\x13ExportSchemaRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
-	"\aversion\x18\x02 \x01(\x05H\x00R\aversion\x88\x01\x01B\n" +
+	"\aversion\x18\x02 \x01(\x05H\x00R\aversion\x88\x01\x01\x12&\n" +
+	"\fspec_version\x18\x03 \x01(\tH\x01R\vspecVersion\x88\x01\x01B\n" +
 	"\n" +
-	"\b_version\"9\n" +
+	"\b_versionB\x0f\n" +
+	"\r_spec_version\"9\n" +
 	"\x14ExportSchemaResponse\x12!\n" +
 	"\fyaml_content\x18\x01 \x01(\fR\vyamlContent\"[\n" +
 	"\x13ImportSchemaRequest\x12!\n" +

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -359,6 +359,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "specVersion",
+            "description": "Schema-format spec version to emit (e.g. \"v1\"). When omitted, defaults\nto the highest version the server supports. The server returns\nInvalidArgument if the requested version is not registered.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -687,6 +694,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "specVersion",
+            "description": "Config-format spec version to emit (e.g. \"v1\"). When omitted, defaults\nto the highest version the server supports. The server returns\nInvalidArgument if the requested version is not registered.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,8 +1,8 @@
 {
   "cmd/decree": 86.6,
-  "internal": 80.0,
-  "sdk/adminclient": 97.2,
+  "internal": 81.9,
+  "sdk/adminclient": 97.6,
   "sdk/configclient": 87.1,
   "sdk/configwatcher": 90.9,
-  "sdk/tools": 95.8
+  "sdk/tools": 96.1
 }

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -758,6 +758,7 @@ Usage statistics are tracked asynchronously via batched read counters.
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
 | version | [int32](#int32) | optional | Config version to export. If omitted, exports the latest version. |
+| spec_version | [string](#string) | optional | Config-format spec version to emit (e.g. &#34;v1&#34;). When omitted, defaults to the highest version the server supports. The server returns InvalidArgument if the requested version is not registered. |
 
 
 
@@ -1307,6 +1308,7 @@ bypasses the cache and reads directly from the database.
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) |  | Schema ID (UUID). |
 | version | [int32](#int32) | optional | Schema version to export. If omitted, exports the latest version. |
+| spec_version | [string](#string) | optional | Schema-format spec version to emit (e.g. &#34;v1&#34;). When omitted, defaults to the highest version the server supports. The server returns InvalidArgument if the requested version is not registered. |
 
 
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -359,6 +359,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "specVersion",
+            "description": "Schema-format spec version to emit (e.g. \"v1\"). When omitted, defaults\nto the highest version the server supports. The server returns\nInvalidArgument if the requested version is not registered.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -687,6 +694,13 @@
             "required": false,
             "type": "integer",
             "format": "int32"
+          },
+          {
+            "name": "specVersion",
+            "description": "Config-format spec version to emit (e.g. \"v1\"). When omitted, defaults\nto the highest version the server supports. The server returns\nInvalidArgument if the requested version is not registered.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [

--- a/docs/concepts/meta-schema.md
+++ b/docs/concepts/meta-schema.md
@@ -99,6 +99,14 @@ https://schemas.opendecree.io/schema/v{MAJOR}.{MINOR}.{PATCH}/decree-{schema|con
 
 **Post-1.0.0 (future):** switch to major-only paths (`/v1/`) with permanent redirects from historical full-SemVer URLs. Matches the OpenAPI 3.x dated-URL practice.
 
+## Multi-version evolution
+
+The server supports multiple schema-format versions concurrently — schemas imported under `v1` continue to work after `v2` is registered, and the export path can emit either. Internally, each spec version is a small parser plug-in that registers itself in a package-level registry; adding `v2` means landing a single new file (e.g. `parser_v2.go`) that declares the parser and calls `init() { Register(&v2Parser{}) }`. The service layer dispatches through the registry on both `ImportSchema` and `ExportSchema` paths.
+
+`ExportSchema` (and `ExportConfig`) accept an optional `spec_version` request field — when omitted, the server emits the highest version it supports. Unknown values produce `InvalidArgument` with the supported version list in the error message.
+
+This pattern keeps the v1 code unchanged when v2 lands and gives the server a single registry of versions to advertise to clients.
+
 ## Stability policy
 
 The meta-schema follows SemVer. Versions are bumped in a separate cadence from the decree server release; the meta-schema version is always present in the URL.

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// Parser converts a single spec_version of decree.config.yaml to and from
+// the internal interchange shape. New versions of the config format
+// register an implementation of this interface via init() in their own
+// file under internal/config/ — see parser_v1.go for the v1
+// implementation. The service layer dispatches through DispatchImport
+// on import and MarshalConfigAt on export, so adding v2 support means
+// landing a single new parser_v2.go file with init() and nothing else.
+//
+// Parser.Parse takes the schema's field types as input so it can coerce
+// YAML-native primitives (numbers, bools, durations) to the canonical
+// string representation the storage layer expects. Layer-2 semantic
+// checks (field locks, per-field validation, dependentRequired) run at
+// the service layer on the parser's output — not inside Parse — so
+// different versions can share the same enforcement.
+type Parser interface {
+	// SpecVersion is the literal `spec_version:` value this parser handles
+	// (e.g. "v1"). Used as the registry key.
+	SpecVersion() string
+
+	// Parse converts YAML bytes to a parsed import. fieldTypes maps each
+	// field path to its declared schema type so the parser can coerce
+	// typed YAML primitives to the canonical string representation.
+	// Returns an error on malformed YAML or type-mismatch between a YAML
+	// value and its declared field type.
+	Parse(data []byte, fieldTypes map[string]domain.FieldType) (ParsedImport, error)
+
+	// Marshal converts a list of stored config rows back to YAML bytes for
+	// export. fieldTypes is needed so the parser can render strings as
+	// their typed YAML form.
+	Marshal(version int32, description string, rows []configRow, fieldTypes map[string]domain.FieldType) ([]byte, error)
+}
+
+// ParsedImport carries everything the service layer needs from a parsed
+// import: the values to write, plus the document's top-level description
+// (used as the audit description if the request did not supply one).
+// Future fields — e.g. an explicit `version` declared by the YAML — slot
+// in here without churning the Parser interface signature.
+type ParsedImport struct {
+	Description string
+	Values      []configValueImport
+}
+
+var (
+	parsersMu sync.RWMutex
+	parsers   = map[string]Parser{}
+)
+
+// Register adds a parser to the registry. Called from each parser's init()
+// function. Panics on duplicate registration — that is a programming error
+// at compile time, not a runtime input.
+func Register(p Parser) {
+	parsersMu.Lock()
+	defer parsersMu.Unlock()
+	v := p.SpecVersion()
+	if _, exists := parsers[v]; exists {
+		panic(fmt.Sprintf("config: duplicate parser registered for spec_version %q", v))
+	}
+	parsers[v] = p
+}
+
+// SupportedVersions returns the registered spec_version values in sorted
+// order. Used in error messages so users see which versions the server
+// accepts.
+func SupportedVersions() []string {
+	parsersMu.RLock()
+	defer parsersMu.RUnlock()
+	out := make([]string, 0, len(parsers))
+	for v := range parsers {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LatestVersion returns the highest registered spec_version (lexicographic
+// order — sufficient while versions follow a "v1", "v2", … pattern). Used
+// as the default when ExportConfig is called without an explicit version.
+func LatestVersion() string {
+	versions := SupportedVersions()
+	if len(versions) == 0 {
+		return ""
+	}
+	return versions[len(versions)-1]
+}
+
+// peekHeader is a minimal struct used to extract spec_version from a YAML
+// document before handing the bytes to the version-specific parser.
+type peekHeader struct {
+	SpecVersion string `yaml:"spec_version"`
+}
+
+// DispatchImport routes an incoming config YAML document to the parser
+// registered for its spec_version. Returns an error naming the supported
+// versions if spec_version is missing or unrecognized; otherwise delegates
+// to the matching parser.
+func DispatchImport(data []byte, fieldTypes map[string]domain.FieldType) (ParsedImport, error) {
+	var hdr peekHeader
+	if err := yaml.Unmarshal(data, &hdr); err != nil {
+		return ParsedImport{}, fmt.Errorf("invalid YAML: %w", err)
+	}
+	if hdr.SpecVersion == "" {
+		return ParsedImport{}, fmt.Errorf("spec_version is required (supported: %v)", SupportedVersions())
+	}
+	parsersMu.RLock()
+	p, ok := parsers[hdr.SpecVersion]
+	parsersMu.RUnlock()
+	if !ok {
+		return ParsedImport{}, fmt.Errorf("unsupported spec_version %q (supported: %v)", hdr.SpecVersion, SupportedVersions())
+	}
+	return p.Parse(data, fieldTypes)
+}
+
+// MarshalConfigAt selects the parser for the requested spec_version and
+// emits the config in that version's wire format. version may be empty —
+// in which case LatestVersion is used. Returns an error if no parser is
+// registered for the requested version.
+func MarshalConfigAt(version int32, description string, rows []configRow, fieldTypes map[string]domain.FieldType, specVersion string) ([]byte, error) {
+	if specVersion == "" {
+		specVersion = LatestVersion()
+	}
+	parsersMu.RLock()
+	p, ok := parsers[specVersion]
+	parsersMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported spec_version %q (supported: %v)", specVersion, SupportedVersions())
+	}
+	return p.Marshal(version, description, rows, fieldTypes)
+}

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// --- Registry plumbing ---
+
+func TestSupportedVersions_IncludesV1(t *testing.T) {
+	versions := SupportedVersions()
+	require.NotEmpty(t, versions)
+	assert.Contains(t, versions, "v1")
+}
+
+func TestLatestVersion_IsLexicographicMax(t *testing.T) {
+	assert.Equal(t, "v1", LatestVersion())
+}
+
+func TestDispatchImport_RouteToV1(t *testing.T) {
+	parsed, err := DispatchImport([]byte(`
+spec_version: v1
+description: import desc
+values:
+  payments.fee:
+    value: 0.025
+`), map[string]domain.FieldType{
+		"payments.fee": domain.FieldTypeNumber,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "import desc", parsed.Description)
+	require.Len(t, parsed.Values, 1)
+	assert.Equal(t, "payments.fee", parsed.Values[0].FieldPath)
+	assert.Equal(t, "0.025", parsed.Values[0].Value)
+}
+
+func TestDispatchImport_MissingSpecVersion(t *testing.T) {
+	_, err := DispatchImport([]byte(`
+values:
+  payments.fee:
+    value: 0.025
+`), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec_version is required")
+}
+
+func TestDispatchImport_UnknownSpecVersion(t *testing.T) {
+	_, err := DispatchImport([]byte(`
+spec_version: v99
+values:
+  payments.fee:
+    value: 0.025
+`), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"v99"`)
+	assert.Contains(t, err.Error(), "v1")
+}
+
+func TestMarshalConfigAt_DefaultsToLatest(t *testing.T) {
+	rows := []configRow{
+		{FieldPath: "payments.fee", Value: "0.025"},
+	}
+	data, err := MarshalConfigAt(1, "first import", rows, map[string]domain.FieldType{
+		"payments.fee": domain.FieldTypeNumber,
+	}, "")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "spec_version: v1")
+}
+
+func TestMarshalConfigAt_UnknownVersion(t *testing.T) {
+	_, err := MarshalConfigAt(1, "x", nil, nil, "v99")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"v99"`)
+}

--- a/internal/config/parser_v1.go
+++ b/internal/config/parser_v1.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// parserV1 is the config parser for spec_version "v1" — the only version
+// in v0.1.0 of the config format. It delegates to the existing
+// ConfigYAML-based unmarshal/marshal helpers in yaml.go; the registry
+// indirection is what gives us the room to add v2 as a sibling file
+// alongside this one without touching v1 code.
+type parserV1 struct{}
+
+func (parserV1) SpecVersion() string { return yamlSpecVersionV1 }
+
+func (parserV1) Parse(data []byte, fieldTypes map[string]domain.FieldType) (ParsedImport, error) {
+	doc, err := unmarshalConfigYAML(data)
+	if err != nil {
+		return ParsedImport{}, err
+	}
+	values, err := yamlToConfigValues(doc, fieldTypes)
+	if err != nil {
+		return ParsedImport{}, err
+	}
+	return ParsedImport{
+		Description: doc.Description,
+		Values:      values,
+	}, nil
+}
+
+func (parserV1) Marshal(version int32, description string, rows []configRow, fieldTypes map[string]domain.FieldType) ([]byte, error) {
+	return marshalConfigYAML(configToYAML(version, description, rows, fieldTypes))
+}
+
+func init() {
+	Register(parserV1{})
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -809,10 +809,13 @@ func (s *Service) ExportConfig(ctx context.Context, req *pb.ExportConfigRequest)
 		description = *cv.Description
 	}
 
-	doc := configToYAML(version, description, rows, fieldTypes)
-	data, err := marshalConfigYAML(doc)
+	specVersion := ""
+	if req.SpecVersion != nil {
+		specVersion = *req.SpecVersion
+	}
+	data, err := MarshalConfigAt(version, description, rows, fieldTypes, specVersion)
 	if err != nil {
-		return nil, status.Error(codes.Internal, "failed to marshal YAML")
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	return &pb.ExportConfigResponse{YamlContent: data}, nil
@@ -833,11 +836,6 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 		return nil, err
 	}
 
-	doc, err := unmarshalConfigYAML(req.YamlContent)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid config YAML: %v", err)
-	}
-
 	actor := s.getActor(ctx)
 
 	// Verify tenant exists.
@@ -845,17 +843,19 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 		return nil, status.Error(codes.NotFound, "tenant not found")
 	}
 
-	// Get schema field types for type-aware conversion.
+	// Get schema field types for type-aware parsing.
 	fieldTypes, err := s.getFieldTypeMap(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Convert YAML values to string representations.
-	values, err := yamlToConfigValues(doc, fieldTypes)
+	// Dispatch to the parser registered for the document's spec_version,
+	// converting YAML values to canonical string form along the way.
+	parsed, err := DispatchImport(req.YamlContent, fieldTypes)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "value conversion error: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid config YAML: %v", err)
 	}
+	values := parsed.Values
 
 	// Check field locks and validate.
 	for _, v := range values {
@@ -900,8 +900,8 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 	desc := "Import from YAML"
 	if req.Description != nil {
 		desc = *req.Description
-	} else if doc.Description != "" {
-		desc = doc.Description
+	} else if parsed.Description != "" {
+		desc = parsed.Description
 	}
 
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)

--- a/internal/schema/parser.go
+++ b/internal/schema/parser.go
@@ -1,0 +1,132 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+// Parser converts a single spec_version of decree.schema.yaml to and from
+// the internal proto domain. New versions of the schema format register an
+// implementation of this interface via init() in their own file under
+// internal/schema/ — see parser_v1.go for the v1 implementation. The
+// service layer dispatches through Registry on import and Marshal on
+// export, so adding v2 support means landing a single new parser_v2.go
+// file with init() and nothing else.
+//
+// Parse should return the proto Schema with its fields, info,
+// DependentRequired, and Validations populated. Layer-2 semantic checks
+// (referential integrity, prefix-overlap, range sanity) run at the
+// service layer on the proto value — not inside Parse — so different
+// versions can share the same semantic enforcement.
+type Parser interface {
+	// SpecVersion is the literal `spec_version:` value this parser handles
+	// (e.g. "v1"). Used as the registry key.
+	SpecVersion() string
+
+	// Parse converts YAML bytes to a proto Schema. Returns an error if the
+	// document is malformed at the layer-1 structural level (unknown keys,
+	// invalid types, bad regexes).
+	Parse(data []byte) (*pb.Schema, error)
+
+	// Marshal converts a proto Schema back to YAML bytes for export. The
+	// caller has already chosen which parser to dispatch to based on the
+	// requested spec_version; Marshal does not re-check the value.
+	Marshal(s *pb.Schema) ([]byte, error)
+}
+
+var (
+	parsersMu sync.RWMutex
+	parsers   = map[string]Parser{}
+)
+
+// Register adds a parser to the registry. Called from each parser's init()
+// function. Panics on duplicate registration — that is a programming error
+// at compile time, not a runtime input.
+func Register(p Parser) {
+	parsersMu.Lock()
+	defer parsersMu.Unlock()
+	v := p.SpecVersion()
+	if _, exists := parsers[v]; exists {
+		panic(fmt.Sprintf("schema: duplicate parser registered for spec_version %q", v))
+	}
+	parsers[v] = p
+}
+
+// SupportedVersions returns the registered spec_version values in sorted
+// order. Used in error messages so users see which versions the server
+// accepts.
+func SupportedVersions() []string {
+	parsersMu.RLock()
+	defer parsersMu.RUnlock()
+	out := make([]string, 0, len(parsers))
+	for v := range parsers {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LatestVersion returns the highest registered spec_version (lexicographic
+// order — sufficient while versions follow a "v1", "v2", … pattern). Used
+// as the default when ExportSchema is called without an explicit version.
+// Returns "" if no parsers are registered, which is a server
+// misconfiguration the caller surfaces as Internal.
+func LatestVersion() string {
+	versions := SupportedVersions()
+	if len(versions) == 0 {
+		return ""
+	}
+	return versions[len(versions)-1]
+}
+
+// peekHeader is a minimal struct used to extract spec_version from a YAML
+// document before handing the bytes to the version-specific parser. Any
+// fields outside spec_version are ignored at this stage so a malformed
+// document still produces a clear "unsupported spec_version" error
+// before falling into the per-parser shape lint.
+type peekHeader struct {
+	SpecVersion string `yaml:"spec_version"`
+}
+
+// Dispatch routes an incoming schema YAML document to the parser
+// registered for its spec_version. Returns an error naming the supported
+// versions if spec_version is missing or unrecognized; otherwise delegates
+// to the matching parser.
+func Dispatch(data []byte) (*pb.Schema, error) {
+	var hdr peekHeader
+	if err := yaml.Unmarshal(data, &hdr); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+	if hdr.SpecVersion == "" {
+		return nil, fmt.Errorf("spec_version is required (supported: %v)", SupportedVersions())
+	}
+	parsersMu.RLock()
+	p, ok := parsers[hdr.SpecVersion]
+	parsersMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported spec_version %q (supported: %v)", hdr.SpecVersion, SupportedVersions())
+	}
+	return p.Parse(data)
+}
+
+// MarshalSchemaAt selects the parser for the requested spec_version and
+// emits the schema in that version's wire format. version may be empty —
+// in which case LatestVersion is used. Returns an error if no parser is
+// registered for the requested version.
+func MarshalSchemaAt(s *pb.Schema, version string) ([]byte, error) {
+	if version == "" {
+		version = LatestVersion()
+	}
+	parsersMu.RLock()
+	p, ok := parsers[version]
+	parsersMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unsupported spec_version %q (supported: %v)", version, SupportedVersions())
+	}
+	return p.Marshal(s)
+}

--- a/internal/schema/parser_test.go
+++ b/internal/schema/parser_test.go
@@ -1,0 +1,165 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Registry plumbing ---
+//
+// These tests exercise the Dispatch / MarshalSchemaAt entry points
+// directly. The full v1 round-trip behavior is covered by yaml_test.go.
+
+func TestSupportedVersions_IncludesV1(t *testing.T) {
+	versions := SupportedVersions()
+	require.NotEmpty(t, versions, "at least v1 must be registered via init()")
+	assert.Contains(t, versions, "v1")
+}
+
+func TestLatestVersion_IsLexicographicMax(t *testing.T) {
+	assert.Equal(t, "v1", LatestVersion(), "v1 is the only registered parser today")
+}
+
+func TestDispatch_RouteToV1(t *testing.T) {
+	pb, err := Dispatch([]byte(`
+spec_version: v1
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.NoError(t, err)
+	require.NotNil(t, pb)
+	assert.Equal(t, "payments", pb.Name)
+	require.Len(t, pb.Fields, 1)
+	assert.Equal(t, "payments.fee", pb.Fields[0].Path)
+}
+
+func TestDispatch_MissingSpecVersion(t *testing.T) {
+	_, err := Dispatch([]byte(`
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spec_version is required")
+	// Error message must list the supported versions so users self-correct.
+	assert.Contains(t, err.Error(), "v1")
+}
+
+func TestDispatch_UnknownSpecVersion(t *testing.T) {
+	_, err := Dispatch([]byte(`
+spec_version: v99
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported spec_version")
+	assert.Contains(t, err.Error(), `"v99"`)
+	assert.Contains(t, err.Error(), "v1") // supported list
+}
+
+func TestDispatch_MalformedYAML(t *testing.T) {
+	_, err := Dispatch([]byte("not: valid: yaml: at: all"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid YAML")
+}
+
+func TestMarshalSchemaAt_DefaultsToLatest(t *testing.T) {
+	schema, err := Dispatch([]byte(`
+spec_version: v1
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.NoError(t, err)
+
+	// Empty version string means "use LatestVersion".
+	data, err := MarshalSchemaAt(schema, "")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "spec_version: v1")
+	assert.Contains(t, string(data), "name: payments")
+}
+
+func TestMarshalSchemaAt_ExplicitV1(t *testing.T) {
+	schema, err := Dispatch([]byte(`
+spec_version: v1
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.NoError(t, err)
+
+	data, err := MarshalSchemaAt(schema, "v1")
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "spec_version: v1")
+}
+
+func TestMarshalSchemaAt_UnknownVersionRejected(t *testing.T) {
+	schema, err := Dispatch([]byte(`
+spec_version: v1
+name: payments
+fields:
+  payments.fee:
+    type: number
+`))
+	require.NoError(t, err)
+
+	_, err = MarshalSchemaAt(schema, "v99")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"v99"`)
+}
+
+// TestDispatch_RoundTrip verifies that Dispatch → MarshalSchemaAt → Dispatch
+// produces a structurally equivalent schema. Catches accidental field
+// drops in either direction of the v1 parser.
+func TestDispatch_RoundTrip(t *testing.T) {
+	yamlIn := []byte(`
+spec_version: v1
+name: payments
+description: payments service
+version: 3
+version_description: added refund window
+info:
+  title: Payments
+  author: platform
+fields:
+  payments.fee:
+    type: number
+    constraints: { minimum: 0, maximum: 1 }
+  payments.refunds_enabled:
+    type: bool
+  payments.refund_window:
+    type: duration
+    nullable: true
+dependentRequired:
+  payments.refunds_enabled: [payments.refund_window]
+validations:
+  - path: payments
+    rule: "self.payments.fee >= 0"
+    message: "fee must be non-negative"
+`)
+	first, err := Dispatch(yamlIn)
+	require.NoError(t, err)
+
+	out, err := MarshalSchemaAt(first, "v1")
+	require.NoError(t, err)
+
+	second, err := Dispatch(out)
+	require.NoError(t, err)
+
+	assert.Equal(t, first.Name, second.Name)
+	assert.Equal(t, first.Description, second.Description)
+	assert.Equal(t, first.Version, second.Version)
+	assert.Equal(t, first.VersionDescription, second.VersionDescription)
+	assert.Len(t, second.Fields, len(first.Fields))
+	assert.Len(t, second.DependentRequired, len(first.DependentRequired))
+	assert.Len(t, second.Validations, len(first.Validations))
+}

--- a/internal/schema/parser_v1.go
+++ b/internal/schema/parser_v1.go
@@ -1,0 +1,65 @@
+package schema
+
+import (
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+// parserV1 is the schema parser for spec_version "v1" — the only version
+// in v0.1.0 of the schema spec. It delegates to the existing
+// SchemaYAML-based unmarshal/marshal helpers in yaml.go; the registry
+// indirection is what gives us the room to add v2 as a sibling file
+// alongside this one without touching v1 code.
+type parserV1 struct{}
+
+func (parserV1) SpecVersion() string { return yamlSpecVersionV1 }
+
+func (parserV1) Parse(data []byte) (*pb.Schema, error) {
+	doc, err := unmarshalSchemaYAML(data)
+	if err != nil {
+		return nil, err
+	}
+	fields := yamlToProtoFields(doc)
+	depReqs := yamlToProtoDependentRequired(doc.DependentRequired)
+	validations := yamlToProtoValidations(doc.Validations)
+	return &pb.Schema{
+		Name:               doc.Name,
+		Description:        doc.Description,
+		Version:            doc.Version,
+		VersionDescription: doc.VersionDescription,
+		Info:               yamlToProtoInfo(doc.Info),
+		Fields:             fields,
+		DependentRequired:  depReqs,
+		Validations:        validations,
+	}, nil
+}
+
+func (parserV1) Marshal(s *pb.Schema) ([]byte, error) {
+	return marshalSchemaYAML(schemaToYAML(s))
+}
+
+func init() {
+	Register(parserV1{})
+}
+
+// yamlToProtoInfo lifts the optional info block out of the YAML doc into
+// the proto SchemaInfo. Lives here rather than yaml.go because it's only
+// used by the parser-side conversion; yaml.go's existing converters
+// handle fields and the schema-level metadata separately.
+func yamlToProtoInfo(yi *SchemaInfoYAML) *pb.SchemaInfo {
+	if yi == nil {
+		return nil
+	}
+	info := &pb.SchemaInfo{
+		Title:  yi.Title,
+		Author: yi.Author,
+		Labels: yi.Labels,
+	}
+	if yi.Contact != nil {
+		info.Contact = &pb.SchemaContact{
+			Name:  yi.Contact.Name,
+			Email: yi.Contact.Email,
+			Url:   yi.Contact.URL,
+		}
+	}
+	return info
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -592,23 +592,26 @@ func (s *Service) ExportSchema(ctx context.Context, req *pb.ExportSchemaRequest)
 		return nil, status.Error(codes.Internal, "unexpected nil schema response")
 	}
 
-	doc := schemaToYAML(getResp.Schema)
-	data, err := marshalSchemaYAML(doc)
+	specVersion := ""
+	if req.SpecVersion != nil {
+		specVersion = *req.SpecVersion
+	}
+	data, err := MarshalSchemaAt(getResp.Schema, specVersion)
 	if err != nil {
-		return nil, status.Error(codes.Internal, "failed to marshal schema to YAML")
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	return &pb.ExportSchemaResponse{YamlContent: data}, nil
 }
 
 func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest) (*pb.ImportSchemaResponse, error) {
-	doc, err := unmarshalSchemaYAML(req.YamlContent)
+	parsed, err := Dispatch(req.YamlContent)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid schema YAML: %v", err)
 	}
 
-	fields := yamlToProtoFields(doc)
-	depReqs := yamlToProtoDependentRequired(doc.DependentRequired)
+	fields := parsed.Fields
+	depReqs := parsed.DependentRequired
 	if err := validateDependentRequiredAgainstFields(depReqs, fields); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -616,22 +619,21 @@ func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to encode dependentRequired: %v", err)
 	}
-	validations := yamlToProtoValidations(doc.Validations)
-	validationsJSON, err := MarshalValidations(validations)
+	validationsJSON, err := MarshalValidations(parsed.Validations)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to encode validations: %v", err)
 	}
 	checksum := computeChecksum(fields)
 
 	// Check if schema already exists by name.
-	existing, err := s.store.GetSchemaByName(ctx, doc.Name)
+	existing, err := s.store.GetSchemaByName(ctx, parsed.Name)
 	if err != nil && !errors.Is(err, domain.ErrNotFound) {
 		return nil, status.Error(codes.Internal, "failed to look up schema")
 	}
 
 	if errors.Is(err, domain.ErrNotFound) {
 		// New schema — create with v1.
-		resp, err := s.importCreateNew(ctx, doc, fields, checksum, depReqJSON, validationsJSON)
+		resp, err := s.importCreateNew(ctx, parsed, fields, checksum, depReqJSON, validationsJSON)
 		if err != nil || !req.AutoPublish {
 			return resp, err
 		}
@@ -656,17 +658,17 @@ func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest)
 	}
 
 	// Create new version.
-	resp, err := s.importNewVersion(ctx, existing, latestVersion, doc, fields, checksum, depReqJSON, validationsJSON)
+	resp, err := s.importNewVersion(ctx, existing, latestVersion, parsed, fields, checksum, depReqJSON, validationsJSON)
 	if err != nil || !req.AutoPublish {
 		return resp, err
 	}
 	return s.autoPublish(ctx, resp)
 }
 
-func (s *Service) importCreateNew(ctx context.Context, doc *SchemaYAML, fields []*pb.SchemaField, checksum string, depReqJSON, validationsJSON []byte) (*pb.ImportSchemaResponse, error) {
+func (s *Service) importCreateNew(ctx context.Context, parsed *pb.Schema, fields []*pb.SchemaField, checksum string, depReqJSON, validationsJSON []byte) (*pb.ImportSchemaResponse, error) {
 	schema, err := s.store.CreateSchema(ctx, CreateSchemaParams{
-		Name:        doc.Name,
-		Description: ptrString(doc.Description),
+		Name:        parsed.Name,
+		Description: ptrString(parsed.Description),
 	})
 	if err != nil {
 		s.logger.ErrorContext(ctx, "import: create schema", "error", err)
@@ -676,7 +678,7 @@ func (s *Service) importCreateNew(ctx context.Context, doc *SchemaYAML, fields [
 	version, err := s.store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
 		SchemaID:          schema.ID,
 		Version:           1,
-		Description:       ptrString(doc.VersionDescription),
+		Description:       ptrString(parsed.VersionDescription),
 		Checksum:          checksum,
 		DependentRequired: depReqJSON,
 		Validations:       validationsJSON,
@@ -696,12 +698,12 @@ func (s *Service) importCreateNew(ctx context.Context, doc *SchemaYAML, fields [
 	}, nil
 }
 
-func (s *Service) importNewVersion(ctx context.Context, schema domain.Schema, latestVersion domain.SchemaVersion, doc *SchemaYAML, fields []*pb.SchemaField, checksum string, depReqJSON, validationsJSON []byte) (*pb.ImportSchemaResponse, error) {
+func (s *Service) importNewVersion(ctx context.Context, schema domain.Schema, latestVersion domain.SchemaVersion, parsed *pb.Schema, fields []*pb.SchemaField, checksum string, depReqJSON, validationsJSON []byte) (*pb.ImportSchemaResponse, error) {
 	newVersion, err := s.store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
 		SchemaID:          schema.ID,
 		Version:           latestVersion.Version + 1,
 		ParentVersion:     &latestVersion.Version,
-		Description:       ptrString(doc.VersionDescription),
+		Description:       ptrString(parsed.VersionDescription),
 		Checksum:          checksum,
 		DependentRequired: depReqJSON,
 		Validations:       validationsJSON,

--- a/proto/centralconfig/v1/config_service.proto
+++ b/proto/centralconfig/v1/config_service.proto
@@ -309,6 +309,11 @@ message ExportConfigRequest {
 
   // Config version to export. If omitted, exports the latest version.
   optional int32 version = 2;
+
+  // Config-format spec version to emit (e.g. "v1"). When omitted, defaults
+  // to the highest version the server supports. The server returns
+  // InvalidArgument if the requested version is not registered.
+  optional string spec_version = 3;
 }
 
 message ExportConfigResponse {

--- a/proto/centralconfig/v1/schema_service.proto
+++ b/proto/centralconfig/v1/schema_service.proto
@@ -336,6 +336,11 @@ message ExportSchemaRequest {
 
   // Schema version to export. If omitted, exports the latest version.
   optional int32 version = 2;
+
+  // Schema-format spec version to emit (e.g. "v1"). When omitted, defaults
+  // to the highest version the server supports. The server returns
+  // InvalidArgument if the requested version is not registered.
+  optional string spec_version = 3;
 }
 
 message ExportSchemaResponse {


### PR DESCRIPTION
Closes #129. Final cross-cutting issue in the Schema Spec v0.1.0 milestone.

## Summary

Extracts the schema and config YAML parsers behind a small \`Parser\` interface + package-level registry. Each spec version is now a single sibling file (e.g. \`parser_v1.go\`) that declares a parser struct and registers it via \`init()\`. Adding v2 in the future means landing one new file — the existing v1 path stays untouched, and nothing else in the codebase changes.

## Design

\`\`\`go
type Parser interface {
    SpecVersion() string
    Parse(data []byte) (*pb.Schema, error)
    Marshal(s *pb.Schema) ([]byte, error)
}

func Register(p Parser)            // called from each parser's init()
func Dispatch(data []byte) (*pb.Schema, error)              // routes by spec_version
func MarshalSchemaAt(s *pb.Schema, version string) (...)    // emits in chosen version
func SupportedVersions() []string                           // surfaced in errors
func LatestVersion() string                                 // default for export
\`\`\`

(Symmetric in \`internal/config/\` — \`DispatchImport\` carries the schema's \`fieldTypes\` since the config parser needs them for type-aware coercion, and returns a \`ParsedImport\` struct so the service layer can pick up the YAML's \`description:\` for audit purposes.)

## Layer split

- **Layer 1 (per-version, in the parser):** YAML shape — required keys, regex patterns, type enums, basic structural lint.
- **Layer 2 (version-agnostic, in the service):** referential integrity (`redirect_to`, `dependentRequired` field existence), prefix-overlap rejection, range sanity, runtime cross-field rules (`dependentRequired`).

The dispatch point sits between the two — \`Dispatch\` returns a \`*pb.Schema\`, then service.go runs the layer-2 checks on that proto value, identical regardless of which version produced it.

## Wire surface

- Adds optional \`spec_version\` field to \`ExportSchemaRequest\` (proto field 3) and \`ExportConfigRequest\` (proto field 3). Additive — buf breaking passes.
- Default behavior unchanged: when \`spec_version\` is omitted, the server emits the highest registered version. With v1 as the only registered parser, that's the same output as before.
- Unknown \`spec_version\` produces \`InvalidArgument\` with the supported version list in the error message.

## Test coverage

- \`internal/schema/parser_test.go\` and \`internal/config/parser_test.go\`:
  - SupportedVersions / LatestVersion
  - Dispatch routing — happy path, missing spec_version, unknown version, malformed YAML
  - MarshalSchemaAt — default (latest), explicit v1, unknown version rejected
  - Round-trip: \`Dispatch → MarshalSchemaAt → Dispatch\` preserves all fields including \`dependentRequired\` and \`validations\`
- Existing \`yaml_test.go\` suites unchanged — \`parser_v1\` is a thin wrapper over the same underlying functions.

## Docs

- \`docs/concepts/meta-schema.md\` gains a \"Multi-version evolution\" section describing the plug-in pattern and the \`spec_version\` request field.
- \`.agents/context/schema-spec.md\` updated with the registry shape so future-me / next contributor knows where v2 plugs in.

## Test plan

- [x] \`make test\` passes (full suite, race detector on)
- [x] \`make lint\` passes
- [x] \`make generate docs\` regenerated and committed
- [x] No semantic changes to existing v1 parsing — yaml_test.go suites pass without modification