### PR TITLE
Handle rand.Reader failure in request ID generation

### DIFF
--- a/internal/server/logfields.go
+++ b/internal/server/logfields.go
@@ -3,14 +3,21 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"strings"
+	"sync/atomic"
 
 	"google.golang.org/grpc"
 
 	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/telemetry"
+)
+
+var (
+	randReader   io.Reader    = rand.Reader
+	reqIDCounter atomic.Uint64
 )
 
 // logFieldsUnaryInterceptor injects tenant_id, actor, and request_id into the
@@ -38,10 +45,14 @@ func enrichLogFields(ctx context.Context) context.Context {
 	return telemetry.WithLogFields(ctx, tenantID, actor, newRequestID())
 }
 
-// newRequestID returns a random UUID v4.
+// newRequestID returns a UUID v4. On rand failure (OS entropy starvation),
+// falls back to an atomic counter so IDs remain unique and log correlation intact.
 func newRequestID() string {
 	var b [16]byte
-	_, _ = io.ReadFull(rand.Reader, b[:])
+	if _, err := io.ReadFull(randReader, b[:]); err != nil {
+		n := reqIDCounter.Add(1)
+		binary.BigEndian.PutUint64(b[8:], n)
+	}
 	b[6] = (b[6] & 0x0f) | 0x40
 	b[8] = (b[8] & 0x3f) | 0x80
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",

--- a/internal/server/logfields.go
+++ b/internal/server/logfields.go
@@ -15,10 +15,9 @@ import (
 	"github.com/opendecree/decree/internal/telemetry"
 )
 
-var (
-	randReader   io.Reader    = rand.Reader
-	reqIDCounter atomic.Uint64
-)
+var randReader io.Reader = rand.Reader
+
+var reqIDCounter atomic.Uint64
 
 // logFieldsUnaryInterceptor injects tenant_id, actor, and request_id into the
 // context after auth so the slog handler attaches them to every log record.

--- a/internal/server/logfields_test.go
+++ b/internal/server/logfields_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"regexp"
 	"testing"
@@ -40,6 +41,22 @@ func TestNewRequestID_UniqueUUIDv4(t *testing.T) {
 	a := newRequestID()
 	b := newRequestID()
 	assert.Regexp(t, uuidRE, a)
+	assert.NotEqual(t, a, b)
+}
+
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) { return 0, errors.New("entropy unavailable") }
+
+func TestNewRequestID_RandFailure_FallbackToCounter(t *testing.T) {
+	orig := randReader
+	t.Cleanup(func() { randReader = orig })
+	randReader = failReader{}
+
+	a := newRequestID()
+	b := newRequestID()
+	assert.Regexp(t, uuidRE, a)
+	assert.Regexp(t, uuidRE, b)
 	assert.NotEqual(t, a, b)
 }
 


### PR DESCRIPTION
## Summary

- Silently discarding the `io.ReadFull` error left every request with the same UUID during OS entropy starvation, breaking log correlation exactly when it's most needed
- Falls back to an atomic counter on rand failure so IDs stay unique without blocking or failing the request
- `randReader` is a package-level variable to make the error path testable

## Test plan

- [x] `TestNewRequestID_RandFailure_FallbackToCounter` — injects a failing reader, asserts both IDs match UUID v4 format and are distinct
- [x] Existing `TestNewRequestID_UniqueUUIDv4` still passes
- [x] `make test` clean (all packages, `-race`)

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)