### PR TITLE
fix(audit): enforce tenant access on read handlers

### DIFF
--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/opendecree/decree/sdk/adminclient"
 )
 
 // writeRPCSpec describes one write RPC that should enforce tenant access.
@@ -123,6 +125,76 @@ func TestTenantAccessMatrix(t *testing.T) {
 				otherFx := bootstrapMatrixFixture(t, "m2-out-other")
 
 				// Caller is scoped to a DIFFERENT tenant than the target.
+				caller := scopedClients(t, conn, roleAdmin, otherFx.tenantID)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				err := spec.invoke(ctx, t, caller, targetFx.tenantID, targetFx.schemaID)
+				assert.True(t, isAuthDenied(err),
+					"out-of-scope admin must be denied on %s; got: %v", spec.name, err)
+			})
+		})
+	}
+}
+
+// auditRPCs covers every audit read RPC. These are reads, but the bypass
+// class is the same as matrix 2: a handler that fails to call
+// auth.CheckTenantAccess lets a tenant-A admin read tenant-B data.
+func auditRPCs() []writeRPCSpec {
+	return []writeRPCSpec{
+		{
+			name: "QueryWriteLog",
+			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
+				_, err := c.admin.QueryWriteLog(ctx, adminclient.WithAuditTenant(tenantID))
+				return err
+			},
+		},
+		{
+			name: "GetFieldUsage",
+			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
+				_, err := c.admin.GetFieldUsage(ctx, tenantID, "app.name", nil, nil)
+				return err
+			},
+		},
+		{
+			name: "GetTenantUsage",
+			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
+				_, err := c.admin.GetTenantUsage(ctx, tenantID, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "GetUnusedFields",
+			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
+				_, err := c.admin.GetUnusedFields(ctx, tenantID, time.Now().Add(-time.Hour))
+				return err
+			},
+		},
+	}
+}
+
+func TestAuditTenantAccessMatrix(t *testing.T) {
+	conn := dial(t)
+	rpcs := auditRPCs()
+
+	for _, spec := range rpcs {
+		spec := spec
+		t.Run(spec.name, func(t *testing.T) {
+			t.Run("in_scope_allowed", func(t *testing.T) {
+				fx := bootstrapMatrixFixture(t, "m2-audit-in")
+				caller := scopedClients(t, conn, roleAdmin, fx.tenantID)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				err := spec.invoke(ctx, t, caller, fx.tenantID, fx.schemaID)
+				assert.False(t, isAuthDenied(err),
+					"in-scope admin must not get auth denial on %s; got: %v", spec.name, err)
+			})
+
+			t.Run("out_of_scope_denied", func(t *testing.T) {
+				targetFx := bootstrapMatrixFixture(t, "m2-audit-out-target")
+				otherFx := bootstrapMatrixFixture(t, "m2-audit-out-other")
+
 				caller := scopedClients(t, conn, roleAdmin, otherFx.tenantID)
 
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/pagination"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
@@ -68,7 +69,12 @@ func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogReques
 		if err != nil {
 			return nil, err
 		}
+		if err := auth.CheckTenantAccess(ctx, resolved); err != nil {
+			return nil, err
+		}
 		params.TenantID = resolved
+	} else if claims, ok := auth.ClaimsFromContext(ctx); ok && !claims.IsSuperAdmin() {
+		return nil, status.Error(codes.PermissionDenied, "tenant_id required for non-superadmin callers")
 	}
 	if req.Actor != nil {
 		params.Actor = *req.Actor
@@ -110,6 +116,9 @@ func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogReques
 func (s *Service) GetFieldUsage(ctx context.Context, req *pb.GetFieldUsageRequest) (*pb.GetFieldUsageResponse, error) {
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
+		return nil, err
+	}
+	if err := auth.CheckTenantAccess(ctx, tenantID); err != nil {
 		return nil, err
 	}
 
@@ -162,6 +171,9 @@ func (s *Service) GetTenantUsage(ctx context.Context, req *pb.GetTenantUsageRequ
 	if err != nil {
 		return nil, err
 	}
+	if err := auth.CheckTenantAccess(ctx, tenantID); err != nil {
+		return nil, err
+	}
 
 	params := GetTenantUsageParams{
 		TenantID: tenantID,
@@ -200,6 +212,9 @@ func (s *Service) GetTenantUsage(ctx context.Context, req *pb.GetTenantUsageRequ
 func (s *Service) GetUnusedFields(ctx context.Context, req *pb.GetUnusedFieldsRequest) (*pb.GetUnusedFieldsResponse, error) {
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
+		return nil, err
+	}
+	if err := auth.CheckTenantAccess(ctx, tenantID); err != nil {
 		return nil, err
 	}
 

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -14,8 +14,24 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
+
+const (
+	testTenantID  = "22222222-2222-2222-2222-222222222222"
+	otherTenantID = "00000000-0000-0000-0000-000000000999"
+)
+
+// outOfScopeAdminCtx returns context with admin claims scoped to otherTenantID
+// — i.e. NOT testTenantID. Used to verify audit RPCs reject callers without
+// tenant access.
+func outOfScopeAdminCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleAdmin,
+		TenantIDs: []string{otherTenantID},
+	})
+}
 
 type mockStore struct{ mock.Mock }
 
@@ -196,6 +212,57 @@ func TestGetUnusedFields_InvalidTenantID(t *testing.T) {
 		Since:    timestamppb.Now(),
 	})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// --- Tenant access enforcement ---
+
+func TestQueryWriteLog_DeniedForOutOfScopeAdmin(t *testing.T) {
+	svc, _ := newTestService()
+	tenantID := testTenantID
+
+	_, err := svc.QueryWriteLog(outOfScopeAdminCtx(), &pb.QueryWriteLogRequest{TenantId: &tenantID})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestQueryWriteLog_DeniedForNonSuperAdminWithoutTenantID(t *testing.T) {
+	svc, _ := newTestService()
+
+	_, err := svc.QueryWriteLog(outOfScopeAdminCtx(), &pb.QueryWriteLogRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestGetFieldUsage_DeniedForOutOfScopeAdmin(t *testing.T) {
+	svc, _ := newTestService()
+
+	_, err := svc.GetFieldUsage(outOfScopeAdminCtx(), &pb.GetFieldUsageRequest{
+		TenantId:  testTenantID,
+		FieldPath: "app.fee",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestGetTenantUsage_DeniedForOutOfScopeAdmin(t *testing.T) {
+	svc, _ := newTestService()
+
+	_, err := svc.GetTenantUsage(outOfScopeAdminCtx(), &pb.GetTenantUsageRequest{
+		TenantId: testTenantID,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestGetUnusedFields_DeniedForOutOfScopeAdmin(t *testing.T) {
+	svc, _ := newTestService()
+
+	_, err := svc.GetUnusedFields(outOfScopeAdminCtx(), &pb.GetUnusedFieldsRequest{
+		TenantId: testTenantID,
+		Since:    timestamppb.Now(),
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary
- All four AuditService handlers (QueryWriteLog, GetFieldUsage, GetTenantUsage, GetUnusedFields) bypassed tenant access checks — a tenant-A admin could read tenant-B's audit log, usage stats, and unused-field reports. Each now calls `auth.CheckTenantAccess` on the resolved tenant ID.
- `QueryWriteLog` with no `tenant_id` returns `PermissionDenied` for non-superadmin callers; superadmins retain cross-tenant visibility (the documented contract in `docs/concepts/auth.md`).
- Surfaced by the matrix harness from #114 — adds a sibling `TestAuditTenantAccessMatrix` so any future audit RPC missing a tenant check is caught the same way.

## Test plan
- [x] `make pre-commit` (build, vet, fmt, lint, test, coverage) clean
- [x] `make lint-proto` (buf lint + breaking) clean
- [x] Unit deny-path tests for each handler in `internal/audit/service_test.go`
- [x] `make e2e` — `TestAuditTenantAccessMatrix` 8/8 cells pass (in_scope_allowed + out_of_scope_denied for each of 4 RPCs)

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)