### PR TITLE
docs: add feature_request.yml issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a new feature or improvement for the OpenDecree server, CLI, or Go SDKs
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What's the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Server
+        - CLI
+        - Go SDK (configclient)
+        - Go SDK (adminclient)
+        - Go SDK (configwatcher)
+        - Go SDK (tools)
+        - Proto / API
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, examples, links to related discussions, or anything else that helps.


### PR DESCRIPTION
## Summary

Adds a YAML form-based feature request template to decree, matching the structure and tone of the existing `bug_report.yml`. Resolves the inconsistency where decree previously had only a bug template, causing feature asks to be filed as bugs or routed to Discussions.

Fields (all match the acceptance criteria in the issue):
- Problem (required)
- Proposed solution (required)
- Alternatives considered
- Component dropdown (Server / CLI / Go SDKs / Proto / Other)
- Additional context

Auto-labels `enhancement`.

Closes #161

## Notes

- The issue references Python/TS `feature_request.yml`, but those repos currently have `feature_request.md` (legacy markdown form). This PR uses the richer YAML form to align with decree's existing `bug_report.yml`. Bringing the SDK repos in line is out of scope here.
- The issue's stretch suggestion (centralize templates in the org `.github` repo) is left for a follow-up — flagship behavior is more discoverable when the template lives in the repo itself.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Verify template renders correctly in GitHub's "New issue" picker after merge