### PR TITLE
feat(schema): compile and lint CEL validations at ImportSchema

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -22,6 +22,8 @@ OpenDecree is configured entirely through environment variables. No config files
 | `SCHEMA_MAX_DOC_BYTES` | Maximum serialized YAML document size accepted by `ImportSchema`, in bytes. Requests above this return `InvalidArgument`. Set to `0` to disable. | `5242880` (5 MiB) | No |
 | `SCHEMA_COMPILE_TIMEOUT` | Wall-clock cap on a single JSON-Schema compile (per-field constraint). Format: Go duration (e.g., `5s`, `2s`). Set to `0` to disable the timeout. | `5s` | No |
 | `SCHEMA_MAX_REF_DEPTH` | Maximum structural nesting depth of a JSON-Schema constraint document. Schemas deeper than this are rejected before compilation. Set to `0` to disable. | `64` | No |
+| `DECREE_CEL_COST_LIMIT` | DoS guard for CEL `validations:` rules. `cel.CostLimit` value used when building each `cel.Program`; evaluation aborts when the rule's internal cost counter exceeds this limit. | `100000` | No |
+| `DECREE_CEL_INTERRUPT_FREQ` | How often the CEL cost counter is sampled while a rule's loops or comprehensions run. Lower values catch runaway evaluation sooner at small per-evaluation overhead. | `100` | No |
 
 ## gRPC Server Options
 

