### PR TITLE
fix(server): fresh shutdown ctx and sanitize panic log values

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -389,10 +389,15 @@ func run() int {
 	// cancellation — they need explicit Stop / Shutdown.
 	cancel()
 	recorder.Stop() // nil-safe; waits for final flush
+
+	// Use a fresh context for the grace period — the original ctx is already
+	// cancelled, so passing it would cause immediate timeout.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
 	if gw != nil {
-		gw.Shutdown(ctx)
+		gw.Shutdown(shutdownCtx)
 	}
-	srv.GracefulStop(ctx)
+	srv.GracefulStop(shutdownCtx)
 
 	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
 		logger.ErrorContext(ctx, "server error", "error", err)

--- a/internal/server/recovery.go
+++ b/internal/server/recovery.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"strconv"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -13,6 +15,17 @@ import (
 // genericInternalError is returned to clients on panic. It deliberately omits
 // the panic value so handler internals are not leaked across the trust boundary.
 const genericInternalError = "internal server error"
+
+// sanitizePanicValue converts a panic value to a safe, bounded string for
+// logging. It truncates to 1024 bytes and quotes the result to prevent log
+// injection from attacker-controlled panic values.
+func sanitizePanicValue(v any) string {
+	s := fmt.Sprintf("%v", v)
+	if len(s) > 1024 {
+		s = s[:1024] + "...[truncated]"
+	}
+	return strconv.Quote(s)
+}
 
 // recoveryUnaryInterceptor returns a unary interceptor that recovers from panics
 // in downstream handlers, logs the panic with a stack trace, and returns
@@ -24,7 +37,7 @@ func recoveryUnaryInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
 			if r := recover(); r != nil {
 				logger.ErrorContext(ctx, "panic in unary handler",
 					"method", info.FullMethod,
-					"panic", r,
+					"panic", sanitizePanicValue(r),
 					"stack", string(debug.Stack()),
 				)
 				err = status.Error(codes.Internal, genericInternalError)
@@ -41,7 +54,7 @@ func recoveryStreamInterceptor(logger *slog.Logger) grpc.StreamServerInterceptor
 			if r := recover(); r != nil {
 				logger.ErrorContext(ss.Context(), "panic in stream handler",
 					"method", info.FullMethod,
-					"panic", r,
+					"panic", sanitizePanicValue(r),
 					"stack", string(debug.Stack()),
 				)
 				err = status.Error(codes.Internal, genericInternalError)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -300,7 +300,7 @@ func TestRecovery_Unary_ReturnsInternalAndLogs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bytes.TrimRight(logBuf.Bytes(), "\n"), &entry))
 	assert.Equal(t, "panic in unary handler", entry["msg"])
 	assert.Equal(t, "/test.Panic/Boom", entry["method"])
-	assert.Equal(t, "kaboom-unary", entry["panic"])
+	assert.Equal(t, `"kaboom-unary"`, entry["panic"])
 	assert.Contains(t, entry["stack"], "recovery.go")
 }
 
@@ -330,7 +330,7 @@ func TestRecovery_Stream_ReturnsInternalAndLogs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bytes.TrimRight(logBuf.Bytes(), "\n"), &entry))
 	assert.Equal(t, "panic in stream handler", entry["msg"])
 	assert.Equal(t, "/test.Panic/BoomStream", entry["method"])
-	assert.Equal(t, "kaboom-stream", entry["panic"])
+	assert.Equal(t, `"kaboom-stream"`, entry["panic"])
 	assert.Contains(t, entry["stack"], "recovery.go")
 }
 


### PR DESCRIPTION
## Summary
- #289: Gateway shutdown used the already-cancelled context, causing in-flight requests to be dropped; use a fresh 10s context for the grace window
- #293: Raw panic values were logged without sanitization; truncate to 1024 bytes and quote to prevent log injection

## Test plan
- [ ] Server shuts down gracefully when SIGTERM is received with in-flight requests
- [ ] Panic values in recovery logs are truncated and quoted

Closes #289
Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)