### PR TITLE
feat(schema): configurable ingest limits + functional options for NewService

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -148,6 +148,12 @@ a unary/stream interceptor.
 Fix: cap field count (e.g. 10 000), schema-document bytes (e.g. 5 MB),
 and wrap compilation in a context deadline (e.g. 5 s).
 
+Field count + doc bytes landed via `schema.Limits` (`internal/schema/limits.go`),
+configurable through `WithLimits` and env vars `SCHEMA_MAX_FIELDS` /
+`SCHEMA_MAX_DOC_BYTES`. Compile timeout still pending — needs a refactor
+of `internal/validation/json_schema.go` since `jsonschema/v6` has no
+`CompileContext`.
+
 ### 7. Audit log not tamper-evident — High
 
 `db/migrations/001_initial_schema.sql:106-118` defines

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -238,7 +238,15 @@ func run() int {
 
 	// Register services.
 	if srv.IsServiceEnabled("schema") {
-		schemaSvc := schema.NewService(schemaStoreVal, logger, schemaMetrics, validatorFactory)
+		schemaSvc := schema.NewService(schemaStoreVal,
+			schema.WithLogger(logger),
+			schema.WithMetrics(schemaMetrics),
+			schema.WithValidators(validatorFactory),
+			schema.WithLimits(schema.Limits{
+				MaxFields:   cfg.SchemaMaxFields,
+				MaxDocBytes: cfg.SchemaMaxDocBytes,
+			}),
+		)
 		pb.RegisterSchemaServiceServer(srv.GRPCServer(), schemaSvc)
 		srv.SetServiceHealthy("centralconfig.v1.SchemaService")
 		logger.InfoContext(ctx, "schema service enabled")
@@ -342,6 +350,8 @@ type serverConfig struct {
 	UsageFlushInterval       time.Duration
 	GRPCMaxRecvMsgBytes      int
 	GRPCMaxSendMsgBytes      int
+	SchemaMaxFields          int
+	SchemaMaxDocBytes        int
 	InsecureListen           bool
 	TLSCertFile              string
 	TLSKeyFile               string
@@ -394,6 +404,8 @@ func loadConfig() serverConfig {
 		UsageFlushInterval:       flushInterval,
 		GRPCMaxRecvMsgBytes:      parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
 		GRPCMaxSendMsgBytes:      parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
+		SchemaMaxFields:          parseEnvInt("SCHEMA_MAX_FIELDS", 10_000),
+		SchemaMaxDocBytes:        parseEnvInt("SCHEMA_MAX_DOC_BYTES", 5*1024*1024),
 		InsecureListen:           getEnv("INSECURE_LISTEN", "") == "1",
 		TLSCertFile:              getEnv("TLS_CERT_FILE", ""),
 		TLSKeyFile:               getEnv("TLS_KEY_FILE", ""),

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -18,6 +18,8 @@ OpenDecree is configured entirely through environment variables. No config files
 | `USAGE_FLUSH_INTERVAL` | How often accumulated read counts are flushed to storage. Format: Go duration (e.g., `30s`, `1m`). | `30s` | No |
 | `GRPC_MAX_RECV_MSG_BYTES` | Maximum size of an inbound gRPC message, in bytes. Requests above this return `ResourceExhausted`. Set to `0` for the default. | `20971520` (20 MiB) | No |
 | `GRPC_MAX_SEND_MSG_BYTES` | Maximum size of an outbound gRPC message, in bytes. Responses above this return `ResourceExhausted` to the client. Set to `0` for the default. | `20971520` (20 MiB) | No |
+| `SCHEMA_MAX_FIELDS` | Maximum number of fields per schema accepted by `CreateSchema` and `ImportSchema`. Requests above this return `InvalidArgument`. Set to `0` to disable. | `10000` | No |
+| `SCHEMA_MAX_DOC_BYTES` | Maximum serialized YAML document size accepted by `ImportSchema`, in bytes. Requests above this return `InvalidArgument`. Set to `0` to disable. | `5242880` (5 MiB) | No |
 
 ## Transport Security (TLS)
 

--- a/internal/schema/limits.go
+++ b/internal/schema/limits.go
@@ -1,0 +1,25 @@
+package schema
+
+// Limits caps the size and complexity of schema documents accepted by
+// CreateSchema and ImportSchema. Zero values mean "no limit" for that
+// dimension. Use [DefaultLimits] for safe defaults.
+//
+// Limits guard against pathological inputs that would otherwise hang or
+// OOM the server (cyclic $ref, exponential allOf/anyOf, million-element
+// enum). They are tracked in opendecree/decree#217 (security review).
+type Limits struct {
+	// MaxFields caps the number of SchemaField entries per schema version.
+	MaxFields int
+
+	// MaxDocBytes caps the serialized YAML document size at ImportSchema.
+	MaxDocBytes int
+}
+
+// DefaultLimits returns conservative defaults: 10 000 fields and 5 MiB
+// per document. Tune via env vars at the call site (cmd/server).
+func DefaultLimits() Limits {
+	return Limits{
+		MaxFields:   10_000,
+		MaxDocBytes: 5 * 1024 * 1024,
+	}
+}

--- a/internal/schema/limits_test.go
+++ b/internal/schema/limits_test.go
@@ -1,0 +1,103 @@
+package schema
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+func TestDefaultLimits(t *testing.T) {
+	l := DefaultLimits()
+	assert.Equal(t, 10_000, l.MaxFields)
+	assert.Equal(t, 5*1024*1024, l.MaxDocBytes)
+}
+
+func TestCreateSchema_ExceedsMaxFields(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxFields: 2}),
+	)
+
+	fields := []*pb.SchemaField{
+		{Path: "a", Type: pb.FieldType_FIELD_TYPE_STRING},
+		{Path: "b", Type: pb.FieldType_FIELD_TYPE_STRING},
+		{Path: "c", Type: pb.FieldType_FIELD_TYPE_STRING},
+	}
+	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{
+		Name:   "too-big",
+		Fields: fields,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 2")
+	store.AssertNotCalled(t, "CreateSchema")
+}
+
+func TestCreateSchema_AtLimitAllowed(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxFields: 2}),
+	)
+
+	store.On("CreateSchema", mock.Anything, mock.Anything).
+		Return(domain.Schema{ID: testSchemaID, Name: "ok"}, nil)
+	store.On("CreateSchemaVersion", mock.Anything, mock.Anything).
+		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1}, nil)
+	store.On("CreateSchemaField", mock.Anything, mock.Anything).
+		Return(domain.SchemaField{Path: "a", FieldType: "string"}, nil)
+
+	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{
+		Name: "ok",
+		Fields: []*pb.SchemaField{
+			{Path: "a", Type: pb.FieldType_FIELD_TYPE_STRING},
+			{Path: "b", Type: pb.FieldType_FIELD_TYPE_STRING},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestImportSchema_ExceedsMaxDocBytes(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxDocBytes: 100}),
+	)
+
+	yaml := []byte(strings.Repeat("x", 200))
+	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+		YamlContent: yaml,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 100")
+}
+
+func TestImportSchema_ExceedsMaxFields(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxFields: 1}),
+	)
+
+	yaml := []byte("spec_version: v1\nname: too-many\nfields:\n  a:\n    type: string\n  b:\n    type: string\n")
+	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+		YamlContent: yaml,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 1")
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -70,6 +70,40 @@ func containsStr(slice []string, s string) bool {
 	return false
 }
 
