### PR TITLE
feat(server): enforce TLS for gRPC + gateway dial

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -172,6 +172,17 @@ func run() int {
 		extraOpts = append(extraOpts, grpc.StatsHandler(otelgrpc.NewServerHandler()))
 	}
 
+	var serverTLS *server.TLSConfig
+	if !cfg.InsecureListen {
+		serverTLS = &server.TLSConfig{
+			CertFile:     cfg.TLSCertFile,
+			KeyFile:      cfg.TLSKeyFile,
+			ClientCAFile: cfg.TLSClientCAFile,
+		}
+	} else {
+		logger.WarnContext(ctx, "INSECURE_LISTEN=1 set — gRPC server will accept plaintext connections (local dev only)")
+	}
+
 	srv, err := server.New(server.Config{
 		GRPCPort:        cfg.GRPCPort,
 		EnableServices:  cfg.EnableServices,
@@ -180,6 +191,8 @@ func run() int {
 		ExtraOptions:    extraOpts,
 		MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
 		MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
+		TLS:             serverTLS,
+		Insecure:        cfg.InsecureListen,
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create server", "error", err)
@@ -253,6 +266,16 @@ func run() int {
 	// Optional HTTP gateway (REST/JSON proxy to gRPC).
 	var gw *server.Gateway
 	if cfg.HTTPPort != "" {
+		var gwTLS *server.GatewayTLSConfig
+		if !cfg.InsecureListen {
+			gwTLS = &server.GatewayTLSConfig{
+				CAFile:         cfg.TLSGatewayCAFile,
+				ServerName:     cfg.TLSGatewayServerName,
+				ClientCertFile: cfg.TLSGatewayClientCertFile,
+				ClientKeyFile:  cfg.TLSGatewayClientKeyFile,
+			}
+		}
+
 		gw, err = server.NewGateway(ctx, server.GatewayConfig{
 			HTTPPort:        cfg.HTTPPort,
 			GRPCAddr:        fmt.Sprintf("localhost:%s", cfg.GRPCPort),
@@ -260,6 +283,8 @@ func run() int {
 			OpenAPISpec:     openAPISpec,
 			MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
 			MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
+			TLS:             gwTLS,
+			Insecure:        cfg.InsecureListen,
 		})
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create HTTP gateway", "error", err)
@@ -300,20 +325,28 @@ func run() int {
 }
 
 type serverConfig struct {
-	GRPCPort             string
-	HTTPPort             string
-	StorageBackend       string
-	DBWriteURL           string
-	DBReadURL            string
-	RedisURL             string
-	EnableServices       []string
-	JWTIssuer            string
-	JWTJWKSURL           string
-	LogLevel             string
-	UsageTrackingEnabled bool
-	UsageFlushInterval   time.Duration
-	GRPCMaxRecvMsgBytes  int
-	GRPCMaxSendMsgBytes  int
+	GRPCPort                 string
+	HTTPPort                 string
+	StorageBackend           string
+	DBWriteURL               string
+	DBReadURL                string
+	RedisURL                 string
+	EnableServices           []string
+	JWTIssuer                string
+	JWTJWKSURL               string
+	LogLevel                 string
+	UsageTrackingEnabled     bool
+	UsageFlushInterval       time.Duration
+	GRPCMaxRecvMsgBytes      int
+	GRPCMaxSendMsgBytes      int
+	InsecureListen           bool
+	TLSCertFile              string
+	TLSKeyFile               string
+	TLSClientCAFile          string
+	TLSGatewayCAFile         string
+	TLSGatewayServerName     string
+	TLSGatewayClientCertFile string
+	TLSGatewayClientKeyFile  string
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -344,20 +377,28 @@ func loadConfig() serverConfig {
 	}
 
 	return serverConfig{
-		GRPCPort:             getEnv("GRPC_PORT", "9090"),
-		HTTPPort:             getEnv("HTTP_PORT", ""),
-		StorageBackend:       getEnv("STORAGE_BACKEND", "postgres"),
-		DBWriteURL:           dbWriteURL,
-		DBReadURL:            dbReadURL,
-		RedisURL:             getEnv("REDIS_URL", ""),
-		EnableServices:       parseServices(enableServices),
-		JWTIssuer:            getEnv("JWT_ISSUER", ""),
-		JWTJWKSURL:           getEnv("JWT_JWKS_URL", ""),
-		LogLevel:             getEnv("LOG_LEVEL", "info"),
-		UsageTrackingEnabled: getEnv("USAGE_TRACKING_ENABLED", "true") != "false",
-		UsageFlushInterval:   flushInterval,
-		GRPCMaxRecvMsgBytes:  parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
-		GRPCMaxSendMsgBytes:  parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
+		GRPCPort:                 getEnv("GRPC_PORT", "9090"),
+		HTTPPort:                 getEnv("HTTP_PORT", ""),
+		StorageBackend:           getEnv("STORAGE_BACKEND", "postgres"),
+		DBWriteURL:               dbWriteURL,
+		DBReadURL:                dbReadURL,
+		RedisURL:                 getEnv("REDIS_URL", ""),
+		EnableServices:           parseServices(enableServices),
+		JWTIssuer:                getEnv("JWT_ISSUER", ""),
+		JWTJWKSURL:               getEnv("JWT_JWKS_URL", ""),
+		LogLevel:                 getEnv("LOG_LEVEL", "info"),
+		UsageTrackingEnabled:     getEnv("USAGE_TRACKING_ENABLED", "true") != "false",
+		UsageFlushInterval:       flushInterval,
+		GRPCMaxRecvMsgBytes:      parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
+		GRPCMaxSendMsgBytes:      parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
+		InsecureListen:           getEnv("INSECURE_LISTEN", "") == "1",
+		TLSCertFile:              getEnv("TLS_CERT_FILE", ""),
+		TLSKeyFile:               getEnv("TLS_KEY_FILE", ""),
+		TLSClientCAFile:          getEnv("TLS_CLIENT_CA_FILE", ""),
+		TLSGatewayCAFile:         getEnv("TLS_GATEWAY_CA_FILE", ""),
+		TLSGatewayServerName:     getEnv("TLS_GATEWAY_SERVER_NAME", ""),
+		TLSGatewayClientCertFile: getEnv("TLS_GATEWAY_CLIENT_CERT_FILE", ""),
+		TLSGatewayClientKeyFile:  getEnv("TLS_GATEWAY_CLIENT_KEY_FILE", ""),
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       ENABLE_SERVICES: "schema,config,audit"
       HTTP_PORT: "8080"
       USAGE_FLUSH_INTERVAL: "1s"
+      INSECURE_LISTEN: "1"
     ports:
       - "9090:9090"
       - "8080:8080"

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -19,6 +19,40 @@ OpenDecree is configured entirely through environment variables. No config files
 | `GRPC_MAX_RECV_MSG_BYTES` | Maximum size of an inbound gRPC message, in bytes. Requests above this return `ResourceExhausted`. Set to `0` for the default. | `20971520` (20 MiB) | No |
 | `GRPC_MAX_SEND_MSG_BYTES` | Maximum size of an outbound gRPC message, in bytes. Responses above this return `ResourceExhausted` to the client. Set to `0` for the default. | `20971520` (20 MiB) | No |
 
+## Transport Security (TLS)
+
+TLS is **required by default** for the gRPC server and the gateway-to-gRPC dial. Set `INSECURE_LISTEN=1` to opt out for local dev only.
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `INSECURE_LISTEN` | Set to `1` to listen in plaintext and have the gateway dial gRPC in plaintext. **Local dev only.** | -- | No |
+| `TLS_CERT_FILE` | Path to the server's PEM-encoded TLS certificate. | -- | Yes (unless `INSECURE_LISTEN=1`) |
+| `TLS_KEY_FILE` | Path to the server's PEM-encoded private key. | -- | Yes (unless `INSECURE_LISTEN=1`) |
+| `TLS_CLIENT_CA_FILE` | Path to PEM CA bundle that signs allowed client certificates. When set, the server requires and verifies client certificates (mTLS). | -- | No |
+| `TLS_GATEWAY_CA_FILE` | CA bundle the gateway uses to verify the upstream gRPC server's certificate. When unset, the system root pool is used. | system roots | No |
+| `TLS_GATEWAY_SERVER_NAME` | SNI / verification hostname the gateway expects on the upstream gRPC certificate. | dial address host | No |
+| `TLS_GATEWAY_CLIENT_CERT_FILE` | Client certificate the gateway presents to the upstream gRPC server (when the server requires mTLS). | -- | No |
+| `TLS_GATEWAY_CLIENT_KEY_FILE` | Private key for `TLS_GATEWAY_CLIENT_CERT_FILE`. Must be set together with the cert file. | -- | No |
+
+Example (TLS, no mTLS):
+
+```bash
+TLS_CERT_FILE=/etc/decree/tls/server.crt
+TLS_KEY_FILE=/etc/decree/tls/server.key
+TLS_GATEWAY_CA_FILE=/etc/decree/tls/server.crt   # self-signed: trust the server cert
+TLS_GATEWAY_SERVER_NAME=localhost
+```
+
+Example (mTLS):
+
+```bash
+TLS_CERT_FILE=/etc/decree/tls/server.crt
+TLS_KEY_FILE=/etc/decree/tls/server.key
+TLS_CLIENT_CA_FILE=/etc/decree/tls/clients-ca.crt
+TLS_GATEWAY_CLIENT_CERT_FILE=/etc/decree/tls/gateway.crt
+TLS_GATEWAY_CLIENT_KEY_FILE=/etc/decree/tls/gateway.key
+```
+
 ### In-Memory Mode
 
 Set `STORAGE_BACKEND=memory` to run without PostgreSQL or Redis. All data is stored in memory and lost on restart. Useful for evaluation, local development, and testing:

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -39,6 +40,10 @@ type GatewayConfig struct {
 	// MaxSendMsgBytes caps outbound gRPC request size to the upstream server.
 	// Zero or negative → DefaultMaxMsgBytes.
 	MaxSendMsgBytes int
+	// TLS configures the upstream gRPC dial. Required unless Insecure is true.
+	TLS *GatewayTLSConfig
+	// Insecure dials the upstream gRPC server in plaintext (INSECURE_LISTEN=1).
+	Insecure bool
 }
 
 // NewGateway creates a new HTTP gateway that proxies to the given gRPC address.
@@ -46,6 +51,13 @@ type GatewayConfig struct {
 func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 	if cfg.HTTPPort == "" {
 		return nil, nil
+	}
+
+	if cfg.TLS == nil && !cfg.Insecure {
+		return nil, errors.New("gateway TLS config is required; set Insecure=true (INSECURE_LISTEN=1) to opt out for local dev")
+	}
+	if cfg.TLS != nil && cfg.Insecure {
+		return nil, errors.New("gateway TLS and Insecure are mutually exclusive")
 	}
 
 	recvCap := cfg.MaxRecvMsgBytes
@@ -57,9 +69,20 @@ func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 		sendCap = DefaultMaxMsgBytes
 	}
 
+	var transportCreds grpc.DialOption
+	if cfg.Insecure {
+		transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
+	} else {
+		creds, err := cfg.TLS.ClientCredentials()
+		if err != nil {
+			return nil, fmt.Errorf("build gateway TLS credentials: %w", err)
+		}
+		transportCreds = grpc.WithTransportCredentials(creds)
+	}
+
 	conn, err := grpc.NewClient(
 		cfg.GRPCAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		transportCreds,
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(recvCap),
 			grpc.MaxCallSendMsgSize(sendCap),

--- a/internal/server/gateway_test.go
+++ b/internal/server/gateway_test.go
@@ -18,6 +18,7 @@ func TestNewGateway_DisabledWhenNoPort(t *testing.T) {
 		HTTPPort: "",
 		GRPCAddr: "localhost:9090",
 		Logger:   slog.Default(),
+		Insecure: true,
 	})
 	require.NoError(t, err)
 	assert.Nil(t, gw, "gateway should be nil when HTTPPort is empty")
@@ -28,9 +29,20 @@ func TestNewGateway_CreatesWithValidConfig(t *testing.T) {
 		HTTPPort: "0",
 		GRPCAddr: "localhost:9090",
 		Logger:   slog.Default(),
+		Insecure: true,
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
+}
+
+func TestNewGateway_RequiresTLSOrInsecure(t *testing.T) {
+	_, err := NewGateway(context.Background(), GatewayConfig{
+		HTTPPort: "0",
+		GRPCAddr: "localhost:9090",
+		Logger:   slog.Default(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gateway TLS config is required")
 }
 
 func TestGateway_ServeAndShutdown(t *testing.T) {
@@ -38,6 +50,7 @@ func TestGateway_ServeAndShutdown(t *testing.T) {
 		HTTPPort: "0",
 		GRPCAddr: "localhost:9090",
 		Logger:   slog.Default(),
+		Insecure: true,
 	})
 	require.NoError(t, err)
 
@@ -123,6 +136,7 @@ func TestNewGateway_WithOpenAPISpec(t *testing.T) {
 		GRPCAddr:    "localhost:9090",
 		Logger:      slog.Default(),
 		OpenAPISpec: spec,
+		Insecure:    true,
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
@@ -133,6 +147,7 @@ func TestNewGateway_WithoutOpenAPISpec(t *testing.T) {
 		HTTPPort: "0",
 		GRPCAddr: "localhost:9090",
 		Logger:   slog.Default(),
+		Insecure: true,
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
@@ -145,6 +160,7 @@ func TestGateway_DocsEndpoints(t *testing.T) {
 		GRPCAddr:    "localhost:9090",
 		Logger:      slog.Default(),
 		OpenAPISpec: spec,
+		Insecure:    true,
 	})
 	require.NoError(t, err)
 

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -34,6 +34,7 @@ func TestMemoryBackend_Integration(t *testing.T) {
 		EnableServices:  []string{"schema", "config", "audit"},
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -33,6 +34,10 @@ type Config struct {
 	MaxRecvMsgBytes int
 	// MaxSendMsgBytes caps outbound gRPC message size. Zero or negative → DefaultMaxMsgBytes.
 	MaxSendMsgBytes int
+	// TLS enables transport security. Required unless Insecure is true.
+	TLS *TLSConfig
+	// Insecure listens in plaintext. Intended for local dev (INSECURE_LISTEN=1).
+	Insecure bool
 }
 
 // Server wraps the gRPC server and health service.
@@ -45,6 +50,13 @@ type Server struct {
 
 // New creates a new gRPC server with interceptors.
 func New(cfg Config) (*Server, error) {
+	if cfg.TLS == nil && !cfg.Insecure {
+		return nil, errors.New("TLS config is required; set Insecure=true (INSECURE_LISTEN=1) to opt out for local dev")
+	}
+	if cfg.TLS != nil && cfg.Insecure {
+		return nil, errors.New("TLS and Insecure are mutually exclusive")
+	}
+
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", cfg.GRPCPort))
 	if err != nil {
 		return nil, fmt.Errorf("listen on port %s: %w", cfg.GRPCPort, err)
@@ -59,8 +71,16 @@ func New(cfg Config) (*Server, error) {
 		sendCap = DefaultMaxMsgBytes
 	}
 
-	opts := make([]grpc.ServerOption, 0, len(cfg.ExtraOptions)+4)
+	opts := make([]grpc.ServerOption, 0, len(cfg.ExtraOptions)+5)
 	opts = append(opts, cfg.ExtraOptions...)
+	if cfg.TLS != nil {
+		creds, err := cfg.TLS.ServerCredentials()
+		if err != nil {
+			_ = listener.Close()
+			return nil, fmt.Errorf("build TLS credentials: %w", err)
+		}
+		opts = append(opts, grpc.Creds(creds))
+	}
 	// Recovery is registered first so it wraps auth and any future middleware.
 	opts = append(opts,
 		grpc.MaxRecvMsgSize(recvCap),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,6 +37,7 @@ func TestNew_Success(t *testing.T) {
 		EnableServices:  []string{"schema", "config"},
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, srv.GRPCServer())
@@ -48,8 +49,31 @@ func TestNew_InvalidPort(t *testing.T) {
 		GRPCPort:        "99999",
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	assert.Error(t, err)
+}
+
+func TestNew_RequiresTLSOrInsecure(t *testing.T) {
+	_, err := New(Config{
+		GRPCPort:        "0",
+		Logger:          slog.Default(),
+		AuthInterceptor: &noopInterceptor{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "TLS config is required")
+}
+
+func TestNew_TLSAndInsecureMutuallyExclusive(t *testing.T) {
+	_, err := New(Config{
+		GRPCPort:        "0",
+		Logger:          slog.Default(),
+		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
+		TLS:             &TLSConfig{CertFile: "x", KeyFile: "y"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestIsServiceEnabled(t *testing.T) {
@@ -58,6 +82,7 @@ func TestIsServiceEnabled(t *testing.T) {
 		EnableServices:  []string{"schema", "config"},
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 	defer srv.GracefulStop(context.Background())
@@ -73,6 +98,7 @@ func TestSetServiceHealthy(t *testing.T) {
 		EnableServices:  []string{"schema"},
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 	defer srv.GracefulStop(context.Background())
@@ -111,6 +137,7 @@ func startTestServer(t *testing.T, recvCap, sendCap int) (*grpc.ClientConn, func
 		AuthInterceptor: &noopInterceptor{},
 		MaxRecvMsgBytes: recvCap,
 		MaxSendMsgBytes: sendCap,
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 
@@ -248,6 +275,7 @@ func startPanicServer(t *testing.T) (*grpc.ClientConn, *bytes.Buffer, func()) {
 		GRPCPort:        "0",
 		Logger:          logger,
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 	srv.grpcServer.RegisterService(&panicServiceDesc, struct{}{})
@@ -328,6 +356,7 @@ func TestServe_AndGracefulStop(t *testing.T) {
 		EnableServices:  []string{"schema"},
 		Logger:          slog.Default(),
 		AuthInterceptor: &noopInterceptor{},
+		Insecure:        true,
 	})
 	require.NoError(t, err)
 

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// TLSConfig configures TLS for the gRPC server.
+//
+// CertFile and KeyFile are required. When ClientCAFile is set, the server
+// requires and verifies client certificates (mTLS).
+type TLSConfig struct {
+	CertFile     string
+	KeyFile      string
+	ClientCAFile string
+}
+
+// ServerCredentials builds gRPC server credentials from the TLS config.
+func (c TLSConfig) ServerCredentials() (credentials.TransportCredentials, error) {
+	if c.CertFile == "" || c.KeyFile == "" {
+		return nil, errors.New("TLS cert and key files are required")
+	}
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("load server keypair: %w", err)
+	}
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if c.ClientCAFile != "" {
+		pool, err := loadCAPool(c.ClientCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("load client CA: %w", err)
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return credentials.NewTLS(tlsCfg), nil
+}
+
+// GatewayTLSConfig configures TLS for the gateway's outbound gRPC dial.
+//
+// CAFile is the trusted CA for the gRPC server's certificate; if empty, the
+// system root pool is used. ServerName overrides the SNI/verification name
+// (defaults to the dial address host). ClientCertFile/ClientKeyFile enable
+// client certificate auth (mTLS) when the upstream server requires it.
+type GatewayTLSConfig struct {
+	CAFile         string
+	ServerName     string
+	ClientCertFile string
+	ClientKeyFile  string
+}
+
+// ClientCredentials builds gRPC client credentials for the gateway dial.
+func (c GatewayTLSConfig) ClientCredentials() (credentials.TransportCredentials, error) {
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	if c.CAFile != "" {
+		pool, err := loadCAPool(c.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("load gateway CA: %w", err)
+		}
+		tlsCfg.RootCAs = pool
+	}
+	if c.ServerName != "" {
+		tlsCfg.ServerName = c.ServerName
+	}
+	if c.ClientCertFile != "" || c.ClientKeyFile != "" {
+		if c.ClientCertFile == "" || c.ClientKeyFile == "" {
+			return nil, errors.New("gateway client cert and key must be set together")
+		}
+		cert, err := tls.LoadX509KeyPair(c.ClientCertFile, c.ClientKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load gateway client keypair: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+	return credentials.NewTLS(tlsCfg), nil
+}
+
+func loadCAPool(path string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no certificates parsed from %s", path)
+	}
+	return pool, nil
+}

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// certBundle holds a CA + an end-entity keypair signed by it.
+type certBundle struct {
+	caCertPEM   []byte
+	leafCertPEM []byte
+	leafKeyPEM  []byte
+}
+
+// writeFiles writes the bundle to dir and returns the file paths.
+func (b certBundle) writeFiles(t *testing.T, dir, prefix string) (caFile, certFile, keyFile string) {
+	t.Helper()
+	caFile = filepath.Join(dir, prefix+"_ca.pem")
+	certFile = filepath.Join(dir, prefix+"_cert.pem")
+	keyFile = filepath.Join(dir, prefix+"_key.pem")
+	require.NoError(t, os.WriteFile(caFile, b.caCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(certFile, b.leafCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyFile, b.leafKeyPEM, 0o600))
+	return
+}
+
+// genCertBundle generates a self-signed CA and an end-entity cert/key signed
+// by it. The leaf cert lists 127.0.0.1 + ::1 + "localhost" as SANs.
+func genCertBundle(t *testing.T, commonName string, isClient bool) certBundle {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA " + commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	if isClient {
+		leafTmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		leafTmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		leafTmpl.DNSNames = []string{"localhost"}
+		leafTmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caTmpl, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+
+	return certBundle{
+		caCertPEM:   pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		leafCertPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
+		leafKeyPEM:  pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER}),
+	}
+}
+
+// startTLSServer starts a gRPC server with the given TLS config and returns
+// its listen address + cleanup func.
+func startTLSServer(t *testing.T, tlsCfg *TLSConfig) (string, func()) {
+	t.Helper()
+	srv, err := New(Config{
+		GRPCPort:        "0",
+		Logger:          slog.Default(),
+		AuthInterceptor: &noopInterceptor{},
+		TLS:             tlsCfg,
+	})
+	require.NoError(t, err)
+	addr := srv.listener.Addr().String()
+	go func() { _ = srv.Serve(context.Background()) }()
+	return addr, func() { srv.GracefulStop(context.Background()) }
+}
+
+func dialHealth(ctx context.Context, addr string, opt grpc.DialOption) error {
+	conn, err := grpc.NewClient(addr, opt)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	_, err = grpc_health_v1.NewHealthClient(conn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	return err
+}
+
+func TestTLSConfig_RequiresCertAndKey(t *testing.T) {
+	_, err := TLSConfig{}.ServerCredentials()
+	require.Error(t, err)
+}
+
+func TestTLS_RejectsPlaintextDial(t *testing.T) {
+	dir := t.TempDir()
+	server := genCertBundle(t, "localhost", false)
+	_, srvCert, srvKey := server.writeFiles(t, dir, "srv")
+
+	addr, stop := startTLSServer(t, &TLSConfig{CertFile: srvCert, KeyFile: srvKey})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := dialHealth(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.Error(t, err, "plaintext dial against TLS server must fail")
+}
+
+func TestTLS_AcceptsTLSDial(t *testing.T) {
+	dir := t.TempDir()
+	server := genCertBundle(t, "localhost", false)
+	caFile, srvCert, srvKey := server.writeFiles(t, dir, "srv")
+
+	addr, stop := startTLSServer(t, &TLSConfig{CertFile: srvCert, KeyFile: srvKey})
+	defer stop()
+
+	creds, err := GatewayTLSConfig{CAFile: caFile, ServerName: "localhost"}.ClientCredentials()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = dialHealth(ctx, addr, grpc.WithTransportCredentials(creds))
+	require.NoError(t, err)
+}
+
+func TestMTLS_AcceptsSignedClient(t *testing.T) {
+	dir := t.TempDir()
+	server := genCertBundle(t, "localhost", false)
+	srvCAFile, srvCert, srvKey := server.writeFiles(t, dir, "srv")
+
+	client := genCertBundle(t, "client", true)
+	clientCAFile, clientCert, clientKey := client.writeFiles(t, dir, "cli")
+
+	addr, stop := startTLSServer(t, &TLSConfig{
+		CertFile:     srvCert,
+		KeyFile:      srvKey,
+		ClientCAFile: clientCAFile,
+	})
+	defer stop()
+
+	creds, err := GatewayTLSConfig{
+		CAFile:         srvCAFile,
+		ServerName:     "localhost",
+		ClientCertFile: clientCert,
+		ClientKeyFile:  clientKey,
+	}.ClientCredentials()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = dialHealth(ctx, addr, grpc.WithTransportCredentials(creds))
+	require.NoError(t, err, "mTLS dial with signed client cert must succeed")
+}
+
+func TestMTLS_RejectsUnsignedClient(t *testing.T) {
+	dir := t.TempDir()
+	server := genCertBundle(t, "localhost", false)
+	srvCAFile, srvCert, srvKey := server.writeFiles(t, dir, "srv")
+
+	clientCA := genCertBundle(t, "trusted", true)
+	clientCAFile := filepath.Join(dir, "trusted_ca.pem")
+	require.NoError(t, os.WriteFile(clientCAFile, clientCA.caCertPEM, 0o600))
+
+	// Foreign client cert — signed by an untrusted CA.
+	foreign := genCertBundle(t, "foreign", true)
+	_, foreignCert, foreignKey := foreign.writeFiles(t, dir, "foreign")
+
+	addr, stop := startTLSServer(t, &TLSConfig{
+		CertFile:     srvCert,
+		KeyFile:      srvKey,
+		ClientCAFile: clientCAFile,
+	})
+	defer stop()
+
+	creds, err := GatewayTLSConfig{
+		CAFile:         srvCAFile,
+		ServerName:     "localhost",
+		ClientCertFile: foreignCert,
+		ClientKeyFile:  foreignKey,
+	}.ClientCredentials()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = dialHealth(ctx, addr, grpc.WithTransportCredentials(creds))
+	require.Error(t, err, "mTLS dial with foreign client cert must fail")
+}
+
+func TestGatewayTLSConfig_RequiresCertKeyPair(t *testing.T) {
+	_, err := GatewayTLSConfig{ClientCertFile: "x"}.ClientCredentials()
+	require.Error(t, err)
+	_, err = GatewayTLSConfig{ClientKeyFile: "y"}.ClientCredentials()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Closes part of #213 (Split A — gRPC + gateway transport security).

- **TLS required by default.** `server.Config` and `gateway.GatewayConfig` now demand `TLS` or an explicit `Insecure: true`. `INSECURE_LISTEN=1` is the only opt-out, intended for local dev.
- **Gateway-to-gRPC dial is no longer plaintext.** `insecure.NewCredentials()` is replaced by `credentials.NewTLS(...)` against a configurable CA + server name.
- **mTLS supported.** `TLS_CLIENT_CA_FILE` makes the server require client certs; `TLS_GATEWAY_CLIENT_CERT_FILE`/`KEY_FILE` let the gateway present one.
- Why: in Kubernetes east-west deployments JWTs and config payloads were transiting cleartext (security review #26 finding 2).

## Test plan

- [x] `make pre-commit` passes (build, vet, format, lint, race tests, coverage ratchet)
- [x] `TestNew_RequiresTLSOrInsecure` — `New()` errors when neither is set
- [x] `TestNew_TLSAndInsecureMutuallyExclusive` — both set is rejected
- [x] `TestTLS_RejectsPlaintextDial` — TLS server refuses plaintext clients
- [x] `TestTLS_AcceptsTLSDial` — TLS server accepts properly-configured clients
- [x] `TestMTLS_AcceptsSignedClient` — mTLS server accepts client signed by trusted CA
- [x] `TestMTLS_RejectsUnsignedClient` — mTLS server rejects client signed by foreign CA
- [x] `TestNewGateway_RequiresTLSOrInsecure` — gateway requires TLS or `Insecure: true`

## Follow-ups (still open under #213)

- DSN/URL enforcement: reject `DB_WRITE_URL`/`DB_READ_URL` without `sslmode=require`, and `REDIS_URL` not using `rediss://`, with `ALLOW_INSECURE_DB`/`ALLOW_INSECURE_REDIS` opt-outs.
- Helm: cert secret mount + TLS values block + `existingSecret` documentation.

Refs #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)