### PR TITLE
feat(validation): JSON-Schema compile timeout + depth pre-scan

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -148,11 +148,18 @@ a unary/stream interceptor.
 Fix: cap field count (e.g. 10 000), schema-document bytes (e.g. 5 MB),
 and wrap compilation in a context deadline (e.g. 5 s).
 
-Field count + doc bytes landed via `schema.Limits` (`internal/schema/limits.go`),
-configurable through `WithLimits` and env vars `SCHEMA_MAX_FIELDS` /
-`SCHEMA_MAX_DOC_BYTES`. Compile timeout still pending — needs a refactor
-of `internal/validation/json_schema.go` since `jsonschema/v6` has no
-`CompileContext`.
+All four bounds shipped:
+
+- Field count + doc bytes via `schema.Limits` (`internal/schema/limits.go`),
+  configurable through `schema.WithLimits` and env vars `SCHEMA_MAX_FIELDS` /
+  `SCHEMA_MAX_DOC_BYTES`.
+- Compile timeout + structural depth scan via `validation.Limits`
+  (`internal/validation/limits.go`), configurable through
+  `validation.WithLimits` and env vars `SCHEMA_COMPILE_TIMEOUT` /
+  `SCHEMA_MAX_REF_DEPTH`. Because `jsonschema/v6` has no `CompileContext`,
+  the timeout is a goroutine-level wrapper — the underlying compile may
+  continue past the deadline, but the depth pre-scan and upstream doc-byte
+  cap bound the worst-case work.
 
 ### 7. Audit log not tamper-evident — High
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -210,7 +210,12 @@ func run() int {
 	schemaMetrics := telemetry.NewSchemaMetrics(otelCfg)
 
 	// Validator factory (shared between schema + config services).
-	validatorFactory := validation.NewValidatorFactory(validatorStore)
+	validatorFactory := validation.NewValidatorFactory(validatorStore,
+		validation.WithLimits(validation.Limits{
+			CompileTimeout: cfg.SchemaCompileTimeout,
+			MaxDepth:       cfg.SchemaMaxRefDepth,
+		}),
+	)
 
 	// Usage recorder — async batched read tracking for audit stats.
 	var recorder *audit.UsageRecorder
@@ -352,6 +357,8 @@ type serverConfig struct {
 	GRPCMaxSendMsgBytes      int
 	SchemaMaxFields          int
 	SchemaMaxDocBytes        int
+	SchemaCompileTimeout     time.Duration
+	SchemaMaxRefDepth        int
 	InsecureListen           bool
 	TLSCertFile              string
 	TLSKeyFile               string
@@ -389,6 +396,16 @@ func loadConfig() serverConfig {
 		}
 	}
 
+	compileTimeout := 5 * time.Second
+	if v := getEnv("SCHEMA_COMPILE_TIMEOUT", ""); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Error("invalid duration env var", "key", "SCHEMA_COMPILE_TIMEOUT", "value", v, "error", err)
+			os.Exit(1)
+		}
+		compileTimeout = d
+	}
+
 	return serverConfig{
 		GRPCPort:                 getEnv("GRPC_PORT", "9090"),
 		HTTPPort:                 getEnv("HTTP_PORT", ""),
@@ -406,6 +423,8 @@ func loadConfig() serverConfig {
 		GRPCMaxSendMsgBytes:      parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
 		SchemaMaxFields:          parseEnvInt("SCHEMA_MAX_FIELDS", 10_000),
 		SchemaMaxDocBytes:        parseEnvInt("SCHEMA_MAX_DOC_BYTES", 5*1024*1024),
+		SchemaCompileTimeout:     compileTimeout,
+		SchemaMaxRefDepth:        parseEnvInt("SCHEMA_MAX_REF_DEPTH", 64),
 		InsecureListen:           getEnv("INSECURE_LISTEN", "") == "1",
 		TLSCertFile:              getEnv("TLS_CERT_FILE", ""),
 		TLSKeyFile:               getEnv("TLS_KEY_FILE", ""),

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -20,6 +20,8 @@ OpenDecree is configured entirely through environment variables. No config files
 | `GRPC_MAX_SEND_MSG_BYTES` | Maximum size of an outbound gRPC message, in bytes. Responses above this return `ResourceExhausted` to the client. Set to `0` for the default. | `20971520` (20 MiB) | No |
 | `SCHEMA_MAX_FIELDS` | Maximum number of fields per schema accepted by `CreateSchema` and `ImportSchema`. Requests above this return `InvalidArgument`. Set to `0` to disable. | `10000` | No |
 | `SCHEMA_MAX_DOC_BYTES` | Maximum serialized YAML document size accepted by `ImportSchema`, in bytes. Requests above this return `InvalidArgument`. Set to `0` to disable. | `5242880` (5 MiB) | No |
+| `SCHEMA_COMPILE_TIMEOUT` | Wall-clock cap on a single JSON-Schema compile (per-field constraint). Format: Go duration (e.g., `5s`, `2s`). Set to `0` to disable the timeout. | `5s` | No |
+| `SCHEMA_MAX_REF_DEPTH` | Maximum structural nesting depth of a JSON-Schema constraint document. Schemas deeper than this are rejected before compilation. Set to `0` to disable. | `64` | No |
 
 ## Transport Security (TLS)
 

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -24,13 +24,17 @@ type ValidatorFactory struct {
 	store      Store
 	cache      *ValidatorCache
 	rulesCache sync.Map // tenantID → []byte (raw dependent_required JSON)
+	limits     Limits
 }
 
-// NewValidatorFactory creates a new validator factory.
-func NewValidatorFactory(store Store) *ValidatorFactory {
+// NewValidatorFactory creates a new validator factory. Pass [WithLimits]
+// to override the JSON-Schema compile defaults.
+func NewValidatorFactory(store Store, opts ...Option) *ValidatorFactory {
+	o := resolveOptions(opts)
 	return &ValidatorFactory{
-		store: store,
-		cache: NewValidatorCache(0),
+		store:  store,
+		cache:  NewValidatorCache(0),
+		limits: o.limits,
 	}
 }
 
@@ -107,7 +111,7 @@ func (f *ValidatorFactory) GetValidators(ctx context.Context, tenantID string) (
 			constraints = &pb.FieldConstraints{}
 			_ = json.Unmarshal(field.Constraints, constraints)
 		}
-		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, constraints)
+		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, constraints, WithLimits(f.limits))
 	}
 
 	f.cache.Set(tenantID, validators)

