### PR TITLE
fix(cli): pin man-page date so docs check is deterministic

### DIFF
--- a/cmd/decree/gendocs.go
+++ b/cmd/decree/gendocs.go
@@ -5,10 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
+
+// manPageDate pins the timestamp embedded in generated man pages so the
+// output is byte-deterministic across runs. cobra/doc defaults to
+// time.Now(), which produces a different "Mon YYYY" header every month
+// and breaks the docs-up-to-date CI check on the 1st of each month.
+var manPageDate = time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 var genDocsCmd = &cobra.Command{
 	Use:    "gen-docs [output-dir]",
@@ -66,6 +73,7 @@ var genManCmd = &cobra.Command{
 			Section: "1",
 			Source:  "OpenDecree",
 			Manual:  "OpenDecree CLI",
+			Date:    &manPageDate,
 		}
 
 		rootCmd.DisableAutoGenTag = true

--- a/docs/man/decree-audit-query.1
+++ b/docs/man/decree-audit-query.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-audit-query - Query the config change audit log

--- a/docs/man/decree-audit-unused.1
+++ b/docs/man/decree-audit-unused.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-audit-unused - Find fields not read since the given duration (e.g. 7d, 24h)

--- a/docs/man/decree-audit-usage.1
+++ b/docs/man/decree-audit-usage.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-audit-usage - Show read usage statistics for a field

--- a/docs/man/decree-audit.1
+++ b/docs/man/decree-audit.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-audit - Query audit logs and usage statistics

--- a/docs/man/decree-completion-bash.1
+++ b/docs/man/decree-completion-bash.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-completion-bash - Generate the autocompletion script for bash

--- a/docs/man/decree-completion-fish.1
+++ b/docs/man/decree-completion-fish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-completion-fish - Generate the autocompletion script for fish

--- a/docs/man/decree-completion-powershell.1
+++ b/docs/man/decree-completion-powershell.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-completion-powershell - Generate the autocompletion script for powershell

--- a/docs/man/decree-completion-zsh.1
+++ b/docs/man/decree-completion-zsh.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-completion-zsh - Generate the autocompletion script for zsh

--- a/docs/man/decree-completion.1
+++ b/docs/man/decree-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-completion - Generate the autocompletion script for the specified shell

--- a/docs/man/decree-config-export.1
+++ b/docs/man/decree-config-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-export - Export config to YAML

--- a/docs/man/decree-config-get-all.1
+++ b/docs/man/decree-config-get-all.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-get-all - Get all config values for a tenant

--- a/docs/man/decree-config-get.1
+++ b/docs/man/decree-config-get.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-get - Get a single config value

--- a/docs/man/decree-config-import.1
+++ b/docs/man/decree-config-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-import - Import config from a YAML file

--- a/docs/man/decree-config-rollback.1
+++ b/docs/man/decree-config-rollback.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-rollback - Rollback config to a previous version

--- a/docs/man/decree-config-set-many.1
+++ b/docs/man/decree-config-set-many.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-set-many - Set multiple config values atomically

--- a/docs/man/decree-config-set.1
+++ b/docs/man/decree-config-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-set - Set a single config value

--- a/docs/man/decree-config-versions.1
+++ b/docs/man/decree-config-versions.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config-versions - List config versions

--- a/docs/man/decree-config.1
+++ b/docs/man/decree-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-config - Read and write configuration values

--- a/docs/man/decree-diff.1
+++ b/docs/man/decree-diff.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-diff - Show differences between two config versions or files

--- a/docs/man/decree-docgen.1
+++ b/docs/man/decree-docgen.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-docgen - Generate markdown documentation from a schema

--- a/docs/man/decree-dump.1
+++ b/docs/man/decree-dump.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-dump - Export a full tenant backup (schema + config + locks)

--- a/docs/man/decree-lock-list.1
+++ b/docs/man/decree-lock-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-lock-list - List field locks for a tenant

--- a/docs/man/decree-lock-remove.1
+++ b/docs/man/decree-lock-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-lock-remove - Unlock a field

--- a/docs/man/decree-lock-set.1
+++ b/docs/man/decree-lock-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-lock-set - Lock a field (prevents modification by non-superadmin)

--- a/docs/man/decree-lock.1
+++ b/docs/man/decree-lock.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-lock - Manage field locks

--- a/docs/man/decree-schema-create.1
+++ b/docs/man/decree-schema-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-create - Create a new schema from a YAML file

--- a/docs/man/decree-schema-delete.1
+++ b/docs/man/decree-schema-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-delete - Delete a schema and all its versions (cascades to tenants)

--- a/docs/man/decree-schema-export.1
+++ b/docs/man/decree-schema-export.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-export - Export a schema to YAML

--- a/docs/man/decree-schema-get.1
+++ b/docs/man/decree-schema-get.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-get - Show a schema

--- a/docs/man/decree-schema-import.1
+++ b/docs/man/decree-schema-import.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-import - Import a schema from a YAML file

--- a/docs/man/decree-schema-list.1
+++ b/docs/man/decree-schema-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-list - List all schemas

--- a/docs/man/decree-schema-publish.1
+++ b/docs/man/decree-schema-publish.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema-publish - Publish a schema version (makes it immutable and assignable to tenants)

--- a/docs/man/decree-schema.1
+++ b/docs/man/decree-schema.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-schema - Manage configuration schemas

--- a/docs/man/decree-seed.1
+++ b/docs/man/decree-seed.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-seed - Seed a schema, tenant, and/or config from a YAML file

--- a/docs/man/decree-server-info.1
+++ b/docs/man/decree-server-info.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-server-info - Show server version and enabled features

--- a/docs/man/decree-server.1
+++ b/docs/man/decree-server.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-server - Server information and management

--- a/docs/man/decree-tenant-create.1
+++ b/docs/man/decree-tenant-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-tenant-create - Create a new tenant on a published schema version

--- a/docs/man/decree-tenant-delete.1
+++ b/docs/man/decree-tenant-delete.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-tenant-delete - Delete a tenant and all its configuration data

--- a/docs/man/decree-tenant-get.1
+++ b/docs/man/decree-tenant-get.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-tenant-get - Show a tenant

--- a/docs/man/decree-tenant-list.1
+++ b/docs/man/decree-tenant-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-tenant-list - List tenants

--- a/docs/man/decree-tenant.1
+++ b/docs/man/decree-tenant.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-tenant - Manage tenants

--- a/docs/man/decree-validate.1
+++ b/docs/man/decree-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-validate - Validate a config YAML against a schema YAML (offline)

--- a/docs/man/decree-version.1
+++ b/docs/man/decree-version.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-version - Print the CLI version

--- a/docs/man/decree-watch.1
+++ b/docs/man/decree-watch.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree-watch - Stream live config changes (like tail -f)

--- a/docs/man/decree.1
+++ b/docs/man/decree.1
@@ -1,5 +1,5 @@
 .nh
-.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
 
 .SH NAME
 decree - OpenDecree CLI


### PR DESCRIPTION
## Summary

`cobra/doc.GenManHeader.Date` defaults to `time.Now()` when nil, so every regenerated man page embeds the build-time month/year in its `.TH` header (e.g. `.TH "DECREE" "1" "Apr 2026" "OpenDecree" "OpenDecree CLI"`).

This breaks the **Docs check** CI job on the **1st of every month**: the committed pages still carry last month's name while the regenerator emits the current month, so `git diff --exit-code docs/` fails. Today (May 1, 2026) every open PR is currently red for this reason — including the seven P0 PRs for `v0.10.0-alpha.2` (#322–#328).

This change:

- Adds a `manPageDate` constant (`2026-01-01 UTC`) in `cmd/decree/gendocs.go` and wires it through `GenManHeader.Date`.
- Sed-rewrites the 45 committed `docs/man/*.1` headers from `"Apr 2026"` to `"Jan 2026"` so the regenerated output matches what's committed.

The constant is bumped intentionally (e.g. on a release) rather than implicitly drifting with wall-clock. The man page date is informational; pinning it has no functional impact.

## Test plan

- [x] `go build ./cmd/decree/...` clean
- [x] `go vet ./cmd/decree/...` clean
- [ ] CI — Docs check should now pass (`make generate docs` produces zero diff against committed pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)