### PR TITLE
feat(server): gate gRPC reflection behind ENABLE_REFLECTION flag

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -281,11 +281,13 @@ prevents security-patch propagation. Fix: default to `Always` for
 non-pinned tags, or document that production deployments must pin by
 digest.
 
-### 18. CodeQL not a required check — Low
+### 18. CodeQL not a required check — Low ✅ RESOLVED (#223)
 
 CodeQL is configured (advanced setup, per memory `feedback_…`) and
 runs on PR, but is not in the branch-protection required-checks list.
 Fix: add `CodeQL / Analyze` to the required checks set.
+
+**Resolution:** Added `CodeQL / Analyze (actions)`, `CodeQL / Analyze (go)`, and `CodeQL / Analyze (python)` to the required checks set on the `main` branch.
 
 ### 19. Unknown role echoed — Low
 
@@ -299,13 +301,15 @@ Echoes whatever the JWT claim said. Mostly cosmetic, but fits the
 "don't echo input" rule. Fix: log full string, return
 `"unknown role"`.
 
-### 20. gRPC reflection always registered — Low
+### 20. gRPC reflection always registered — Low ✅ RESOLVED (#223)
 
 `internal/server/server.go:55` always calls
 `reflection.Register(grpcServer)`. Reflection is *not* in `skipAuth`
 (verified at `internal/auth/metadata.go:15-17` and corresponding JWT
 path), so a caller must authenticate before listing services. Still:
 in a hardened production deployment reflection should be off.
+
+**Resolution:** Added `WithReflection()` option; reflection is off by default. Enabled via `ENABLE_REFLECTION=1` (env) or `grpc.enableReflection: true` (Helm). Docker Compose enables it for local dev.
 
 Fix: gate behind a config flag, defaulting off in production builds /
 Helm values.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -239,6 +239,10 @@ func run() int {
 		)
 	}
 
