### PR TITLE
Inject tenant_id, actor, request_id into every log record via context

### DIFF
--- a/.agents/context/completed.md
+++ b/.agents/context/completed.md
@@ -128,6 +128,10 @@ New Claude Code skills: `/before-pr` (PR checklist), `/merge` (merge + cleanup),
 
 Labels aligned across decree, decree-python, decree-typescript, decree-ui (14 common labels, size S/M/L with descriptions). `admin-gui` label renamed to `decree-ui`. Project auto-add workflow (`project.yml`) added to all 4 repos — new issues/PRs auto-appear on OpenDecree Roadmap board. Admin GUI issues #131, #128, #126 moved from decree to decree-ui. CI improvement issues created (12 total: hardening, performance, readability × 4 repos).
 
+## Context-Carried Log Fields (#239)
+
+`telemetry.NewLogHandler` extended to inject `tenant_id`, `actor`, and `request_id` from context into every slog record. New `telemetry.WithLogFields(ctx, tenantID, actor, requestID)` stores the values. New `server.logFieldsUnaryInterceptor` / `logFieldsStreamInterceptor` run after auth, pull `auth.Claims` from context, and call `WithLogFields` with a fresh UUID v4 `request_id`. Handler now always applied (not gated on OTel). Stdlib only.
+
 ## Seed Decoupling (#137, #140)
 
 `decree seed <file>` dispatches on which top-level sections are present (schema-only / tenant-only / schema+tenant / config-only / combined). Config-only files name the target schema via `tenant.schema`; `tenant.schema_version` omitted → latest published version resolved client-side via new `adminclient.GetLatestPublishedSchemaVersion` (walks backward past drafts). Re-seeding identical content is now a no-op on both axes — `ImportConfig` returning `AlreadyExists` is treated as a skip instead of erroring. Tenant-schema mismatches in config-only mode error out rather than silently re-binding. Combined envelope preserved byte-for-byte. Design brief: `.agents/context/seed-decoupling.md`.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,8 +50,7 @@ func run() int {
 	cfg := loadConfig()
 	otelCfg := telemetry.ConfigFromEnv()
 
-	// Logger — wrap with trace correlation if OTel is enabled.
-	logger := newLogger(cfg.LogLevel, otelCfg.Enabled)
+	logger := newLogger(cfg.LogLevel)
 	logger.Info("starting decree", "version", version.Version, "commit", version.Commit)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -565,7 +564,7 @@ func parseServices(s string) []string {
 	return services
 }
 
-func newLogger(level string, traceCorrelation bool) *slog.Logger {
+func newLogger(level string) *slog.Logger {
 	var logLevel slog.Level
 	switch strings.ToLower(level) {
 	case "debug":
@@ -577,9 +576,6 @@ func newLogger(level string, traceCorrelation bool) *slog.Logger {
 	default:
 		logLevel = slog.LevelInfo
 	}
-	var handler slog.Handler = slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})
-	if traceCorrelation {
-		handler = telemetry.NewLogHandler(handler)
-	}
-	return slog.New(handler)
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})
+	return slog.New(telemetry.NewLogHandler(handler))
 }

--- a/internal/server/logfields.go
+++ b/internal/server/logfields.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/telemetry"
+)
+
+// logFieldsUnaryInterceptor injects tenant_id, actor, and request_id into the
+// context after auth so the slog handler attaches them to every log record.
+func logFieldsUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		return handler(enrichLogFields(ctx), req)
+	}
+}
+
+// logFieldsStreamInterceptor is the streaming counterpart to logFieldsUnaryInterceptor.
+func logFieldsStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, &logFieldsStream{ServerStream: ss, ctx: enrichLogFields(ss.Context())})
+	}
+}
+
+func enrichLogFields(ctx context.Context) context.Context {
+	tenantID := ""
+	actor := ""
+	if claims, ok := auth.ClaimsFromContext(ctx); ok {
+		actor = claims.Subject
+		tenantID = strings.Join(claims.TenantIDs, ",")
+	}
+	return telemetry.WithLogFields(ctx, tenantID, actor, newRequestID())
+}
+
+// newRequestID returns a random UUID v4.
+func newRequestID() string {
+	var b [16]byte
+	_, _ = io.ReadFull(rand.Reader, b[:])
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+type logFieldsStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *logFieldsStream) Context() context.Context { return s.ctx }

