### PR TITLE
ci+build: digest-pin base images, SHA-pin non-trusted actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
           persist-credentials: false
 
       - name: Run path filter
-        uses: dorny/paths-filter@v4
+        # dorny/paths-filter@v4
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
         id: filter
         with:
           filters: |
@@ -162,6 +163,9 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: git fetch origin main:main
 
+      - name: Check supply-chain pins
+        run: ./scripts/check-supply-chain-pins.sh
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -169,7 +173,8 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Go lint
-        uses: golangci/golangci-lint-action@v9
+        # golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
         with:
           version: v2.11.4
 
@@ -484,7 +489,8 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
+        # golang/govulncheck-action@v1
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
           go-version-file: go.mod
           work-dir: .
@@ -529,7 +535,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: All green gate
-        uses: re-actors/alls-green@release/v1
+        # re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: lint, test, sdk-compat, docs, e2e, examples, govulncheck, deps-review

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,8 +144,9 @@ jobs:
           persist-credentials: false
 
       - name: Deploy to GitHub Pages
+        # squidfunk/mkdocs-material:9.7.6
         run: >
           docker run --rm
           -v ${{ github.workspace }}:/docs
-          squidfunk/mkdocs-material:9.7.6
+          squidfunk/mkdocs-material@sha256:868ad4d39fb5865b72d00173ade00f4eae2b38dde7ff790a011cc44ce4a8ff8e
           gh-deploy --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,8 @@ jobs:
           go-version: "1.25"
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        # goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
         with:
           version: "~> v2"
           args: release --clean
@@ -194,7 +195,8 @@ jobs:
           persist-credentials: false
 
       - name: Push to BSR
-        uses: bufbuild/buf-action@v1
+        # bufbuild/buf-action@v1
+        uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff
         with:
           token: ${{ secrets.BUF_TOKEN }}
           push: true

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM golang:1.26-bookworm AS builder
+# golang:1.26-bookworm
+FROM golang@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
 
 WORKDIR /app
 
@@ -17,7 +18,8 @@ RUN CGO_ENABLED=0 go build \
     -o /bin/decree ./cmd/server
 
 # Runtime stage
-FROM gcr.io/distroless/static-debian12:nonroot
+# gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=builder /bin/decree /bin/decree
 

--- a/build/Dockerfile.decree
+++ b/build/Dockerfile.decree
@@ -1,5 +1,6 @@
 # Build stage
-FROM golang:1.26-bookworm AS builder
+# golang:1.26-bookworm
+FROM golang@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
 
 WORKDIR /app
 
@@ -24,7 +25,8 @@ RUN cd cmd/decree && CGO_ENABLED=0 go build \
     -o /bin/decree .
 
 # Runtime stage
-FROM gcr.io/distroless/static-debian12:nonroot
+# gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=builder /bin/decree /bin/decree
 

--- a/build/Dockerfile.tools
+++ b/build/Dockerfile.tools
@@ -1,4 +1,5 @@
-FROM golang:1.26-bookworm
+# golang:1.26-bookworm
+FROM golang@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19
 
 # Tools are grouped by purpose so bumping one pin rebuilds only its layer.
 # Cache mounts persist Go module downloads and build artifacts within a build;

--- a/docs/development/checklists.md
+++ b/docs/development/checklists.md
@@ -87,6 +87,29 @@ Standard development workflow checklists.
 - [ ] Edit release notes if needed: `gh release edit v{X.Y.Z} --notes "..."`
 - [ ] Milestone auto-closed by CI (verify)
 
+## Supply-chain pinning policy
+
+To prevent silent base-image or third-party-action substitution, the repo
+enforces these rules. CI runs `scripts/check-supply-chain-pins.sh` to keep
+PRs honest.
+
+- **Base images.** Every `FROM` line in `build/*` must pin to an
+  `image@sha256:<digest>`. Add a comment on the line above recording the
+  human-readable tag (e.g. `# golang:1.26-bookworm`). Dependabot's
+  `docker` ecosystem keeps these digests current.
+- **Third-party actions.** Every `uses:` reference to an action outside a
+  trusted org must pin to a 40-char commit SHA, with a comment on the line
+  above recording the original tag. Trusted orgs (`actions/`, `github/`,
+  `docker/`) may continue to pin by major-version tag. Dependabot's
+  `github-actions` ecosystem updates SHA pins automatically when the
+  original ref is itself a SHA.
+- **`docker run` invocations** in workflow steps follow the same digest
+  rule as `FROM` lines.
+
+When adding a new external action, run
+`gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'` to
+resolve a tag to its commit SHA before pinning.
+
 ## Milestone Lifecycle
 
 Milestones represent efforts (e.g. "Admin GUI", "Security Review"), not releases.

