### PR TITLE
ci: add artifact attestations for Docker images and Go binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io
@@ -136,6 +138,19 @@ jobs:
           docker pull ghcr.io/opendecree/decree:${VERSION}
           docker pull ghcr.io/opendecree/decree-cli:${VERSION}
           \`\`\`
+
+          ## Verify provenance
+
+          All binaries and Docker images are signed with [Sigstore](https://sigstore.dev) via GitHub Actions artifact attestations.
+
+          \`\`\`bash
+          # Verify a downloaded binary
+          gh attestation verify decree_linux_amd64.tar.gz --owner opendecree
+
+          # Verify a Docker image
+          gh attestation verify oci://ghcr.io/opendecree/decree:${VERSION} --owner opendecree
+          gh attestation verify oci://ghcr.io/opendecree/decree-cli:${VERSION} --owner opendecree
+          \`\`\`
           INSTALL
           } > /tmp/release-body.md
 
@@ -162,6 +177,8 @@ jobs:
     needs: release-notes
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -182,6 +199,14 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest binary provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
 
   # Pushes the versioned proto module to the Buf Schema Registry so SDK
   # consumers can pin a specific commit and pull generated stubs.
@@ -283,6 +308,11 @@ jobs:
     name: Manifest ${{ matrix.image }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -323,3 +353,17 @@ jobs:
 
       - name: Inspect manifest
         run: docker buildx imagetools inspect "${{ env.IMAGE_REF }}:${{ steps.meta.outputs.version }}"
+
+      - name: Get manifest digest
+        id: manifest_digest
+        run: |
+          DIGEST=$(docker buildx imagetools inspect "${{ env.IMAGE_REF }}:${{ steps.meta.outputs.version }}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_REF }}
+          subject-digest: ${{ steps.manifest_digest.outputs.digest }}
+          push-to-registry: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,27 @@ You should receive a response within 48 hours. We will work with you to understa
 |---------|-----------|
 | latest  | Yes       |
 
+## Artifact Attestations
+
+All release binaries and Docker images are signed with [Sigstore](https://sigstore.dev) via GitHub Actions artifact attestations ([SLSA](https://slsa.dev) provenance).
+
+### Verify a downloaded binary
+
+```bash
+gh attestation verify decree_linux_amd64.tar.gz --owner opendecree
+```
+
+Replace the filename with the archive you downloaded (e.g. `decree-server_darwin_arm64.tar.gz`).
+
+### Verify a Docker image
+
+```bash
+gh attestation verify oci://ghcr.io/opendecree/decree:VERSION --owner opendecree
+gh attestation verify oci://ghcr.io/opendecree/decree-cli:VERSION --owner opendecree
+```
+
+Replace `VERSION` with the release version (e.g. `0.10.0-alpha.1`).
+
 ## Scope
 
 This policy covers the OpenDecree server, CLI, and SDK packages in this repository.


### PR DESCRIPTION
## Summary
- Sigstore/SLSA provenance for Docker images and Go release binaries addresses supply-chain integrity requirements for a config service
- Docker manifests attested by digest after multi-arch merge; Go binaries attested by glob over `dist/`
- `gh attestation verify` instructions added to `SECURITY.md` and appended to every release body

## Test plan
- [ ] Trigger a test release tag and confirm the `Attest binary provenance` and `Attest image provenance` steps pass in CI
- [ ] Run `gh attestation verify decree_linux_amd64.tar.gz --owner opendecree` against a downloaded release asset
- [ ] Run `gh attestation verify oci://ghcr.io/opendecree/decree:VERSION --owner opendecree` against the published image

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)