### PR TITLE
feat(server): enforce configurable gRPC message size limits

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -177,6 +178,8 @@ func run() int {
 		Logger:          logger,
 		AuthInterceptor: authInterceptor,
 		ExtraOptions:    extraOpts,
+		MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
+		MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create server", "error", err)
@@ -251,10 +254,12 @@ func run() int {
 	var gw *server.Gateway
 	if cfg.HTTPPort != "" {
 		gw, err = server.NewGateway(ctx, server.GatewayConfig{
-			HTTPPort:    cfg.HTTPPort,
-			GRPCAddr:    fmt.Sprintf("localhost:%s", cfg.GRPCPort),
-			Logger:      logger,
-			OpenAPISpec: openAPISpec,
+			HTTPPort:        cfg.HTTPPort,
+			GRPCAddr:        fmt.Sprintf("localhost:%s", cfg.GRPCPort),
+			Logger:          logger,
+			OpenAPISpec:     openAPISpec,
+			MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
+			MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
 		})
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create HTTP gateway", "error", err)
@@ -307,6 +312,8 @@ type serverConfig struct {
 	LogLevel             string
 	UsageTrackingEnabled bool
 	UsageFlushInterval   time.Duration
+	GRPCMaxRecvMsgBytes  int
+	GRPCMaxSendMsgBytes  int
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -349,7 +356,24 @@ func loadConfig() serverConfig {
 		LogLevel:             getEnv("LOG_LEVEL", "info"),
 		UsageTrackingEnabled: getEnv("USAGE_TRACKING_ENABLED", "true") != "false",
 		UsageFlushInterval:   flushInterval,
+		GRPCMaxRecvMsgBytes:  parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
+		GRPCMaxSendMsgBytes:  parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
 	}
+}
+
+// parseEnvInt parses an integer env var. Returns fallback when unset or invalid;
+// invalid values exit with an error so misconfiguration is loud, not silent.
+func parseEnvInt(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		slog.Error("invalid integer env var", "key", key, "value", raw, "error", err)
+		os.Exit(1)
+	}
+	return v
 }
 
 func getEnv(key, fallback string) string {

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -16,6 +16,8 @@ OpenDecree is configured entirely through environment variables. No config files
 | `LOG_LEVEL` | Log verbosity. One of: `debug`, `info`, `warn`, `error`. Logs are JSON-formatted to stdout. | `info` | No |
 | `USAGE_TRACKING_ENABLED` | Enable automatic recording of config field reads (`GetField`, `GetConfig`, `GetFields`). Set to `false` to disable. | `true` | No |
 | `USAGE_FLUSH_INTERVAL` | How often accumulated read counts are flushed to storage. Format: Go duration (e.g., `30s`, `1m`). | `30s` | No |
+| `GRPC_MAX_RECV_MSG_BYTES` | Maximum size of an inbound gRPC message, in bytes. Requests above this return `ResourceExhausted`. Set to `0` for the default. | `20971520` (20 MiB) | No |
+| `GRPC_MAX_SEND_MSG_BYTES` | Maximum size of an outbound gRPC message, in bytes. Responses above this return `ResourceExhausted` to the client. Set to `0` for the default. | `20971520` (20 MiB) | No |
 
 ### In-Memory Mode
 

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -33,6 +33,12 @@ type GatewayConfig struct {
 	// OpenAPISpec is the raw OpenAPI JSON spec to serve at /docs/openapi.json.
 	// If nil, the docs endpoints are not registered.
 	OpenAPISpec []byte
+	// MaxRecvMsgBytes caps inbound gRPC response size from the upstream server.
+	// Zero or negative → DefaultMaxMsgBytes.
+	MaxRecvMsgBytes int
+	// MaxSendMsgBytes caps outbound gRPC request size to the upstream server.
+	// Zero or negative → DefaultMaxMsgBytes.
+	MaxSendMsgBytes int
 }
 
 // NewGateway creates a new HTTP gateway that proxies to the given gRPC address.
@@ -42,9 +48,22 @@ func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 		return nil, nil
 	}
 
+	recvCap := cfg.MaxRecvMsgBytes
+	if recvCap <= 0 {
+		recvCap = DefaultMaxMsgBytes
+	}
+	sendCap := cfg.MaxSendMsgBytes
+	if sendCap <= 0 {
+		sendCap = DefaultMaxMsgBytes
+	}
+
 	conn, err := grpc.NewClient(
 		cfg.GRPCAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(recvCap),
+			grpc.MaxCallSendMsgSize(sendCap),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("dial gRPC server: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,10 @@ type GRPCInterceptor interface {
 	StreamInterceptor() grpc.StreamServerInterceptor
 }
 
+// DefaultMaxMsgBytes is applied to inbound and outbound gRPC messages when
+// Config.MaxRecvMsgBytes / MaxSendMsgBytes are zero or negative.
+const DefaultMaxMsgBytes = 20 * 1024 * 1024
+
 // Config holds the server configuration.
 type Config struct {
 	GRPCPort        string
@@ -25,6 +29,10 @@ type Config struct {
 	Logger          *slog.Logger
 	AuthInterceptor GRPCInterceptor
 	ExtraOptions    []grpc.ServerOption
+	// MaxRecvMsgBytes caps inbound gRPC message size. Zero or negative → DefaultMaxMsgBytes.
+	MaxRecvMsgBytes int
+	// MaxSendMsgBytes caps outbound gRPC message size. Zero or negative → DefaultMaxMsgBytes.
+	MaxSendMsgBytes int
 }
 
 // Server wraps the gRPC server and health service.
@@ -42,9 +50,20 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("listen on port %s: %w", cfg.GRPCPort, err)
 	}
 
-	opts := make([]grpc.ServerOption, 0, len(cfg.ExtraOptions)+2)
+	recvCap := cfg.MaxRecvMsgBytes
+	if recvCap <= 0 {
+		recvCap = DefaultMaxMsgBytes
+	}
+	sendCap := cfg.MaxSendMsgBytes
+	if sendCap <= 0 {
+		sendCap = DefaultMaxMsgBytes
+	}
+
+	opts := make([]grpc.ServerOption, 0, len(cfg.ExtraOptions)+4)
 	opts = append(opts, cfg.ExtraOptions...)
 	opts = append(opts,
+		grpc.MaxRecvMsgSize(recvCap),
+		grpc.MaxSendMsgSize(sendCap),
 		grpc.ChainUnaryInterceptor(cfg.AuthInterceptor.UnaryInterceptor()),
 		grpc.ChainStreamInterceptor(cfg.AuthInterceptor.StreamInterceptor()),
 	)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 type noopInterceptor struct{}
@@ -73,6 +77,119 @@ func TestSetServiceHealthy(t *testing.T) {
 
 	// Should not panic.
 	srv.SetServiceHealthy("centralconfig.v1.SchemaService")
+}
+
+// echoServiceDesc registers an "/test.Echo/Echo" unary RPC that returns its
+// input verbatim. Used to drive message-size-cap tests without spinning up
+// a full proto package.
+var echoServiceDesc = grpc.ServiceDesc{
+	ServiceName: "test.Echo",
+	HandlerType: (*any)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Echo",
+			Handler: func(_ any, ctx context.Context, dec func(any) error, _ grpc.UnaryServerInterceptor) (any, error) {
+				in := &wrapperspb.BytesValue{}
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				return in, nil
+			},
+		},
+	},
+}
+
+// startTestServer spins up a Server on a random port with the given size caps,
+// registers the echo service, and returns a connected client + cleanup func.
+func startTestServer(t *testing.T, recvCap, sendCap int) (*grpc.ClientConn, func()) {
+	t.Helper()
+	srv, err := New(Config{
+		GRPCPort:        "0",
+		Logger:          slog.Default(),
+		AuthInterceptor: &noopInterceptor{},
+		MaxRecvMsgBytes: recvCap,
+		MaxSendMsgBytes: sendCap,
+	})
+	require.NoError(t, err)
+
+	srv.grpcServer.RegisterService(&echoServiceDesc, struct{}{})
+
+	addr := srv.listener.Addr().String()
+	go func() { _ = srv.Serve(context.Background()) }()
+
+	conn, err := grpc.NewClient(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(64*1024*1024),
+			grpc.MaxCallSendMsgSize(64*1024*1024),
+		),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.GracefulStop(context.Background())
+	}
+	return conn, cleanup
+}
+
+func invokeEcho(ctx context.Context, conn *grpc.ClientConn, payload []byte) (*wrapperspb.BytesValue, error) {
+	in := wrapperspb.Bytes(payload)
+	out := &wrapperspb.BytesValue{}
+	err := conn.Invoke(ctx, "/test.Echo/Echo", in, out)
+	return out, err
+}
+
+func TestServer_MaxRecvMsgSize_RejectsOversizeRequest(t *testing.T) {
+	conn, cleanup := startTestServer(t, 1024, 1024)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := invokeEcho(ctx, conn, make([]byte, 4096))
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestServer_MaxSendMsgSize_RejectsOversizeResponse(t *testing.T) {
+	// Server's send cap (1 KB) is hit by a 4 KB echo response;
+	// request itself stays under the 64 KB recv cap.
+	conn, cleanup := startTestServer(t, 64*1024, 1024)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := invokeEcho(ctx, conn, make([]byte, 4096))
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+func TestServer_UnderCap_OK(t *testing.T) {
+	conn, cleanup := startTestServer(t, 64*1024, 64*1024)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := invokeEcho(ctx, conn, make([]byte, 4096))
+	require.NoError(t, err)
+	assert.Len(t, out.Value, 4096)
+}
+
+func TestServer_ZeroCap_AppliesDefault(t *testing.T) {
+	// Zero/negative configured caps should fall back to DefaultMaxMsgBytes.
+	// 1 KB through is well under the 20 MB default and must succeed.
+	conn, cleanup := startTestServer(t, 0, -1)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := invokeEcho(ctx, conn, make([]byte, 1024))
+	require.NoError(t, err)
+	assert.Len(t, out.Value, 1024)
 }
 
 func TestServe_AndGracefulStop(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `MaxRecvMsgBytes` / `MaxSendMsgBytes` to `server.Config` and `server.GatewayConfig`, applied via `grpc.MaxRecvMsgSize` / `grpc.MaxSendMsgSize` on the server and `grpc.WithDefaultCallOptions` on the gateway-to-gRPC client.
- Default is 20 MiB on both directions; zero or negative configured values fall back to the default so existing call sites are unaffected.
- Wired through `cmd/server/main.go` via two new env vars: `GRPC_MAX_RECV_MSG_BYTES` and `GRPC_MAX_SEND_MSG_BYTES`. Invalid integer values exit with a clear error rather than silently using the default.
- Documented in `docs/server/configuration.md`.

Closes #212. From security review #26.

## Test plan

- [x] `make pre-commit` clean (build, vet, format, lint, full test suite, coverage thresholds — `internal` ticked from 82.1 → 82.2%).
- [x] New unit tests in `internal/server/server_test.go`:
  - oversize request → `ResourceExhausted`
  - oversize response → `ResourceExhausted`
  - under cap → success
  - zero/negative cap → default applied (1 KiB request through default 20 MiB cap succeeds)
- [x] Tests use a tiny inline `test.Echo/Echo` service registered via raw `grpc.ServiceDesc` to avoid coupling to a real proto package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)