--- a/scripts/check-supply-chain-pins.sh
+++ b/scripts/check-supply-chain-pins.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check-supply-chain-pins.sh — Enforce supply-chain pinning policy.
+#
+# 1. Every `uses:` line in .github/workflows/*.yml that references a
+#    non-trusted action must pin to a 40-char commit SHA.
+#    Trusted orgs (allowed to pin by tag): actions, github, docker.
+# 2. Every `FROM` line in build/* must pin to an `@sha256:<digest>`.
+#
+# Exits non-zero with a list of offenders.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# --- workflows ---------------------------------------------------------------
+# Match `uses: <ref>` (ignore lines inside comments). Skip trusted orgs.
+# A pinned ref is `<owner>/<repo>[/path]@<40-hex>`.
+while IFS= read -r line; do
+  # Strip leading "<file>:<n>:" prefix from grep -n -H
+  file_loc="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  content="${rest#*:}"
+  # Trim leading whitespace
+  trimmed="${content#"${content%%[![:space:]]*}"}"
+  # Skip comment lines
+  [[ "$trimmed" == \#* ]] && continue
+  # Strip optional list-item prefix `- `
+  trimmed="${trimmed#- }"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  # Extract the ref after `uses:`
+  ref="${trimmed#uses:}"
+  ref="${ref#"${ref%%[![:space:]]*}"}"
+  # Skip local workflow refs
+  [[ "$ref" == ./* ]] && continue
+  # Trusted orgs may continue to pin by tag
+  case "$ref" in
+    actions/*|github/*|docker/*) continue ;;
+  esac
+  # Ref must look like owner/repo[/path]@<sha>
+  sha="${ref##*@}"
+  if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "non-trusted action not SHA-pinned: $file_loc:$lineno: $ref" >&2
+    fail=1
+  fi
+done < <(grep -rHnE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]' .github/workflows/ || true)
+
+# --- Dockerfiles -------------------------------------------------------------
+while IFS= read -r line; do
+  file_loc="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+  content="${rest#*:}"
+  # Extract image ref after FROM (drop `AS <name>` suffix)
+  ref="${content#FROM }"
+  ref="${ref%% AS *}"
+  ref="${ref%% as *}"
+  if [[ "$ref" != *"@sha256:"* ]]; then
+    echo "Dockerfile FROM not digest-pinned: $file_loc:$lineno: $content" >&2
+    fail=1
+  fi
+done < <(grep -rHnE '^FROM ' build/ || true)
+
+if [[ $fail -ne 0 ]]; then
+  echo "" >&2
+  echo "See docs/development/checklists.md for the supply-chain pinning policy." >&2
+  exit 1
+fi
+
+echo "supply-chain pins OK"


### PR DESCRIPTION
## Summary

- Closes a supply-chain pinning gap surfaced by security review #26: floating base-image tags and tag-pinned third-party actions can be silently substituted by an upstream maintainer or attacker.
- Every `FROM` in `build/*` and the mkdocs-material `docker run` in `main.yml` now pins to `image@sha256:<digest>`. Every `uses:` outside the trusted orgs (`actions/`, `github/`, `docker/`) pins to a 40-char commit SHA.
- A new `scripts/check-supply-chain-pins.sh` enforces both rules and runs in the `lint` job, so future PRs that drift fail CI. Policy documented in `docs/development/checklists.md`.

## Changes

- Base images digest-pinned: `golang:1.26-bookworm`, `gcr.io/distroless/static-debian12:nonroot`, `squidfunk/mkdocs-material:9.7.6`. Original tags preserved as comments above each pin for human readability.
- Six third-party actions SHA-pinned: `dorny/paths-filter`, `golangci/golangci-lint-action`, `golang/govulncheck-action`, `bufbuild/buf-action`, `goreleaser/goreleaser-action`, `re-actors/alls-green`. Original tags preserved as comments.
- Dependabot config already covers `github-actions` (updates SHA pins when the original ref is itself a SHA) and `docker` (updates digests). No config change needed.

## Test plan

- [x] `make pre-commit` clean (build, vet, fmt, lint, test, coverage)
- [x] `make lint-proto` clean — confirms tools image rebuilds correctly from the new digest-pinned `golang@sha256:…` base
- [x] `bash scripts/check-supply-chain-pins.sh` reports `supply-chain pins OK` on this branch
- [x] Manual: confirmed grep across `.github/workflows/*.yml` shows zero non-trusted refs without a 40-char SHA, and zero `FROM` lines in `build/*` without `@sha256:`

Closes #221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)