### PR TITLE
ci: native ARM runners for multi-arch Docker builds (#9)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 # Runs on every push to main — publishes bleeding-edge Docker images and
 # deploys documentation when docs/ changed. Canonical writer for the
 # `:buildcache` registry cache consumed by ci.yml and release.yml.
+#
+# Multi-arch images are built natively per arch (amd64 on ubuntu-latest,
+# arm64 on ubuntu-24.04-arm) instead of via QEMU emulation — issue #9.
+# Each per-arch build pushes by digest only, then a manifest job per
+# image joins the digests into a single :main multi-arch tag.
 
 name: Main
 
@@ -17,18 +22,28 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # Builds multi-arch server + CLI images tagged :main and populates the
-  # :buildcache tag that all other workflows consume.
-  images:
-    name: Push bleeding-edge images
-    runs-on: ubuntu-latest
+  # Per-arch image builds. 2 images × 2 architectures = 4 jobs running in
+  # parallel. Each pushes by digest only (push-by-digest=true) so the tag
+  # remains free for the manifest job to claim.
+  build:
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - image: decree
-            dockerfile: build/Dockerfile
-          - image: decree-cli
-            dockerfile: build/Dockerfile.decree
+        image:
+          - { name: decree,     dockerfile: build/Dockerfile }
+          - { name: decree-cli, dockerfile: build/Dockerfile.decree }
+        arch:
+          - { platform: linux/amd64, runner: ubuntu-latest,    suffix: amd64 }
+          - { platform: linux/arm64, runner: ubuntu-24.04-arm, suffix: arm64 }
+    # Flatten the 2D matrix manually so each job can address image+arch
+    # via the unified `matrix.image` and `matrix.platform` tuple keys.
+    # GHA's strategy.matrix already produces the cross product; we just
+    # alias the nested fields for readability inline.
+    env:
+      IMAGE_REF: ${{ format('ghcr.io/{0}/{1}', github.repository_owner, matrix.image.name) }}
+      PLATFORM_TAG: ${{ matrix.arch.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,19 +60,79 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          platforms: linux/amd64,linux/arm64
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.arch.platform }}
           build-args: |
             VERSION=main
             COMMIT=${{ github.sha }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:main
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+          # Per-arch buildcache tags so each architecture's layers stay
+          # cleanly separated. Mixing them under a single tag confuses
+          # cache-from when a downstream workflow only wants one arch.
+          cache-from: type=registry,ref=${{ env.IMAGE_REF }}:buildcache-${{ matrix.arch.suffix }}
+          cache-to: type=registry,ref=${{ env.IMAGE_REF }}:buildcache-${{ matrix.arch.suffix }},mode=max
+          # push-by-digest pushes the image WITHOUT a tag, returning only
+          # the manifest digest. The manifest job collects the digests
+          # and assembles the final multi-arch tag.
+          outputs: type=image,name=${{ env.IMAGE_REF }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.arch.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # One manifest job per image. Combines the per-arch digests into a
+  # single multi-arch :main tag, the same shape consumers see today.
+  manifest:
+    name: Manifest ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [decree, decree-cli]
+    env:
+      IMAGE_REF: ${{ format('ghcr.io/{0}/{1}', github.repository_owner, matrix.image) }}
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.IMAGE_REF }}:main" \
+            $(printf '${{ env.IMAGE_REF }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "${{ env.IMAGE_REF }}:main"
 
   # Rebuilds and deploys the MkDocs site to GitHub Pages whenever docs/ changes.
   docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,20 +200,25 @@ jobs:
           push: true
           push_disable_create: true
 
-  # Builds multi-arch release images tagged :version and :latest, reusing the
-  # :buildcache layers populated by main.yml.
-  images:
-    name: Build and push images
-    runs-on: ubuntu-latest
+  # Per-arch image builds. Each matrix entry runs natively on its own
+  # architecture (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm)
+  # rather than going through QEMU emulation — issue #9. push-by-digest
+  # is used so the manifest job downstream can claim the version + latest
+  # tags after both arches finish.
+  build:
+    name: Build ${{ matrix.image.name }} (${{ matrix.arch.platform }})
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - image: decree
-            dockerfile: build/Dockerfile
-            context: .
-          - image: decree-cli
-            dockerfile: build/Dockerfile.decree
-            context: .
+        image:
+          - { name: decree,     dockerfile: build/Dockerfile }
+          - { name: decree-cli, dockerfile: build/Dockerfile.decree }
+        arch:
+          - { platform: linux/amd64, runner: ubuntu-latest,    suffix: amd64 }
+          - { platform: linux/arm64, runner: ubuntu-24.04-arm, suffix: arm64 }
+    env:
+      IMAGE_REF: ${{ format('ghcr.io/{0}/{1}', github.repository_owner, matrix.image.name) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -236,18 +241,80 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: true
-          platforms: linux/amd64,linux/arm64
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.arch.platform }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:latest
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+          # Per-arch buildcache tags shared with main.yml. Reading the
+          # arm64 cache from an amd64 builder (or vice versa) wastes
+          # network round-trips, so we keep them split.
+          cache-from: type=registry,ref=${{ env.IMAGE_REF }}:buildcache-${{ matrix.arch.suffix }}
+          cache-to: type=registry,ref=${{ env.IMAGE_REF }}:buildcache-${{ matrix.arch.suffix }},mode=max
+          outputs: type=image,name=${{ env.IMAGE_REF }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image.name }}-${{ matrix.arch.suffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # One manifest job per image. Joins the per-arch digests into the
+  # final :version + :latest multi-arch tags consumers pull.
+  images:
+    name: Manifest ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [decree, decree-cli]
+    env:
+      IMAGE_REF: ${{ format('ghcr.io/{0}/{1}', github.repository_owner, matrix.image) }}
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ env.IMAGE_REF }}:${{ steps.meta.outputs.version }}" \
+            --tag "${{ env.IMAGE_REF }}:latest" \
+            $(printf '${{ env.IMAGE_REF }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "${{ env.IMAGE_REF }}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
Closes #9.

## Summary

Replaces QEMU emulation of arm64 Docker builds with native \`ubuntu-24.04-arm\` runners. Both \`main.yml\` (publishes \`:main\`) and \`release.yml\` (publishes \`:version\` + \`:latest\`) now use the standard docker/build-push-action multi-platform pattern: per-arch builds run in parallel with native runners, push by digest only, then a per-image manifest job joins the digests into the final multi-arch tag.

## What changed

For each of \`decree\` and \`decree-cli\`:

| Before | After |
|--------|-------|
| 1 job, runs on \`ubuntu-latest\`, builds both arches via QEMU emulation | 2 parallel \`build\` jobs (amd64 on \`ubuntu-latest\`, arm64 on \`ubuntu-24.04-arm\`) + 1 \`manifest\` job that joins them |

Wire shape for consumers is identical — \`docker pull ghcr.io/opendecree/decree:main\` still resolves to a multi-arch manifest pointing at both arches.

## Cache strategy

The single \`:buildcache\` tag becomes per-arch \`:buildcache-amd64\` and \`:buildcache-arm64\`. Mixing arches under one cache tag confuses \`cache-from\` when only one arch's layers are wanted. The old tag is no longer written; on the first merge after this lands, both arches build from scratch and warm up the new caches.

\`ci.yml\` is unaffected — its tools-image pipeline is single-arch (amd64 runners only) with its own \`decree-tools:buildcache\` that this change doesn't touch.

## Caveat: hard to fully validate pre-merge

\`main.yml\` only runs after push to main; \`release.yml\` only on \`v*\` tag push. The CI on this PR exercises neither. The PR-level checks confirm:

- YAML parses cleanly via \`python3 -m yaml\`
- No \`needs:\` dependencies broken (only one downstream — the new \`manifest\`/\`images\` job depends on the new \`build\` job)
- The pattern matches the [docker official multi-platform CI guidance](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)

Real validation comes from the first push-to-main after merge. If the new workflows break, recovery is simple: revert the workflow files; consumer-facing tags continue to work because \`:main\` etc. are pointed at the last successful manifest until the next successful build.