### PR TITLE
chore(deps): ignore grpc >= 1.81.0 for go 1.24-floor modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,9 @@ updates:
       # grpc-gateway 2.29+ also requires go 1.25.
       - dependency-name: "github.com/grpc-ecosystem/grpc-gateway/v2"
         versions: [">=2.29.0"]
+      # grpc 1.81+ requires go 1.25.
+      - dependency-name: "google.golang.org/grpc"
+        versions: [">=1.81.0"]
 
   # ── Tier: 1.22-floor (SDK core: configclient, adminclient, configwatcher) ─
   # Consumer-facing SDK modules; must stay installable with go 1.22 toolchains.


### PR DESCRIPTION
## Summary
- grpc 1.81.0 raised its minimum Go version to 1.25, but our 1.24-floor tier (`/api`, `/cmd/decree`, `/sdk/grpctransport`, `/sdk/tools`) must not cross that boundary until the floor is explicitly raised.
- Without this ignore rule, dependabot opens PRs (currently decree#366) that would break builds for those modules.
- Follows the same pattern already in place for grpc-gateway 2.29+ and otel 1.42+.

## Test plan
- Verify dependabot no longer opens grpc 1.81+ PRs for the 1.24-floor directories
- Confirm decree#366 can now be closed as superseded

🤖 Generated with [Claude Code](https://claude.com/claude-code)