### PR TITLE
feat(config,validation): honour sensitive flag at every read path

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -39,7 +39,7 @@ external deployment, not the alpha cluster.
 | 1 | Critical | Infra / Input | gRPC server has no `MaxRecvMsgSize` / `MaxSendMsgSize`; defaults apply | #212 |
 | 2 | Critical | Infra | gRPC + gateway-to-gRPC traffic is plaintext by default; no TLS option in `server.Config`; Helm chart has no cert wiring; DB/Redis TLS not validated | #213 |
 | 3 | High | Infra | No panic recovery interceptor — a panic in any handler crashes the server and may leak stack to client | #214 |
-| 4 | High | Data | `sensitive: true` flag is stored but NOT honoured in audit log, Subscribe stream, ExportConfig, Redis cache, or validation error messages | #215 |
+| 4 | High | Data | `sensitive: true` flag is stored but NOT honoured in audit log, Subscribe stream, ExportConfig, Redis cache, or validation error messages | #215 ✓ |
 | 5 | High | Infra | No rate limiting at all (no per-tenant, per-method, or global limiter) | #216 ✓ |
 | 6 | High | Input | Schema-complexity bounds missing — no max field count, no max schema-doc size, no JSON-Schema compilation timeout | #217 |
 | 7 | High | Data | Audit log is append-only by convention only — no hash-chain, no UPDATE/DELETE constraint; admin mutations (schema/tenant) not audited | #218 |

--- a/internal/config/mock_store_test.go
+++ b/internal/config/mock_store_test.go
@@ -85,3 +85,15 @@ func (m *mockStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWrit
 	args := m.Called(ctx, arg)
 	return args.Error(0)
 }
+
+// setupNoSensitiveFields configures the mock store to return an empty
+// sensitive field set for tenantID1. Use in tests that exercise code paths
+// that call getSensitiveFieldSet but don't care about redaction.
+func setupNoSensitiveFields(store *mockStore) {
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil).Maybe()
+	store.On("GetSchemaVersion", mock.Anything, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil).Maybe()
+	store.On("GetSchemaFields", mock.Anything, schemaVersionID).
+		Return([]domain.SchemaField{}, nil).Maybe()
+}

--- a/internal/config/redact.go
+++ b/internal/config/redact.go
@@ -1,0 +1,10 @@
+package config
+
+const redactedSentinel = "[REDACTED]"
+
+func redactIfSensitive(sensitive bool, value string) string {
+	if sensitive {
+		return redactedSentinel
+	}
+	return value
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -238,19 +238,25 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 		return nil, status.Error(codes.Internal, "failed to get config")
 	}
 
+	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
 	values := make([]*pb.ConfigValue, 0, len(rows))
 	cacheMap := make(map[string]string, len(rows))
 	for _, row := range rows {
+		displayValue := redactIfSensitive(sensitiveFields[row.FieldPath], derefString(row.Value))
 		cv := &pb.ConfigValue{
 			FieldPath: row.FieldPath,
-			Value:     stringToTypedValue(row.Value, lookupFieldType(types, row.FieldPath)),
+			Value:     stringToTypedValue(&displayValue, lookupFieldType(types, row.FieldPath)),
 			Checksum:  derefString(row.Checksum),
 		}
 		if req.IncludeDescriptions && row.Description != nil {
 			cv.Description = row.Description
 		}
 		values = append(values, cv)
-		cacheMap[row.FieldPath] = derefString(row.Value)
+		cacheMap[row.FieldPath] = displayValue
 	}
 
 	// Populate cache (values only, no descriptions).
@@ -424,6 +430,11 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	}
 	oldValue := s.getCurrentValue(ctx, tenantID, req.FieldPath, latestVersion)
 
+	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to load dependentRequired rules")
@@ -459,13 +470,15 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 		}
 
 		newValueStr := typedValueToString(req.Value)
+		redactedOld := redactIfSensitive(sensitiveFields[req.FieldPath], oldValue)
+		redactedNew := redactIfSensitive(sensitiveFields[req.FieldPath], derefString(newValueStr))
 		return tx.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
 			TenantID:      tenantID,
 			Actor:         actor,
 			Action:        "set_field",
 			FieldPath:     ptrString(req.FieldPath),
