### PR TITLE
feat(auth): enforce role-based RPC policy

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -382,8 +382,11 @@ to be correctly protected at the audit date:
 ## Out-of-scope / tracked elsewhere
 
 - **Release artifact attestations** — already tracked at #159 (P0).
-- **Role-based RPC policy** — already tracked at #205 (P0, L) and
-  #206 (P0, M).
+- **Role-based RPC policy** — #205 implemented (feat/role-rpc-policy-205):
+  `RequireSuperAdmin` + `RequireAdminOrAbove` helpers in `internal/auth/access.go`,
+  enforcement in schema and config service handlers, unit tests in
+  `role_policy_test.go`, e2e matrix updated. #206 (pluggable Guard interface)
+  deferred until #205 merges.
 - **Audit cross-tenant visibility for superadmin** — verified correct
   per the #207 fix (commit `fa1bcb9`).
 - **CEL validation security** — engine not yet implemented; design

--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -6,23 +6,17 @@ package e2e
 //
 // Iterates {superadmin, admin, user} × every authenticated RPC and asserts
 // allow/deny. The point is to catch any new RPC that forgets to call
-// auth.CheckTenantAccess (or, in future, a role-based gate). Each cell is
-// scoped so the caller HAS access to the target tenant; matrix 2 covers
-// the out-of-scope case.
+// auth.CheckTenantAccess or a role gate. Each cell is scoped so the caller
+// HAS access to the target tenant; matrix 2 covers the out-of-scope case.
 //
-// Current policy (docs/concepts/auth.md describes the intended policy):
+// Policy (docs/concepts/auth.md):
 //
 //   - superadmin: allowed on every RPC
-//   - admin (with x-tenant-id matching target): allowed on every RPC
-//   - user  (with x-tenant-id matching target): allowed on every RPC
+//   - admin: read + write config, manage field locks; denied schema management and tenant creation
+//   - user: read-only; denied all mutating RPCs
 //
