### PR TITLE
test(e2e): cover validation-limit rejections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,11 @@ services:
       HTTP_PORT: "8080"
       USAGE_FLUSH_INTERVAL: "1s"
       INSECURE_LISTEN: "1"
+      # Tight ingest limits so the validation-limit e2e tests can trip
+      # them with small payloads. Existing fixtures use at most a few
+      # fields and small YAMLs (< 1 KiB), well under these caps.
+      SCHEMA_MAX_FIELDS: "100"
+      SCHEMA_MAX_DOC_BYTES: "4096"
     ports:
       - "9090:9090"
       - "8080:8080"

--- a/e2e/validation_limits_test.go
+++ b/e2e/validation_limits_test.go
@@ -4,21 +4,22 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/opendecree/decree/sdk/adminclient"
 )
 
 // docker-compose pins the server to:
-//   SCHEMA_MAX_FIELDS=100
-//   SCHEMA_MAX_DOC_BYTES=4096
+//
+//	SCHEMA_MAX_FIELDS=100
+//	SCHEMA_MAX_DOC_BYTES=4096
+//
 // so these tests can trip each limit with small payloads.
 const (
 	maxFields   = 100
@@ -43,8 +44,8 @@ func TestValidationLimits_MaxFieldsRejected(t *testing.T) {
 
 	_, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-fields-%s", randSuffix()), fields, "")
 	require.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, status.Code(err))
-	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxFields))
+	assert.True(t, errors.Is(err, adminclient.ErrInvalidArgument))
+	assert.Contains(t, err.Error(), fmt.Sprintf("exceeds limit of %d", maxFields))
 }
 
 // TestValidationLimits_MaxFieldsAtLimitAccepted: CreateSchema with
@@ -92,6 +93,6 @@ fields:
 
 	_, err := admin.ImportSchema(ctx, yaml)
 	require.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, status.Code(err))
-	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxDocBytes))
+	assert.True(t, errors.Is(err, adminclient.ErrInvalidArgument))
+	assert.Contains(t, err.Error(), fmt.Sprintf("exceeds limit of %d", maxDocBytes))
 }

--- a/e2e/validation_limits_test.go
+++ b/e2e/validation_limits_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+)
+
+// docker-compose pins the server to:
+//   SCHEMA_MAX_FIELDS=100
+//   SCHEMA_MAX_DOC_BYTES=4096
+// so these tests can trip each limit with small payloads.
+const (
+	maxFields   = 100
+	maxDocBytes = 4096
+)
+
+// TestValidationLimits_MaxFieldsRejected: CreateSchema with more fields
+// than the configured cap is rejected with InvalidArgument and a message
+// citing the limit.
+func TestValidationLimits_MaxFieldsRejected(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	fields := make([]adminclient.Field, maxFields+1)
+	for i := range fields {
+		fields[i] = adminclient.Field{
+			Path: fmt.Sprintf("f.field_%d", i),
+			Type: "FIELD_TYPE_STRING",
+		}
+	}
+
+	_, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-fields-%s", randSuffix()), fields, "")
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxFields))
+}
+
+// TestValidationLimits_MaxFieldsAtLimitAccepted: CreateSchema with
+// exactly maxFields entries succeeds — the cap is inclusive at the limit
+// and exclusive only above it.
+func TestValidationLimits_MaxFieldsAtLimitAccepted(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	fields := make([]adminclient.Field, maxFields)
+	for i := range fields {
+		fields[i] = adminclient.Field{
+			Path: fmt.Sprintf("f.field_%d", i),
+			Type: "FIELD_TYPE_STRING",
+		}
+	}
+
+	schemaName := fmt.Sprintf("limits-fields-ok-%s", randSuffix())
+	s, err := admin.CreateSchema(ctx, schemaName, fields, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.DeleteSchema(ctx, s.ID) })
+}
+
+// TestValidationLimits_MaxDocBytesRejected: ImportSchema with a YAML body
+// larger than SCHEMA_MAX_DOC_BYTES is rejected with InvalidArgument and a
+// message citing the limit.
+func TestValidationLimits_MaxDocBytesRejected(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	ctx := context.Background()
+
+	// Build a syntactically valid YAML, then pad with a large comment so
+	// the byte count exceeds the cap. The pre-parse byte check fires
+	// before the YAML parser cares about comment size.
+	header := fmt.Sprintf(`spec_version: "v1"
+name: limits-bytes-%s
+fields:
+  app.name:
+    type: string
+`, randSuffix())
+	padding := "\n# " + strings.Repeat("x", maxDocBytes)
+	yaml := []byte(header + padding)
+	require.Greater(t, len(yaml), maxDocBytes, "test fixture must exceed the cap")
+
+	_, err := admin.ImportSchema(ctx, yaml)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxDocBytes))
+}


### PR DESCRIPTION
## Summary

PR #254 added configurable schema ingest limits (`MaxFields`, `MaxDocBytes`). The validators have unit tests; this lands the live e2e coverage of the user-facing rejection paths.

Lowers the docker-compose service caps to small values (`SCHEMA_MAX_FIELDS=100`, `SCHEMA_MAX_DOC_BYTES=4096`) so the new tests can trip them with cheap payloads. Existing e2e fixtures use at most a few fields and well under 1 KiB of YAML, so other tests are unaffected.

Adds three tests in `e2e/validation_limits_test.go`:

- `TestValidationLimits_MaxFieldsRejected` — `CreateSchema` with 101 fields returns `InvalidArgument` and the message cites the configured cap.
- `TestValidationLimits_MaxFieldsAtLimitAccepted` — exactly 100 fields is accepted; the cap is inclusive at the limit.
- `TestValidationLimits_MaxDocBytesRejected` — `ImportSchema` with a YAML body padded past the cap is rejected before the parser runs.

### Why no JSON-Schema MaxDepth coverage here

`internal/validation/validator.go:147` silently swallows `newJSONSchemaValidator` errors in the `constraints.JsonSchema` branch — a depth-exceeded schema is accepted at `CreateSchema` and only surfaces later as a missing JSON-Schema check on writes. The swallow is worth a separate issue; the depth trigger itself is unit-tested in `internal/validation/json_schema_test.go`.

Closes #283

## Test plan

- [x] `go vet -tags=e2e ./e2e/...` clean
- [x] Unit suite green (`make test`)
- [ ] CI green (e2e job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)