### PR TITLE
refactor(server): functional options for New + NewGateway

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -183,17 +183,19 @@ func run() int {
 		logger.WarnContext(ctx, "INSECURE_LISTEN=1 set — gRPC server will accept plaintext connections (local dev only)")
 	}
 
-	srv, err := server.New(server.Config{
-		GRPCPort:        cfg.GRPCPort,
-		EnableServices:  cfg.EnableServices,
-		Logger:          logger,
-		AuthInterceptor: authInterceptor,
-		ExtraOptions:    extraOpts,
-		MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
-		MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
-		TLS:             serverTLS,
-		Insecure:        cfg.InsecureListen,
-	})
+	srvOpts := []server.Option{
+		server.WithEnableServices(cfg.EnableServices),
+		server.WithLogger(logger),
+		server.WithGRPCServerOptions(extraOpts...),
+		server.WithMaxRecvMsgBytes(cfg.GRPCMaxRecvMsgBytes),
+		server.WithMaxSendMsgBytes(cfg.GRPCMaxSendMsgBytes),
+	}
+	if cfg.InsecureListen {
+		srvOpts = append(srvOpts, server.WithInsecure())
+	} else {
+		srvOpts = append(srvOpts, server.WithTLS(serverTLS))
+	}
+	srv, err := server.New(cfg.GRPCPort, authInterceptor, srvOpts...)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create server", "error", err)
 		return 1
@@ -276,16 +278,18 @@ func run() int {
 			}
 		}
 
-		gw, err = server.NewGateway(ctx, server.GatewayConfig{
-			HTTPPort:        cfg.HTTPPort,
-			GRPCAddr:        fmt.Sprintf("localhost:%s", cfg.GRPCPort),
-			Logger:          logger,
-			OpenAPISpec:     openAPISpec,
-			MaxRecvMsgBytes: cfg.GRPCMaxRecvMsgBytes,
-			MaxSendMsgBytes: cfg.GRPCMaxSendMsgBytes,
-			TLS:             gwTLS,
-			Insecure:        cfg.InsecureListen,
-		})
+		gwOpts := []server.GatewayOption{
+			server.WithGatewayLogger(logger),
+			server.WithOpenAPISpec(openAPISpec),
+			server.WithGatewayMaxRecvMsgBytes(cfg.GRPCMaxRecvMsgBytes),
+			server.WithGatewayMaxSendMsgBytes(cfg.GRPCMaxSendMsgBytes),
+		}
+		if cfg.InsecureListen {
+			gwOpts = append(gwOpts, server.WithGatewayInsecure())
+		} else {
+			gwOpts = append(gwOpts, server.WithGatewayTLS(gwTLS))
+		}
+		gw, err = server.NewGateway(ctx, cfg.HTTPPort, fmt.Sprintf("localhost:%s", cfg.GRPCPort), gwOpts...)
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create HTTP gateway", "error", err)
 			return 1

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -17,63 +17,46 @@ import (
 )
 
 // Gateway is an HTTP reverse proxy that translates REST/JSON requests to gRPC.
-// It is optional — only started when HTTPPort is configured.
+// It is optional — only started when httpPort is non-empty.
 type Gateway struct {
 	httpServer *http.Server
 	logger     *slog.Logger
 }
 