-			OldValue:      ptrString(oldValue),
-			NewValue:      newValueStr,
+			OldValue:      ptrString(redactedOld),
+			NewValue:      ptrString(redactedNew),
 			ConfigVersion: &newVersion.Version,
 		})
 	}); err != nil {
@@ -479,7 +492,10 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	if err := s.cache.Invalidate(ctx, tenantID); err != nil {
 		s.logger.WarnContext(ctx, "failed to invalidate cache", "error", err)
 	}
-	s.publishChange(ctx, tenantID, newVersion.Version, req.FieldPath, oldValue, typedValueToDisplayString(req.Value), actor)
+	s.publishChange(ctx, tenantID, newVersion.Version, req.FieldPath,
+		redactIfSensitive(sensitiveFields[req.FieldPath], oldValue),
+		redactIfSensitive(sensitiveFields[req.FieldPath], typedValueToDisplayString(req.Value)),
+		actor)
 
 	s.metrics.RecordWrite(ctx, tenantID, "set_field")
 	s.metrics.RecordVersion(ctx, tenantID, int64(newVersion.Version))
@@ -534,6 +550,11 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 		})
 	}
 
+	sensitiveFieldsMulti, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to load dependentRequired rules")
@@ -566,13 +587,15 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 			}
 
 			newValueStr := typedValueToString(update.Value)
+			redactedNew := redactIfSensitive(sensitiveFieldsMulti[update.FieldPath], derefString(newValueStr))
+			redactedOld := redactIfSensitive(sensitiveFieldsMulti[update.FieldPath], changes[i].oldValue)
 			if txErr = tx.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
 				TenantID:      tenantID,
 				Actor:         actor,
 				Action:        "set_field",
 				FieldPath:     ptrString(update.FieldPath),
-				OldValue:      ptrString(changes[i].oldValue),
-				NewValue:      newValueStr,
+				OldValue:      ptrString(redactedOld),
+				NewValue:      ptrString(redactedNew),
 				ConfigVersion: &newVersion.Version,
 			}); txErr != nil {
 				return fmt.Errorf("insert audit log for %s: %w", update.FieldPath, txErr)
@@ -592,7 +615,10 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 		s.logger.WarnContext(ctx, "failed to invalidate cache", "error", err)
 	}
 	for _, ch := range changes {
-		s.publishChange(ctx, tenantID, newVersion.Version, ch.fieldPath, ch.oldValue, ch.newValue, actor)
+		s.publishChange(ctx, tenantID, newVersion.Version, ch.fieldPath,
+			redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.oldValue),
+			redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.newValue),
+			actor)
 	}
 
 	s.metrics.RecordWrite(ctx, tenantID, "set_fields")
@@ -851,6 +877,14 @@ func (s *Service) ExportConfig(ctx context.Context, req *pb.ExportConfigRequest)
 		rows[i] = configRow{FieldPath: r.FieldPath, Value: derefString(r.Value), Description: r.Description}
 	}
 
