### PR TITLE
docs(cli): add generated reference for audit verify subcommand

### DIFF
--- a/docs/cli/decree_audit_verify.md
+++ b/docs/cli/decree_audit_verify.md
@@ -1,0 +1,44 @@
+---
+title: decree audit verify
+---
+
+## decree audit verify
+
+Verify the tamper-evident audit chain for a tenant
+
+### Synopsis
+
+Fetches all audit entries for the tenant (or the global chain if --tenant is
+omitted), recomputes each entry_hash, and reports any breaks.
+
+Requires migration 002_audit_tamper_evident to be applied.
+
+```
+decree audit verify [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for verify
+      --tenant string   tenant ID to verify (empty = global chain)
+```
+
+### Options inherited from parent commands
+
+```
+      --insecure              skip TLS verification (default true)
+  -o, --output string         output format: table, json, yaml (default "table")
+      --role string           actor role (x-role header) (default "superadmin")
+      --server string         gRPC server address (default "localhost:9090")
+      --subject string        actor identity (x-subject header)
+      --tenant-id string      auth tenant ID (x-tenant-id header)
+      --token string          JWT bearer token
+      --wait                  wait for the server to be ready before executing the command
+      --wait-timeout string   maximum time to wait for server readiness (default "60s")
+```
+
+### SEE ALSO
+
+* [decree audit](decree_audit.md)	 - Query audit logs and usage statistics
+

--- a/docs/man/decree-audit-verify.1
+++ b/docs/man/decree-audit-verify.1
@@ -1,0 +1,67 @@
+.nh
+.TH "DECREE" "1" "Jan 2026" "OpenDecree" "OpenDecree CLI"
+
+.SH NAME
+decree-audit-verify - Verify the tamper-evident audit chain for a tenant
+
+
+.SH SYNOPSIS
+\fBdecree audit verify [flags]\fP
+
+
+.SH DESCRIPTION
+Fetches all audit entries for the tenant (or the global chain if --tenant is
+omitted), recomputes each entry_hash, and reports any breaks.
+
+.PP
+Requires migration 002_audit_tamper_evident to be applied.
+
+
+.SH OPTIONS
+\fB-h\fP, \fB--help\fP[=false]
+	help for verify
+
+.PP
+\fB--tenant\fP=""
+	tenant ID to verify (empty = global chain)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+\fB--insecure\fP[=true]
+	skip TLS verification
+
+.PP
+\fB-o\fP, \fB--output\fP="table"
+	output format: table, json, yaml
+
+.PP
+\fB--role\fP="superadmin"
+	actor role (x-role header)
+
+.PP
+\fB--server\fP="localhost:9090"
+	gRPC server address
+
+.PP
+\fB--subject\fP=""
+	actor identity (x-subject header)
+
+.PP
+\fB--tenant-id\fP=""
+	auth tenant ID (x-tenant-id header)
+
+.PP
+\fB--token\fP=""
+	JWT bearer token
+
+.PP
+\fB--wait\fP[=false]
+	wait for the server to be ready before executing the command
+
+.PP
+\fB--wait-timeout\fP="60s"
+	maximum time to wait for server readiness
+
+
+.SH SEE ALSO
+\fBdecree-audit(1)\fP


### PR DESCRIPTION
## Summary
- The `decree audit verify` command was implemented but its generated CLI reference (markdown) and man page were never committed alongside it, leaving a gap in the published docs.

## Test plan
- Verify `docs/cli/decree_audit_verify.md` renders correctly in the docs site
- Verify `docs/man/decree-audit-verify.1` follows the same format as sibling man pages (e.g. `decree-audit-query.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)