### PR TITLE
fix(ratelimit): bound InProcessLimiter.keys with LRU cap

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -129,7 +129,9 @@ Implemented in `internal/ratelimit/`. Per-tenant + per-method in-process
 token-bucket limiter via `golang.org/x/time/rate`. Health check exempt.
 Returns `codes.ResourceExhausted` + `RetryInfo` detail. `Limiter` interface
 allows future Redis-backed replacement. `OTEL_METRICS_RATE_LIMIT` counter
-for observability.
+for observability. Bucket map is LRU-capped (`defaultMaxBuckets=100_000`,
+configurable via `WithMaxBuckets`) — prevents unbounded growth from cycling
+subjects (#287).
 
 ### 6. Schema-complexity bounds missing — High
 

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,10 +1,13 @@
 package ratelimit
 
 import (
+	"container/list"
 	"sync"
 
 	"golang.org/x/time/rate"
 )
+
+const defaultMaxBuckets = 100_000
 
 // Limiter decides whether a request for a given key should proceed.
 // Implementations may be in-process or backed by an external store (e.g. Redis).
@@ -13,30 +16,63 @@ type Limiter interface {
 }
 
 // InProcessLimiter is a per-key token-bucket limiter backed by golang.org/x/time/rate.
-// Each unique key gets its own bucket; buckets are allocated on first use.
+// Each unique key gets its own bucket, allocated on first use. Buckets are evicted
+// via LRU when the cache reaches capacity, preventing unbounded memory growth.
 type InProcessLimiter struct {
-	limit rate.Limit
-	burst int
-	mu    sync.Mutex
-	keys  map[string]*rate.Limiter
+	limit      rate.Limit
+	burst      int
+	maxBuckets int
+	mu         sync.Mutex
+	ll         *list.List
+	keys       map[string]*list.Element
+}
+
+type lruEntry struct {
+	key string
+	rl  *rate.Limiter
+}
+
+// InProcessOption configures an InProcessLimiter.
+type InProcessOption func(*InProcessLimiter)
+
+// WithMaxBuckets sets the maximum number of key buckets held in memory.
+// When the cap is reached the least-recently-used bucket is evicted; the next
+// request for that key starts a fresh full bucket. Defaults to 100_000.
+func WithMaxBuckets(n int) InProcessOption {
+	return func(l *InProcessLimiter) { l.maxBuckets = n }
 }
 
 // NewInProcess returns an InProcessLimiter with the given rate (events/sec) and burst size.
-func NewInProcess(limit rate.Limit, burst int) *InProcessLimiter {
-	return &InProcessLimiter{
-		limit: limit,
-		burst: burst,
-		keys:  make(map[string]*rate.Limiter),
+func NewInProcess(limit rate.Limit, burst int, opts ...InProcessOption) *InProcessLimiter {
+	l := &InProcessLimiter{
+		limit:      limit,
+		burst:      burst,
+		maxBuckets: defaultMaxBuckets,
+		ll:         list.New(),
+		keys:       make(map[string]*list.Element),
 	}
+	for _, o := range opts {
+		o(l)
+	}
+	return l
 }
 
 // Allow reports whether a request for key should be allowed under the rate limit.
 func (l *InProcessLimiter) Allow(key string) bool {
 	l.mu.Lock()
-	rl, ok := l.keys[key]
-	if !ok {
-		rl = rate.NewLimiter(l.limit, l.burst)
-		l.keys[key] = rl
+	if el, ok := l.keys[key]; ok {
+		l.ll.MoveToFront(el)
+		rl := el.Value.(*lruEntry).rl
+		l.mu.Unlock()
+		return rl.Allow()
+	}
+	rl := rate.NewLimiter(l.limit, l.burst)
+	el := l.ll.PushFront(&lruEntry{key: key, rl: rl})
+	l.keys[key] = el
+	if l.ll.Len() > l.maxBuckets {
+		back := l.ll.Back()
+		l.ll.Remove(back)
+		delete(l.keys, back.Value.(*lruEntry).key)
 	}
 	l.mu.Unlock()
 	return rl.Allow()

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1,0 +1,31 @@
+package ratelimit_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+
+	"github.com/opendecree/decree/internal/ratelimit"
+)
+
+// TestInProcessLimiter_LRUEviction verifies that inserting cap+1 unique keys evicts
+// the least-recently-used bucket, and the evicted key gets a fresh full bucket on reuse.
+func TestInProcessLimiter_LRUEviction(t *testing.T) {
+	const cap = 3
+	// rate=0: no token replenishment; burst=1: one token per fresh bucket.
+	lim := ratelimit.NewInProcess(rate.Limit(0), 1, ratelimit.WithMaxBuckets(cap))
+
+	// Fill to capacity; each call consumes the sole token.
+	// After three inserts, LRU order (back→front): key-0, key-1, key-2.
+	lim.Allow("key-0")
+	lim.Allow("key-1")
+	lim.Allow("key-2")
+
+	// Inserting key-3 evicts key-0 (LRU).
+	lim.Allow("key-3")
+
+	// key-0 was evicted; requesting it yields a fresh bucket with 1 token.
+	assert.True(t, lim.Allow("key-0"), "evicted key should get a fresh bucket")
+	assert.False(t, lim.Allow("key-0"), "fresh bucket has only one token")
+}


### PR DESCRIPTION
## Summary

- Replaces the unbounded `map[string]*rate.Limiter` in `InProcessLimiter` with an LRU cache backed by `container/list` (stdlib — no new dependency)
- When the cap is reached, the least-recently-used bucket is evicted; the next request for that key starts a fresh full bucket
- Adds `WithMaxBuckets(n int)` functional option; default cap is 100,000
- Eviction preserves atomicity: the `*rate.Limiter` pointer is captured under the mutex before release, so in-flight `Allow()` calls on the returned limiter are safe even if the entry is simultaneously evicted

Fixes the unbounded memory growth identified in the 2026-04-30 pre-release audit (finding A3), where a malicious client cycling subject values could accumulate buckets indefinitely.

## Test plan

- [ ] `go test ./internal/ratelimit/` — all existing tests pass
- [ ] `go test -race -count=5 ./internal/ratelimit/` — race-clean
- [ ] `TestInProcessLimiter_LRUEviction`: inserts cap+1 keys, verifies oldest is evicted and gets a fresh bucket on reuse
- [ ] `make test` — full suite clean

Closes #287