### PR TITLE
test(validation): cover CompileTimeout fired path

### DIFF
--- a/internal/validation/json_schema_test.go
+++ b/internal/validation/json_schema_test.go
@@ -53,6 +53,17 @@ func TestNewJSONSchemaValidator_TimeoutZeroIsUnbounded(t *testing.T) {
 	require.NotNil(t, v)
 }
 
+func TestNewJSONSchemaValidator_CompileTimeoutFires(t *testing.T) {
+	// A 1ns timeout has timer.C ready before the compile goroutine can be
+	// scheduled, unmarshal the document, and push to the (buffered) result
+	// channel — the select therefore reaches the timeout branch.
+	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0})
+	require.Error(t, err)
+	require.Nil(t, v)
+	assert.Contains(t, err.Error(), "compile json schema: timeout after")
+}
+
 func TestScanJSONDepth(t *testing.T) {
 	// Object nesting.
 	require.NoError(t, scanJSONDepth(`{"a":{"b":{"c":1}}}`, 5))


### PR DESCRIPTION
## Summary

PR #256 added a wall-clock `CompileTimeout` to `newJSONSchemaValidator` as a defense-in-depth backstop. The success and disabled-timeout branches were tested; the timeout-fired branch was not.

Adds `TestNewJSONSchemaValidator_CompileTimeoutFires`: a 1ns timeout against a small valid schema. `timer.C` is ready before the compile goroutine can be scheduled and push to the buffered result channel, so the `select` reaches the timeout branch. Verified deterministic across 20 consecutive runs.

Closes #281

## Test plan

- [x] `go test -run TestNewJSONSchemaValidator_CompileTimeoutFires -count=20 ./internal/validation/` — 20/20 pass
- [x] `make test` — full suite green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)