+// Option configures a Service.
+type Option func(*serviceOptions)
+
+type serviceOptions struct {
+	logger    *slog.Logger
+	metrics   *telemetry.SchemaMetrics
+	validator *validation.ValidatorFactory
+	limits    Limits
+}
+
+// WithLogger sets the service logger. Defaults to slog.Default() when unset.
+func WithLogger(l *slog.Logger) Option {
+	return func(o *serviceOptions) { o.logger = l }
+}
+
+// WithMetrics wires schema metrics. Nil disables them.
+func WithMetrics(m *telemetry.SchemaMetrics) Option {
+	return func(o *serviceOptions) { o.metrics = m }
+}
+
+// WithValidators wires the schema validator factory. Production callers
+// should pass the same factory the config service uses so cache
+// invalidation is observed by both. Nil is acceptable for tests that do
+// not exercise tenant updates.
+func WithValidators(v *validation.ValidatorFactory) Option {
+	return func(o *serviceOptions) { o.validator = v }
+}
+
+// WithLimits caps schema document size and field count. Zero fields mean
+// no limit for that dimension. Defaults to [DefaultLimits] when unset.
+func WithLimits(l Limits) Option {
+	return func(o *serviceOptions) { o.limits = l }
+}
+
 // Service implements the SchemaService gRPC server.
 type Service struct {
 	pb.UnimplementedSchemaServiceServer
@@ -77,18 +111,25 @@ type Service struct {
 	logger    *slog.Logger
 	metrics   *telemetry.SchemaMetrics
 	validator *validation.ValidatorFactory
+	limits    Limits
 }
 
-// NewService creates a new SchemaService. The validator factory may be nil
-// for tests that do not exercise tenant updates; production callers should
-// pass the same factory the config service uses so cache invalidation is
-// observed by both.
-func NewService(store Store, logger *slog.Logger, metrics *telemetry.SchemaMetrics, validator *validation.ValidatorFactory) *Service {
+// NewService creates a new SchemaService. Only the store is required;
+// everything else is optional and may be passed via With...() options.
+func NewService(store Store, opts ...Option) *Service {
+	o := serviceOptions{
+		logger: slog.Default(),
+		limits: DefaultLimits(),
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return &Service{
 		store:     store,
-		logger:    logger,
-		metrics:   metrics,
-		validator: validator,
+		logger:    o.logger,
+		metrics:   o.metrics,
+		validator: o.validator,
+		limits:    o.limits,
 	}
 }
 
@@ -100,6 +141,9 @@ func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest)
 	}
 	if !isValidSlug(req.Name) {
 		return nil, status.Error(codes.InvalidArgument, "name must be a slug: lowercase alphanumeric and hyphens, 1-63 chars")
+	}
+	if s.limits.MaxFields > 0 && len(req.Fields) > s.limits.MaxFields {
+		return nil, status.Errorf(codes.InvalidArgument, "schema has %d fields, exceeds limit of %d", len(req.Fields), s.limits.MaxFields)
 	}
 
 	schema, err := s.store.CreateSchema(ctx, CreateSchemaParams{
@@ -608,12 +652,18 @@ func (s *Service) ExportSchema(ctx context.Context, req *pb.ExportSchemaRequest)
 }
 
 func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest) (*pb.ImportSchemaResponse, error) {
+	if s.limits.MaxDocBytes > 0 && len(req.YamlContent) > s.limits.MaxDocBytes {
+		return nil, status.Errorf(codes.InvalidArgument, "schema document is %d bytes, exceeds limit of %d", len(req.YamlContent), s.limits.MaxDocBytes)
+	}
 	parsed, err := Dispatch(req.YamlContent)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid schema YAML: %v", err)
 	}
 
 	fields := parsed.Fields
+	if s.limits.MaxFields > 0 && len(fields) > s.limits.MaxFields {
+		return nil, status.Errorf(codes.InvalidArgument, "schema has %d fields, exceeds limit of %d", len(fields), s.limits.MaxFields)
+	}
 	depReqs := parsed.DependentRequired
 	if err := validateDependentRequiredAgainstFields(depReqs, fields); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -41,7 +41,7 @@ func testTenant() domain.Tenant {
 
 func TestListSchemas_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{
 		testSchema(),
@@ -56,7 +56,7 @@ func TestListSchemas_Success(t *testing.T) {
 
 func TestListSchemas_Pagination(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	s1 := testSchema()
 	s2 := testSchema()
@@ -96,7 +96,7 @@ func TestListSchemas_Pagination(t *testing.T) {
 }
 
 func TestListSchemas_InvalidPageToken(t *testing.T) {
-	svc := NewService(&mockStore{}, testLogger, nil, nil)
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
 
 	_, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageToken: "garbage"})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -106,7 +106,7 @@ func TestListSchemas_InvalidPageToken(t *testing.T) {
 
 func TestDeleteSchema_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetSchemaByID", mock.Anything, testSchemaID).Return(testSchema(), nil)
 	store.On("DeleteSchema", mock.Anything, testSchemaID).Return(nil)
@@ -117,7 +117,7 @@ func TestDeleteSchema_Success(t *testing.T) {
 
 func TestDeleteSchema_InvalidID(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	// "bad" is not a UUID, so resolveSchema tries name lookup.
 	store.On("GetSchemaByName", mock.Anything, "bad").Return(domain.Schema{}, domain.ErrNotFound)
@@ -129,7 +129,7 @@ func TestDeleteSchema_InvalidID(t *testing.T) {
 
 func TestGetTenant_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
@@ -140,7 +140,7 @@ func TestGetTenant_Success(t *testing.T) {
 
 func TestGetTenant_NotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	missingID := "99999999-9999-9999-9999-999999999999"
 	store.On("GetTenantByID", mock.Anything, missingID).Return(domain.Tenant{}, domain.ErrNotFound)
@@ -153,7 +153,7 @@ func TestGetTenant_NotFound(t *testing.T) {
 
 func TestListTenants_BySchema(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	schemaID := testSchemaID
 	store.On("ListTenantsBySchema", mock.Anything, mock.Anything).Return([]domain.Tenant{testTenant()}, nil)
@@ -165,7 +165,7 @@ func TestListTenants_BySchema(t *testing.T) {
 
 func TestListTenants_All(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListTenants", mock.Anything, mock.Anything).Return([]domain.Tenant{testTenant()}, nil)
 
@@ -178,7 +178,7 @@ func TestListTenants_All(t *testing.T) {
 
 func TestDeleteTenant_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("DeleteTenant", mock.Anything, testTenantID).Return(nil)
@@ -189,7 +189,7 @@ func TestDeleteTenant_Success(t *testing.T) {
 
 func TestDeleteTenant_InvalidID(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByName", mock.Anything, "bad").Return(domain.Tenant{}, domain.ErrNotFound)
 	_, err := svc.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{Id: "bad"})
@@ -200,7 +200,7 @@ func TestDeleteTenant_InvalidID(t *testing.T) {
 
 func TestLockField_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("CreateFieldLock", mock.Anything, mock.Anything).Return(nil)
@@ -216,7 +216,7 @@ func TestLockField_Success(t *testing.T) {
 
 func TestUnlockField_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("DeleteFieldLock", mock.Anything, mock.Anything).Return(nil)
@@ -232,7 +232,7 @@ func TestUnlockField_Success(t *testing.T) {
 
 func TestListFieldLocks_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("GetFieldLocks", mock.Anything, testTenantID).Return([]domain.TenantFieldLock{
@@ -261,7 +261,7 @@ func outOfScopeAdminCtx() context.Context {
 
 func TestLockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
 	_, err := svc.LockField(outOfScopeAdminCtx(), &pb.LockFieldRequest{
@@ -274,7 +274,7 @@ func TestLockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 
 func TestUnlockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
 	_, err := svc.UnlockField(outOfScopeAdminCtx(), &pb.UnlockFieldRequest{
@@ -287,7 +287,7 @@ func TestUnlockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 
 func TestListFieldLocks_DeniedForOutOfScopeAdmin(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
 	_, err := svc.ListFieldLocks(outOfScopeAdminCtx(), &pb.ListFieldLocksRequest{TenantId: testTenantID})
@@ -299,7 +299,7 @@ func TestListFieldLocks_DeniedForOutOfScopeAdmin(t *testing.T) {
 
 func TestUpdateTenant_UpdateName_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	newName := "new-acme"
 	updated := testTenant()
@@ -322,7 +322,7 @@ func TestUpdateTenant_UpdateName_Success(t *testing.T) {
 
 func TestUpdateTenant_UpdateSchemaVersion_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	newVersion := int32(2)
 	updated := testTenant()
@@ -345,7 +345,7 @@ func TestUpdateTenant_UpdateSchemaVersion_Success(t *testing.T) {
 
 func TestUpdateTenant_UpdateBothNameAndVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	newName := "renamed"
 	newVersion := int32(3)
@@ -377,7 +377,7 @@ func TestUpdateTenant_UpdateBothNameAndVersion(t *testing.T) {
 
 func TestUpdateTenant_NoFieldsUpdated_FetchesCurrent(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
@@ -391,7 +391,7 @@ func TestUpdateTenant_NoFieldsUpdated_FetchesCurrent(t *testing.T) {
 
 func TestUpdateTenant_InvalidID(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	// "bad" is not a UUID, so resolveTenant tries name lookup.
 	store.On("GetTenantByName", mock.Anything, "bad").Return(domain.Tenant{}, domain.ErrNotFound)
@@ -401,7 +401,7 @@ func TestUpdateTenant_InvalidID(t *testing.T) {
 
 func TestUpdateTenant_InvalidSlugName(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	badName := "NOT A SLUG!"
@@ -414,7 +414,7 @@ func TestUpdateTenant_InvalidSlugName(t *testing.T) {
 
 func TestUpdateTenant_NameNotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	newName := "new-name"
@@ -429,7 +429,7 @@ func TestUpdateTenant_NameNotFound(t *testing.T) {
 
 func TestUpdateTenant_SchemaVersionNotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	v := int32(99)
@@ -444,7 +444,7 @@ func TestUpdateTenant_SchemaVersionNotFound(t *testing.T) {
 
 func TestUpdateTenant_NoFieldsUpdated_NotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	missingID := "99999999-9999-9999-9999-999999999999"
 	store.On("GetTenantByID", mock.Anything, missingID).Return(domain.Tenant{}, domain.ErrNotFound)
@@ -476,7 +476,7 @@ func (a *validatorStoreAdapter) GetSchemaFields(ctx context.Context, schemaVersi
 func TestUpdateTenant_SchemaVersionInvalidatesCache(t *testing.T) {
 	store := &mockStore{}
 	factory := validation.NewValidatorFactory(&validatorStoreAdapter{s: store})
-	svc := NewService(store, testLogger, nil, factory)
+	svc := NewService(store, WithLogger(testLogger), WithValidators(factory))
 
 	newVersion := int32(2)
 	updated := testTenant()
@@ -498,7 +498,7 @@ func TestUpdateTenant_SchemaVersionInvalidatesCache(t *testing.T) {
 
 func TestGetTenant_ByName(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByName", mock.Anything, "acme").Return(testTenant(), nil)
 
@@ -509,7 +509,7 @@ func TestGetTenant_ByName(t *testing.T) {
 
 func TestGetSchema_ByName(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetSchemaByName", mock.Anything, "test-schema").Return(testSchema(), nil)
 	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
@@ -526,7 +526,7 @@ func TestGetSchema_ByName(t *testing.T) {
 
 func TestListTenants_SuperadminSeesAll(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
 		Role: auth.RoleSuperAdmin,
@@ -544,7 +544,7 @@ func TestListTenants_SuperadminSeesAll(t *testing.T) {
 
 func TestListTenants_NonSuperadminFiltered(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	allowedIDs := []string{testTenantID}
 	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
@@ -566,7 +566,7 @@ func TestListTenants_NonSuperadminFiltered(t *testing.T) {
 
 func TestListTenants_BySchemaFiltered(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	allowedIDs := []string{testTenantID}
 	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
@@ -587,7 +587,7 @@ func TestListTenants_BySchemaFiltered(t *testing.T) {
 
 func TestListTenants_NoAuthContext_SeesAll(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background() // No auth claims — permissive.
 
 	store.On("ListTenants", ctx, ListTenantsParams{
@@ -601,7 +601,7 @@ func TestListTenants_NoAuthContext_SeesAll(t *testing.T) {
 }
 
 func TestListTenants_InvalidPageToken(t *testing.T) {
-	svc := NewService(&mockStore{}, testLogger, nil, nil)
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
 	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
 
 	_, err := svc.ListTenants(ctx, &pb.ListTenantsRequest{PageToken: "garbage"})
@@ -612,7 +612,7 @@ func TestListTenants_InvalidPageToken(t *testing.T) {
 
 func TestExportSchema_LatestVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
@@ -635,7 +635,7 @@ func TestExportSchema_LatestVersion(t *testing.T) {
 
 func TestExportSchema_SpecificVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 	v := int32(2)
 
@@ -657,7 +657,7 @@ func TestExportSchema_SpecificVersion(t *testing.T) {
 
 func TestExportSchema_SchemaNotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).Return(domain.Schema{}, domain.ErrNotFound)
@@ -668,7 +668,7 @@ func TestExportSchema_SchemaNotFound(t *testing.T) {
 
 func TestExportSchema_InvalidID(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetSchemaByName", mock.Anything, "bad").Return(domain.Schema{}, domain.ErrNotFound)
 	_, err := svc.ExportSchema(context.Background(), &pb.ExportSchemaRequest{Id: "bad"})
@@ -683,7 +683,7 @@ func validYAML(name string) []byte {
 
 func TestImportSchema_NewSchema(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByName", ctx, "my-schema").Return(domain.Schema{}, domain.ErrNotFound)
@@ -705,7 +705,7 @@ func TestImportSchema_NewSchema(t *testing.T) {
 
 func TestImportSchema_NewSchemaWithAutoPublish(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByName", ctx, "pub-schema").Return(domain.Schema{}, domain.ErrNotFound)
@@ -734,7 +734,7 @@ func TestImportSchema_NewSchemaWithAutoPublish(t *testing.T) {
 
 func TestImportSchema_ExistingSchemaNewVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	existingSchema := domain.Schema{ID: testSchemaID, Name: "my-schema"}
@@ -761,7 +761,7 @@ func TestImportSchema_ExistingSchemaNewVersion(t *testing.T) {
 
 func TestImportSchema_IdenticalChecksum_AlreadyExists(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	// Compute the real checksum that the service will produce for this YAML.
@@ -794,7 +794,7 @@ func TestImportSchema_IdenticalChecksum_AlreadyExists(t *testing.T) {
 
 func TestImportSchema_InvalidYAML(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
 		YamlContent: []byte("not: valid: yaml: content"),
@@ -804,7 +804,7 @@ func TestImportSchema_InvalidYAML(t *testing.T) {
 
 func TestImportSchema_MissingSyntax(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
 		YamlContent: []byte("name: test\nfields:\n  app.name:\n    type: string\n"),
@@ -814,7 +814,7 @@ func TestImportSchema_MissingSyntax(t *testing.T) {
 
 func TestImportSchema_LookupError(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByName", ctx, "my-schema").
@@ -828,7 +828,7 @@ func TestImportSchema_LookupError(t *testing.T) {
 
 func TestImportSchema_ExistingWithAutoPublish(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	existingSchema := domain.Schema{ID: testSchemaID, Name: "my-schema"}

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -28,7 +28,7 @@ const (
 
 func TestCreateSchema_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
@@ -54,7 +54,7 @@ func TestCreateSchema_Success(t *testing.T) {
 
 func TestCreateSchema_EmptyName(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 
 	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{Name: ""})
 
@@ -66,7 +66,7 @@ func TestCreateSchema_EmptyName(t *testing.T) {
 
 func TestGetSchema_LatestVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
@@ -85,7 +85,7 @@ func TestGetSchema_LatestVersion(t *testing.T) {
 
 func TestGetSchema_SpecificVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	v := int32(2)
@@ -106,7 +106,7 @@ func TestGetSchema_SpecificVersion(t *testing.T) {
 
 func TestGetSchema_NotFound(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
@@ -122,7 +122,7 @@ func TestGetSchema_NotFound(t *testing.T) {
 
 func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	oldVersionID := "00000000-0000-0000-0000-000000000010"
@@ -159,7 +159,7 @@ func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 
 func TestPublishSchema_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
@@ -180,7 +180,7 @@ func TestPublishSchema_Success(t *testing.T) {
 
 func TestCreateTenant_RequiresPublishedSchema(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
@@ -198,7 +198,7 @@ func TestCreateTenant_RequiresPublishedSchema(t *testing.T) {
 
 func TestCreateTenant_Success(t *testing.T) {
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
@@ -229,7 +229,7 @@ func TestCreateSchema_FieldTagsNotPersisted(t *testing.T) {
 	// CreateSchemaFieldParams → domain.SchemaField → DB → fieldToProto.
 
 	store := &mockStore{}
-	svc := NewService(store, testLogger, nil, nil)
+	svc := NewService(store, WithLogger(testLogger))
 	ctx := context.Background()
 
 	title := "Fee Rate"

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -51,7 +51,11 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	}
 	validatorFactory := validation.NewValidatorFactory(validatorStore)
 
-	schemaSvc := schema.NewService(memSchema, slog.Default(), telemetry.NewSchemaMetrics(telemetry.Config{}), validatorFactory)
+	schemaSvc := schema.NewService(memSchema,
+		schema.WithLogger(slog.Default()),
+		schema.WithMetrics(telemetry.NewSchemaMetrics(telemetry.Config{})),
+		schema.WithValidators(validatorFactory),
+	)
 	pb.RegisterSchemaServiceServer(srv.GRPCServer(), schemaSvc)
 
 	configSvc := config.NewService(memConfig, cache.NewMemoryCache(0), memPubSub, memPubSub,


### PR DESCRIPTION
## Summary

- Lands the first half of #217 (security review finding 6): bound schema doc size and field count at `CreateSchema` / `ImportSchema`, so a single malicious import cannot exhaust the server before validator caching helps.
- New `schema.Limits` struct (`MaxFields`, `MaxDocBytes`) wired through a fresh `WithLimits` option. `DefaultLimits` is 10 000 fields / 5 MiB.
- Refactors `schema.NewService` to functional options (matches the recent `config` / `audit` / `auth` / `server` sweep from #235 / #236 / #249) — only `store` stays positional.
- Compile-timeout for the JSON-Schema compiler is shipped in the stacked follow-up #255 (touches `internal/validation`).

## Test plan

- [x] `make pre-commit` (build, vet, format, lint, test, coverage)
- [x] New unit tests in `internal/schema/limits_test.go` cover: `DefaultLimits`, `CreateSchema` over `MaxFields`, `CreateSchema` exactly at limit, `ImportSchema` over `MaxDocBytes`, `ImportSchema` over `MaxFields` after parsing
- [x] Existing `service_test.go` / `service_extended_test.go` migrated to the new constructor signature and still pass
- [x] `cmd/server` callsite updated; `internal/server/memory_integration_test.go` migrated and passes
- [x] Env vars `SCHEMA_MAX_FIELDS` and `SCHEMA_MAX_DOC_BYTES` documented in `docs/server/configuration.md`
- [x] `.agents/context/security-review.md` updated with progress note on #217

Refs #217. Merge before #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)