### PR TITLE
fix(ci): anchor digest-artifact pattern on non-shared image suffix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,10 @@ jobs:
       - name: Upload digest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image.name }}-${{ matrix.arch.suffix }}
+          # Image name LAST so the manifest job's download pattern
+          # (`digests-*-<image>`) doesn't accidentally match a different
+          # image whose name starts with this one (decree vs decree-cli).
+          name: digests-${{ matrix.arch.suffix }}-${{ matrix.image.name }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -106,7 +109,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.image }}-*
+          pattern: digests-*-${{ matrix.image }}
           merge-multiple: true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,10 @@ jobs:
       - name: Upload digest artifact
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image.name }}-${{ matrix.arch.suffix }}
+          # Image name LAST so the manifest job's download pattern
+          # (`digests-*-<image>`) doesn't accidentally match a different
+          # image whose name starts with this one (decree vs decree-cli).
+          name: digests-${{ matrix.arch.suffix }}-${{ matrix.image.name }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -289,7 +292,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-${{ matrix.image }}-*
+          pattern: digests-*-${{ matrix.image }}
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Second hotfix on the #9 native-ARM workflows. The first run after #203 landed showed all 4 build jobs succeeded natively (~60-75s each, big win over the prior QEMU emulation), but \`Manifest decree\` failed:

\`\`\`
ERROR: ghcr.io/opendecree/decree@sha256:577943...: not found
\`\`\`

Root cause: the download pattern \`digests-decree-*\` also matched \`decree-cli\`'s artifacts, because \`decree-cli\` starts with \`decree-\`. minimatch's \`*\` happily crosses hyphens, so the manifest job pulled the wrong digests and tried to look them up against the wrong image ref.

Fix: swap the order so image name goes LAST in the artifact name. New pattern is \`digests-*-decree\`, which does NOT match \`digests-amd64-decree-cli\` because the candidate doesn't end with \`-decree\`. decree-cli's pattern likewise doesn't match decree's artifacts.

Applied to both \`main.yml\` and \`release.yml\` so the release path doesn't repeat the same mistake.

Failing run: https://github.com/opendecree/decree/actions/runs/25010994670