### PR TITLE
fix(compose): bump Jaeger to 1.76.0, align service image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,13 +48,13 @@ services:
         condition: service_started
 
   jaeger:
-    image: jaegertracing/all-in-one:1.69
+    image: jaegertracing/all-in-one:1.76.0
     ports:
       - "16686:16686" # Jaeger UI
       - "14268:14268" # Jaeger collector
 
   service:
-    image: ${SERVICE_IMAGE:-decree-service}
+    image: ${SERVICE_IMAGE:-decree-server}
     build:
       context: .
       dockerfile: build/Dockerfile


### PR DESCRIPTION
## Summary

- Jaeger 1.69 is no longer available on Docker Hub, breaking `docker compose up` for local dev and e2e
- Aligns the `SERVICE_IMAGE` default with what `make image` produces (`decree-server`) so `docker compose up` works out of the box without overriding the env var

## Test plan

- [x] `docker compose up -d postgres redis migrate service` completes without image-not-found errors
- [x] `docker compose up` (full stack including Jaeger) pulls `1.76.0` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)