--- a/internal/schema/cel/compile.go
+++ b/internal/schema/cel/compile.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"sync"
@@ -96,7 +97,7 @@ func costLimit() uint64 {
 }
 
 func interruptFreq() uint {
-	if v, ok := readUint64(envInterruptFreq); ok {
+	if v, ok := readUint64(envInterruptFreq); ok && v <= math.MaxUint32 {
 		return uint(v)
 	}
 	return defaultInterruptFreq

--- a/internal/schema/cel/compile.go
+++ b/internal/schema/cel/compile.go
@@ -1,0 +1,115 @@
+package cel
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/google/cel-go/cel"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+// Default DoS guards per the design brief. cel.CostLimit aborts a program
+// whose internal cost counter exceeds the limit; cel.InterruptCheckFrequency
+// pins how often the cost counter is sampled while a loop or comprehension
+// runs. The brief picked 100_000 and 100; both are tunable per deployment.
+const (
+	defaultCostLimit     uint64 = 100_000
+	defaultInterruptFreq uint   = 100
+
+	envCostLimit     = "DECREE_CEL_COST_LIMIT"
+	envInterruptFreq = "DECREE_CEL_INTERRUPT_FREQ"
+)
+
+// Cache memoises compiled CEL programs across config writes. Keys are tuples
+// of (schemaID, schemaVersion, ruleIndex); the program holds its own copy of
+// the env and is safe for concurrent evaluation. Invalidate by deleting all
+// entries for a schemaID whenever a tenant's schema binding moves.
+type Cache struct {
+	entries sync.Map // cacheKey → cel.Program
+}
+
+type cacheKey struct {
+	SchemaID  string
+	Version   int32
+	RuleIndex int
+}
+
+// NewCache returns an empty program cache.
+func NewCache() *Cache { return &Cache{} }
+
+// ProgramFor returns the cached program for the rule at the given index,
+// compiling and caching it on first use. The rule string is taken verbatim
+// from pb.ValidationRule.Rule. Compilation errors propagate to the caller
+// — they have already been surfaced by LintValidations at schema-import
+// time, but the runtime path defensively returns them rather than panicking
+// on a corrupted schema row.
+func (c *Cache) ProgramFor(env *cel.Env, rule *pb.ValidationRule, schemaID string, version int32, idx int) (cel.Program, error) {
+	key := cacheKey{SchemaID: schemaID, Version: version, RuleIndex: idx}
+	if v, ok := c.entries.Load(key); ok {
+		return v.(cel.Program), nil
+	}
+	prog, err := compileProgram(env, rule.GetRule())
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := c.entries.LoadOrStore(key, prog)
+	return actual.(cel.Program), nil
+}
+
+// InvalidateSchema drops every cached program whose key belongs to the
+// given schemaID. Called when a tenant's schema version moves so the next
+// evaluation re-compiles against the new field set.
+func (c *Cache) InvalidateSchema(schemaID string) {
+	c.entries.Range(func(k, _ any) bool {
+		if key, ok := k.(cacheKey); ok && key.SchemaID == schemaID {
+			c.entries.Delete(key)
+		}
+		return true
+	})
+}
+
+// compileProgram compiles a single CEL rule against the env and wraps it
+// with the configured cost-limit and interrupt-check guards.
+func compileProgram(env *cel.Env, rule string) (cel.Program, error) {
+	ast, issues := env.Compile(rule)
+	if issues != nil && issues.Err() != nil {
+		return nil, issues.Err()
+	}
+	prog, err := env.Program(ast,
+		cel.CostLimit(costLimit()),
+		cel.InterruptCheckFrequency(interruptFreq()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build program: %w", err)
+	}
+	return prog, nil
+}
+
+func costLimit() uint64 {
+	if v, ok := readUint64(envCostLimit); ok {
+		return v
+	}
+	return defaultCostLimit
+}
+
+func interruptFreq() uint {
+	if v, ok := readUint64(envInterruptFreq); ok {
+		return uint(v)
+	}
+	return defaultInterruptFreq
+}
+
+func readUint64(name string) (uint64, bool) {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/schema/cel/compile_test.go
+++ b/internal/schema/cel/compile_test.go
@@ -1,0 +1,74 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+func TestCache_ProgramFor_CompilesAndMemoises(t *testing.T) {
+	env, err := BuildEnv(showcaseFields())
+	require.NoError(t, err)
+
+	cache := NewCache()
+	rule := &pb.ValidationRule{Rule: "self.payments.min_amount < self.payments.max_amount"}
+
+	first, err := cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.NoError(t, err)
+	assert.Same(t, first, second, "second lookup must return the cached program")
+}
+
+func TestCache_ProgramFor_DifferentKeysHoldDifferentPrograms(t *testing.T) {
+	env, err := BuildEnv(showcaseFields())
+	require.NoError(t, err)
+
+	cache := NewCache()
+	rule := &pb.ValidationRule{Rule: "self.payments.min_amount < self.payments.max_amount"}
+
+	a, err := cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.NoError(t, err)
+	b, err := cache.ProgramFor(env, rule, "schema-1", 2, 0)
+	require.NoError(t, err)
+	assert.NotSame(t, a, b, "different versions key separately")
+}
+
+func TestCache_InvalidateSchema_DropsMatchingEntriesOnly(t *testing.T) {
+	env, err := BuildEnv(showcaseFields())
+	require.NoError(t, err)
+
+	cache := NewCache()
+	rule := &pb.ValidationRule{Rule: "self.payments.min_amount < self.payments.max_amount"}
+
+	prog1, err := cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.NoError(t, err)
+	prog2, err := cache.ProgramFor(env, rule, "schema-2", 1, 0)
+	require.NoError(t, err)
+
+	cache.InvalidateSchema("schema-1")
+
+	reprog1, err := cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.NoError(t, err)
+	assert.NotSame(t, prog1, reprog1, "schema-1 entry must be recompiled after invalidation")
+
+	stillCached, err := cache.ProgramFor(env, rule, "schema-2", 1, 0)
+	require.NoError(t, err)
+	assert.Same(t, prog2, stillCached, "schema-2 entries must remain cached")
+}
+
+func TestCache_ProgramFor_ReportsCompileFailure(t *testing.T) {
+	env, err := BuildEnv(showcaseFields())
+	require.NoError(t, err)
+
+	cache := NewCache()
+	rule := &pb.ValidationRule{Rule: "self.payments.min_amount <"}
+
+	_, err = cache.ProgramFor(env, rule, "schema-1", 1, 0)
+	require.Error(t, err)
+}

--- a/internal/schema/cel/lint.go
+++ b/internal/schema/cel/lint.go
@@ -1,0 +1,514 @@
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+// LintValidations runs every lint rule over every entry in rules and returns
+// the aggregated set of failures. Each rule is checked independently; one
+// rule's failure does not short-circuit the rest. The returned error wraps
+// every per-rule error via errors.Join so callers receive a single multi-line
+// message at the gRPC boundary.
+//
+// Lint rules (all blocking at ImportSchema time):
+//
+//  1. cel.Compile succeeds; syntax errors surface with line and column.
+//  2. The compiled AST references at least one self.* path; pure-constant
+//     and tenant-only rules are rejected.
+//  3. Every self.<path> chain resolves to a declared field path (with
+//     intermediate prefixes tolerated when their full path is a parent of
+//     a real leaf).
+//  4. The rule cannot be expressed by a native constraint or
+//     dependentRequired entry; if it can, the suggested keyword is named.
+func LintValidations(rules []*pb.ValidationRule, fields []*pb.SchemaField) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	env, err := BuildEnv(fields)
+	if err != nil {
+		return fmt.Errorf("build CEL env: %w", err)
+	}
+	leafPaths, parentPaths := buildPathSets(fields)
+
+	var errs []error
+	for i, r := range rules {
+		if err := lintOne(env, leafPaths, parentPaths, r); err != nil {
+			errs = append(errs, fmt.Errorf("validations[%d]: %w", i, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func lintOne(env *cel.Env, leaves, parents map[string]struct{}, r *pb.ValidationRule) error {
+	celAst, issues := env.Compile(r.GetRule())
+	if issues != nil && issues.Err() != nil {
+		return issues.Err()
+	}
+
+	root := celAst.NativeRep().Expr()
+	chains := collectSelfChains(root)
+
+	if len(chains) == 0 {
+		return fmt.Errorf("rule must reference at least one self.* field")
+	}
+
+	var resolutionErrs []error
+	for _, c := range chains {
+		path := strings.Join(c, ".")
+		if _, ok := leaves[path]; ok {
+			continue
+		}
+		if _, ok := parents[path]; ok {
+			continue
+		}
+		resolutionErrs = append(resolutionErrs, fmt.Errorf("self.%s does not resolve to a declared field", path))
+	}
+
+	if suggestion, sub := patternSubstitutable(root); sub {
+		resolutionErrs = append(resolutionErrs, fmt.Errorf("rule is expressible with a native constraint — %s", suggestion))
+	}
+
+	return errors.Join(resolutionErrs...)
+}
+
+// buildPathSets returns two sets: leaf paths (exact field paths declared on
+// the schema) and parent paths (every dotted prefix of a leaf path).
+// Intermediate self.foo accesses where foo.bar is a declared leaf are
+// tolerated so that rules like `has(self.foo) || self.foo.bar > 0` lint
+// cleanly.
+func buildPathSets(fields []*pb.SchemaField) (leaves, parents map[string]struct{}) {
+	leaves = make(map[string]struct{}, len(fields))
+	parents = make(map[string]struct{}, len(fields))
+	for _, f := range fields {
+		p := f.GetPath()
+		leaves[p] = struct{}{}
+		segments := strings.Split(p, ".")
+		for i := 1; i < len(segments); i++ {
+			parents[strings.Join(segments[:i], ".")] = struct{}{}
+		}
+	}
+	return leaves, parents
+}
+
+// collectSelfChains walks the AST and returns every dotted-path chain rooted
+// at the self identifier. Both `self.x.y` (Select chains) and `self["x"].y`
+// (Index plus Select) collapse to ["x", "y"]. Chains that terminate in a
+// non-self operand are ignored. The bare `self` identifier (an empty chain)
+// is filtered out — buildPathSets cannot resolve it and a rule that does
+// nothing but reference `self` itself is rejected by rule 2's empty-chain
+// count check.
+func collectSelfChains(root ast.Expr) [][]string {
+	var chains [][]string
+	visit(root, func(e ast.Expr) {
+		if chain, ok := selfChainOf(e); ok && len(chain) > 0 {
+			chains = append(chains, chain)
+		}
+	})
+	dedupe := chains[:0]
+	seen := make(map[string]struct{}, len(chains))
+	for _, c := range chains {
+		key := strings.Join(c, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		dedupe = append(dedupe, c)
+	}
+	sort.Slice(dedupe, func(i, j int) bool {
+		return strings.Join(dedupe[i], ".") < strings.Join(dedupe[j], ".")
+	})
+	return dedupe
+}
+
+// selfChainOf returns the dotted path of a Select/Index chain rooted at
+// `self`, or false when the expression is not such a chain. The shallowest
+// expression rooted at `self.x` returns ["x"]; nested chains return the full
+// path. Only the *outermost* self chain is returned per call site — the
+// recursive walker emits intermediate chains too, which is fine because
+// `buildPathSets` accepts parents as resolved paths.
+func selfChainOf(e ast.Expr) ([]string, bool) {
+	if e == nil {
+		return nil, false
+	}
+	switch e.Kind() {
+	case ast.SelectKind:
+		sel := e.AsSelect()
+		base, ok := selfChainOf(sel.Operand())
+		if !ok {
+			return nil, false
+		}
+		return append(base, sel.FieldName()), true
+	case ast.CallKind:
+		call := e.AsCall()
+		if call.FunctionName() != "_[_]" || len(call.Args()) != 2 {
+			return nil, false
+		}
+		base, ok := selfChainOf(call.Args()[0])
+		if !ok {
+			return nil, false
+		}
+		idx := call.Args()[1]
+		if idx.Kind() != ast.LiteralKind {
+			return nil, false
+		}
+		if str, isStr := stringLiteral(idx.AsLiteral()); isStr {
+			return append(base, str), true
+		}
+		return nil, false
+	case ast.IdentKind:
+		if e.AsIdent() == "self" {
+			return []string{}, true
+		}
+	}
+	return nil, false
+}
+
+// patternSubstitutable returns a suggestion describing the native constraint
+// that subsumes the rule, when the rule's AST matches one of the well-known
+// substitutable shapes. False-negatives are accepted; false-positives are
+// not — a genuine cross-field rule must never match.
+func patternSubstitutable(root ast.Expr) (string, bool) {
+	if root.Kind() != ast.CallKind {
+		return "", false
+	}
+	call := root.AsCall()
+	args := call.Args()
+	switch call.FunctionName() {
+	case "_<_", "_<=_", "_>_", "_>=_":
+		return suggestComparisonAgainstLiteral(call.FunctionName(), args)
+	case "_==_":
+		return suggestEqualityLiteral(args)
+	case "_||_":
+		if s, ok := suggestEnumChain(args); ok {
+			return s, true
+		}
+		if s, ok := suggestDependentRequiredImplication(args); ok {
+			return s, true
+		}
+	case "_&&_":
+		return suggestBoundedRange(args)
+	}
+	return "", false
+}
+
+func suggestComparisonAgainstLiteral(fn string, args []ast.Expr) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	_, leftIsSelf := singleSelfChain(args[0])
+	rightLit, rightIsLit := constLiteral(args[1])
+	leftLit, leftIsLit := constLiteral(args[0])
+	_, rightIsSelf := singleSelfChain(args[1])
+
+	if leftIsSelf && rightIsLit {
+		return comparisonSuggestion(fn, rightLit, false), true
+	}
+	if rightIsSelf && leftIsLit {
+		return comparisonSuggestion(fn, leftLit, true), true
+	}
+	return "", false
+}
+
+func comparisonSuggestion(fn, literal string, flipped bool) string {
+	op := fn
+	if flipped {
+		op = flipOp(fn)
+	}
+	switch op {
+	case "_>_":
+		return fmt.Sprintf("use exclusiveMinimum: %s on the field", literal)
+	case "_>=_":
+		return fmt.Sprintf("use minimum: %s on the field", literal)
+	case "_<_":
+		return fmt.Sprintf("use exclusiveMaximum: %s on the field", literal)
+	case "_<=_":
+		return fmt.Sprintf("use maximum: %s on the field", literal)
+	}
+	return "use a native bound on the field"
+}
+
+func flipOp(fn string) string {
+	switch fn {
+	case "_<_":
+		return "_>_"
+	case "_<=_":
+		return "_>=_"
+	case "_>_":
+		return "_<_"
+	case "_>=_":
+		return "_<=_"
+	}
+	return fn
+}
+
+func suggestEqualityLiteral(args []ast.Expr) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	if _, ok := singleSelfChain(args[0]); ok {
+		if lit, isLit := constLiteral(args[1]); isLit {
+			return fmt.Sprintf("use enum: [%s] on the field", lit), true
+		}
+	}
+	if _, ok := singleSelfChain(args[1]); ok {
+		if lit, isLit := constLiteral(args[0]); isLit {
+			return fmt.Sprintf("use enum: [%s] on the field", lit), true
+		}
+	}
+	return "", false
+}
+
+// suggestEnumChain matches `self.x == "a" || self.x == "b" || ...` —
+// every leaf of the OR tree must be `self.x == literal` with the same self
+// path on the left or right side.
+func suggestEnumChain(args []ast.Expr) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	var path string
+	var values []string
+	if !collectEqualityLeaves(args[0], &path, &values) {
+		return "", false
+	}
+	if !collectEqualityLeaves(args[1], &path, &values) {
+		return "", false
+	}
+	if path == "" || len(values) < 2 {
+		return "", false
+	}
+	return fmt.Sprintf("use enum: [%s] on field %s", strings.Join(values, ", "), path), true
+}
+
+func collectEqualityLeaves(e ast.Expr, path *string, values *[]string) bool {
+	if e.Kind() != ast.CallKind {
+		return false
+	}
+	call := e.AsCall()
+	if call.FunctionName() == "_||_" {
+		args := call.Args()
+		if len(args) != 2 {
+			return false
+		}
+		return collectEqualityLeaves(args[0], path, values) && collectEqualityLeaves(args[1], path, values)
+	}
+	if call.FunctionName() != "_==_" {
+		return false
+	}
+	args := call.Args()
+	if len(args) != 2 {
+		return false
+	}
+	chain, lit, ok := equalityComponents(args)
+	if !ok {
+		return false
+	}
+	got := strings.Join(chain, ".")
+	if *path != "" && *path != got {
+		return false
+	}
+	*path = got
+	*values = append(*values, lit)
+	return true
+}
+
+func equalityComponents(args []ast.Expr) (chain []string, literal string, ok bool) {
+	if c, isSelf := singleSelfChain(args[0]); isSelf {
+		if lit, isLit := constLiteral(args[1]); isLit {
+			return c, lit, true
+		}
+	}
+	if c, isSelf := singleSelfChain(args[1]); isSelf {
+		if lit, isLit := constLiteral(args[0]); isLit {
+			return c, lit, true
+		}
+	}
+	return nil, "", false
+}
+
+// suggestDependentRequiredImplication matches `!has(self.a) || has(self.b)`
+// (the CEL desugaring of `has(self.a) -> has(self.b)`) and suggests the
+// equivalent dependentRequired entry.
+func suggestDependentRequiredImplication(args []ast.Expr) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	trigger, ok := negatedHasSelf(args[0])
+	if !ok {
+		return "", false
+	}
+	dependent, ok := hasSelf(args[1])
+	if !ok {
+		return "", false
+	}
+	return fmt.Sprintf("use dependentRequired: { %s: [%s] }", trigger, dependent), true
+}
+
+func negatedHasSelf(e ast.Expr) (string, bool) {
+	if e.Kind() != ast.CallKind {
+		return "", false
+	}
+	call := e.AsCall()
+	if call.FunctionName() != "!_" || len(call.Args()) != 1 {
+		return "", false
+	}
+	return hasSelf(call.Args()[0])
+}
+
+// hasSelf matches the `has(self.<path>)` macro. cel-go's parser desugars the
+// macro into a SelectKind with IsTestOnly()=true, so we detect that flag
+// rather than searching for a CallKind named "has".
+func hasSelf(e ast.Expr) (string, bool) {
+	if e.Kind() != ast.SelectKind {
+		return "", false
+	}
+	sel := e.AsSelect()
+	if !sel.IsTestOnly() {
+		return "", false
+	}
+	chain, ok := selfChainOf(e)
+	if !ok || len(chain) == 0 {
+		return "", false
+	}
+	return strings.Join(chain, "."), true
+}
+
+// suggestBoundedRange matches `lo <op> self.x && self.x <op> hi` with both
+// operands referencing the same self path. Either side may carry the lower
+// bound.
+func suggestBoundedRange(args []ast.Expr) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	leftChain, leftLit, leftOk := boundComponents(args[0])
+	rightChain, rightLit, rightOk := boundComponents(args[1])
+	if !leftOk || !rightOk {
+		return "", false
+	}
+	if strings.Join(leftChain, ".") != strings.Join(rightChain, ".") {
+		return "", false
+	}
+	return fmt.Sprintf("use minimum: %s and maximum: %s on field %s", leftLit, rightLit, strings.Join(leftChain, ".")), true
+}
+
+func boundComponents(e ast.Expr) (chain []string, literal string, ok bool) {
+	if e.Kind() != ast.CallKind {
+		return nil, "", false
+	}
+	call := e.AsCall()
+	switch call.FunctionName() {
+	case "_<_", "_<=_", "_>_", "_>=_":
+	default:
+		return nil, "", false
+	}
+	args := call.Args()
+	if len(args) != 2 {
+		return nil, "", false
+	}
+	if c, isSelf := singleSelfChain(args[0]); isSelf {
+		if lit, isLit := constLiteral(args[1]); isLit {
+			return c, lit, true
+		}
+	}
+	if c, isSelf := singleSelfChain(args[1]); isSelf {
+		if lit, isLit := constLiteral(args[0]); isLit {
+			return c, lit, true
+		}
+	}
+	return nil, "", false
+}
+
+// singleSelfChain returns the dotted-path chain of the expression iff the
+// expression is itself a self.* chain and contains no other identifiers. It
+// rejects expressions with nested calls, comparisons, or arithmetic.
+func singleSelfChain(e ast.Expr) ([]string, bool) {
+	chain, ok := selfChainOf(e)
+	if !ok || len(chain) == 0 {
+		return nil, false
+	}
+	return chain, true
+}
+
+func constLiteral(e ast.Expr) (string, bool) {
+	if e.Kind() != ast.LiteralKind {
+		return "", false
+	}
+	return literalString(e.AsLiteral()), true
+}
+
+func stringLiteral(v ref.Val) (string, bool) {
+	if v == nil {
+		return "", false
+	}
+	if v.Type() == types.StringType {
+		s, ok := v.Value().(string)
+		return s, ok
+	}
+	return "", false
+}
+
+func literalString(v ref.Val) string {
+	if v == nil {
+		return ""
+	}
+	switch raw := v.Value().(type) {
+	case string:
+		return fmt.Sprintf("%q", raw)
+	case bool:
+		return fmt.Sprintf("%t", raw)
+	default:
+		return fmt.Sprintf("%v", raw)
+	}
+}
+
+// visit performs a pre-order traversal of the AST and invokes fn for every
+// non-nil expression. Used by the chain collector; rule-4 patterns inspect
+// only the root and a small fixed depth, so they do not need a visitor.
+func visit(e ast.Expr, fn func(ast.Expr)) {
+	if e == nil {
+		return
+	}
+	fn(e)
+	switch e.Kind() {
+	case ast.CallKind:
+		call := e.AsCall()
+		if call.IsMemberFunction() {
+			visit(call.Target(), fn)
+		}
+		for _, a := range call.Args() {
+			visit(a, fn)
+		}
+	case ast.SelectKind:
+		visit(e.AsSelect().Operand(), fn)
+	case ast.ListKind:
+		for _, el := range e.AsList().Elements() {
+			visit(el, fn)
+		}
+	case ast.MapKind:
+		for _, entry := range e.AsMap().Entries() {
+			m := entry.AsMapEntry()
+			visit(m.Key(), fn)
+			visit(m.Value(), fn)
+		}
+	case ast.StructKind:
+		for _, f := range e.AsStruct().Fields() {
+			visit(f.AsStructField().Value(), fn)
+		}
+	case ast.ComprehensionKind:
+		c := e.AsComprehension()
+		visit(c.IterRange(), fn)
+		visit(c.AccuInit(), fn)
+		visit(c.LoopCondition(), fn)
+		visit(c.LoopStep(), fn)
+		visit(c.Result(), fn)
+	}
+}

--- a/internal/schema/cel/lint_test.go
+++ b/internal/schema/cel/lint_test.go
@@ -1,0 +1,165 @@
+package cel
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+func TestLintValidations_AcceptsValidRules(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.payments.min_amount < self.payments.max_amount", Message: "min < max"},
+		{Rule: "self.payments.refunds_enabled ? has(self.payments.refund_window) : true", Message: "refund window required"},
+	}
+	require.NoError(t, LintValidations(rules, showcaseFields()))
+}
+
+func TestLintValidations_Rule1_SyntaxError(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.payments.min_amount <", Message: "broken"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validations[0]:")
+}
+
+func TestLintValidations_Rule2_NoSelfReference(t *testing.T) {
+	cases := []struct {
+		name string
+		rule string
+	}{
+		{"constant", "1 == 1"},
+		{"tenant only", `tenant.id == "x"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := LintValidations([]*pb.ValidationRule{{Rule: tc.rule, Message: "x"}}, showcaseFields())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "at least one self.* field")
+		})
+	}
+}
+
+func TestLintValidations_Rule3_UnknownPath(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.unknown.path > 0", Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "self.unknown.path does not resolve")
+}
+
+func TestLintValidations_Rule3_HyphenatedSegmentResolves(t *testing.T) {
+	fields := []*pb.SchemaField{
+		{Path: "app-name.title", Type: pb.FieldType_FIELD_TYPE_STRING},
+	}
+	rules := []*pb.ValidationRule{
+		{Rule: `self["app-name"].title != ""`, Message: "title required"},
+	}
+	require.NoError(t, LintValidations(rules, fields))
+}
+
+func TestLintValidations_Rule3_ParentPrefixTolerated(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "has(self.payments) && self.payments.min_amount < self.payments.max_amount", Message: "x"},
+	}
+	require.NoError(t, LintValidations(rules, showcaseFields()),
+		"self.payments alone is a parent prefix of declared leaves, must be tolerated")
+}
+
+func TestLintValidations_Rule4_NumericComparison(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.payments.min_amount > 0.0", Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use exclusiveMinimum")
+}
+
+func TestLintValidations_Rule4_GTE(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.payments.max_amount >= 100.0", Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use minimum: 100")
+}
+
+func TestLintValidations_Rule4_Equality(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: `self.payments.refunds_enabled == true`, Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use enum:")
+}
+
+func TestLintValidations_Rule4_EnumOrChain(t *testing.T) {
+	fields := []*pb.SchemaField{
+		{Path: "mode", Type: pb.FieldType_FIELD_TYPE_STRING},
+	}
+	rules := []*pb.ValidationRule{
+		{Rule: `self.mode == "a" || self.mode == "b" || self.mode == "c"`, Message: "x"},
+	}
+	err := LintValidations(rules, fields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use enum:")
+	assert.Contains(t, err.Error(), `"a"`)
+	assert.Contains(t, err.Error(), `"c"`)
+}
+
+func TestLintValidations_Rule4_DependentRequired(t *testing.T) {
+	fields := []*pb.SchemaField{
+		{Path: "a", Type: pb.FieldType_FIELD_TYPE_STRING, Nullable: true},
+		{Path: "b", Type: pb.FieldType_FIELD_TYPE_STRING, Nullable: true},
+	}
+	rules := []*pb.ValidationRule{
+		{Rule: "!has(self.a) || has(self.b)", Message: "x"},
+	}
+	err := LintValidations(rules, fields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use dependentRequired")
+	assert.Contains(t, err.Error(), "a: [b]")
+}
+
+func TestLintValidations_Rule4_BoundedRange(t *testing.T) {
+	fields := []*pb.SchemaField{
+		{Path: "x", Type: pb.FieldType_FIELD_TYPE_NUMBER},
+	}
+	rules := []*pb.ValidationRule{
+		{Rule: "self.x > 0.0 && self.x < 100.0", Message: "x"},
+	}
+	err := LintValidations(rules, fields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use minimum:")
+	assert.Contains(t, err.Error(), "and maximum:")
+}
+
+func TestLintValidations_Rule4_CrossFieldNotSubstitutable(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "self.payments.min_amount < self.payments.max_amount", Message: "x"},
+	}
+	require.NoError(t, LintValidations(rules, showcaseFields()))
+}
+
+func TestLintValidations_AggregatesAcrossRules(t *testing.T) {
+	rules := []*pb.ValidationRule{
+		{Rule: "1 == 1", Message: "no self ref"},
+		{Rule: "self.unknown > 0.0", Message: "bad path"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "validations[0]:")
+	assert.Contains(t, msg, "validations[1]:")
+	assert.Equal(t, 2, strings.Count(msg, "validations["))
+}
+
+func TestLintValidations_NoRulesIsNoOp(t *testing.T) {
+	require.NoError(t, LintValidations(nil, showcaseFields()))
+	require.NoError(t, LintValidations([]*pb.ValidationRule{}, showcaseFields()))
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/authz"
 	"github.com/opendecree/decree/internal/pagination"
+	celpkg "github.com/opendecree/decree/internal/schema/cel"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/telemetry"
 	"github.com/opendecree/decree/internal/validation"
@@ -844,6 +845,9 @@ func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest)
 	}
 	depReqs := parsed.DependentRequired
 	if err := validateDependentRequiredAgainstFields(depReqs, fields); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := celpkg.LintValidations(parsed.Validations, fields); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	depReqJSON, err := marshalDependentRequired(depReqs)

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -812,6 +812,59 @@ func TestImportSchema_MissingSyntax(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func TestImportSchema_RejectsInvalidCELRule(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	yaml := []byte(`spec_version: v1
+name: cel-bad
+fields:
+  payments.min:
+    type: integer
+  payments.max:
+    type: integer
+validations:
+  - rule: "self.unknown.path > 0"
+    message: "unknown field"
+`)
+
+	_, err := svc.ImportSchema(ctx, &pb.ImportSchemaRequest{YamlContent: yaml})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "self.unknown.path does not resolve")
+}
+
+func TestImportSchema_AcceptsValidCELRule(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	store.On("GetSchemaByName", ctx, "cel-good").Return(domain.Schema{}, domain.ErrNotFound)
+	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
+		Return(domain.Schema{ID: testSchemaID, Name: "cel-good"}, nil)
+	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
+		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
+	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
+		Return(domain.SchemaField{Path: "payments.min", FieldType: "integer"}, nil)
+
+	yaml := []byte(`spec_version: v1
+name: cel-good
+fields:
+  payments.min:
+    type: integer
+  payments.max:
+    type: integer
+validations:
+  - rule: "self.payments.min < self.payments.max"
+    message: "min must be less than max"
+`)
+
+	resp, err := svc.ImportSchema(ctx, &pb.ImportSchemaRequest{YamlContent: yaml})
+	require.NoError(t, err)
+	assert.Equal(t, "cel-good", resp.Schema.Name)
+}
+
 func TestImportSchema_LookupError(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	reflpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 	"google.golang.org/grpc/status"
@@ -371,11 +372,35 @@ func startReflectionTestServer(t *testing.T, enableReflection bool) (*grpc.Clien
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 
+	waitForReady(t, conn)
+
 	cleanup := func() {
 		_ = conn.Close()
 		srv.GracefulStop(context.Background())
 	}
 	return conn, cleanup
+}
+
+// waitForReady drives the lazy ClientConn to Ready before returning. Without
+// this, the test goroutine can race with the server's accept loop: grpc.NewClient
+// is non-blocking and the first RPC may resolve before the gRPC server has
+// registered handlers on the kernel-queued connection, surfacing as
+// codes.Unknown instead of codes.Unimplemented. Polling state instead of
+// blocking on grpc.WithBlock (deprecated) keeps the test on the supported API.
+func waitForReady(t *testing.T, conn *grpc.ClientConn) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn.Connect()
+	for {
+		state := conn.GetState()
+		if state == connectivity.Ready {
+			return
+		}
+		if !conn.WaitForStateChange(ctx, state) {
+			t.Fatalf("ClientConn did not reach Ready within deadline (last state %s)", state)
+		}
+	}
 }
 
 func callReflection(ctx context.Context, conn *grpc.ClientConn) error {


### PR DESCRIPTION
## Summary

- Compiles every `ValidationRule` at `ImportSchema` time and surfaces violations as `InvalidArgument` with one aggregated multi-line message per schema. Cross-field rules now fail-closed at schema-publish time instead of failing one user later.
- Caches the resulting `cel.Program` in an in-process `sync.Map` keyed by `(schemaID, schemaVersion, ruleIndex)` with `cel.CostLimit` and `cel.InterruptCheckFrequency` set as `ProgramOption`s, ready for the per-write evaluation pass landing in #373.
- Implements all four brief lint rules:
  1. Syntactic CEL validity, with line/column.
  2. At least one `self.*` reference (rejects pure-constant and tenant-only rules).
  3. Every `self.<path>` chain resolves to a declared field path, with parent prefixes tolerated and hyphenated segments handled via `self["foo-bar"]` index syntax. `has()` is detected via cel-go's `IsTestOnly` rather than a `Call` name match.
  4. Native-substitutable patterns rejected with the suggested keyword: numeric comparisons → `minimum`/`maximum`/`exclusive*`; OR-chain of equalities → `enum`; `!has(a) || has(b)` → `dependentRequired`; `lo < self.x && self.x < hi` → `min`+`max`. Anything else passes (false-negatives accepted; no false-positives).
- Operator-tunable DoS guard via two env vars documented in `docs/server/configuration.md`: `DECREE_CEL_COST_LIMIT` (default 100_000) and `DECREE_CEL_INTERRUPT_FREQ` (default 100).

## Test plan

- [x] `go test ./internal/schema/cel/...` — lint rules 1–4 (every shape), aggregation across rules, hyphenated path resolution, parent-prefix tolerance, cross-field non-substitutability, cache memoisation, cache invalidation by schema, compile-failure surfacing.
- [x] `go test ./internal/schema/...` — `TestImportSchema_RejectsInvalidCELRule` and `TestImportSchema_AcceptsValidCELRule` cover the wired path through the service.
- [x] `make pre-commit` green; `internal` coverage holds above threshold (82.6% > 81.9%).
- [x] `make lint-proto` clean (no proto touched).

Closes #372. Part of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)