-// The intended policy in docs/concepts/auth.md narrows admin/user further
-// (e.g. schema management is superadmin-only, user is read-only). The
-// server does not yet enforce that role-action policy — only tenant
-// scoping is enforced today. This matrix is the harness that will fail
-// loudly when role-based gating is added without an expected-policy
-// update; conversely, it locks down today's surface so a regression
-// (e.g. an RPC silently dropping its CheckTenantAccess call) is caught.
+// Per-cell expected policy is declared in each rpcSpec.policy field.
+// Update that field when adding a new RPC or changing the role policy.
 
 import (
 	"context"
@@ -37,6 +31,27 @@ import (
 	"github.com/opendecree/decree/sdk/configclient"
 )
 
+// allow is shorthand for a fully-allowed policy (all three roles).
+var allow = map[roleName]bool{
+	roleSuperadmin: true,
+	roleAdmin:      true,
+	roleUser:       true,
+}
+
+// superadminOnly is a policy that only superadmin can execute.
+var superadminOnly = map[roleName]bool{
+	roleSuperadmin: true,
+	roleAdmin:      false,
+	roleUser:       false,
+}
+
+// adminOrAbove is a policy that superadmin and admin can execute but user cannot.
+var adminOrAbove = map[roleName]bool{
+	roleSuperadmin: true,
+	roleAdmin:      true,
+	roleUser:       false,
+}
+
 // rpcSpec describes one RPC under test.
 type rpcSpec struct {
 	name string
@@ -44,6 +59,8 @@ type rpcSpec struct {
 	// It may use bootstrapAdmin (always superadmin) to create throwaway
 	// resources. The returned error is checked with isAuthDenied.
 	invoke func(ctx context.Context, t *testing.T, role *clients, fx *matrixFixture) error
+	// policy maps each roleName to true (expect allow) or false (expect deny).
+	policy map[roleName]bool
 }
 
 // allRPCs covers every authenticated RPC across SchemaService,
@@ -53,28 +70,32 @@ func allRPCs() []rpcSpec {
 	return []rpcSpec{
 		// --- SchemaService — schema management ---
 		{
-			name: "CreateSchema",
+			name:   "CreateSchema",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				_, err := c.admin.CreateSchema(ctx, fmt.Sprintf("m1-create-%s", randSuffix()), oneStringField(), "")
 				return err
 			},
 		},
 		{
-			name: "GetSchema",
+			name:   "GetSchema",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetSchema(ctx, fx.schemaID)
 				return err
 			},
 		},
 		{
-			name: "ListSchemas",
+			name:   "ListSchemas",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				_, err := c.admin.ListSchemas(ctx)
 				return err
 			},
 		},
 		{
-			name: "UpdateSchema",
+			name:   "UpdateSchema",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				s := mustCreateThrowawaySchema(ctx, t, c.bootstrapAdmin, "m1-update")
 				_, err := c.admin.UpdateSchema(ctx, s.ID,
@@ -83,7 +104,8 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
-			name: "PublishSchema",
+			name:   "PublishSchema",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				s := mustCreateThrowawaySchema(ctx, t, c.bootstrapAdmin, "m1-publish")
 				_, err := c.admin.PublishSchema(ctx, s.ID, 1)
@@ -91,21 +113,24 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
-			name: "DeleteSchema",
+			name:   "DeleteSchema",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				s := mustCreateThrowawaySchema(ctx, t, c.bootstrapAdmin, "m1-delete")
 				return c.admin.DeleteSchema(ctx, s.ID)
 			},
 		},
 		{
-			name: "ExportSchema",
+			name:   "ExportSchema",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.ExportSchema(ctx, fx.schemaID, nil)
 				return err
 			},
 		},
 		{
-			name: "ImportSchema",
+			name:   "ImportSchema",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				yaml := []byte(fmt.Sprintf("name: m1-import-%s\nfields:\n  - path: x\n    type: FIELD_TYPE_STRING\n", randSuffix()))
 				_, err := c.admin.ImportSchema(ctx, yaml)
@@ -115,34 +140,34 @@ func allRPCs() []rpcSpec {
 
 		// --- SchemaService — tenant management ---
 		{
-			name: "CreateTenant",
+			name:   "CreateTenant",
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
-				// CreateTenant runs CheckTenantAccess(newTenantID); since the
-				// ID is server-generated, only superadmin (which bypasses
-				// scope) can satisfy the check.
-				if c.role != roleSuperadmin {
-					t.Skip("CreateTenant: server-generated tenant ID can never be in a non-superadmin caller's pre-existing scope")
-				}
+				// Non-superadmin callers are denied by the role check before
+				// reaching the server-generated tenant ID scoping problem.
 				_, err := c.admin.CreateTenant(ctx, fmt.Sprintf("m1-ct-%s", randSuffix()), fx.schemaID, 1)
 				return err
 			},
 		},
 		{
-			name: "GetTenant",
+			name:   "GetTenant",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetTenant(ctx, fx.tenantID)
 				return err
 			},
 		},
 		{
-			name: "ListTenants",
+			name:   "ListTenants",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				_, err := c.admin.ListTenants(ctx, "")
 				return err
 			},
 		},
 		{
-			name: "UpdateTenant",
+			name:   "UpdateTenant",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				newName := fmt.Sprintf("m1-upd-%s", randSuffix())
 				_, err := c.admin.UpdateTenant(ctx, fx.tenantID, &newName, nil)
@@ -150,19 +175,21 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
-			name: "DeleteTenant",
+			name:   "DeleteTenant",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
-				// Delete a throwaway tenant. For non-superadmin, rebuild the
-				// caller's scope to include the throwaway tenant's UUID so
-				// CheckTenantAccess passes; the role × action assertion is
-				// what we are isolating.
+				// Delete a throwaway tenant. Rebuild the caller's scope to
+				// include the throwaway tenant UUID so CheckTenantAccess passes;
+				// the role × action gate is what we are isolating here.
+				// For user, RequireAdminOrAbove fires before CheckTenantAccess.
 				tenant := mustCreateThrowawayTenant(ctx, t, c.bootstrapAdmin, "m1-dt", fx.schemaID)
 				caller := scopedClients(t, c.conn, c.role, tenant.ID)
 				return caller.admin.DeleteTenant(ctx, tenant.ID)
 			},
 		},
 		{
-			name: "LockField",
+			name:   "LockField",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				field := fmt.Sprintf("app.lock-%s", randSuffix())
 				// Field doesn't exist in schema, so server may return
@@ -171,13 +198,15 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
-			name: "UnlockField",
+			name:   "UnlockField",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				return c.admin.UnlockField(ctx, fx.tenantID, "app.name")
 			},
 		},
 		{
-			name: "ListFieldLocks",
+			name:   "ListFieldLocks",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.ListFieldLocks(ctx, fx.tenantID)
 				return err
@@ -186,34 +215,39 @@ func allRPCs() []rpcSpec {
 
 		// --- ConfigService ---
 		{
-			name: "GetConfig",
+			name:   "GetConfig",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.cfg.GetAll(ctx, fx.tenantID)
 				return err
 			},
 		},
 		{
-			name: "GetField",
+			name:   "GetField",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.cfg.Get(ctx, fx.tenantID, "app.name")
 				return err
 			},
 		},
 		{
-			name: "GetFields",
+			name:   "GetFields",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.cfg.GetFields(ctx, fx.tenantID, []string{"app.name"})
 				return err
 			},
 		},
 		{
-			name: "SetField",
+			name:   "SetField",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				return c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("m1-%s", randSuffix()))
 			},
 		},
 		{
-			name: "SetFields",
+			name:   "SetFields",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				return c.cfg.SetMany(ctx, fx.tenantID, map[string]string{
 					"app.name": fmt.Sprintf("m1-many-%s", randSuffix()),
@@ -221,44 +255,52 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
-			name: "ListVersions",
+			name:   "ListVersions",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.ListConfigVersions(ctx, fx.tenantID)
 				return err
 			},
 		},
 		{
-			name: "GetVersion",
+			name:   "GetVersion",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetConfigVersion(ctx, fx.tenantID, 1)
 				return err
 			},
 		},
 		{
-			name: "RollbackToVersion",
+			name:   "RollbackToVersion",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
-				// Produce a second version so rollback has somewhere to roll
-				// back from; the fixture seeds version 1.
+				// Produce a second version so rollback has somewhere to go;
+				// the fixture seeds version 1. For user, the Set call is also
+				// denied but the error is discarded — RollbackConfig is the
+				// RPC under test.
 				_ = c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("rb-%s", randSuffix()))
 				_, err := c.admin.RollbackConfig(ctx, fx.tenantID, 1, "matrix rollback")
 				return err
 			},
 		},
 		{
-			name: "Subscribe",
+			name:   "Subscribe",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				return invokeSubscribe(c, fx.tenantID)
 			},
 		},
 		{
-			name: "ExportConfig",
+			name:   "ExportConfig",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.ExportConfig(ctx, fx.tenantID, nil)
 				return err
 			},
 		},
 		{
-			name: "ImportConfig",
+			name:   "ImportConfig",
+			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				yaml := []byte(fmt.Sprintf("values:\n  app.name: import-%s\n", randSuffix()))
 				_, err := c.admin.ImportConfig(ctx, fx.tenantID, yaml, "matrix import")
@@ -268,28 +310,32 @@ func allRPCs() []rpcSpec {
 
 		// --- AuditService ---
 		{
-			name: "QueryWriteLog",
+			name:   "QueryWriteLog",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.QueryWriteLog(ctx, adminclient.WithAuditTenant(fx.tenantID))
 				return err
 			},
 		},
 		{
-			name: "GetFieldUsage",
+			name:   "GetFieldUsage",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetFieldUsage(ctx, fx.tenantID, "app.name", nil, nil)
 				return err
 			},
 		},
 		{
-			name: "GetTenantUsage",
+			name:   "GetTenantUsage",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetTenantUsage(ctx, fx.tenantID, nil, nil)
 				return err
 			},
 		},
 		{
-			name: "GetUnusedFields",
+			name:   "GetUnusedFields",
+			policy: allow,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				_, err := c.admin.GetUnusedFields(ctx, fx.tenantID, time.Time{})
 				return err
@@ -309,16 +355,20 @@ func TestRoleActionMatrix(t *testing.T) {
 			caller := buildRoleCaller(t, conn, role, fx.tenantID)
 			for _, spec := range rpcs {
 				spec := spec
-				// Subtest suffix is "_allow" because matrix 1 only asserts
-				// the allow direction with proper tenant scope. The deny
-				// direction (out-of-scope tenant) lives in matrix 2.
-				t.Run(spec.name+"_allow", func(t *testing.T) {
+				expectAllow := spec.policy[role]
+				t.Run(spec.name, func(t *testing.T) {
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 					defer cancel()
 					err := spec.invoke(ctx, t, caller, fx)
-					assert.False(t, isAuthDenied(err),
-						"role=%s rpc=%s expected no auth denial; got: %v",
-						role, spec.name, err)
+					if expectAllow {
+						assert.False(t, isAuthDenied(err),
+							"role=%s rpc=%s expected allow; got: %v",
+							role, spec.name, err)
+					} else {
+						assert.True(t, isAuthDenied(err),
+							"role=%s rpc=%s expected auth denial; got: %v",
+							role, spec.name, err)
+					}
 				})
 			}
 		})

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -22,6 +22,32 @@ func CheckTenantAccess(ctx context.Context, tenantID string) error {
 	return status.Errorf(codes.PermissionDenied, "no access to tenant %s", tenantID)
 }
 
+// RequireSuperAdmin returns PermissionDenied if the caller is not superadmin.
+// No-ops when no auth context is present (internal/test calls).
+func RequireSuperAdmin(ctx context.Context) error {
+	claims, ok := ClaimsFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if claims.IsSuperAdmin() {
+		return nil
+	}
+	return status.Error(codes.PermissionDenied, "superadmin required")
+}
+
+// RequireAdminOrAbove returns PermissionDenied for the user (read-only) role.
+// No-ops when no auth context is present (internal/test calls).
+func RequireAdminOrAbove(ctx context.Context) error {
+	claims, ok := ClaimsFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if claims.Role == RoleUser {
+		return status.Error(codes.PermissionDenied, "admin or superadmin required")
+	}
+	return nil
+}
+
 // AllowedTenantIDs returns the caller's allowed tenant IDs.
 // Returns nil for superadmins (meaning all tenants).
 func AllowedTenantIDs(ctx context.Context) []string {

--- a/internal/config/role_policy_test.go
+++ b/internal/config/role_policy_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
+)
+
+// userCtx returns a context with user-role claims scoped to tenantID1.
+func userCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleUser,
+		TenantIDs: []string{tenantID1},
+	})
+}
+
+func assertPermissionDenied(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// --- user role must be denied on all write RPCs ---
+
+func TestSetField_DeniedForUser(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	_, err := svc.SetField(userCtx(), &pb.SetFieldRequest{TenantId: tenantID1, FieldPath: "app.x"})
+	assertPermissionDenied(t, err)
+}
+
+func TestSetFields_DeniedForUser(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	_, err := svc.SetFields(userCtx(), &pb.SetFieldsRequest{TenantId: tenantID1})
+	assertPermissionDenied(t, err)
+}
+
+func TestRollbackToVersion_DeniedForUser(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	_, err := svc.RollbackToVersion(userCtx(), &pb.RollbackToVersionRequest{TenantId: tenantID1, Version: 1})
+	assertPermissionDenied(t, err)
+}
+
+func TestImportConfig_DeniedForUser(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	_, err := svc.ImportConfig(userCtx(), &pb.ImportConfigRequest{TenantId: tenantID1})
+	assertPermissionDenied(t, err)
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -379,6 +379,9 @@ func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.
 // --- Write operations ---
 
 func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.SetFieldResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
 		if req.TenantId == "" {
@@ -478,6 +481,9 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 }
 
 func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.SetFieldsResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
 		if req.TenantId == "" {
@@ -675,6 +681,9 @@ func (s *Service) GetVersion(ctx context.Context, req *pb.GetVersionRequest) (*p
 }
 
 func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersionRequest) (*pb.RollbackToVersionResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
 		if req.TenantId == "" {
@@ -911,6 +920,9 @@ func (s *Service) ExportConfig(ctx context.Context, req *pb.ExportConfigRequest)
 }
 
 func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest) (*pb.ImportConfigResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
 		if req.TenantId == "" {

--- a/internal/schema/role_policy_test.go
+++ b/internal/schema/role_policy_test.go
@@ -1,0 +1,148 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
+)
+
+// userCtx returns a context carrying user-role claims scoped to testTenantID.
+func userCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleUser,
+		TenantIDs: []string{testTenantID},
+	})
+}
+
+// adminCtx returns a context carrying admin-role claims scoped to testTenantID.
+func adminCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleAdmin,
+		TenantIDs: []string{testTenantID},
+	})
+}
+
+func assertPermissionDenied(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// --- superadmin-only RPCs: admin and user must be denied ---
+
+func TestCreateSchema_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.CreateSchema(adminCtx(), &pb.CreateSchemaRequest{Name: "s"})
+	assertPermissionDenied(t, err)
+}
+
+func TestCreateSchema_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.CreateSchema(userCtx(), &pb.CreateSchemaRequest{Name: "s"})
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateSchema_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.UpdateSchema(adminCtx(), &pb.UpdateSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestUpdateSchema_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.UpdateSchema(userCtx(), &pb.UpdateSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestDeleteSchema_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.DeleteSchema(adminCtx(), &pb.DeleteSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestDeleteSchema_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.DeleteSchema(userCtx(), &pb.DeleteSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestPublishSchema_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.PublishSchema(adminCtx(), &pb.PublishSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestPublishSchema_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.PublishSchema(userCtx(), &pb.PublishSchemaRequest{Id: testSchemaID})
+	assertPermissionDenied(t, err)
+}
+
+func TestImportSchema_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.ImportSchema(adminCtx(), &pb.ImportSchemaRequest{YamlContent: []byte("x: 1")})
+	assertPermissionDenied(t, err)
+}
+
+func TestImportSchema_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.ImportSchema(userCtx(), &pb.ImportSchemaRequest{YamlContent: []byte("x: 1")})
+	assertPermissionDenied(t, err)
+}
+
+func TestCreateTenant_DeniedForAdmin(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.CreateTenant(adminCtx(), &pb.CreateTenantRequest{
+		Name:     "t",
+		SchemaId: testSchemaID,
+	})
+	assertPermissionDenied(t, err)
+}
+
+func TestCreateTenant_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.CreateTenant(userCtx(), &pb.CreateTenantRequest{
+		Name:     "t",
+		SchemaId: testSchemaID,
+	})
+	assertPermissionDenied(t, err)
+}
+
+// --- admin-or-above RPCs: user must be denied, admin must pass role check ---
+
+func TestUpdateTenant_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.UpdateTenant(userCtx(), &pb.UpdateTenantRequest{Id: testTenantID})
+	assertPermissionDenied(t, err)
+}
+
+func TestDeleteTenant_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.DeleteTenant(userCtx(), &pb.DeleteTenantRequest{Id: testTenantID})
+	assertPermissionDenied(t, err)
+}
+
+func TestLockField_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.LockField(userCtx(), &pb.LockFieldRequest{
+		TenantId:  testTenantID,
+		FieldPath: "app.x",
+	})
+	assertPermissionDenied(t, err)
+}
+
+func TestUnlockField_DeniedForUser(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+	_, err := svc.UnlockField(userCtx(), &pb.UnlockFieldRequest{
+		TenantId:  testTenantID,
+		FieldPath: "app.x",
+	})
+	assertPermissionDenied(t, err)
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -136,6 +136,9 @@ func NewService(store Store, opts ...Option) *Service {
 // --- Schema operations ---
 
 func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest) (*pb.CreateSchemaResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.Name == "" {
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
@@ -259,6 +262,9 @@ func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (
 }
 
 func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest) (*pb.UpdateSchemaResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "schema id or name required")
 	}
@@ -326,6 +332,9 @@ func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest)
 }
 
 func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest) (*pb.DeleteSchemaResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "schema id or name required")
 	}
