### PR TITLE
refactor(authz): delegate FieldLockGuard superadmin check to auth.IsSuperAdmin

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -385,7 +385,7 @@ to be correctly protected at the audit date:
 
 - **Release artifact attestations** — already tracked at #159 (P0).
 - **Role-based RPC policy + pluggable guard** — #205 + #206 implemented:
-  `RequireSuperAdmin` + `RequireAdminOrAbove` in `internal/auth/access.go`.
+  `RequireSuperAdmin`, `RequireAdminOrAbove`, `IsSuperAdmin` (bool, nil-safe) in `internal/auth/access.go`.
   `internal/authz` package provides `Guard` interface, `ChainGuard`, `TenantScopeGuard`,
   `RolePolicyGuard`, `FieldLockGuard`. All three services wire the chain via
   `WithGuard`; `checkFieldLock` removed from config service.

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -69,6 +69,13 @@ func AllowedTenantIDs(ctx context.Context) []string {
 	return claims.TenantIDs
 }
 
+// IsSuperAdmin reports whether the caller has the superadmin role.
+// Returns true when no auth context is present (permissive, consistent with other access helpers).
+func IsSuperAdmin(ctx context.Context) bool {
+	claims, ok := ClaimsFromContext(ctx)
+	return !ok || claims.IsSuperAdmin()
+}
+
 // MustHaveClaims returns codes.Unauthenticated if no auth claims are present in ctx.
 // Use in handler bodies as a defense-in-depth guard for RPCs that must never be
 // reachable without authentication, even if the method is accidentally added to skipAuth.

--- a/internal/authz/fieldlock.go
+++ b/internal/authz/fieldlock.go
@@ -30,8 +30,7 @@ func (g FieldLockGuard) Check(ctx context.Context, action Action, r Resource) er
 	if action != ActionWrite || r.FieldPath == "" {
 		return nil
 	}
-	claims, ok := auth.ClaimsFromContext(ctx)
-	if !ok || claims.Role == auth.RoleSuperAdmin {
+	if auth.IsSuperAdmin(ctx) {
 		return nil
 	}
 	locks, err := g.store.GetFieldLocks(ctx, r.TenantID)


### PR DESCRIPTION
## Summary
- `FieldLockGuard` was the only guard calling `ClaimsFromContext` directly, creating implicit nil safety via short-circuit evaluation
- Adds `auth.IsSuperAdmin(ctx) bool` (nil-safe: true when no claims or role is superadmin) and delegates to it from `FieldLockGuard.Check`
- Aligns `FieldLockGuard` with `RolePolicyGuard` and `TenantScopeGuard`, which already delegate entirely to `auth` package helpers

## Test plan
- [x] All existing tests pass (`make test` — no behavioral change)
- [x] `auth.IsSuperAdmin` covered by existing superadmin paths in `internal/auth` and `internal/authz` tests

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)