### PR TITLE
fix(ci): correct matrix refs in main.yml build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
   # parallel. Each pushes by digest only (push-by-digest=true) so the tag
   # remains free for the manifest job to claim.
   build:
-    name: Build ${{ matrix.image }} (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.image.name }} (${{ matrix.arch.platform }})
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,13 +37,8 @@ jobs:
         arch:
           - { platform: linux/amd64, runner: ubuntu-latest,    suffix: amd64 }
           - { platform: linux/arm64, runner: ubuntu-24.04-arm, suffix: arm64 }
-    # Flatten the 2D matrix manually so each job can address image+arch
-    # via the unified `matrix.image` and `matrix.platform` tuple keys.
-    # GHA's strategy.matrix already produces the cross product; we just
-    # alias the nested fields for readability inline.
     env:
       IMAGE_REF: ${{ format('ghcr.io/{0}/{1}', github.repository_owner, matrix.image.name) }}
-      PLATFORM_TAG: ${{ matrix.arch.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Hotfix for the broken \`Main\` workflow run after merging #202. The 2D matrix (image × arch) needs nested field access — \`matrix.image.name\` and \`matrix.arch.runner\` / \`matrix.arch.platform\` / \`matrix.arch.suffix\`, not the bare \`matrix.image\` / \`matrix.runner\` / \`matrix.platform\` I mis-typed.

\`release.yml\` had the correct form already; \`main.yml\` was the only file with the bug. The bad references caused \`runs-on:\` to evaluate to empty per matrix instance, so the build jobs never started, the manifest job's \`needs: build\` was unsatisfied, and the workflow failed silently.

Run that broke: https://github.com/opendecree/decree/actions/runs/25010604152