--- a/internal/validation/json_schema.go
+++ b/internal/validation/json_schema.go
@@ -1,8 +1,10 @@
 package validation
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
@@ -13,20 +15,57 @@ type jsonSchemaValidator struct {
 }
 
 // newJSONSchemaValidator compiles a JSON Schema document for validation.
-func newJSONSchemaValidator(schemaDoc string) (*jsonSchemaValidator, error) {
-	c := jsonschema.NewCompiler()
-	doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaDoc))
-	if err != nil {
-		return nil, fmt.Errorf("invalid json schema: %w", err)
+// limits.MaxDepth bounds structural nesting before compile;
+// limits.CompileTimeout caps the wall-clock duration of the compile call.
+//
+// Note: jsonschema/v6 has no CompileContext, so a compile that exceeds the
+// deadline will continue running in its goroutine until it finishes (or
+// the process exits). The pre-compile depth check and upstream document-
+// size cap (schema.Limits.MaxDocBytes) bound the worst-case work; the
+// timeout is a defense-in-depth backstop against unanticipated pathologies.
+func newJSONSchemaValidator(schemaDoc string, limits Limits) (*jsonSchemaValidator, error) {
+	if limits.MaxDepth > 0 {
+		if err := scanJSONDepth(schemaDoc, limits.MaxDepth); err != nil {
+			return nil, err
+		}
 	}
-	if err := c.AddResource("schema.json", doc); err != nil {
-		return nil, fmt.Errorf("add json schema resource: %w", err)
+
+	type result struct {
+		v   *jsonSchemaValidator
+		err error
 	}
-	schema, err := c.Compile("schema.json")
-	if err != nil {
-		return nil, fmt.Errorf("compile json schema: %w", err)
+	ch := make(chan result, 1)
+	go func() {
+		c := jsonschema.NewCompiler()
+		doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaDoc))
+		if err != nil {
+			ch <- result{nil, fmt.Errorf("invalid json schema: %w", err)}
+			return
+		}
+		if err := c.AddResource("schema.json", doc); err != nil {
+			ch <- result{nil, fmt.Errorf("add json schema resource: %w", err)}
+			return
+		}
+		schema, err := c.Compile("schema.json")
+		if err != nil {
+			ch <- result{nil, fmt.Errorf("compile json schema: %w", err)}
+			return
+		}
+		ch <- result{&jsonSchemaValidator{schema: schema}, nil}
+	}()
+
+	if limits.CompileTimeout <= 0 {
+		r := <-ch
+		return r.v, r.err
 	}
-	return &jsonSchemaValidator{schema: schema}, nil
+	timer := time.NewTimer(limits.CompileTimeout)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.v, r.err
+	case <-timer.C:
+		return nil, fmt.Errorf("compile json schema: timeout after %s", limits.CompileTimeout)
+	}
 }
 
 // validate checks a JSON string against the compiled schema.
