### PR TITLE
security(auth): scope skipAuth to exact GetServerInfo method

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -336,6 +336,11 @@ to be correctly protected at the audit date:
 - **Auth interceptor coverage** — every non-`skipAuth` RPC method
   passes through the interceptor (`internal/server/server.go:48-49`).
   Disabled services (`ENABLE_SERVICES`) are not registered at all.
+- **skipAuth scope** — `internal/auth/metadata.go` matches exact method
+  paths, not service prefixes. Audited in #355: only
+  `/grpc.health.v1.Health/*` (probes) and
+  `/centralconfig.v1.ServerService/GetServerInfo` (read-only capability
+  discovery, documented as unauthenticated in the proto) are exempt.
 - **Field-path grammar** —
   `internal/schema/yaml.go:20-28` enforces
   `^[a-zA-Z_][a-zA-Z0-9_.-]*$`. No traversal possible by grammar.

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -15,15 +15,17 @@ import (
 // skipAuth returns true for gRPC methods that should bypass authentication.
 //
 // Methods listed here are exempt from BOTH authentication and authorization.
-// Only public, side-effect-free RPCs belong here (e.g. health checks).
-// Adding any authenticated method silently bypasses all auth and authz checks.
-// Every entry requires an explicit security review.
+// Only public, side-effect-free RPCs belong here. Adding any authenticated
+// method silently bypasses all auth and authz checks. Every entry requires
+// an explicit security review.
 //
-// TODO(security): Audit whether /centralconfig.v1.ServerService/ belongs here (#355).
-// It was added alongside health checks but is not documented as a public endpoint.
+// Allowed methods and rationale:
+//   - /grpc.health.v1.Health/*             — standard liveness/readiness probes; no data access
+//   - /centralconfig.v1.ServerService/GetServerInfo — read-only capability discovery (version,
+//     commit, feature flags); explicitly documented as unauthenticated in the proto; no side effects
 func skipAuth(fullMethod string) bool {
 	return strings.HasPrefix(fullMethod, "/grpc.health.v1.Health/") ||
-		strings.HasPrefix(fullMethod, "/centralconfig.v1.ServerService/")
+		fullMethod == "/centralconfig.v1.ServerService/GetServerInfo"
 }
 
 const (


### PR DESCRIPTION
## Summary

- The `skipAuth` function matched the entire `/centralconfig.v1.ServerService/` prefix, meaning any future RPC added to that service would silently bypass both authentication and authorization.
- Audited per #355: `GetServerInfo` is read-only, side-effect-free, and explicitly documented as unauthenticated in the proto. It belongs in `skipAuth`.
- Changed to an exact method match and updated the contract comment to enumerate each exempted method with its security rationale.

## Test plan

- [x] Existing unit tests in `internal/auth/` (both metadata and JWT interceptor paths) already cover the exact `GetServerInfo` method path — all pass
- [x] E2e suite passed (`make e2e`) — auth bypass, role matrix, and integration tests confirmed
- [x] `make pre-commit` passed — build, vet, lint, format, test, coverage all clean
- [x] Updated `.agents/context/security-review.md` to record the audit result

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)