### PR TITLE
fix(ci): replace docker/helm labels with infra in release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -23,8 +23,7 @@ changelog:
     - title: "Infrastructure"
       labels:
         - ci
-        - docker
-        - helm
+        - infra
     - title: "Documentation"
       labels:
         - docs


### PR DESCRIPTION
## Summary

- The "Infrastructure" category in `.github/release.yml` referenced `docker` and `helm` labels, neither of which exists in the repo. Infrastructure PRs were silently falling through to "Other Changes" in generated release notes.
- Replaced both with the actual `infra` label, keeping `ci` in place.

## Test plan

- [x] Dry-run via `gh api -X POST repos/opendecree/decree/releases/generate-notes -f tag_name=v0.10.0-alpha.2 -f previous_tag_name=v0.10.0-alpha.1`: PRs #227, #228, #266 now appear under "Infrastructure".
- [x] PRs still missing the `infra` label (e.g. #261) remain in "Other Changes" as expected — label backfill is tracked in #311.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)