### PR TITLE
docs(security): populate supported-versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,10 @@ You should receive a response within 48 hours. We will work with you to understa
 
 | Version | Supported |
 |---------|-----------|
-| latest  | Yes       |
+| 0.10.x (alpha) | ✅ |
+| < 0.10 | ❌ |
+
+During alpha, only the latest minor release receives security backports. See [GitHub Releases](https://github.com/opendecree/decree/releases) for the current version.
 
 ## Artifact Attestations
 


### PR DESCRIPTION
## Summary

- Replaces the `latest: yes` placeholder in `SECURITY.md` with concrete version rows for the v0.10.x alpha lineage
- Adds a note clarifying that only the latest minor receives backports during alpha
- Links to GitHub Releases for the current version

## Test plan

- [ ] Verify table renders correctly on GitHub
- [ ] Confirm reporting process and attestation sections are unchanged

Closes #309