+	sensitiveFieldsExport, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	for i, row := range rows {
+		rows[i].Value = redactIfSensitive(sensitiveFieldsExport[row.FieldPath], row.Value)
+	}
+
 	// Get version description.
 	var description string
 	cv, err := s.store.GetConfigVersion(ctx, GetConfigVersionParams{
@@ -1095,6 +1129,33 @@ func (s *Service) getFieldTypeMap(ctx context.Context, tenantID string) (map[str
 	result := make(map[string]domain.FieldType, len(fields))
 	for _, f := range fields {
 		result[f.Path] = f.FieldType
+	}
+	return result, nil
+}
+
+// getSensitiveFieldSet returns a set of field paths that are marked sensitive
+// for the tenant's current schema version.
+func (s *Service) getSensitiveFieldSet(ctx context.Context, tenantID string) (map[string]bool, error) {
+	tenant, err := s.store.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return nil, status.Error(codes.NotFound, "tenant not found")
+	}
+	sv, err := s.store.GetSchemaVersion(ctx, domain.SchemaVersionKey{
+		SchemaID: tenant.SchemaID,
+		Version:  tenant.SchemaVersion,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get schema version")
+	}
+	fields, err := s.store.GetSchemaFields(ctx, sv.ID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get schema fields")
+	}
+	result := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		if f.Sensitive {
+			result[f.Path] = true
+		}
 	}
 	return result, nil
 }

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -211,6 +211,7 @@ func TestSetFields_Success(t *testing.T) {
 	store.On("InsertAuditWriteLog", ctx, mock.Anything).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
 	pub.On("Publish", mock.Anything, mock.Anything).Return(nil)
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
 		TenantId: tenantID1,

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -17,6 +17,7 @@ import (
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/audit"
 	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/pubsub"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/validation"
 )
@@ -96,6 +97,7 @@ func TestGetConfig_CacheMiss(t *testing.T) {
 		}, nil)
 	cache.On("Set", ctx, tenantID1, int32(3), mock.AnythingOfType("map[string]string"), mock.Anything).
 		Return(nil)
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
 
@@ -116,6 +118,7 @@ func TestGetConfig_IncludeDescriptions_BypassesCache(t *testing.T) {
 		Return([]GetFullConfigAtVersionRow{
 			{FieldPath: "fee", Value: strPtr("0.5"), Description: &desc},
 		}, nil)
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.GetConfig(ctx, &pb.GetConfigRequest{
 		TenantId:            tenantID1,
@@ -146,6 +149,7 @@ func TestSetField_Success(t *testing.T) {
 	cache.On("Invalidate", ctx, tenantID1).Return(nil)
 	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
 	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
 		TenantId:  tenantID1,
@@ -598,6 +602,7 @@ func TestGetConfig_RecordsUsage(t *testing.T) {
 		}, nil)
 	c.On("Set", ctx, tenantID1, int32(1), mock.AnythingOfType("map[string]string"), mock.Anything).
 		Return(nil)
+	setupNoSensitiveFields(store)
 
 	_, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
 	require.NoError(t, err)
@@ -752,4 +757,162 @@ func TestSetField_ValidatorLookupError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// --- Sensitive field redaction ---
+
+func sensitiveSchemaSetup(store *mockStore, ctx context.Context) {
+	store.On("GetTenantByID", ctx, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", ctx, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", ctx, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "app.secret", FieldType: domain.FieldTypeString, Sensitive: true},
+			{Path: "app.name", FieldType: domain.FieldTypeString, Sensitive: false},
+		}, nil)
+}
+
+func TestGetConfig_RedactsSensitiveFields(t *testing.T) {
+	svc, store, cache, _ := newTestService()
+	ctx := context.Background()
+
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	cache.On("Get", ctx, tenantID1, int32(1)).Return(nil, nil)
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 1}).
+		Return([]GetFullConfigAtVersionRow{
+			{FieldPath: "app.secret", Value: strPtr("s3cr3t")},
+			{FieldPath: "app.name", Value: strPtr("myapp")},
+		}, nil)
+
+	var capturedCacheMap map[string]string
+	cache.On("Set", ctx, tenantID1, int32(1), mock.MatchedBy(func(m map[string]string) bool {
+		capturedCacheMap = m
+		return true
+	}), mock.Anything).Return(nil)
+
+	sensitiveSchemaSetup(store, ctx)
+
+	resp, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
+
+	require.NoError(t, err)
+	vals := make(map[string]string, len(resp.Config.Values))
+	for _, v := range resp.Config.Values {
+		vals[v.FieldPath] = typedValueToDisplayString(v.Value)
+	}
+	assert.Equal(t, redactedSentinel, vals["app.secret"])
+	assert.Equal(t, "myapp", vals["app.name"])
+
+	// Cache must also store the sentinel, not the raw value.
+	require.NotNil(t, capturedCacheMap)
+	assert.Equal(t, redactedSentinel, capturedCacheMap["app.secret"])
+	assert.Equal(t, "myapp", capturedCacheMap["app.name"])
+}
+
+func TestSetField_AuditRedactsSensitiveField(t *testing.T) {
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, GetConfigValueAtVersionParams{
+		TenantID: tenantID1, FieldPath: "app.secret", Version: 1,
+	}).Return(GetConfigValueAtVersionRow{Value: strPtr("old-secret")}, nil)
+
+	sensitiveSchemaSetup(store, ctx)
+
+	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
+	cache.On("Invalidate", ctx, tenantID1).Return(nil)
+	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+
+	var capturedAudit InsertAuditWriteLogParams
+	store.On("InsertAuditWriteLog", ctx, mock.MatchedBy(func(p InsertAuditWriteLogParams) bool {
+		capturedAudit = p
+		return true
+	})).Return(nil)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.secret",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "new-secret"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, redactedSentinel, derefString(capturedAudit.OldValue))
+	assert.Equal(t, redactedSentinel, derefString(capturedAudit.NewValue))
+}
+
+func TestSetField_PublishRedactsSensitiveField(t *testing.T) {
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, GetConfigValueAtVersionParams{
+		TenantID: tenantID1, FieldPath: "app.secret", Version: 1,
+	}).Return(GetConfigValueAtVersionRow{Value: strPtr("old-secret")}, nil)
+
+	sensitiveSchemaSetup(store, ctx)
+
+	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
+	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	cache.On("Invalidate", ctx, tenantID1).Return(nil)
+
+	var capturedEvent pubsub.ConfigChangeEvent
+	pub.On("Publish", ctx, mock.MatchedBy(func(e pubsub.ConfigChangeEvent) bool {
+		capturedEvent = e
+		return true
+	})).Return(nil)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.secret",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "new-secret"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, redactedSentinel, capturedEvent.OldValue)
+	assert.Equal(t, redactedSentinel, capturedEvent.NewValue)
+}
+
+func TestExportConfig_RedactsSensitiveFields(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := context.Background()
+
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 1}).
+		Return([]GetFullConfigAtVersionRow{
+			{FieldPath: "app.secret", Value: strPtr("s3cr3t")},
+			{FieldPath: "app.name", Value: strPtr("myapp")},
+		}, nil)
+	desc := "v1"
+	store.On("GetConfigVersion", ctx, GetConfigVersionParams{TenantID: tenantID1, Version: 1}).
+		Return(domain.ConfigVersion{Version: 1, Description: &desc}, nil)
+
+	// getFieldTypeMap call
+	store.On("GetTenantByID", ctx, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", ctx, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", ctx, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "app.secret", FieldType: domain.FieldTypeString, Sensitive: true},
+			{Path: "app.name", FieldType: domain.FieldTypeString, Sensitive: false},
+		}, nil)
+
+	resp, err := svc.ExportConfig(ctx, &pb.ExportConfigRequest{TenantId: tenantID1})
+
+	require.NoError(t, err)
+	yaml := string(resp.YamlContent)
+	assert.NotContains(t, yaml, "s3cr3t")
+	assert.Contains(t, yaml, redactedSentinel)
+	assert.Contains(t, yaml, "myapp")
 }

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -109,6 +109,23 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	require.NoError(t, err)
 	tenantID := tenantResp.Tenant.Id
 