--- a/internal/server/logfields_test.go
+++ b/internal/server/logfields_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/telemetry"
+)
+
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// logCapture is a minimal slog.Handler that records handled records.
+type logCapture struct{ records []slog.Record }
+
+func (c *logCapture) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	c.records = append(c.records, r)
+	return nil
+}
+func (c *logCapture) WithAttrs(_ []slog.Attr) slog.Handler { return c }
+func (c *logCapture) WithGroup(_ string) slog.Handler      { return c }
+
+func attrsMap(r slog.Record) map[string]string {
+	out := map[string]string{}
+	r.Attrs(func(a slog.Attr) bool {
+		out[a.Key] = a.Value.String()
+		return true
+	})
+	return out
+}
+
+func TestNewRequestID_UniqueUUIDv4(t *testing.T) {
+	a := newRequestID()
+	b := newRequestID()
+	assert.Regexp(t, uuidRE, a)
+	assert.NotEqual(t, a, b)
+}
+
+func TestLogFieldsUnaryInterceptor_InjectsFields(t *testing.T) {
+	claims := &auth.Claims{Role: auth.RoleAdmin, TenantIDs: []string{"t1", "t2"}}
+	claims.Subject = "alice"
+	ctx := auth.ContextWithClaims(context.Background(), claims)
+
+	var capturedCtx context.Context
+	_, err := logFieldsUnaryInterceptor()(ctx, nil, &grpc.UnaryServerInfo{}, func(c context.Context, _ any) (any, error) {
+		capturedCtx = c
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	cap := &logCapture{}
+	logger := slog.New(telemetry.NewLogHandler(cap))
+	logger.InfoContext(capturedCtx, "test")
+	require.Len(t, cap.records, 1)
+
+	attrs := attrsMap(cap.records[0])
+	assert.Equal(t, "t1,t2", attrs["tenant_id"])
+	assert.Equal(t, "alice", attrs["actor"])
+	assert.Regexp(t, uuidRE, attrs["request_id"])
+}
+
+func TestLogFieldsUnaryInterceptor_NoClaims_RequestIDStillSet(t *testing.T) {
+	var capturedCtx context.Context
+	_, err := logFieldsUnaryInterceptor()(context.Background(), nil, &grpc.UnaryServerInfo{}, func(c context.Context, _ any) (any, error) {
+		capturedCtx = c
+		return nil, nil
+	})
+	require.NoError(t, err)
+
+	cap := &logCapture{}
+	logger := slog.New(telemetry.NewLogHandler(cap))
+	logger.InfoContext(capturedCtx, "test")
+	require.Len(t, cap.records, 1)
+
+	attrs := attrsMap(cap.records[0])
+	assert.NotContains(t, attrs, "tenant_id")
+	assert.NotContains(t, attrs, "actor")
+	assert.Regexp(t, uuidRE, attrs["request_id"])
+}
+
+func TestLogFieldsStreamInterceptor_InjectsFields(t *testing.T) {
+	claims := &auth.Claims{Role: auth.RoleAdmin, TenantIDs: []string{"t1"}}
+	claims.Subject = "bob"
+	ctx := auth.ContextWithClaims(context.Background(), claims)
+
+	ss := &fakeServerStream{ctx: ctx}
+	var capturedCtx context.Context
+	err := logFieldsStreamInterceptor()(nil, ss, &grpc.StreamServerInfo{}, func(_ any, s grpc.ServerStream) error {
+		capturedCtx = s.Context()
+		return nil
+	})
+	require.NoError(t, err)
+
+	cap := &logCapture{}
+	logger := slog.New(telemetry.NewLogHandler(cap))
+	logger.InfoContext(capturedCtx, "test")
+	require.Len(t, cap.records, 1)
+
+	attrs := attrsMap(cap.records[0])
+	assert.Equal(t, "t1", attrs["tenant_id"])
+	assert.Equal(t, "bob", attrs["actor"])
+	assert.Regexp(t, uuidRE, attrs["request_id"])
+}
+
+// fakeServerStream satisfies grpc.ServerStream with a fixed context.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeServerStream) Context() context.Context { return f.ctx }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,14 +74,18 @@ func New(grpcPort string, auth GRPCInterceptor, opts ...Option) (*Server, error)
 		}
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
-	// Recovery wraps all middleware. Auth runs second. Rate limiter (when set) runs after auth.
+	// Recovery wraps all middleware. Auth runs second. Log-fields runs third to
+	// pull identity from auth claims into context for the slog handler.
+	// Rate limiter (when set) runs after log-fields.
 	unaryChain := []grpc.UnaryServerInterceptor{
 		recoveryUnaryInterceptor(o.logger),
 		auth.UnaryInterceptor(),
+		logFieldsUnaryInterceptor(),
 	}
 	streamChain := []grpc.StreamServerInterceptor{
 		recoveryStreamInterceptor(o.logger),
 		auth.StreamInterceptor(),
+		logFieldsStreamInterceptor(),
 	}
 	if o.rateLimiter != nil {
 		unaryChain = append(unaryChain, o.rateLimiter.UnaryInterceptor())

--- a/internal/telemetry/logctx.go
+++ b/internal/telemetry/logctx.go
@@ -1,0 +1,18 @@
+package telemetry
+
+import "context"
+
+type (
+	logTenantIDKey  struct{}
+	logActorKey     struct{}
+	logRequestIDKey struct{}
+)
+
+// WithLogFields stores tenant_id, actor, and request_id in ctx so the slog
+// handler injects them into every log record for the request lifetime.
+func WithLogFields(ctx context.Context, tenantID, actor, requestID string) context.Context {
+	ctx = context.WithValue(ctx, logTenantIDKey{}, tenantID)
+	ctx = context.WithValue(ctx, logActorKey{}, actor)
+	ctx = context.WithValue(ctx, logRequestIDKey{}, requestID)
+	return ctx
+}

--- a/internal/telemetry/slog.go
+++ b/internal/telemetry/slog.go
@@ -7,22 +7,22 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// NewLogHandler wraps an slog.Handler to inject trace_id and span_id
-// from the context into every log record. When no active span is present,
-// the log record passes through unmodified.
+// NewLogHandler wraps an slog.Handler to inject context-carried fields into
+// every log record: trace_id and span_id from the active OTel span (when
+// present), and tenant_id, actor, and request_id set by WithLogFields.
 func NewLogHandler(inner slog.Handler) slog.Handler {
-	return &traceLogHandler{inner: inner}
+	return &contextLogHandler{inner: inner}
 }
 
-type traceLogHandler struct {
+type contextLogHandler struct {
 	inner slog.Handler
 }
 
-func (h *traceLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+func (h *contextLogHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	return h.inner.Enabled(ctx, level)
 }
 
-func (h *traceLogHandler) Handle(ctx context.Context, record slog.Record) error {
+func (h *contextLogHandler) Handle(ctx context.Context, record slog.Record) error {
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {
 		record.AddAttrs(
@@ -30,13 +30,22 @@ func (h *traceLogHandler) Handle(ctx context.Context, record slog.Record) error 
 			slog.String("span_id", span.SpanContext().SpanID().String()),
 		)
 	}
+	if v, _ := ctx.Value(logTenantIDKey{}).(string); v != "" {
+		record.AddAttrs(slog.String("tenant_id", v))
+	}
+	if v, _ := ctx.Value(logActorKey{}).(string); v != "" {
+		record.AddAttrs(slog.String("actor", v))
+	}
+	if v, _ := ctx.Value(logRequestIDKey{}).(string); v != "" {
+		record.AddAttrs(slog.String("request_id", v))
+	}
 	return h.inner.Handle(ctx, record)
 }
 
-func (h *traceLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &traceLogHandler{inner: h.inner.WithAttrs(attrs)}
+func (h *contextLogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &contextLogHandler{inner: h.inner.WithAttrs(attrs)}
 }
 
-func (h *traceLogHandler) WithGroup(name string) slog.Handler {
-	return &traceLogHandler{inner: h.inner.WithGroup(name)}
+func (h *contextLogHandler) WithGroup(name string) slog.Handler {
+	return &contextLogHandler{inner: h.inner.WithGroup(name)}
 }

--- a/internal/telemetry/slog_test.go
+++ b/internal/telemetry/slog_test.go
@@ -142,3 +142,47 @@ func TestLogHandler_WithGroup_WrapsInnerResult(t *testing.T) {
 	got := attrsOf(inner.records[len(inner.records)-1])
 	assert.Equal(t, span.SpanContext().SpanID().String(), got["span_id"])
 }
+
+func TestLogHandler_Handle_WithLogFields_InjectsIdentity(t *testing.T) {
+	inner := &capturingHandler{}
+	h := NewLogHandler(inner)
+
+	ctx := WithLogFields(context.Background(), "tenant-abc", "alice", "req-123")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	require.NoError(t, h.Handle(ctx, r))
+	require.Len(t, inner.records, 1)
+
+	got := attrsOf(inner.records[0])
+	assert.Equal(t, "tenant-abc", got["tenant_id"])
+	assert.Equal(t, "alice", got["actor"])
+	assert.Equal(t, "req-123", got["request_id"])
+}
+
+func TestLogHandler_Handle_EmptyLogFields_Omitted(t *testing.T) {
+	inner := &capturingHandler{}
+	h := NewLogHandler(inner)
+
+	ctx := WithLogFields(context.Background(), "", "", "")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	require.NoError(t, h.Handle(ctx, r))
+	require.Len(t, inner.records, 1)
+
+	got := attrsOf(inner.records[0])
+	assert.NotContains(t, got, "tenant_id")
+	assert.NotContains(t, got, "actor")
+	assert.NotContains(t, got, "request_id")
+}
+
+func TestLogHandler_Handle_NoLogFields_Omitted(t *testing.T) {
+	inner := &capturingHandler{}
+	h := NewLogHandler(inner)
+
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	require.NoError(t, h.Handle(context.Background(), r))
+	require.Len(t, inner.records, 1)
+
+	got := attrsOf(inner.records[0])
+	assert.NotContains(t, got, "tenant_id")
+	assert.NotContains(t, got, "actor")
+	assert.NotContains(t, got, "request_id")
+}


### PR DESCRIPTION
## Summary

- Removes boilerplate of repeating identity fields at every log call site — the slog handler now injects them automatically from context
- A new gRPC interceptor (`logFieldsUnaryInterceptor` / `logFieldsStreamInterceptor`) runs after auth, pulls `Claims` from context, and calls `telemetry.WithLogFields` with a fresh UUID v4 `request_id`
- `telemetry.NewLogHandler` now always applied (not gated on OTel), so identity fields appear in every environment

## Test plan

- [x] `TestLogHandler_Handle_WithLogFields_InjectsIdentity` — handler injects all three fields from context
- [x] `TestLogHandler_Handle_EmptyLogFields_Omitted` — empty strings not written as blank attrs
- [x] `TestLogHandler_Handle_NoLogFields_Omitted` — bare context produces no identity attrs
- [x] `TestLogFieldsUnaryInterceptor_InjectsFields` — unary interceptor fills tenant_id + actor + request_id
- [x] `TestLogFieldsUnaryInterceptor_NoClaims_RequestIDStillSet` — unauthenticated path still gets request_id
- [x] `TestLogFieldsStreamInterceptor_InjectsFields` — streaming counterpart works identically
- [x] `TestNewRequestID_UniqueUUIDv4` — UUIDs are v4-compliant and unique
- [x] All existing telemetry + server tests still pass

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)