@@ -346,6 +355,9 @@ func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest)
 }
 
 func (s *Service) PublishSchema(ctx context.Context, req *pb.PublishSchemaRequest) (*pb.PublishSchemaResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "schema id or name required")
 	}
@@ -384,6 +396,9 @@ func (s *Service) PublishSchema(ctx context.Context, req *pb.PublishSchemaReques
 // --- Tenant operations ---
 
 func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) (*pb.CreateTenantResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if req.Name == "" {
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
@@ -484,6 +499,9 @@ func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (
 }
 
 func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest) (*pb.UpdateTenantResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	resolved, err := s.resolveTenantWithAccess(ctx, req.Id)
 	if err != nil {
 		return nil, err
@@ -548,6 +566,9 @@ func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest)
 }
 
 func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest) (*pb.DeleteTenantResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.Id)
 	if err != nil {
 		return nil, err
@@ -564,6 +585,9 @@ func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest)
 // --- Field locking ---
 
 func (s *Service) LockField(ctx context.Context, req *pb.LockFieldRequest) (*pb.LockFieldResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
@@ -587,6 +611,9 @@ func (s *Service) LockField(ctx context.Context, req *pb.LockFieldRequest) (*pb.
 }
 
 func (s *Service) UnlockField(ctx context.Context, req *pb.UnlockFieldRequest) (*pb.UnlockFieldResponse, error) {
+	if err := auth.RequireAdminOrAbove(ctx); err != nil {
+		return nil, err
+	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
@@ -652,6 +679,9 @@ func (s *Service) ExportSchema(ctx context.Context, req *pb.ExportSchemaRequest)
 }
 
 func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest) (*pb.ImportSchemaResponse, error) {
+	if err := auth.RequireSuperAdmin(ctx); err != nil {
+		return nil, err
+	}
 	if s.limits.MaxDocBytes > 0 && len(req.YamlContent) > s.limits.MaxDocBytes {
 		return nil, status.Errorf(codes.InvalidArgument, "schema document is %d bytes, exceeds limit of %d", len(req.YamlContent), s.limits.MaxDocBytes)
 	}


### PR DESCRIPTION
## Summary

- Docs described a role policy (superadmin-only schema management, read-only user role) that the server never enforced — every authenticated caller with tenant scope could do anything
- Adds `RequireSuperAdmin` and `RequireAdminOrAbove` helpers to `internal/auth` and wires them into every restricted handler in the schema and config services
- Updates the e2e role-action matrix from an all-allow table to a per-cell policy map so regressions are caught automatically

## Test plan

- [x] 20 new unit tests in `role_policy_test.go` cover every new deny path (admin denied on superadmin-only RPCs, user denied on write RPCs)
- [x] `make test` passes across all modules
- [x] `make lint` clean
- [x] `make e2e` passes — matrix subtests now assert both allow and deny per policy cell
- [x] superadmin row: all 31 RPCs still pass (no regression)
- [x] admin row: denied on CreateSchema, UpdateSchema, PublishSchema, DeleteSchema, ImportSchema, CreateTenant; allowed on all others
- [x] user row: denied on all of the above plus UpdateTenant, DeleteTenant, LockField, UnlockField, SetField, SetFields, RollbackToVersion, ImportConfig

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)