### PR TITLE
ci: add stale bot for inactive issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: Stale issues and PRs
+
+# Daily sweep: marks inactive issues/PRs as stale and eventually closes
+# them. The `keep` label opts an item out entirely; `good first issue`
+# and `bug` are also exempt for issues. Issues #162 (decree).
+#
+# Tuning happens here per-repo so each project can adjust independently
+# if traffic patterns diverge.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'  # daily 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been inactive for 60 days and is being marked
+            stale. It will be closed in 14 days unless there is new
+            activity. Add the `keep` label to opt out of future sweeps.
+          stale-pr-message: >
+            This PR has been inactive for 30 days and is being marked
+            stale. It will be closed in 7 days unless there is new
+            activity. Add the `keep` label to opt out of future sweeps.
+          close-issue-message: >
+            Closing for inactivity. Reopen if this is still relevant.
+          close-pr-message: >
+            Closing for inactivity. Reopen if this is still relevant.
+          stale-issue-label: stale
+          stale-pr-label: stale
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          exempt-issue-labels: 'keep,good first issue,bug'
+          exempt-pr-labels: 'keep'
+          close-issue-reason: not_planned
+          operations-per-run: 100


### PR DESCRIPTION
## Summary

- Adds a daily \`actions/stale@v9\` sweep so the alpha backlog doesn't grow stale issues + PRs unbounded as discoverability ramps up.
- Issues: stale at 60d, close at 74d; PRs: stale at 30d, close at 37d. Issues close with reason \`not_planned\`.
- Exempt labels: \`keep\` (both), plus \`good first issue\` and \`bug\` for issues. The \`keep\` label has been pre-created in every repo so the exemption actually filters from day one.

## Approach

Self-contained per-repo workflow rather than a reusable in \`opendecree/.github\`. The file is small, retuning is unlikely on an alpha project, and each repo can adjust independently if traffic patterns diverge. Identical workflows will follow in the four other repos.

## Test plan

- [x] \`scripts/check-supply-chain-pins.sh\` clean (\`actions/stale@v9\` is in a trusted org, tag pin allowed)
- [ ] First scheduled run executes cleanly (next 01:30 UTC) — will verify in Actions tab post-merge
- [ ] Manual \`workflow_dispatch\` from the Actions tab as a smoke test

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)