### PR TITLE
ci: add Dependencies category + exclude noise from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,9 @@
 changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
   categories:
     - title: "⚠️ Breaking Changes"
       labels:
@@ -23,6 +28,10 @@ changelog:
     - title: "Documentation"
       labels:
         - docs
+        - documentation
+    - title: "Dependencies"
+      labels:
+        - dependencies
     - title: "Other Changes"
       labels:
         - "*"


### PR DESCRIPTION
## Summary

- Adds `Dependencies` category to `.github/release.yml` so Dependabot PRs (label `dependencies`) get grouped in auto-generated release notes.
- Adds `exclude.labels` block (`duplicate`, `invalid`, `wontfix`) so triage-noise PRs don't show up in release notes.
- Adds `documentation` alongside `docs` in the Documentation bucket.

Preserves the existing domain-based scheme (Proto / Server / SDK / CLI / Infrastructure) since it's more informative for users than the generic Features/Fixes split.

Closes #145 (decree side).

## Test plan

- [ ] Next release auto-categorizes — Dependabot PRs land under Dependencies, no `duplicate`/`invalid`/`wontfix` PRs in notes.