### PR TITLE
refactor(audit,auth): functional options for NewUsageRecorder + NewInterceptor

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -153,7 +153,10 @@ func run() int {
 	// Auth interceptor.
 	var authInterceptor server.GRPCInterceptor
 	if cfg.JWTJWKSURL != "" {
-		jwtInterceptor, jwtErr := auth.NewInterceptor(ctx, cfg.JWTJWKSURL, cfg.JWTIssuer, logger)
+		jwtInterceptor, jwtErr := auth.NewInterceptor(ctx, cfg.JWTJWKSURL,
+			auth.WithIssuer(cfg.JWTIssuer),
+			auth.WithLogger(logger),
+		)
 		if jwtErr != nil {
 			logger.ErrorContext(ctx, "failed to create auth interceptor", "error", jwtErr)
 			return 1
@@ -212,10 +215,10 @@ func run() int {
 	// Usage recorder — async batched read tracking for audit stats.
 	var recorder *audit.UsageRecorder
 	if cfg.UsageTrackingEnabled {
-		recorder = audit.NewUsageRecorder(auditStoreVal, audit.RecorderConfig{
-			FlushInterval: cfg.UsageFlushInterval,
-			Logger:        logger,
-		})
+		recorder = audit.NewUsageRecorder(auditStoreVal,
+			audit.WithFlushInterval(cfg.UsageFlushInterval),
+			audit.WithLogger(logger),
+		)
 		go recorder.Start(ctx)
 		logger.InfoContext(ctx, "usage tracking enabled", "flush_interval", cfg.UsageFlushInterval)
 	} else {

--- a/internal/audit/recorder.go
+++ b/internal/audit/recorder.go
@@ -7,10 +7,23 @@ import (
 	"time"
 )
 
-// RecorderConfig holds configuration for the UsageRecorder.
-type RecorderConfig struct {
-	FlushInterval time.Duration
-	Logger        *slog.Logger
+// Option configures a UsageRecorder.
+type Option func(*recorderOptions)
+
+type recorderOptions struct {
+	flushInterval time.Duration
+	logger        *slog.Logger
+}
+
+// WithFlushInterval sets how often pending stats are flushed to the store.
+// Zero or negative falls back to 30s.
+func WithFlushInterval(d time.Duration) Option {
+	return func(o *recorderOptions) { o.flushInterval = d }
+}
+
+// WithLogger sets the recorder logger. Defaults to slog.Default() when unset.
+func WithLogger(l *slog.Logger) Option {
+	return func(o *recorderOptions) { o.logger = l }
 }
 
 // usageKey identifies a unique (tenant, field) pair for batching.
@@ -42,19 +55,24 @@ type UsageRecorder struct {
 }
 
 // NewUsageRecorder creates a new recorder. Call Start to begin the background flush goroutine.
-func NewUsageRecorder(store Store, cfg RecorderConfig) *UsageRecorder {
-	interval := cfg.FlushInterval
-	if interval <= 0 {
-		interval = 30 * time.Second
+func NewUsageRecorder(store Store, opts ...Option) *UsageRecorder {
+	o := recorderOptions{
+		flushInterval: 30 * time.Second,
+		logger:        slog.Default(),
 	}
-	logger := cfg.Logger
-	if logger == nil {
-		logger = slog.Default()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.flushInterval <= 0 {
+		o.flushInterval = 30 * time.Second
+	}
+	if o.logger == nil {
+		o.logger = slog.Default()
 	}
 	return &UsageRecorder{
 		store:    store,
-		logger:   logger,
-		interval: interval,
+		logger:   o.logger,
+		interval: o.flushInterval,
 		pending:  make(map[usageKey]*usageBucket),
 		done:     make(chan struct{}),
 	}

--- a/internal/audit/recorder_test.go
+++ b/internal/audit/recorder_test.go
@@ -17,10 +17,10 @@ import (
 var testRecorderLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 func newTestRecorder(store *MemoryStore) *UsageRecorder {
-	return NewUsageRecorder(store, RecorderConfig{
-		FlushInterval: time.Hour, // manual flush in tests
-		Logger:        testRecorderLogger,
-	})
+	return NewUsageRecorder(store,
+		WithFlushInterval(time.Hour), // manual flush in tests
+		WithLogger(testRecorderLogger),
+	)
 }
 
 func TestRecordRead_SingleField(t *testing.T) {
@@ -151,10 +151,10 @@ func TestFlush_EmptyBuffer(t *testing.T) {
 
 func TestFlush_StoreError(t *testing.T) {
 	store := &failingStore{MemoryStore: NewMemoryStore(), err: errors.New("db down")}
-	r := NewUsageRecorder(store, RecorderConfig{
-		FlushInterval: time.Hour,
-		Logger:        testRecorderLogger,
-	})
+	r := NewUsageRecorder(store,
+		WithFlushInterval(time.Hour),
+		WithLogger(testRecorderLogger),
+	)
 
 	r.RecordRead("t1", "app.fee", nil)
 	err := r.Flush(context.Background())
@@ -173,10 +173,10 @@ func TestNilRecorder_SafeToCall(t *testing.T) {
 
 func TestAutoFlush(t *testing.T) {
 	store := NewMemoryStore()
-	r := NewUsageRecorder(store, RecorderConfig{
-		FlushInterval: 20 * time.Millisecond,
-		Logger:        testRecorderLogger,
-	})
+	r := NewUsageRecorder(store,
+		WithFlushInterval(20*time.Millisecond),
+		WithLogger(testRecorderLogger),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go r.Start(ctx)
@@ -200,10 +200,10 @@ func TestAutoFlush(t *testing.T) {
 
 func TestStop_FinalFlush(t *testing.T) {
 	store := NewMemoryStore()
-	r := NewUsageRecorder(store, RecorderConfig{
-		FlushInterval: time.Hour, // won't auto-flush
-		Logger:        testRecorderLogger,
-	})
+	r := NewUsageRecorder(store,
+		WithFlushInterval(time.Hour), // won't auto-flush
+		WithLogger(testRecorderLogger),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go r.Start(ctx)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -70,9 +70,33 @@ type Interceptor struct {
 	logger     *slog.Logger
 }
 
-// NewInterceptor creates a new auth interceptor.
-// jwksURL is the JWKS endpoint for key discovery. issuer is optional.
-func NewInterceptor(ctx context.Context, jwksURL, issuer string, logger *slog.Logger) (*Interceptor, error) {
+// InterceptorOption configures a JWT Interceptor.
+type InterceptorOption func(*interceptorOptions)
+
+type interceptorOptions struct {
+	issuer string
+	logger *slog.Logger
+}
+
+// WithIssuer enforces an expected `iss` claim during JWT validation.
+// When unset, the issuer claim is not checked.
+func WithIssuer(issuer string) InterceptorOption {
+	return func(o *interceptorOptions) { o.issuer = issuer }
+}
+
+// WithLogger sets the interceptor logger. Defaults to slog.Default() when unset.
+func WithLogger(l *slog.Logger) InterceptorOption {
+	return func(o *interceptorOptions) { o.logger = l }
+}
+
+// NewInterceptor creates a new auth interceptor. jwksURL is the JWKS endpoint
+// for key discovery; pass WithIssuer / WithLogger for optional configuration.
+func NewInterceptor(ctx context.Context, jwksURL string, opts ...InterceptorOption) (*Interceptor, error) {
+	o := interceptorOptions{logger: slog.Default()}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	jwksCtx, jwksCancel := context.WithCancel(ctx)
 	jwks, err := keyfunc.NewDefaultCtx(jwksCtx, []string{jwksURL})
 	if err != nil {
@@ -83,8 +107,8 @@ func NewInterceptor(ctx context.Context, jwksURL, issuer string, logger *slog.Lo
 	return &Interceptor{
 		jwks:       jwks,
 		jwksCancel: jwksCancel,
-		issuer:     issuer,
-		logger:     logger,
+		issuer:     o.issuer,
+		logger:     o.logger,
 	}, nil
 }
 

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -68,7 +68,10 @@ func newTestInterceptor(t *testing.T, issuer string) *Interceptor {
 	t.Cleanup(srv.Close)
 
 	ctx := context.Background()
-	interceptor, err := NewInterceptor(ctx, srv.URL, issuer, testLogger)
+	interceptor, err := NewInterceptor(ctx, srv.URL,
+		WithIssuer(issuer),
+		WithLogger(testLogger),
+	)
 	require.NoError(t, err)
 	t.Cleanup(interceptor.Close)
 	return interceptor

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -548,10 +548,10 @@ func TestGetField_RecordsUsage(t *testing.T) {
 	store := &mockStore{}
 	c := &mockCache{}
 	auditStore := audit.NewMemoryStore()
-	recorder := audit.NewUsageRecorder(auditStore, audit.RecorderConfig{
-		FlushInterval: time.Hour,
-		Logger:        testLogger,
-	})
+	recorder := audit.NewUsageRecorder(auditStore,
+		audit.WithFlushInterval(time.Hour),
+		audit.WithLogger(testLogger),
+	)
 	svc := NewService(ServiceConfig{
 		Store:    store,
 		Cache:    c,
@@ -583,10 +583,10 @@ func TestGetConfig_RecordsUsage(t *testing.T) {
 	store := &mockStore{}
 	c := &mockCache{}
 	auditStore := audit.NewMemoryStore()
-	recorder := audit.NewUsageRecorder(auditStore, audit.RecorderConfig{
-		FlushInterval: time.Hour,
-		Logger:        testLogger,
-	})
+	recorder := audit.NewUsageRecorder(auditStore,
+		audit.WithFlushInterval(time.Hour),
+		audit.WithLogger(testLogger),
+	)
 	svc := NewService(ServiceConfig{
 		Store:    store,
 		Cache:    c,
@@ -626,10 +626,10 @@ func TestGetFields_RecordsUsage(t *testing.T) {
 	store := &mockStore{}
 	c := &mockCache{}
 	auditStore := audit.NewMemoryStore()
-	recorder := audit.NewUsageRecorder(auditStore, audit.RecorderConfig{
-		FlushInterval: time.Hour,
-		Logger:        testLogger,
-	})
+	recorder := audit.NewUsageRecorder(auditStore,
+		audit.WithFlushInterval(time.Hour),
+		audit.WithLogger(testLogger),
+	)
 	svc := NewService(ServiceConfig{
 		Store:    store,
 		Cache:    c,
@@ -665,10 +665,10 @@ func TestGetConfig_CacheHit_RecordsUsage(t *testing.T) {
 	store := &mockStore{}
 	c := &mockCache{}
 	auditStore := audit.NewMemoryStore()
-	recorder := audit.NewUsageRecorder(auditStore, audit.RecorderConfig{
-		FlushInterval: time.Hour,
-		Logger:        testLogger,
-	})
+	recorder := audit.NewUsageRecorder(auditStore,
+		audit.WithFlushInterval(time.Hour),
+		audit.WithLogger(testLogger),
+	)
 	svc := NewService(ServiceConfig{
 		Store:    store,
 		Cache:    c,


### PR DESCRIPTION
## Summary

Continues the functional-options refactor started in #235. Both constructors gain `With...()` options and drop the positional/struct-config style:

- `audit.NewUsageRecorder(store, opts...)` — `WithFlushInterval`, `WithLogger`. The `RecorderConfig` struct is removed.
- `auth.NewInterceptor(ctx, jwksURL, opts...)` — `WithIssuer`, `WithLogger`. The previous positional `issuer` / `logger` args (where `issuer` was frequently empty) are now options.

`auth` uses the type name `InterceptorOption` so future constructors in the package (e.g. `NewMetadataInterceptor`) can add their own options without conflict.

Closes #233, #234.

## Test plan

- [x] `make test` — all packages green (race, count=1)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...`, `gofumpt -l .` — clean
- [x] `./scripts/check-coverage.sh` — all modules meet thresholds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)