-// GatewayConfig holds configuration for the HTTP gateway.
-type GatewayConfig struct {
-	// HTTPPort is the port the gateway listens on. Empty means gateway is disabled.
-	HTTPPort string
-	// GRPCAddr is the gRPC server address to proxy to (e.g. "localhost:9090").
-	GRPCAddr string
-	// Logger for gateway operations.
-	Logger *slog.Logger
-	// OpenAPISpec is the raw OpenAPI JSON spec to serve at /docs/openapi.json.
-	// If nil, the docs endpoints are not registered.
-	OpenAPISpec []byte
-	// MaxRecvMsgBytes caps inbound gRPC response size from the upstream server.
-	// Zero or negative → DefaultMaxMsgBytes.
-	MaxRecvMsgBytes int
-	// MaxSendMsgBytes caps outbound gRPC request size to the upstream server.
-	// Zero or negative → DefaultMaxMsgBytes.
-	MaxSendMsgBytes int
-	// TLS configures the upstream gRPC dial. Required unless Insecure is true.
-	TLS *GatewayTLSConfig
-	// Insecure dials the upstream gRPC server in plaintext (INSECURE_LISTEN=1).
-	Insecure bool
-}
-
 // NewGateway creates a new HTTP gateway that proxies to the given gRPC address.
