### PR TITLE
security(auth): add MustHaveClaims defense-in-depth guard

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -69,6 +69,9 @@ func (s *Service) resolveTenantID(ctx context.Context, idOrName string) (string,
 }
 
 func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogRequest) (*pb.QueryWriteLogResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	pageSize := pagination.ClampPageSize(req.PageSize, 50, 500)
 
 	offset, err := pagination.DecodePageToken(req.PageToken)

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -33,6 +33,10 @@ func outOfScopeAdminCtx() context.Context {
 	})
 }
 
+func superadminCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
+}
+
 type mockStore struct{ mock.Mock }
 
 func (m *mockStore) QueryAuditWriteLog(ctx context.Context, arg QueryWriteLogParams) ([]domain.AuditWriteLog, error) {
@@ -70,7 +74,7 @@ func newTestService() (*Service, *mockStore) {
 
 func TestQueryWriteLog_Success(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("QueryAuditWriteLog", ctx, mock.Anything).Return([]domain.AuditWriteLog{
 		{
@@ -90,7 +94,7 @@ func TestQueryWriteLog_Success(t *testing.T) {
 
 func TestQueryWriteLog_WithFilters(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	tenantID := "22222222-2222-2222-2222-222222222222"
 	actor := "admin"
@@ -110,7 +114,7 @@ func TestQueryWriteLog_WithFilters(t *testing.T) {
 
 func TestQueryWriteLog_InvalidTenantID(t *testing.T) {
 	svc, _ := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	bad := "not-a-uuid"
 	_, err := svc.QueryWriteLog(ctx, &pb.QueryWriteLogRequest{TenantId: &bad})
@@ -119,7 +123,7 @@ func TestQueryWriteLog_InvalidTenantID(t *testing.T) {
 
 func TestQueryWriteLog_DefaultPageSize(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("QueryAuditWriteLog", ctx, mock.MatchedBy(func(p QueryWriteLogParams) bool {
 		return p.Limit == 51 // 50 (default page size) + 1 (to detect next page)
@@ -131,7 +135,7 @@ func TestQueryWriteLog_DefaultPageSize(t *testing.T) {
 
 func TestQueryWriteLog_InvalidPageToken(t *testing.T) {
 	svc, _ := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	_, err := svc.QueryWriteLog(ctx, &pb.QueryWriteLogRequest{PageToken: "garbage"})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -7,6 +7,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Access functions in this file are permissive when no auth claims are present in the
+// context. The interceptor layer (MetadataInterceptor or JWTInterceptor) is the gate
+// that requires authentication before claims are set.
+//
+// Consequence: any method accidentally added to skipAuth bypasses not just
+// authentication but all authz checks too. Handlers for RPCs that must never be
+// reachable without auth should call MustHaveClaims first as a defense-in-depth guard.
+
 // CheckTenantAccess verifies the caller has access to the given tenant.
 // Returns nil for superadmins. Returns PermissionDenied if the tenant is
 // not in the caller's tenant_ids list.
@@ -59,4 +67,15 @@ func AllowedTenantIDs(ctx context.Context) []string {
 		return nil // nil = all tenants
 	}
 	return claims.TenantIDs
+}
+
+// MustHaveClaims returns codes.Unauthenticated if no auth claims are present in ctx.
+// Use in handler bodies as a defense-in-depth guard for RPCs that must never be
+// reachable without authentication, even if the method is accidentally added to skipAuth.
+func MustHaveClaims(ctx context.Context) error {
+	_, ok := ClaimsFromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "authentication required")
+	}
+	return nil
 }

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -73,3 +73,14 @@ func TestClaims_IsSuperAdmin(t *testing.T) {
 	assert.False(t, (&Claims{Role: RoleAdmin}).IsSuperAdmin())
 	assert.False(t, (&Claims{Role: RoleUser}).IsSuperAdmin())
 }
+
+func TestMustHaveClaims_NoClaims(t *testing.T) {
+	err := MustHaveClaims(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestMustHaveClaims_WithClaims(t *testing.T) {
+	ctx := ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin})
+	assert.NoError(t, MustHaveClaims(ctx))
+}

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -13,6 +13,14 @@ import (
 )
 
 // skipAuth returns true for gRPC methods that should bypass authentication.
+//
+// Methods listed here are exempt from BOTH authentication and authorization.
+// Only public, side-effect-free RPCs belong here (e.g. health checks).
+// Adding any authenticated method silently bypasses all auth and authz checks.
+// Every entry requires an explicit security review.
+//
+// TODO(security): Audit whether /centralconfig.v1.ServerService/ belongs here.
+// It was added alongside health checks but is not documented as a public endpoint.
 func skipAuth(fullMethod string) bool {
 	return strings.HasPrefix(fullMethod, "/grpc.health.v1.Health/") ||
 		strings.HasPrefix(fullMethod, "/centralconfig.v1.ServerService/")

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -19,7 +19,7 @@ import (
 // Adding any authenticated method silently bypasses all auth and authz checks.
 // Every entry requires an explicit security review.
 //
-// TODO(security): Audit whether /centralconfig.v1.ServerService/ belongs here.
+// TODO(security): Audit whether /centralconfig.v1.ServerService/ belongs here (#355).
 // It was added alongside health checks but is not documented as a public endpoint.
 func skipAuth(fullMethod string) bool {
 	return strings.HasPrefix(fullMethod, "/grpc.health.v1.Health/") ||

--- a/internal/config/dependent_required_test.go
+++ b/internal/config/dependent_required_test.go
@@ -61,7 +61,7 @@ func setupDependentRequiredService(t *testing.T) (*Service, *mockStore) {
 // dependent path is null must return InvalidArgument.
 func TestSetField_DependentRequired_TriggerSetWithoutDependent_Rejected(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
@@ -94,7 +94,7 @@ func TestSetField_DependentRequired_TriggerSetWithoutDependent_Rejected(t *testi
 // snapshot.
 func TestSetField_DependentRequired_BothPresent_Allowed(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
@@ -132,7 +132,7 @@ func TestSetField_DependentRequired_BothPresent_Allowed(t *testing.T) {
 // if the dependent is also absent.
 func TestSetField_DependentRequired_TriggerAbsent_Allowed(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
@@ -168,7 +168,7 @@ func TestSetField_DependentRequired_TriggerAbsent_Allowed(t *testing.T) {
 // builder treats as absent.
 func TestSetField_DependentRequired_TriggerSetToNull_Allowed(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
@@ -203,7 +203,7 @@ func TestSetField_DependentRequired_TriggerSetToNull_Allowed(t *testing.T) {
 // path runs the check once over the post-merge snapshot, not per field.
 func TestSetFields_DependentRequired_AggregateCheck(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
@@ -264,7 +264,7 @@ func TestEnforceDependentRequiredInTx_NoRules_NoSnapshotRead(t *testing.T) {
 // state.
 func TestRollbackToVersion_DependentRequired_Rejected(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	// Rollback target (version 2) had only the trigger set; dependent never existed.
 	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{
@@ -301,7 +301,7 @@ func TestRollbackToVersion_DependentRequired_Rejected(t *testing.T) {
 // with InvalidArgument.
 func TestImportConfig_DependentRequired_Rejected(t *testing.T) {
 	svc, store := setupDependentRequiredService(t)
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -395,6 +395,9 @@ func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.
 // --- Write operations ---
 
 func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.SetFieldResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantID(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
@@ -485,6 +488,9 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 }
 
 func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.SetFieldsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	// Upfront role + tenant check before the per-field loop (loop may be empty).
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionWrite)
 	if err != nil {
@@ -653,6 +659,9 @@ func (s *Service) GetVersion(ctx context.Context, req *pb.GetVersionRequest) (*p
 }
 
 func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersionRequest) (*pb.RollbackToVersionResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionWrite)
 	if err != nil {
 		return nil, err
@@ -865,6 +874,9 @@ func (s *Service) ExportConfig(ctx context.Context, req *pb.ExportConfigRequest)
 }
 
 func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest) (*pb.ImportConfigResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	// Upfront role + tenant check before any store reads.
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionWrite)
 	if err != nil {

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -199,7 +199,7 @@ func TestGetConfig_TenantNameNotFound(t *testing.T) {
 
 func TestSetFields_Success(t *testing.T) {
 	svc, store, cache, pub := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
@@ -224,7 +224,7 @@ func TestSetFields_Success(t *testing.T) {
 
 func TestSetFields_InvalidTenantID(t *testing.T) {
 	svc, _, _, _ := newTestService()
-	_, err := svc.SetFields(context.Background(), &pb.SetFieldsRequest{TenantId: ""})
+	_, err := svc.SetFields(superadminCtx(), &pb.SetFieldsRequest{TenantId: ""})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -23,6 +23,10 @@ import (
 
 var testLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
+func superadminCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
+}
+
 const (
 	tenantID1       = "00000001-0000-0000-0000-000000000000"
 	versionID2      = "00000002-0000-0000-0000-000000000000"
@@ -129,7 +133,7 @@ func TestGetConfig_IncludeDescriptions_BypassesCache(t *testing.T) {
 
 func TestSetField_Success(t *testing.T) {
 	svc, store, cache, pub := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFieldLocks", ctx, tenantID1).
 		Return([]domain.TenantFieldLock{}, nil)
@@ -157,7 +161,7 @@ func TestSetField_Success(t *testing.T) {
 
 func TestSetField_ChecksumMismatch(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	wrongChecksum := "wrong"
 
@@ -224,7 +228,7 @@ func TestGetField_NotFound(t *testing.T) {
 
 func TestRollbackToVersion_Success(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{
@@ -295,7 +299,7 @@ func TestExportConfig_Success(t *testing.T) {
 
 func TestImportConfig_Success(t *testing.T) {
 	svc, store, cache, pub := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	yamlContent := []byte(`
 spec_version: "v1"
@@ -347,7 +351,7 @@ values:
 
 func TestImportConfig_ValidationRejectsUnknownField(t *testing.T) {
 	svc, store := newTestServiceWithValidation()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	yamlContent := []byte(`
 spec_version: "v1"
@@ -379,7 +383,7 @@ values:
 
 func TestImportConfig_ValidationRejectsConstraintViolation(t *testing.T) {
 	svc, store := newTestServiceWithValidation()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	// Import an integer value that exceeds max constraint.
 	yamlContent := []byte(`
@@ -421,7 +425,7 @@ values:
 
 func TestImportConfig_MergeMode_SkipsSameValues(t *testing.T) {
 	svc, store, cache, pub := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	yamlContent := []byte(`
 spec_version: "v1"
@@ -477,7 +481,7 @@ values:
 
 func TestImportConfig_DefaultsMode_SkipsExistingValues(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	yamlContent := []byte(`
 spec_version: "v1"
@@ -733,7 +737,7 @@ func TestFieldTypeMap_ValidatorLookupError(t *testing.T) {
 // when the validator store is unavailable (end-to-end fail-closed path).
 func TestSetField_ValidatorLookupError(t *testing.T) {
 	svc, store := newTestServiceWithValidation()
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	storeErr := errors.New("schema store unavailable")
 	store.On("GetTenantByID", ctx, tenantID1).Return(domain.Tenant{}, storeErr)

--- a/internal/schema/limits_test.go
+++ b/internal/schema/limits_test.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestCreateSchema_ExceedsMaxFields(t *testing.T) {
 		{Path: "b", Type: pb.FieldType_FIELD_TYPE_STRING},
 		{Path: "c", Type: pb.FieldType_FIELD_TYPE_STRING},
 	}
-	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{
+	_, err := svc.CreateSchema(superadminCtx(), &pb.CreateSchemaRequest{
 		Name:   "too-big",
 		Fields: fields,
 	})
@@ -58,7 +57,7 @@ func TestCreateSchema_AtLimitAllowed(t *testing.T) {
 	store.On("CreateSchemaField", mock.Anything, mock.Anything).
 		Return(domain.SchemaField{Path: "a", FieldType: "string"}, nil)
 
-	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{
+	_, err := svc.CreateSchema(superadminCtx(), &pb.CreateSchemaRequest{
 		Name: "ok",
 		Fields: []*pb.SchemaField{
 			{Path: "a", Type: pb.FieldType_FIELD_TYPE_STRING},
@@ -76,7 +75,7 @@ func TestImportSchema_ExceedsMaxDocBytes(t *testing.T) {
 	)
 
 	yaml := []byte(strings.Repeat("x", 200))
-	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+	_, err := svc.ImportSchema(superadminCtx(), &pb.ImportSchemaRequest{
 		YamlContent: yaml,
 	})
 
@@ -93,7 +92,7 @@ func TestImportSchema_ExceedsMaxFields(t *testing.T) {
 	)
 
 	yaml := []byte("spec_version: v1\nname: too-many\nfields:\n  a:\n    type: string\n  b:\n    type: string\n")
-	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+	_, err := svc.ImportSchema(superadminCtx(), &pb.ImportSchemaRequest{
 		YamlContent: yaml,
 	})
 

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -148,6 +148,9 @@ func NewService(store Store, opts ...Option) *Service {
 // --- Schema operations ---
 
 func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest) (*pb.CreateSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -268,6 +271,9 @@ func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (
 }
 
 func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest) (*pb.UpdateSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -335,6 +341,9 @@ func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest)
 }
 
 func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest) (*pb.DeleteSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -355,6 +364,9 @@ func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest)
 }
 
 func (s *Service) PublishSchema(ctx context.Context, req *pb.PublishSchemaRequest) (*pb.PublishSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -390,6 +402,9 @@ func (s *Service) PublishSchema(ctx context.Context, req *pb.PublishSchemaReques
 // --- Tenant operations ---
 
 func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest) (*pb.CreateTenantResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -490,6 +505,9 @@ func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (
 }
 
 func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest) (*pb.UpdateTenantResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -548,6 +566,9 @@ func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest)
 }
 
 func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest) (*pb.DeleteTenantResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -567,6 +588,9 @@ func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest)
 // --- Field locking ---
 
 func (s *Service) LockField(ctx context.Context, req *pb.LockFieldRequest) (*pb.LockFieldResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -593,6 +617,9 @@ func (s *Service) LockField(ctx context.Context, req *pb.LockFieldRequest) (*pb.
 }
 
 func (s *Service) UnlockField(ctx context.Context, req *pb.UnlockFieldRequest) (*pb.UnlockFieldResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
 		return nil, err
 	}
@@ -661,6 +688,9 @@ func (s *Service) ExportSchema(ctx context.Context, req *pb.ExportSchemaRequest)
 }
 
 func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest) (*pb.ImportSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
 		return nil, err
 	}

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -111,7 +111,7 @@ func TestDeleteSchema_Success(t *testing.T) {
 	store.On("GetSchemaByID", mock.Anything, testSchemaID).Return(testSchema(), nil)
 	store.On("DeleteSchema", mock.Anything, testSchemaID).Return(nil)
 
-	_, err := svc.DeleteSchema(context.Background(), &pb.DeleteSchemaRequest{Id: testSchemaID})
+	_, err := svc.DeleteSchema(superadminCtx(), &pb.DeleteSchemaRequest{Id: testSchemaID})
 	require.NoError(t, err)
 }
 
@@ -121,7 +121,7 @@ func TestDeleteSchema_InvalidID(t *testing.T) {
 
 	// "bad" is not a UUID, so resolveSchema tries name lookup.
 	store.On("GetSchemaByName", mock.Anything, "bad").Return(domain.Schema{}, domain.ErrNotFound)
-	_, err := svc.DeleteSchema(context.Background(), &pb.DeleteSchemaRequest{Id: "bad"})
+	_, err := svc.DeleteSchema(superadminCtx(), &pb.DeleteSchemaRequest{Id: "bad"})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
@@ -183,7 +183,7 @@ func TestDeleteTenant_Success(t *testing.T) {
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("DeleteTenant", mock.Anything, testTenantID).Return(nil)
 
-	_, err := svc.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{Id: testTenantID})
+	_, err := svc.DeleteTenant(superadminCtx(), &pb.DeleteTenantRequest{Id: testTenantID})
 	require.NoError(t, err)
 }
 
@@ -192,7 +192,7 @@ func TestDeleteTenant_InvalidID(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByName", mock.Anything, "bad").Return(domain.Tenant{}, domain.ErrNotFound)
-	_, err := svc.DeleteTenant(context.Background(), &pb.DeleteTenantRequest{Id: "bad"})
+	_, err := svc.DeleteTenant(superadminCtx(), &pb.DeleteTenantRequest{Id: "bad"})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
@@ -205,7 +205,7 @@ func TestLockField_Success(t *testing.T) {
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("CreateFieldLock", mock.Anything, mock.Anything).Return(nil)
 
-	_, err := svc.LockField(context.Background(), &pb.LockFieldRequest{
+	_, err := svc.LockField(superadminCtx(), &pb.LockFieldRequest{
 		TenantId:  testTenantID,
 		FieldPath: "app.fee",
 	})
@@ -221,7 +221,7 @@ func TestUnlockField_Success(t *testing.T) {
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("DeleteFieldLock", mock.Anything, mock.Anything).Return(nil)
 
-	_, err := svc.UnlockField(context.Background(), &pb.UnlockFieldRequest{
+	_, err := svc.UnlockField(superadminCtx(), &pb.UnlockFieldRequest{
 		TenantId:  testTenantID,
 		FieldPath: "app.fee",
 	})
@@ -311,7 +311,7 @@ func TestUpdateTenant_UpdateName_Success(t *testing.T) {
 		Name: newName,
 	}).Return(updated, nil)
 
-	resp, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	resp, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:   testTenantID,
 		Name: &newName,
 	})
@@ -334,7 +334,7 @@ func TestUpdateTenant_UpdateSchemaVersion_Success(t *testing.T) {
 		SchemaVersion: newVersion,
 	}).Return(updated, nil)
 
-	resp, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	resp, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:            testTenantID,
 		SchemaVersion: &newVersion,
 	})
@@ -364,7 +364,7 @@ func TestUpdateTenant_UpdateBothNameAndVersion(t *testing.T) {
 		SchemaVersion: newVersion,
 	}).Return(afterVersion, nil)
 
-	resp, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	resp, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:            testTenantID,
 		Name:          &newName,
 		SchemaVersion: &newVersion,
@@ -381,7 +381,7 @@ func TestUpdateTenant_NoFieldsUpdated_FetchesCurrent(t *testing.T) {
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
-	resp, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	resp, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id: testTenantID,
 	})
 	require.NoError(t, err)
@@ -395,7 +395,7 @@ func TestUpdateTenant_InvalidID(t *testing.T) {
 
 	// "bad" is not a UUID, so resolveTenant tries name lookup.
 	store.On("GetTenantByName", mock.Anything, "bad").Return(domain.Tenant{}, domain.ErrNotFound)
-	_, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{Id: "bad"})
+	_, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{Id: "bad"})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
@@ -405,7 +405,7 @@ func TestUpdateTenant_InvalidSlugName(t *testing.T) {
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	badName := "NOT A SLUG!"
-	_, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	_, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:   testTenantID,
 		Name: &badName,
 	})
@@ -420,7 +420,7 @@ func TestUpdateTenant_NameNotFound(t *testing.T) {
 	newName := "new-name"
 	store.On("UpdateTenantName", mock.Anything, mock.Anything).Return(domain.Tenant{}, domain.ErrNotFound)
 
-	_, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	_, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:   testTenantID,
 		Name: &newName,
 	})
@@ -435,7 +435,7 @@ func TestUpdateTenant_SchemaVersionNotFound(t *testing.T) {
 	v := int32(99)
 	store.On("UpdateTenantSchemaVersion", mock.Anything, mock.Anything).Return(domain.Tenant{}, domain.ErrNotFound)
 
-	_, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	_, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:            testTenantID,
 		SchemaVersion: &v,
 	})
@@ -449,7 +449,7 @@ func TestUpdateTenant_NoFieldsUpdated_NotFound(t *testing.T) {
 	missingID := "99999999-9999-9999-9999-999999999999"
 	store.On("GetTenantByID", mock.Anything, missingID).Return(domain.Tenant{}, domain.ErrNotFound)
 
-	_, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	_, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id: missingID,
 	})
 	assert.Equal(t, codes.NotFound, status.Code(err))
@@ -485,7 +485,7 @@ func TestUpdateTenant_SchemaVersionInvalidatesCache(t *testing.T) {
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 	store.On("UpdateTenantSchemaVersion", mock.Anything, mock.Anything).Return(updated, nil)
 
-	resp, err := svc.UpdateTenant(context.Background(), &pb.UpdateTenantRequest{
+	resp, err := svc.UpdateTenant(superadminCtx(), &pb.UpdateTenantRequest{
 		Id:            testTenantID,
 		SchemaVersion: &newVersion,
 	})
@@ -684,7 +684,7 @@ func validYAML(name string) []byte {
 func TestImportSchema_NewSchema(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaByName", ctx, "my-schema").Return(domain.Schema{}, domain.ErrNotFound)
 	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
@@ -706,7 +706,7 @@ func TestImportSchema_NewSchema(t *testing.T) {
 func TestImportSchema_NewSchemaWithAutoPublish(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaByName", ctx, "pub-schema").Return(domain.Schema{}, domain.ErrNotFound)
 	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
@@ -735,7 +735,7 @@ func TestImportSchema_NewSchemaWithAutoPublish(t *testing.T) {
 func TestImportSchema_ExistingSchemaNewVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	existingSchema := domain.Schema{ID: testSchemaID, Name: "my-schema"}
 	latestVersion := domain.SchemaVersion{
@@ -762,7 +762,7 @@ func TestImportSchema_ExistingSchemaNewVersion(t *testing.T) {
 func TestImportSchema_IdenticalChecksum_AlreadyExists(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	// Compute the real checksum that the service will produce for this YAML.
 	yamlContent := validYAML("my-schema")
@@ -796,7 +796,7 @@ func TestImportSchema_InvalidYAML(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
 
-	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+	_, err := svc.ImportSchema(superadminCtx(), &pb.ImportSchemaRequest{
 		YamlContent: []byte("not: valid: yaml: content"),
 	})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -806,7 +806,7 @@ func TestImportSchema_MissingSyntax(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
 
-	_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+	_, err := svc.ImportSchema(superadminCtx(), &pb.ImportSchemaRequest{
 		YamlContent: []byte("name: test\nfields:\n  app.name:\n    type: string\n"),
 	})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -815,7 +815,7 @@ func TestImportSchema_MissingSyntax(t *testing.T) {
 func TestImportSchema_LookupError(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaByName", ctx, "my-schema").
 		Return(domain.Schema{}, assert.AnError)
@@ -829,7 +829,7 @@ func TestImportSchema_LookupError(t *testing.T) {
 func TestImportSchema_ExistingWithAutoPublish(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	existingSchema := domain.Schema{ID: testSchemaID, Name: "my-schema"}
 	latestVersion := domain.SchemaVersion{
@@ -879,7 +879,7 @@ func TestImportSchema_BadRegexConstraint_NewSchema(t *testing.T) {
 			svc := NewService(store, WithLogger(testLogger))
 
 			yaml := []byte("spec_version: v1\nname: bad-regex\nfields:\n  app.name:\n    type: string\n    constraints:\n      pattern: " + tc.pat + "\n")
-			_, err := svc.ImportSchema(context.Background(), &pb.ImportSchemaRequest{
+			_, err := svc.ImportSchema(superadminCtx(), &pb.ImportSchemaRequest{
 				YamlContent: yaml,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), "expected InvalidArgument for pattern %s", tc.pat)
@@ -896,7 +896,7 @@ func TestImportSchema_BadRegexConstraint_ExistingSchema(t *testing.T) {
 	// be rejected before any storage write occurs.
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	// The constraint check runs before the schema name lookup, so no store
 	// calls are expected at all.

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
 
@@ -24,12 +25,16 @@ const (
 	testTenantID  = "00000000-0000-0000-0000-000000000003"
 )
 
+func superadminCtx() context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
+}
+
 // --- CreateSchema ---
 
 func TestCreateSchema_Success(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
 		Return(domain.Schema{ID: testSchemaID, Name: "test-schema"}, nil)
@@ -56,7 +61,7 @@ func TestCreateSchema_EmptyName(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
 
-	_, err := svc.CreateSchema(context.Background(), &pb.CreateSchemaRequest{Name: ""})
+	_, err := svc.CreateSchema(superadminCtx(), &pb.CreateSchemaRequest{Name: ""})
 
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
@@ -123,7 +128,7 @@ func TestGetSchema_NotFound(t *testing.T) {
 func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	oldVersionID := "00000000-0000-0000-0000-000000000010"
 	newVersionID := "00000000-0000-0000-0000-000000000011"
@@ -160,7 +165,7 @@ func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 func TestPublishSchema_Success(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(domain.Schema{ID: testSchemaID, Name: "test"}, nil)
@@ -181,7 +186,7 @@ func TestPublishSchema_Success(t *testing.T) {
 func TestCreateTenant_RequiresPublishedSchema(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
 		Return(domain.SchemaVersion{Published: false}, nil)
@@ -199,7 +204,7 @@ func TestCreateTenant_RequiresPublishedSchema(t *testing.T) {
 func TestCreateTenant_Success(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
 		Return(domain.SchemaVersion{Published: true}, nil)
@@ -230,7 +235,7 @@ func TestCreateSchema_FieldTagsNotPersisted(t *testing.T) {
 
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := superadminCtx()
 
 	title := "Fee Rate"
 	format := "percentage"

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/audit"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/cache"
 	"github.com/opendecree/decree/internal/config"
 	"github.com/opendecree/decree/internal/pubsub"
@@ -27,9 +28,10 @@ import (
 // and verifies the core schema→tenant→config flow works end-to-end.
 func TestMemoryBackend_Integration(t *testing.T) {
 	ctx := context.Background()
+	authCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-subject", "integration-test"))
 
 	// Create server.
-	srv, err := New("0", &noopInterceptor{},
+	srv, err := New("0", auth.NewMetadataInterceptor(nil),
 		WithEnableServices([]string{"schema", "config", "audit"}),
 		WithLogger(slog.Default()),
 		WithInsecure(),
@@ -84,7 +86,7 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	configClient := pb.NewConfigServiceClient(conn)
 
 	// 1. Create schema.
-	createResp, err := schemaClient.CreateSchema(ctx, &pb.CreateSchemaRequest{
+	createResp, err := schemaClient.CreateSchema(authCtx, &pb.CreateSchemaRequest{
 		Name: "test-payments",
 		Fields: []*pb.SchemaField{
 			{Path: "fee", Type: pb.FieldType_FIELD_TYPE_NUMBER, Nullable: true},
@@ -97,18 +99,17 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	assert.Equal(t, int32(1), createResp.Schema.Version)
 
 	// 2. Publish schema.
-	_, err = schemaClient.PublishSchema(ctx, &pb.PublishSchemaRequest{Id: schemaID, Version: 1})
+	_, err = schemaClient.PublishSchema(authCtx, &pb.PublishSchemaRequest{Id: schemaID, Version: 1})
 	require.NoError(t, err)
 
 	// 3. Create tenant.
-	tenantResp, err := schemaClient.CreateTenant(ctx, &pb.CreateTenantRequest{
+	tenantResp, err := schemaClient.CreateTenant(authCtx, &pb.CreateTenantRequest{
 		Name: "acme", SchemaId: schemaID, SchemaVersion: 1,
 	})
 	require.NoError(t, err)
 	tenantID := tenantResp.Tenant.Id
 
 	// 4. Set config value.
-	authCtx := metadata.AppendToOutgoingContext(ctx, "x-subject", "test-user")
 	_, err = configClient.SetField(authCtx, &pb.SetFieldRequest{
 		TenantId:  tenantID,
 		FieldPath: "fee",
@@ -117,20 +118,20 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// 5. Read config value.
-	getResp, err := configClient.GetField(ctx, &pb.GetFieldRequest{
+	getResp, err := configClient.GetField(authCtx, &pb.GetFieldRequest{
 		TenantId: tenantID, FieldPath: "fee",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 0.025, getResp.Value.GetValue().GetNumberValue())
 
 	// 6. List versions.
-	versionsResp, err := configClient.ListVersions(ctx, &pb.ListVersionsRequest{TenantId: tenantID})
+	versionsResp, err := configClient.ListVersions(authCtx, &pb.ListVersionsRequest{TenantId: tenantID})
 	require.NoError(t, err)
 	assert.Len(t, versionsResp.Versions, 1)
 
 	// 7. Cleanup.
-	_, err = schemaClient.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: tenantID})
+	_, err = schemaClient.DeleteTenant(authCtx, &pb.DeleteTenantRequest{Id: tenantID})
 	require.NoError(t, err)
-	_, err = schemaClient.DeleteSchema(ctx, &pb.DeleteSchemaRequest{Id: schemaID})
+	_, err = schemaClient.DeleteSchema(authCtx, &pb.DeleteSchemaRequest{Id: schemaID})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- Without this, any RPC accidentally added to `skipAuth` silently bypasses not just authentication but all authorization checks too — the guard chain is also permissive when claims are absent
- `MustHaveClaims(ctx)` provides a handler-level paranoia layer: returns `codes.Unauthenticated` regardless of the interceptor path, so a naively-added skipAuth entry doesn't open a write RPC to unauthenticated callers
- Adds a contract comment to both `access.go` and `skipAuth` in `metadata.go` documenting why the permissive-on-no-claims design exists and what the safe extension path is

## Test plan

- [x] `TestMustHaveClaims_NoClaims` — returns `codes.Unauthenticated` with empty context
- [x] `TestMustHaveClaims_WithClaims` — returns `nil` with superadmin claims
- [x] All write-handler unit tests updated to inject superadmin claims (via `superadminCtx()` helper), confirming the guard fires correctly
- [x] Memory integration test switched from `noopInterceptor` to `MetadataInterceptor` with `x-subject` header — validates the full interceptor→claims→handler path
- [x] `make test` (all 24 packages), `make e2e` — clean
- [x] Spotted and filed #355 for the `ServerService` skipAuth entry that pre-existed this change

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)