### PR TITLE
perf(ci): add GHA cache tier to e2e and examples pre-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,8 +360,15 @@ jobs:
           file: build/Dockerfile
           load: true
           tags: decree-service
-          # Read-only: main.yml is the canonical writer for this cache.
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
+          # Two-tier cache:
+          #   - registry buildcache (read-only; main.yml is canonical writer)
+          #     supplies stable layers like base image + go mod download.
+          #   - GHA cache (read/write, shared scope) carries warm layers
+          #     forward from previous PR runs without round-tripping ghcr.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
+            type=gha,scope=server-build
+          cache-to: type=gha,scope=server-build,mode=max
 
       - name: Run E2E tests
         run: |
@@ -417,8 +424,15 @@ jobs:
           file: build/Dockerfile
           load: true
           tags: decree-service
-          # Read-only: main.yml is the canonical writer for this cache.
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
+          # Two-tier cache:
+          #   - registry buildcache (read-only; main.yml is canonical writer)
+          #     supplies stable layers like base image + go mod download.
+          #   - GHA cache (read/write, shared scope) carries warm layers
+          #     forward from previous PR runs without round-tripping ghcr.
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
+            type=gha,scope=server-build
+          cache-to: type=gha,scope=server-build,mode=max
 
       - name: Run examples
         run: make examples


### PR DESCRIPTION
## Summary
- The Pre-build server image step in `e2e` and `examples` jobs is the longest serial leg on PR CI (~50s wall time, see PRs #208/#204/#202 — runs land in 2:50–3:50 with this leg dominating).
- Today the only cache source is `type=registry,ref=…/decree:buildcache` on ghcr.io. Buildx in `docker-container` driver mode starts a fresh BuildKit per job, so every PR pays the round-trip to ghcr to seed it.
- Adds a second tier: `type=gha` with a shared `server-build` scope. GHA's local cache returns layers from previous PR runs without ghcr round-trip; `cache-to: mode=max` exports intermediates (notably `go mod download`) so they survive between runs.
- Registry cache stays as the cold-start fallback. `main.yml` remains its only writer — no semantic change to the production pipeline.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Watch first 2–3 PR runs after merge to confirm pre-build step drops; expected savings 15–30s once the gha scope warms (cold first-run will be no faster).
- [ ] If the savings don't materialize, follow-ups in the discovery thread are: BuildKit cache mounts in `build/Dockerfile` (`--mount=type=cache,target=/root/.cache/go-build`) which would persist Go's compile cache, OR switching the buildx driver from `docker-container` to `docker` to drop container startup.

## Notes
- This is exploratory perf work. No issue # — opened straight from CI walltime discovery.
- No regression risk: PR e2e still builds from PR sources, just with an extra cache lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)