+	if cfg.EnableReflection {
+		logger.WarnContext(ctx, "ENABLE_REFLECTION=1 set — gRPC server reflection enabled (not recommended for production)")
+	}
+
 	srvBuild := buildServerOptions(cfg, logger, extraOpts, serverTLS, rlInterceptor)
 	srv, err := server.New(cfg.GRPCPort, authInterceptor, srvBuild.Opts...)
 	if err != nil {
@@ -415,6 +419,7 @@ type serverConfig struct {
 	RateLimitAuthedRPS       float64
 	RateLimitSuperAdminRPS   float64 // 0 = unlimited
 	RateLimitBurst           int
+	EnableReflection         bool
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -486,6 +491,7 @@ func loadConfig() serverConfig {
 		RateLimitAuthedRPS:       parseEnvFloat("RATE_LIMIT_AUTHED_RPS", 100),
 		RateLimitSuperAdminRPS:   parseEnvFloat("RATE_LIMIT_SUPERADMIN_RPS", 0),
 		RateLimitBurst:           parseEnvInt("RATE_LIMIT_BURST", 10),
+		EnableReflection:         getEnv("ENABLE_REFLECTION", "") == "1",
 	}
 }
 

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -17,6 +17,7 @@ type serverOptionsBuild struct {
 	UseTLS         bool
 	UseInsecure    bool
 	HasRateLimiter bool
+	HasReflection  bool
 }
 
 func buildServerOptions(
@@ -45,6 +46,10 @@ func buildServerOptions(
 	if rl != nil {
 		out.Opts = append(out.Opts, server.WithRateLimiter(rl))
 		out.HasRateLimiter = true
+	}
+	if cfg.EnableReflection {
+		out.Opts = append(out.Opts, server.WithReflection())
+		out.HasReflection = true
 	}
 	return out
 }

--- a/cmd/server/options_test.go
+++ b/cmd/server/options_test.go
@@ -74,6 +74,28 @@ func TestBuildServerOptions_RateLimiterAbsent(t *testing.T) {
 	assert.Len(t, got.Opts, 6)
 }
 
+func TestBuildServerOptions_ReflectionWired(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+	cfg.EnableReflection = true
+
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+
+	assert.True(t, got.HasReflection, "EnableReflection=true must wire WithReflection option")
+	assert.Len(t, got.Opts, 7, "5 base options + Insecure + Reflection")
+}
+
+func TestBuildServerOptions_ReflectionAbsent(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+	cfg.EnableReflection = false
+
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+
+	assert.False(t, got.HasReflection, "EnableReflection=false must not wire WithReflection option")
+	assert.Len(t, got.Opts, 6)
+}
+
 func TestBuildServerOptions_ExtraGRPCOpts(t *testing.T) {
 	cfg := baseServerCfg()
 	cfg.InsecureListen = true

--- a/deploy/helm/decree/templates/deployment.yaml
+++ b/deploy/helm/decree/templates/deployment.yaml
@@ -149,6 +149,10 @@ spec:
             - name: INSECURE_LISTEN
               value: "1"
             {{- end }}
+            {{- if .Values.grpc.enableReflection }}
+            - name: ENABLE_REFLECTION
+              value: "1"
+            {{- end }}
             {{- if .Values.tls.certSecret }}
             - name: TLS_CERT_FILE
               value: /etc/decree/tls/server/tls.crt

--- a/deploy/helm/decree/values.yaml
+++ b/deploy/helm/decree/values.yaml
@@ -80,6 +80,14 @@ tls:
     # Secret containing tls.crt + tls.key for the gateway to present as a client cert (mTLS).
     clientCertSecret: ""
 
+# --- gRPC server options ---
+
+grpc:
+  # Enable gRPC server reflection. Off by default; enable for dev clusters or
+  # tooling environments (grpcurl, grpc-gateway introspection). Never enable
+  # in production — reflection exposes the full service schema to any caller.
+  enableReflection: false
+
 # --- Authentication ---
 
 auth:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       HTTP_PORT: "8080"
       USAGE_FLUSH_INTERVAL: "1s"
       INSECURE_LISTEN: "1"
+      ENABLE_REFLECTION: "1"
       # Tight ingest limits so the validation-limit e2e tests can trip
       # them with small payloads. Existing fixtures use at most a few
       # fields and small YAMLs (< 1 KiB), well under these caps.

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -23,6 +23,12 @@ OpenDecree is configured entirely through environment variables. No config files
 | `SCHEMA_COMPILE_TIMEOUT` | Wall-clock cap on a single JSON-Schema compile (per-field constraint). Format: Go duration (e.g., `5s`, `2s`). Set to `0` to disable the timeout. | `5s` | No |
 | `SCHEMA_MAX_REF_DEPTH` | Maximum structural nesting depth of a JSON-Schema constraint document. Schemas deeper than this are rejected before compilation. Set to `0` to disable. | `64` | No |
 
+## gRPC Server Options
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `ENABLE_REFLECTION` | Set to `1` to enable gRPC server reflection. Allows tools like `grpcurl` to introspect the server's service schema. **Never enable in production** — reflection exposes the full API to any caller regardless of auth. | disabled | No |
+
 ## Transport Security (TLS)
 
 TLS is **required by default** for the gRPC server and the gateway-to-gRPC dial. Set `INSECURE_LISTEN=1` to opt out for local dev only.

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -10,14 +10,15 @@ import (
 type Option func(*options)
 
 type options struct {
-	enableServices  []string
-	logger          *slog.Logger
-	extraOptions    []grpc.ServerOption
-	maxRecvMsgBytes int
-	maxSendMsgBytes int
-	tls             *TLSConfig
-	insecure        bool
-	rateLimiter     GRPCInterceptor // optional; runs after auth
+	enableServices   []string
+	logger           *slog.Logger
+	extraOptions     []grpc.ServerOption
+	maxRecvMsgBytes  int
+	maxSendMsgBytes  int
+	tls              *TLSConfig
+	insecure         bool
+	rateLimiter      GRPCInterceptor // optional; runs after auth
+	enableReflection bool
 }
 
 // WithLogger sets the server logger. Defaults to slog.Default() when unset.
@@ -65,4 +66,10 @@ func WithInsecure() Option {
 // Pass nil to disable rate limiting.
 func WithRateLimiter(rl GRPCInterceptor) Option {
 	return func(o *options) { o.rateLimiter = rl }
+}
+
+// WithReflection enables gRPC server reflection. Off by default; enable for
+// local dev or tooling environments (grpcurl, grpc-gateway introspection).
+func WithReflection() Option {
+	return func(o *options) { o.enableReflection = true }
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,7 +101,9 @@ func New(grpcPort string, auth GRPCInterceptor, opts ...Option) (*Server, error)
 	grpcServer := grpc.NewServer(grpcOpts...)
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(grpcServer, healthServer)
-	reflection.Register(grpcServer)
+	if o.enableReflection {
+		reflection.Register(grpcServer)
+	}
 
 	return &Server{
 		grpcServer:     grpcServer,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	reflpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -350,4 +351,67 @@ func TestServe_AndGracefulStop(t *testing.T) {
 
 	srv.GracefulStop(context.Background())
 	assert.NoError(t, <-errCh)
+}
+
+func startReflectionTestServer(t *testing.T, enableReflection bool) (*grpc.ClientConn, func()) {
+	t.Helper()
+	opts := []Option{
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	}
+	if enableReflection {
+		opts = append(opts, WithReflection())
+	}
+	srv, err := New("0", &noopInterceptor{}, opts...)
+	require.NoError(t, err)
+
+	addr := srv.listener.Addr().String()
+	go func() { _ = srv.Serve(context.Background()) }()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.GracefulStop(context.Background())
+	}
+	return conn, cleanup
+}
+
+func callReflection(ctx context.Context, conn *grpc.ClientConn) error {
+	client := reflpb.NewServerReflectionClient(conn)
+	stream, err := client.ServerReflectionInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&reflpb.ServerReflectionRequest{
+		MessageRequest: &reflpb.ServerReflectionRequest_ListServices{ListServices: ""},
+	}); err != nil {
+		return err
+	}
+	_, err = stream.Recv()
+	return err
+}
+
+func TestReflection_DisabledByDefault_ReturnsUnimplemented(t *testing.T) {
+	conn, cleanup := startReflectionTestServer(t, false)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := callReflection(ctx, conn)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unimplemented, status.Code(err))
+}
+
+func TestReflection_Enabled_ListServicesSucceeds(t *testing.T) {
+	conn, cleanup := startReflectionTestServer(t, true)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := callReflection(ctx, conn)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- gRPC server reflection was unconditionally registered on every instance, exposing the full service schema to any authenticated caller — a hardened production deployment should be able to disable it entirely.
- CodeQL scans ran on every PR but were not in the branch-protection required-checks list, so a PR with a CodeQL finding could merge without being blocked.

## Test plan

- [x] `TestReflection_DisabledByDefault_ReturnsUnimplemented` — confirms `codes.Unimplemented` when `WithReflection()` is not set
- [x] `TestReflection_Enabled_ListServicesSucceeds` — confirms `ListServices` succeeds when `WithReflection()` is set
- [x] `TestBuildServerOptions_ReflectionWired` / `ReflectionAbsent` — verifies `ENABLE_REFLECTION=1` wires the option and `false` does not
- [x] Full `make test` passes (all modules, `-race`)
- [x] `make lint` passes
- [x] CodeQL required checks added to `main` branch protection: `CodeQL / Analyze (actions|go|python)`
- [x] docker-compose local dev: `ENABLE_REFLECTION=1` set alongside `INSECURE_LISTEN=1`
- [x] Helm `values.yaml`: `grpc.enableReflection` defaults to `false`

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)