### PR TITLE
refactor(schema): replace containsStr with slices.Contains

### DIFF
--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -63,15 +63,6 @@ func errToStatus(err error, notFoundMsg, failedMsg string) error {
 	return status.Error(codes.Internal, failedMsg)
 }
 
-func containsStr(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
 // Option configures a Service.
 type Option func(*serviceOptions)
 

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -345,7 +346,7 @@ func (m *MemoryStore) ListTenants(_ context.Context, arg ListTenantsParams) ([]d
 
 	all := make([]domain.Tenant, 0, len(m.tenants))
 	for _, t := range m.tenants {
-		if arg.AllowedTenantIDs != nil && !containsStr(arg.AllowedTenantIDs, t.ID) {
+		if arg.AllowedTenantIDs != nil && !slices.Contains(arg.AllowedTenantIDs, t.ID) {
 			continue
 		}
 		all = append(all, t)
@@ -364,7 +365,7 @@ func (m *MemoryStore) ListTenantsBySchema(_ context.Context, arg ListTenantsBySc
 		if t.SchemaID != arg.SchemaID {
 			continue
 		}
-		if arg.AllowedTenantIDs != nil && !containsStr(arg.AllowedTenantIDs, t.ID) {
+		if arg.AllowedTenantIDs != nil && !slices.Contains(arg.AllowedTenantIDs, t.ID) {
 			continue
 		}
 		filtered = append(filtered, t)


### PR DESCRIPTION
## Summary

- Removes the hand-rolled `containsStr` helper from the `schema` package in favor of the standard library `slices.Contains` (available since Go 1.21, well within our 1.25 server floor).
- Eliminates dead utility code and makes the intent at each call site clearer without any behavioral change.

## Test plan

- [x] All existing `make test` tests pass without modification — the change is a direct semantic replacement.
- [x] `make lint` passes (gofumpt, golangci-lint).

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)