-// Returns nil if HTTPPort is empty (gateway disabled).
-func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
-	if cfg.HTTPPort == "" {
+// Returns nil if httpPort is empty (gateway disabled). Either WithGatewayTLS
+// or WithGatewayInsecure must be supplied.
+func NewGateway(ctx context.Context, httpPort, grpcAddr string, opts ...GatewayOption) (*Gateway, error) {
+	if httpPort == "" {
 		return nil, nil
 	}
 
-	if cfg.TLS == nil && !cfg.Insecure {
-		return nil, errors.New("gateway TLS config is required; set Insecure=true (INSECURE_LISTEN=1) to opt out for local dev")
-	}
-	if cfg.TLS != nil && cfg.Insecure {
-		return nil, errors.New("gateway TLS and Insecure are mutually exclusive")
+	o := gatewayOptions{logger: slog.Default()}
+	for _, opt := range opts {
+		opt(&o)
 	}
 
-	recvCap := cfg.MaxRecvMsgBytes
+	if o.tls == nil && !o.insecure {
+		return nil, errors.New("gateway TLS config is required; pass WithGatewayTLS or WithGatewayInsecure for local dev (INSECURE_LISTEN=1)")
+	}
+	if o.tls != nil && o.insecure {
+		return nil, errors.New("WithGatewayTLS and WithGatewayInsecure are mutually exclusive")
+	}
+
+	recvCap := o.maxRecvMsgBytes
 	if recvCap <= 0 {
 		recvCap = DefaultMaxMsgBytes
 	}
-	sendCap := cfg.MaxSendMsgBytes
+	sendCap := o.maxSendMsgBytes
 	if sendCap <= 0 {
 		sendCap = DefaultMaxMsgBytes
 	}
 
 	var transportCreds grpc.DialOption
-	if cfg.Insecure {
+	if o.insecure {
 		transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
 	} else {
-		creds, err := cfg.TLS.ClientCredentials()
+		creds, err := o.tls.ClientCredentials()
 		if err != nil {
 			return nil, fmt.Errorf("build gateway TLS credentials: %w", err)
 		}
@@ -81,7 +64,7 @@ func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 	}
 
 	conn, err := grpc.NewClient(
-		cfg.GRPCAddr,
+		grpcAddr,
 		transportCreds,
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(recvCap),
@@ -112,11 +95,11 @@ func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 
 	// Wrap gateway mux with docs routes.
 	handler := http.Handler(mux)
-	if len(cfg.OpenAPISpec) > 0 {
+	if len(o.openAPISpec) > 0 {
 		top := http.NewServeMux()
 		top.HandleFunc("GET /docs/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(cfg.OpenAPISpec)
+			_, _ = w.Write(o.openAPISpec)
 		})
 		top.HandleFunc("GET /docs", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -127,13 +110,13 @@ func NewGateway(ctx context.Context, cfg GatewayConfig) (*Gateway, error) {
 	}
 
 	httpServer := &http.Server{
-		Addr:    fmt.Sprintf(":%s", cfg.HTTPPort),
+		Addr:    fmt.Sprintf(":%s", httpPort),
 		Handler: handler,
 	}
 
 	return &Gateway{
 		httpServer: httpServer,
-		logger:     cfg.Logger,
+		logger:     o.logger,
 	}, nil
 }
 

--- a/internal/server/gateway_options.go
+++ b/internal/server/gateway_options.go
@@ -1,0 +1,51 @@
+package server
+
+import "log/slog"
+
+// GatewayOption configures a Gateway.
+type GatewayOption func(*gatewayOptions)
+
+type gatewayOptions struct {
+	logger          *slog.Logger
+	openAPISpec     []byte
+	maxRecvMsgBytes int
+	maxSendMsgBytes int
+	tls             *GatewayTLSConfig
+	insecure        bool
+}
+
+// WithGatewayLogger sets the gateway logger. Defaults to slog.Default() when unset.
+func WithGatewayLogger(l *slog.Logger) GatewayOption {
+	return func(o *gatewayOptions) { o.logger = l }
+}
+
+// WithOpenAPISpec serves the given raw OpenAPI JSON at /docs/openapi.json
+// (and the Swagger UI at /docs). When unset, the docs endpoints are not
+// registered.
+func WithOpenAPISpec(spec []byte) GatewayOption {
+	return func(o *gatewayOptions) { o.openAPISpec = spec }
+}
+
+// WithGatewayMaxRecvMsgBytes caps inbound gRPC response size from the upstream
+// server. Zero or negative falls back to DefaultMaxMsgBytes.
+func WithGatewayMaxRecvMsgBytes(n int) GatewayOption {
+	return func(o *gatewayOptions) { o.maxRecvMsgBytes = n }
+}
+
+// WithGatewayMaxSendMsgBytes caps outbound gRPC request size to the upstream
+// server. Zero or negative falls back to DefaultMaxMsgBytes.
+func WithGatewayMaxSendMsgBytes(n int) GatewayOption {
+	return func(o *gatewayOptions) { o.maxSendMsgBytes = n }
+}
+
+// WithGatewayTLS configures the upstream gRPC dial. Required unless
+// WithGatewayInsecure is set; mutually exclusive with WithGatewayInsecure.
+func WithGatewayTLS(cfg *GatewayTLSConfig) GatewayOption {
+	return func(o *gatewayOptions) { o.tls = cfg }
+}
+
+// WithGatewayInsecure dials the upstream gRPC server in plaintext
+// (INSECURE_LISTEN=1). Mutually exclusive with WithGatewayTLS.
+func WithGatewayInsecure() GatewayOption {
+	return func(o *gatewayOptions) { o.insecure = true }
+}

--- a/internal/server/gateway_test.go
+++ b/internal/server/gateway_test.go
@@ -14,44 +14,36 @@ import (
 )
 
 func TestNewGateway_DisabledWhenNoPort(t *testing.T) {
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort: "",
-		GRPCAddr: "localhost:9090",
-		Logger:   slog.Default(),
-		Insecure: true,
-	})
+	gw, err := NewGateway(context.Background(), "", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
-	assert.Nil(t, gw, "gateway should be nil when HTTPPort is empty")
+	assert.Nil(t, gw, "gateway should be nil when httpPort is empty")
 }
 
 func TestNewGateway_CreatesWithValidConfig(t *testing.T) {
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort: "0",
-		GRPCAddr: "localhost:9090",
-		Logger:   slog.Default(),
-		Insecure: true,
-	})
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
 func TestNewGateway_RequiresTLSOrInsecure(t *testing.T) {
-	_, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort: "0",
-		GRPCAddr: "localhost:9090",
-		Logger:   slog.Default(),
-	})
+	_, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "gateway TLS config is required")
 }
 
 func TestGateway_ServeAndShutdown(t *testing.T) {
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort: "0",
-		GRPCAddr: "localhost:9090",
-		Logger:   slog.Default(),
-		Insecure: true,
-	})
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)
@@ -131,37 +123,31 @@ func TestForwardAuthHeaders_CaseInsensitive(t *testing.T) {
 
 func TestNewGateway_WithOpenAPISpec(t *testing.T) {
 	spec := []byte(`{"openapi":"3.0.0","info":{"title":"test"}}`)
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort:    "0",
-		GRPCAddr:    "localhost:9090",
-		Logger:      slog.Default(),
-		OpenAPISpec: spec,
-		Insecure:    true,
-	})
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithOpenAPISpec(spec),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
 func TestNewGateway_WithoutOpenAPISpec(t *testing.T) {
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort: "0",
-		GRPCAddr: "localhost:9090",
-		Logger:   slog.Default(),
-		Insecure: true,
-	})
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
 func TestGateway_DocsEndpoints(t *testing.T) {
 	spec := []byte(`{"swagger":"2.0","info":{"title":"test"}}`)
-	gw, err := NewGateway(context.Background(), GatewayConfig{
-		HTTPPort:    "0",
-		GRPCAddr:    "localhost:9090",
-		Logger:      slog.Default(),
-		OpenAPISpec: spec,
-		Insecure:    true,
-	})
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithOpenAPISpec(spec),
+		WithGatewayInsecure(),
+	)
 	require.NoError(t, err)
 
 	// Use the gateway's handler directly via httptest to avoid port binding.

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -29,13 +29,11 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	// Create server.
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		EnableServices:  []string{"schema", "config", "audit"},
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithEnableServices([]string{"schema", "config", "audit"}),
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 
 	// Wire in-memory stores.

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"log/slog"
+
+	"google.golang.org/grpc"
+)
+
+// Option configures a Server.
+type Option func(*options)
+
+type options struct {
+	enableServices  []string
+	logger          *slog.Logger
+	extraOptions    []grpc.ServerOption
+	maxRecvMsgBytes int
+	maxSendMsgBytes int
+	tls             *TLSConfig
+	insecure        bool
+}
+
+// WithLogger sets the server logger. Defaults to slog.Default() when unset.
+func WithLogger(l *slog.Logger) Option {
+	return func(o *options) { o.logger = l }
+}
+
+// WithEnableServices lists which services the server treats as enabled
+// (used by IsServiceEnabled to gate registration).
+func WithEnableServices(svcs []string) Option {
+	return func(o *options) { o.enableServices = svcs }
+}
+
+// WithGRPCServerOptions appends extra grpc.ServerOption values applied
+// alongside the built-in interceptors and message-size caps.
+func WithGRPCServerOptions(opts ...grpc.ServerOption) Option {
+	return func(o *options) { o.extraOptions = append(o.extraOptions, opts...) }
+}
+
+// WithMaxRecvMsgBytes caps inbound gRPC message size. Zero or negative falls
+// back to DefaultMaxMsgBytes.
+func WithMaxRecvMsgBytes(n int) Option {
+	return func(o *options) { o.maxRecvMsgBytes = n }
+}
+
+// WithMaxSendMsgBytes caps outbound gRPC message size. Zero or negative falls
+// back to DefaultMaxMsgBytes.
+func WithMaxSendMsgBytes(n int) Option {
+	return func(o *options) { o.maxSendMsgBytes = n }
+}
+
+// WithTLS enables transport security with the given config. Required unless
+// WithInsecure is set; mutually exclusive with WithInsecure.
+func WithTLS(cfg *TLSConfig) Option {
+	return func(o *options) { o.tls = cfg }
+}
+
+// WithInsecure listens in plaintext. Intended for local dev only
+// (INSECURE_LISTEN=1). Mutually exclusive with WithTLS.
+func WithInsecure() Option {
+	return func(o *options) { o.insecure = true }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -20,91 +21,85 @@ type GRPCInterceptor interface {
 }
 
 // DefaultMaxMsgBytes is applied to inbound and outbound gRPC messages when
-// Config.MaxRecvMsgBytes / MaxSendMsgBytes are zero or negative.
+// WithMaxRecvMsgBytes / WithMaxSendMsgBytes are zero or negative.
 const DefaultMaxMsgBytes = 20 * 1024 * 1024
-
-// Config holds the server configuration.
-type Config struct {
-	GRPCPort        string
-	EnableServices  []string
-	Logger          *slog.Logger
-	AuthInterceptor GRPCInterceptor
-	ExtraOptions    []grpc.ServerOption
-	// MaxRecvMsgBytes caps inbound gRPC message size. Zero or negative → DefaultMaxMsgBytes.
-	MaxRecvMsgBytes int
-	// MaxSendMsgBytes caps outbound gRPC message size. Zero or negative → DefaultMaxMsgBytes.
-	MaxSendMsgBytes int
-	// TLS enables transport security. Required unless Insecure is true.
-	TLS *TLSConfig
-	// Insecure listens in plaintext. Intended for local dev (INSECURE_LISTEN=1).
-	Insecure bool
-}
 
 // Server wraps the gRPC server and health service.
 type Server struct {
-	grpcServer   *grpc.Server
-	healthServer *health.Server
-	listener     net.Listener
-	config       Config
+	grpcServer     *grpc.Server
+	healthServer   *health.Server
+	listener       net.Listener
+	logger         *slog.Logger
+	grpcPort       string
+	enableServices []string
 }
 
-// New creates a new gRPC server with interceptors.
-func New(cfg Config) (*Server, error) {
-	if cfg.TLS == nil && !cfg.Insecure {
-		return nil, errors.New("TLS config is required; set Insecure=true (INSECURE_LISTEN=1) to opt out for local dev")
-	}
-	if cfg.TLS != nil && cfg.Insecure {
-		return nil, errors.New("TLS and Insecure are mutually exclusive")
+// New creates a new gRPC server with interceptors. grpcPort and auth are
+// required; pass options for everything else. Either WithTLS or WithInsecure
+// must be supplied.
+func New(grpcPort string, auth GRPCInterceptor, opts ...Option) (*Server, error) {
+	o := options{logger: slog.Default()}
+	for _, opt := range opts {
+		opt(&o)
 	}
 
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", cfg.GRPCPort))
+	if o.tls == nil && !o.insecure {
+		return nil, errors.New("TLS config is required; pass WithTLS or WithInsecure for local dev (INSECURE_LISTEN=1)")
+	}
+	if o.tls != nil && o.insecure {
+		return nil, errors.New("WithTLS and WithInsecure are mutually exclusive")
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", grpcPort))
 	if err != nil {
-		return nil, fmt.Errorf("listen on port %s: %w", cfg.GRPCPort, err)
+		return nil, fmt.Errorf("listen on port %s: %w", grpcPort, err)
 	}
 
-	recvCap := cfg.MaxRecvMsgBytes
+	recvCap := o.maxRecvMsgBytes
 	if recvCap <= 0 {
 		recvCap = DefaultMaxMsgBytes
 	}
-	sendCap := cfg.MaxSendMsgBytes
+	sendCap := o.maxSendMsgBytes
 	if sendCap <= 0 {
 		sendCap = DefaultMaxMsgBytes
 	}
 
-	opts := make([]grpc.ServerOption, 0, len(cfg.ExtraOptions)+5)
-	opts = append(opts, cfg.ExtraOptions...)
-	if cfg.TLS != nil {
-		creds, err := cfg.TLS.ServerCredentials()
+	grpcOpts := make([]grpc.ServerOption, 0, len(o.extraOptions)+5)
+	grpcOpts = append(grpcOpts, o.extraOptions...)
+	if o.tls != nil {
+		creds, err := o.tls.ServerCredentials()
 		if err != nil {
 			_ = listener.Close()
 			return nil, fmt.Errorf("build TLS credentials: %w", err)
 		}
-		opts = append(opts, grpc.Creds(creds))
+		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
 	// Recovery is registered first so it wraps auth and any future middleware.
-	opts = append(opts,
+	grpcOpts = append(grpcOpts,
 		grpc.MaxRecvMsgSize(recvCap),
 		grpc.MaxSendMsgSize(sendCap),
 		grpc.ChainUnaryInterceptor(
-			recoveryUnaryInterceptor(cfg.Logger),
-			cfg.AuthInterceptor.UnaryInterceptor(),
+			recoveryUnaryInterceptor(o.logger),
+			auth.UnaryInterceptor(),
 		),
 		grpc.ChainStreamInterceptor(
-			recoveryStreamInterceptor(cfg.Logger),
-			cfg.AuthInterceptor.StreamInterceptor(),
+			recoveryStreamInterceptor(o.logger),
+			auth.StreamInterceptor(),
 		),
 	)
 
-	grpcServer := grpc.NewServer(opts...)
+	grpcServer := grpc.NewServer(grpcOpts...)
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(grpcServer, healthServer)
 	reflection.Register(grpcServer)
 
 	return &Server{
-		grpcServer:   grpcServer,
-		healthServer: healthServer,
-		listener:     listener,
-		config:       cfg,
+		grpcServer:     grpcServer,
+		healthServer:   healthServer,
+		listener:       listener,
+		logger:         o.logger,
+		grpcPort:       grpcPort,
+		enableServices: o.enableServices,
 	}, nil
 }
 
@@ -120,23 +115,18 @@ func (s *Server) SetServiceHealthy(service string) {
 
 // Serve starts the gRPC server. Blocks until stopped.
 func (s *Server) Serve(ctx context.Context) error {
-	s.config.Logger.InfoContext(ctx, "gRPC server listening", "port", s.config.GRPCPort)
+	s.logger.InfoContext(ctx, "gRPC server listening", "port", s.grpcPort)
 	return s.grpcServer.Serve(s.listener)
 }
 
 // GracefulStop gracefully stops the gRPC server.
 func (s *Server) GracefulStop(ctx context.Context) {
-	s.config.Logger.InfoContext(ctx, "shutting down gRPC server")
+	s.logger.InfoContext(ctx, "shutting down gRPC server")
 	s.healthServer.Shutdown()
 	s.grpcServer.GracefulStop()
 }
 
 // IsServiceEnabled checks if a service name is in the enabled list.
 func (s *Server) IsServiceEnabled(name string) bool {
-	for _, svc := range s.config.EnableServices {
-		if svc == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.enableServices, name)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,58 +32,48 @@ func (n *noopInterceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 }
 
 func TestNew_Success(t *testing.T) {
-	srv, err := New(Config{
-		GRPCPort:        "0", // OS-assigned port
-		EnableServices:  []string{"schema", "config"},
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithEnableServices([]string{"schema", "config"}),
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, srv.GRPCServer())
 	srv.GracefulStop(context.Background())
 }
 
 func TestNew_InvalidPort(t *testing.T) {
-	_, err := New(Config{
-		GRPCPort:        "99999",
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	_, err := New("99999", &noopInterceptor{},
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	assert.Error(t, err)
 }
 
 func TestNew_RequiresTLSOrInsecure(t *testing.T) {
-	_, err := New(Config{
-		GRPCPort:        "0",
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-	})
+	_, err := New("0", &noopInterceptor{},
+		WithLogger(slog.Default()),
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "TLS config is required")
 }
 
 func TestNew_TLSAndInsecureMutuallyExclusive(t *testing.T) {
-	_, err := New(Config{
-		GRPCPort:        "0",
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-		TLS:             &TLSConfig{CertFile: "x", KeyFile: "y"},
-	})
+	_, err := New("0", &noopInterceptor{},
+		WithLogger(slog.Default()),
+		WithInsecure(),
+		WithTLS(&TLSConfig{CertFile: "x", KeyFile: "y"}),
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestIsServiceEnabled(t *testing.T) {
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		EnableServices:  []string{"schema", "config"},
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithEnableServices([]string{"schema", "config"}),
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 	defer srv.GracefulStop(context.Background())
 
@@ -93,13 +83,11 @@ func TestIsServiceEnabled(t *testing.T) {
 }
 
 func TestSetServiceHealthy(t *testing.T) {
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		EnableServices:  []string{"schema"},
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithEnableServices([]string{"schema"}),
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 	defer srv.GracefulStop(context.Background())
 
@@ -131,14 +119,12 @@ var echoServiceDesc = grpc.ServiceDesc{
 // registers the echo service, and returns a connected client + cleanup func.
 func startTestServer(t *testing.T, recvCap, sendCap int) (*grpc.ClientConn, func()) {
 	t.Helper()
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		MaxRecvMsgBytes: recvCap,
-		MaxSendMsgBytes: sendCap,
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithLogger(slog.Default()),
+		WithMaxRecvMsgBytes(recvCap),
+		WithMaxSendMsgBytes(sendCap),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 
 	srv.grpcServer.RegisterService(&echoServiceDesc, struct{}{})
@@ -271,12 +257,10 @@ func startPanicServer(t *testing.T) (*grpc.ClientConn, *bytes.Buffer, func()) {
 	logBuf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		Logger:          logger,
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithLogger(logger),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 	srv.grpcServer.RegisterService(&panicServiceDesc, struct{}{})
 
@@ -351,13 +335,11 @@ func TestRecovery_Stream_ReturnsInternalAndLogs(t *testing.T) {
 }
 
 func TestServe_AndGracefulStop(t *testing.T) {
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		EnableServices:  []string{"schema"},
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		Insecure:        true,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithEnableServices([]string{"schema"}),
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -93,12 +93,10 @@ func genCertBundle(t *testing.T, commonName string, isClient bool) certBundle {
 // its listen address + cleanup func.
 func startTLSServer(t *testing.T, tlsCfg *TLSConfig) (string, func()) {
 	t.Helper()
-	srv, err := New(Config{
-		GRPCPort:        "0",
-		Logger:          slog.Default(),
-		AuthInterceptor: &noopInterceptor{},
-		TLS:             tlsCfg,
-	})
+	srv, err := New("0", &noopInterceptor{},
+		WithLogger(slog.Default()),
+		WithTLS(tlsCfg),
+	)
 	require.NoError(t, err)
 	addr := srv.listener.Addr().String()
 	go func() { _ = srv.Serve(context.Background()) }()


### PR DESCRIPTION
## Summary

Replaces the `Config` / `GatewayConfig` structs with functional options, matching the convention already used in `sdk/configclient`, `sdk/configwatcher`, `sdk/grpctransport`, and `internal/storage`. Required args stay positional; only optional knobs become `With...()` options.

- `server.New(grpcPort, auth, opts...)` — `WithLogger`, `WithEnableServices`, `WithGRPCServerOptions`, `WithMaxRecvMsgBytes`, `WithMaxSendMsgBytes`, `WithTLS`, `WithInsecure`
- `server.NewGateway(ctx, httpPort, grpcAddr, opts...)` — `WithGatewayLogger`, `WithOpenAPISpec`, `WithGatewayMaxRecvMsgBytes`, `WithGatewayMaxSendMsgBytes`, `WithGatewayTLS`, `WithGatewayInsecure`

Gateway-side options carry a `Gateway` prefix to disambiguate from the server-side ones in the same package (e.g. `WithLogger` vs `WithGatewayLogger`).

Closes #231, #232.

## Test plan

- [x] `make test` — all packages green (race, count=1)
- [x] `make lint` — golangci-lint 0 issues
- [x] `go vet ./...`, `gofumpt -l .` — clean
- [x] `./scripts/check-coverage.sh` — all modules meet thresholds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)