+	// Seed memConfig with tenant and schema data so getSensitiveFieldSet can
+	// resolve tenant→schema info. In production a single Postgres DB serves
+	// both; separate in-memory stores require explicit bridging.
+	{
+		tenant2, err2 := memSchema.GetTenantByID(ctx, tenantID)
+		require.NoError(t, err2)
+		memConfig.SetTenant(tenant2)
+
+		sv2, err2 := memSchema.GetSchemaVersion(ctx, schema.GetSchemaVersionParams{SchemaID: schemaID, Version: 1})
+		require.NoError(t, err2)
+		memConfig.SetSchemaVersion(sv2)
+
+		fields2, err2 := memSchema.GetSchemaFields(ctx, sv2.ID)
+		require.NoError(t, err2)
+		memConfig.SetSchemaFields(sv2.ID, fields2)
+	}
+
 	// 4. Set config value.
 	_, err = configClient.SetField(authCtx, &pb.SetFieldRequest{
 		TenantId:  tenantID,

--- a/internal/validation/cache_race_test.go
+++ b/internal/validation/cache_race_test.go
@@ -23,7 +23,7 @@ func TestValidatorCache_ConcurrentSetGet(t *testing.T) {
 			tenantID := fmt.Sprintf("tenant-%d", g%5)
 			for i := range iterations {
 				validators := map[string]*FieldValidator{
-					fmt.Sprintf("field-%d", i): NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil),
+					fmt.Sprintf("field-%d", i): NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
 				}
 				c.Set(tenantID, validators)
 				c.Get(tenantID)
@@ -49,7 +49,7 @@ func TestValidatorCache_ConcurrentSetInvalidate(t *testing.T) {
 			tenantID := fmt.Sprintf("tenant-%d", g%3)
 			for range iterations {
 				validators := map[string]*FieldValidator{
-					"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil),
+					"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
 				}
 				c.Set(tenantID, validators)
 				c.Invalidate(tenantID)

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -111,7 +111,7 @@ func (f *ValidatorFactory) GetValidators(ctx context.Context, tenantID string) (
 			constraints = &pb.FieldConstraints{}
 			_ = json.Unmarshal(field.Constraints, constraints)
 		}
-		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, constraints, WithLimits(f.limits))
+		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, field.Sensitive, constraints, WithLimits(f.limits))
 	}
 
 	f.cache.Set(tenantID, validators)

--- a/internal/validation/factory_test.go
+++ b/internal/validation/factory_test.go
@@ -196,7 +196,7 @@ func TestCache_ReturnsUnderlyingCache(t *testing.T) {
 
 	// Should be able to manually set/get.
 	v := map[string]*FieldValidator{
-		"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil),
+		"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
 	}
 	c.Set("manual-tenant", v)
 

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -18,6 +18,7 @@ type FieldValidator struct {
 	fieldType       pb.FieldType
 	domainFieldType domain.FieldType
 	nullable        bool
+	sensitive       bool
 	checks          []checkFunc
 }
 
@@ -31,6 +32,11 @@ func (v *FieldValidator) FieldType() pb.FieldType {
 // DomainFieldType returns the domain field type for this validator.
 func (v *FieldValidator) DomainFieldType() domain.FieldType {
 	return v.domainFieldType
+}
+
+// Sensitive reports whether this field is marked sensitive.
+func (v *FieldValidator) Sensitive() bool {
+	return v.sensitive
 }
 
 // Validate checks a TypedValue against this field's constraints.
@@ -62,13 +68,14 @@ func (v *FieldValidator) Validate(tv *pb.TypedValue) error {
 // NewFieldValidator creates a validator for a schema field. Pass
 // [WithLimits] to override the JSON-Schema compile defaults; without it,
 // [DefaultLimits] is used.
-func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, constraints *pb.FieldConstraints, opts ...Option) *FieldValidator {
+func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, sensitive bool, constraints *pb.FieldConstraints, opts ...Option) *FieldValidator {
 	o := resolveOptions(opts)
 	v := &FieldValidator{
 		fieldPath:       fieldPath,
 		fieldType:       fieldType,
 		domainFieldType: domain.FieldTypeFromProto(fieldType),
 		nullable:        nullable,
+		sensitive:       sensitive,
 	}
 
 	// URL validity check is always applied (not constraint-dependent).
@@ -77,6 +84,9 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			val := tv.Kind.(*pb.TypedValue_UrlValue).UrlValue
 			u, err := url.Parse(val)
 			if err != nil || !u.IsAbs() {
+				if v.sensitive {
+					return fmt.Errorf("value is not a valid absolute URL")
+				}
 				return fmt.Errorf("value %q is not a valid absolute URL", val)
 			}
 			return nil
@@ -128,6 +138,9 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 				val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
 				if !re.MatchString(val) {
+					if v.sensitive {
+						return fmt.Errorf("value does not match pattern %s", re.String())
+					}
 					return fmt.Errorf("value %q does not match pattern %s", val, re.String())
 				}
 				return nil
@@ -163,6 +176,9 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 		v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 			s := typedValueToString(tv)
 			if _, ok := allowed[s]; !ok {
+				if v.sensitive {
+					return fmt.Errorf("value is not in allowed values")
+				}
 				return fmt.Errorf("value %q is not in allowed values %v", s, constraints.EnumValues)
 			}
 			return nil

--- a/internal/validation/validator_bench_test.go
+++ b/internal/validation/validator_bench_test.go
@@ -9,7 +9,7 @@ import (
 func ptr64(v float64) *float64 { return &v }
 
 func BenchmarkValidate_Integer_NoConstraints(b *testing.B) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -17,7 +17,7 @@ func BenchmarkValidate_Integer_NoConstraints(b *testing.B) {
 }
 
 func BenchmarkValidate_Integer_MinMax(b *testing.B) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, &pb.FieldConstraints{
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
 		Min: ptr64(0),
 		Max: ptr64(100),
 	})
@@ -29,7 +29,7 @@ func BenchmarkValidate_Integer_MinMax(b *testing.B) {
 
 func BenchmarkValidate_String_Pattern(b *testing.B) {
 	pattern := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, &pb.FieldConstraints{
+	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		Regex: &pattern,
 	})
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "user@example.com"}}
@@ -39,7 +39,7 @@ func BenchmarkValidate_String_Pattern(b *testing.B) {
 }
 
 func BenchmarkValidate_String_Enum(b *testing.B) {
-	v := NewFieldValidator("env", pb.FieldType_FIELD_TYPE_STRING, false, &pb.FieldConstraints{
+	v := NewFieldValidator("env", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		EnumValues: []string{"dev", "staging", "prod"},
 	})
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}}
@@ -49,7 +49,7 @@ func BenchmarkValidate_String_Enum(b *testing.B) {
 }
 
 func BenchmarkValidate_URL(b *testing.B) {
-	v := NewFieldValidator("hook", pb.FieldType_FIELD_TYPE_URL, false, nil)
+	v := NewFieldValidator("hook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com/webhook"}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -58,7 +58,7 @@ func BenchmarkValidate_URL(b *testing.B) {
 
 func BenchmarkValidate_JSON_Schema(b *testing.B) {
 	schema := `{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`
-	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, false, &pb.FieldConstraints{
+	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
 		JsonSchema: &schema,
 	})
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"name":"test"}`}}
@@ -75,15 +75,15 @@ func BenchmarkNewFieldValidator_WithConstraints(b *testing.B) {
 		Regex: &pattern,
 	}
 	for b.Loop() {
-		NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, constraints)
+		NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, constraints)
 	}
 }
 
 func BenchmarkValidatorCache_Get_Hit(b *testing.B) {
 	c := NewValidatorCache(0)
 	validators := map[string]*FieldValidator{
-		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, nil),
-		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, nil),
+		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
+		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
 	}
 	c.Set("tenant-1", validators)
 
@@ -95,8 +95,8 @@ func BenchmarkValidatorCache_Get_Hit(b *testing.B) {
 func BenchmarkValidatorCache_Get_Hit_Parallel(b *testing.B) {
 	c := NewValidatorCache(0)
 	validators := map[string]*FieldValidator{
-		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, nil),
-		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, nil),
+		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
+		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
 	}
 	c.Set("tenant-1", validators)
 

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -16,7 +16,7 @@ func ptr[T any](v T) *T { return &v }
 // --- Type checking ---
 
 func TestValidate_TypeCheck_IntegerField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}}))
@@ -24,28 +24,28 @@ func TestValidate_TypeCheck_IntegerField(t *testing.T) {
 }
 
 func TestValidate_TypeCheck_BoolField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: true}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 1}}))
 }
 
 func TestValidate_TypeCheck_StringField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: ""}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 0}}))
 }
 
 func TestValidate_TypeCheck_TimeField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_TIME, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_TIME, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.Now()}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "not-a-time"}}))
 }
 
 func TestValidate_TypeCheck_DurationField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_DURATION, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_DURATION, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(0)}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "24h"}}))
@@ -54,24 +54,24 @@ func TestValidate_TypeCheck_DurationField(t *testing.T) {
 // --- Nullable ---
 
 func TestValidate_NullOnNonNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
 	assert.Error(t, v.Validate(nil))
 }
 
 func TestValidate_NullOnNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, true, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, true, false, nil)
 	require.NoError(t, v.Validate(nil))
 }
 
 func TestValidate_NilKindOnNonNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
 	assert.Error(t, v.Validate(&pb.TypedValue{}))
 }
 
 // --- Integer constraints ---
 
 func TestValidate_IntegerMinMax(t *testing.T) {
-	v := NewFieldValidator("retries", pb.FieldType_FIELD_TYPE_INT, false, &pb.FieldConstraints{
+	v := NewFieldValidator("retries", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
 		Min: ptr(float64(0)),
 		Max: ptr(float64(10)),
 	})
@@ -86,7 +86,7 @@ func TestValidate_IntegerMinMax(t *testing.T) {
 // --- Number constraints ---
 
 func TestValidate_NumberMinMax(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, &pb.FieldConstraints{
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
 		Min: ptr(float64(0)),
 		Max: ptr(float64(1)),
 	})
@@ -99,7 +99,7 @@ func TestValidate_NumberMinMax(t *testing.T) {
 // --- String constraints ---
 
 func TestValidate_StringMinMaxLength(t *testing.T) {
-	v := NewFieldValidator("name", pb.FieldType_FIELD_TYPE_STRING, false, &pb.FieldConstraints{
+	v := NewFieldValidator("name", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		MinLength: ptr(int32(2)),
 		MaxLength: ptr(int32(10)),
 	})
@@ -110,7 +110,7 @@ func TestValidate_StringMinMaxLength(t *testing.T) {
 }
 
 func TestValidate_StringPattern(t *testing.T) {
-	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, &pb.FieldConstraints{
+	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		Regex: ptr(`^[^@]+@[^@]+$`),
 	})
 
@@ -121,7 +121,7 @@ func TestValidate_StringPattern(t *testing.T) {
 // --- Enum constraints ---
 
 func TestValidate_Enum(t *testing.T) {
-	v := NewFieldValidator("currency", pb.FieldType_FIELD_TYPE_STRING, false, &pb.FieldConstraints{
+	v := NewFieldValidator("currency", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		EnumValues: []string{"USD", "EUR", "GBP"},
 	})
 
@@ -130,7 +130,7 @@ func TestValidate_Enum(t *testing.T) {
 }
 
 func TestValidate_EnumOnInteger(t *testing.T) {
-	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, &pb.FieldConstraints{
+	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
 		EnumValues: []string{"1", "2", "3"},
 	})
 
@@ -141,7 +141,7 @@ func TestValidate_EnumOnInteger(t *testing.T) {
 // --- Duration constraints ---
 
 func TestValidate_DurationMinMax(t *testing.T) {
-	v := NewFieldValidator("timeout", pb.FieldType_FIELD_TYPE_DURATION, false, &pb.FieldConstraints{
+	v := NewFieldValidator("timeout", pb.FieldType_FIELD_TYPE_DURATION, false, false, &pb.FieldConstraints{
 		Min: ptr(float64(1)),    // 1 second
 		Max: ptr(float64(3600)), // 1 hour
 	})
@@ -154,7 +154,7 @@ func TestValidate_DurationMinMax(t *testing.T) {
 // --- Exclusive min/max ---
 
 func TestValidate_ExclusiveMinMax(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, &pb.FieldConstraints{
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
 		ExclusiveMin: ptr(float64(0)),
 		ExclusiveMax: ptr(float64(1)),
 	})
@@ -166,7 +166,7 @@ func TestValidate_ExclusiveMinMax(t *testing.T) {
 }
 
 func TestValidate_ExclusiveMinMax_Integer(t *testing.T) {
-	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, &pb.FieldConstraints{
+	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
 		ExclusiveMin: ptr(float64(0)),
 		ExclusiveMax: ptr(float64(10)),
 	})
@@ -180,7 +180,7 @@ func TestValidate_ExclusiveMinMax_Integer(t *testing.T) {
 // --- URL validation ---
 
 func TestValidate_URL(t *testing.T) {
-	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL, false, nil)
+	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com/hook"}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "not-a-url"}}))
@@ -191,7 +191,7 @@ func TestValidate_URL(t *testing.T) {
 
 func TestValidate_JSONSchema(t *testing.T) {
 	schema := `{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}`
-	v := NewFieldValidator("metadata", pb.FieldType_FIELD_TYPE_JSON, false, &pb.FieldConstraints{
+	v := NewFieldValidator("metadata", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
 		JsonSchema: &schema,
 	})
 
@@ -203,8 +203,51 @@ func TestValidate_JSONSchema(t *testing.T) {
 // --- No constraints (type check only) ---
 
 func TestValidate_NoConstraints(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "anything"}}))
+}
+
+// --- Sensitive field error suppression ---
+
+func TestValidate_Sensitive_URL_ErrorOmitsValue(t *testing.T) {
+	v := NewFieldValidator("secret.webhook", pb.FieldType_FIELD_TYPE_URL, false, true, nil)
+
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "not-a-url"}})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "not-a-url")
+	assert.Contains(t, err.Error(), "not a valid absolute URL")
+}
+
+func TestValidate_Sensitive_Regex_ErrorOmitsValue(t *testing.T) {
+	v := NewFieldValidator("secret.token", pb.FieldType_FIELD_TYPE_STRING, false, true, &pb.FieldConstraints{
+		Regex: ptr(`^\d{4}$`),
+	})
+
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hunter2"}})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "hunter2")
+	assert.Contains(t, err.Error(), "does not match pattern")
+}
+
+func TestValidate_Sensitive_Enum_ErrorOmitsValue(t *testing.T) {
+	v := NewFieldValidator("secret.tier", pb.FieldType_FIELD_TYPE_STRING, false, true, &pb.FieldConstraints{
+		EnumValues: []string{"gold", "silver"},
+	})
+
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "bronze"}})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "bronze")
+	assert.Contains(t, err.Error(), "not in allowed values")
+}
+
+func TestValidate_NonSensitive_ErrorIncludesValue(t *testing.T) {
+	v := NewFieldValidator("public.tier", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		EnumValues: []string{"gold", "silver"},
+	})
+
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "bronze"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bronze")
 }
 
 // --- Cache ---
@@ -215,7 +258,7 @@ func TestValidatorCache(t *testing.T) {
 	_, ok := c.Get("t1")
 	assert.False(t, ok)
 
-	validators := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil)}
+	validators := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
 	c.Set("t1", validators)
 
 	got, ok := c.Get("t1")
@@ -230,9 +273,9 @@ func TestValidatorCache(t *testing.T) {
 func TestValidatorCache_EvictsOldestWhenFull(t *testing.T) {
 	c := NewValidatorCache(2)
 
-	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil)}
-	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)}
-	v3 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, nil)}
+	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
+	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)}
+	v3 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)}
 
 	c.Set("t1", v1)
 	c.Set("t2", v2)
@@ -255,14 +298,14 @@ func TestValidatorCache_EvictsOldestWhenFull(t *testing.T) {
 func TestValidatorCache_UpdateExistingDoesNotGrow(t *testing.T) {
 	c := NewValidatorCache(2)
 
-	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, nil)}
-	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, nil)}
+	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
+	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)}
 
 	c.Set("t1", v1)
 	c.Set("t2", v2)
 
 	// Update t1 — should not trigger eviction.
-	v1Updated := map[string]*FieldValidator{"y": NewFieldValidator("y", pb.FieldType_FIELD_TYPE_BOOL, false, nil)}
+	v1Updated := map[string]*FieldValidator{"y": NewFieldValidator("y", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)}
 	c.Set("t1", v1Updated)
 	assert.Equal(t, 2, c.Len())
 


### PR DESCRIPTION
## Summary

- The `sensitive: true` schema flag was stored in `domain.SchemaField.Sensitive` but never consulted at runtime, allowing secret values to flow unredacted through five distinct paths.
- This PR closes all leaks by introducing a single `redactIfSensitive` helper and wiring it into every path that reads or emits field values: `GetConfig` responses, Redis cache writes, audit log entries, Subscribe stream events, `ExportConfig` YAML output, and validation error messages.
- `ExportConfig` is now safe to share with non-admin operators: sensitive fields appear as `[REDACTED]` regardless of the caller's role.

## Test plan

- [x] `TestGetConfig_RedactsSensitiveFields` — DB-path and cache-write both produce `[REDACTED]`; non-sensitive field is unchanged
- [x] `TestSetField_AuditRedactsSensitiveField` — `old_value` / `new_value` in audit row are `[REDACTED]`
- [x] `TestSetField_PublishRedactsSensitiveField` — published change event carries `[REDACTED]` values
- [x] `TestExportConfig_RedactsSensitiveFields` — YAML export omits sensitive value, preserves non-sensitive value
- [x] Validator tests for URL, regex, and enum errors on sensitive fields — value absent from error message
- [x] `make test` — all packages green
- [x] `make lint` — 0 issues

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)