@@ -37,6 +76,39 @@ func (v *jsonSchemaValidator) validate(jsonStr string) error {
 	}
 	if err := v.schema.Validate(inst); err != nil {
 		return fmt.Errorf("json schema validation failed: %w", err)
+	}
+	return nil
+}
+
+// scanJSONDepth walks the parsed JSON document and returns an error if
+// nesting exceeds maxDepth. Non-JSON input is ignored and left for the
+// compiler to report — this scan exists to short-circuit obvious bombs,
+// not to validate syntax.
+func scanJSONDepth(doc string, maxDepth int) error {
+	var v any
+	if jsonErr := json.Unmarshal([]byte(doc), &v); jsonErr != nil {
+		return nil //nolint:nilerr // non-JSON input is intentionally left for the compiler to report
+	}
+	return checkDepth(v, 0, maxDepth)
+}
+
+func checkDepth(v any, depth, max int) error {
+	if depth > max {
+		return fmt.Errorf("compile json schema: nesting depth exceeds limit of %d", max)
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		for _, child := range t {
+			if err := checkDepth(child, depth+1, max); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, child := range t {
+			if err := checkDepth(child, depth+1, max); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/internal/validation/json_schema_test.go
+++ b/internal/validation/json_schema_test.go
@@ -1,0 +1,67 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultLimits(t *testing.T) {
+	l := DefaultLimits()
+	assert.Equal(t, 5*time.Second, l.CompileTimeout)
+	assert.Equal(t, 64, l.MaxDepth)
+}
+
+func TestNewJSONSchemaValidator_Compiles(t *testing.T) {
+	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	v, err := newJSONSchemaValidator(doc, DefaultLimits())
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	require.NoError(t, v.validate(`{"name":"x"}`))
+	require.Error(t, v.validate(`{"name":1}`))
+}
+
+func TestNewJSONSchemaValidator_DepthExceeded(t *testing.T) {
+	// Build a schema with nesting depth 10, then cap MaxDepth to 5.
+	doc := strings.Repeat(`{"properties":{"x":`, 10) + `{"type":"string"}` + strings.Repeat(`}}`, 10)
+	_, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 5})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nesting depth exceeds limit of 5")
+}
+
+func TestNewJSONSchemaValidator_DepthDisabled(t *testing.T) {
+	doc := strings.Repeat(`{"properties":{"x":`, 5) + `{"type":"string"}` + strings.Repeat(`}}`, 5)
+	v, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 0})
+	require.NoError(t, err)
+	require.NotNil(t, v)
+}
+
+func TestNewJSONSchemaValidator_MalformedJSONFallsThrough(t *testing.T) {
+	// Pre-scan ignores non-JSON; compiler reports the syntax error.
+	_, err := newJSONSchemaValidator(`not-json`, DefaultLimits())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid json schema")
+}
+
+func TestNewJSONSchemaValidator_TimeoutZeroIsUnbounded(t *testing.T) {
+	doc := `{"type":"string"}`
+	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 0, MaxDepth: 0})
+	require.NoError(t, err)
+	require.NotNil(t, v)
+}
+
+func TestScanJSONDepth(t *testing.T) {
+	// Object nesting.
+	require.NoError(t, scanJSONDepth(`{"a":{"b":{"c":1}}}`, 5))
+	require.Error(t, scanJSONDepth(`{"a":{"b":{"c":1}}}`, 2))
+
+	// Array nesting counts too.
+	require.NoError(t, scanJSONDepth(`[[[[1]]]]`, 5))
+	require.Error(t, scanJSONDepth(`[[[[1]]]]`, 3))
+
+	// Non-JSON: scan is a no-op.
+	require.NoError(t, scanJSONDepth(`not json`, 0))
+}

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -1,0 +1,56 @@
+package validation
+
+import "time"
+
+// Limits caps JSON-Schema compilation cost. Zero values mean "no limit"
+// for that dimension. Use [DefaultLimits] for safe defaults.
+//
+// These guard against pathological JSON Schema documents (cyclic $ref,
+// exponential allOf/anyOf, extreme nesting) that would otherwise hang or
+// OOM the server during the first compile. Tracked in
+// opendecree/decree#217 (security review finding 6).
+type Limits struct {
+	// CompileTimeout caps the wall-clock duration of a single
+	// jsonschema.Compile call. Because jsonschema/v6 has no
+	// CompileContext, the underlying goroutine may continue running
+	// past the deadline; the bound on input depth and document size
+	// (enforced upstream) keeps the worst-case work finite.
+	CompileTimeout time.Duration
+
+	// MaxDepth caps the structural nesting of the schema document
+	// before compilation. A schema deeper than this is rejected
+	// without invoking the compiler.
+	MaxDepth int
+}
+
+// DefaultLimits returns conservative defaults: a 5-second compile
+// timeout and a max nesting depth of 64. Tune via env vars at the call
+// site (cmd/server).
+func DefaultLimits() Limits {
+	return Limits{
+		CompileTimeout: 5 * time.Second,
+		MaxDepth:       64,
+	}
+}
+
+// Option configures a [ValidatorFactory] or [FieldValidator]. See
+// [WithLimits].
+type Option func(*options)
+
+type options struct {
+	limits Limits
+}
+
+// WithLimits sets the JSON-Schema compile limits. Defaults to
+// [DefaultLimits] when unset.
+func WithLimits(l Limits) Option {
+	return func(o *options) { o.limits = l }
+}
+
+func resolveOptions(opts []Option) options {
+	o := options{limits: DefaultLimits()}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -59,8 +59,11 @@ func (v *FieldValidator) Validate(tv *pb.TypedValue) error {
 	return nil
 }
 
-// NewFieldValidator creates a validator for a schema field.
-func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, constraints *pb.FieldConstraints) *FieldValidator {
+// NewFieldValidator creates a validator for a schema field. Pass
+// [WithLimits] to override the JSON-Schema compile defaults; without it,
+// [DefaultLimits] is used.
+func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, constraints *pb.FieldConstraints, opts ...Option) *FieldValidator {
+	o := resolveOptions(opts)
 	v := &FieldValidator{
 		fieldPath:       fieldPath,
 		fieldType:       fieldType,
@@ -140,7 +143,7 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 
 	case pb.FieldType_FIELD_TYPE_JSON:
 		if constraints.JsonSchema != nil {
-			jv, err := newJSONSchemaValidator(*constraints.JsonSchema)
+			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o.limits)
 			if err == nil {
 				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 					val := tv.Kind.(*pb.TypedValue_JsonValue).JsonValue


### PR DESCRIPTION
## Summary

- Follow-up to #254 (now merged). Lands the second half of #217: bound the JSON-Schema compiler so a malicious per-field `json_schema` constraint cannot hang the server on first compile.
- New `validation.Limits` (`CompileTimeout`, `MaxDepth`) with a shared `Option` / `WithLimits` pattern — same option type works for both `NewValidatorFactory` and `NewFieldValidator`. `DefaultLimits` is 5 s + depth 64.
- Pre-compile depth scan walks the parsed JSON-Schema document and rejects pathological nesting before invoking the compiler. The compile itself runs in a goroutine and is bounded by `CompileTimeout`. Because `jsonschema/v6` has no `CompileContext`, the timeout is a wall-clock backstop — the goroutine may continue past the deadline, but the pre-scan plus the upstream `MaxDocBytes` cap (#254) bound the worst-case work.
- `cmd/server` reads `SCHEMA_COMPILE_TIMEOUT` (Go duration) and `SCHEMA_MAX_REF_DEPTH` env vars and threads them through the shared validator factory.

(Replaces #255, which was auto-closed when its base branch `feat/schema-limits` was deleted on #254 merge.)

## Test plan

- [x] `make pre-commit` (build, vet, format, lint, test, coverage)
- [x] New unit tests in `internal/validation/json_schema_test.go` cover: `DefaultLimits`, depth-exceeded rejection, depth-disabled (`MaxDepth: 0`), malformed-JSON falls through to compiler, timeout-zero-is-unbounded, and direct `scanJSONDepth` cases (objects, arrays, non-JSON)
- [x] Existing `factory_concurrent_test.go` / `validator_bench_test.go` / `cache_race_test.go` callers continue to compile (zero-opt form preserved)
- [x] Env vars `SCHEMA_COMPILE_TIMEOUT` and `SCHEMA_MAX_REF_DEPTH` documented in `docs/server/configuration.md`
- [x] `.agents/context/security-review.md` updated — finding 6 now marked complete across both halves

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)