### PR TITLE
refactor: consolidate stream-wrapper types into internal/grpcutil

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -12,6 +12,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/opendecree/decree/internal/grpcutil"
 )
 
 // Role represents a user's role in the system.
@@ -139,7 +141,7 @@ func (i *Interceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 		if err != nil {
 			return err
 		}
-		return handler(srv, &wrappedStream{ServerStream: ss, ctx: newCtx})
+		return handler(srv, grpcutil.NewWrappedStream(ss, newCtx))
 	}
 }
 
@@ -194,14 +196,4 @@ func extractBearerToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("invalid authorization format")
 	}
 	return strings.TrimPrefix(token, "Bearer "), nil
-}
-
-// wrappedStream wraps a grpc.ServerStream to override the context.
-type wrappedStream struct {
-	grpc.ServerStream
-	ctx context.Context
-}
-
-func (w *wrappedStream) Context() context.Context {
-	return w.ctx
 }

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/opendecree/decree/internal/grpcutil"
 )
 
 // skipAuth returns true for gRPC methods that should bypass authentication.
@@ -96,7 +98,7 @@ func (m *MetadataInterceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 		if err != nil {
 			return err
 		}
-		return handler(srv, &wrappedStream{ServerStream: ss, ctx: newCtx})
+		return handler(srv, grpcutil.NewWrappedStream(ss, newCtx))
 	}
 }
 

--- a/internal/grpcutil/stream.go
+++ b/internal/grpcutil/stream.go
@@ -1,0 +1,23 @@
+package grpcutil
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// WrappedStream wraps a grpc.ServerStream to override its context.
+type WrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+// NewWrappedStream returns a WrappedStream that substitutes the given context
+// for the stream's original context.
+func NewWrappedStream(ss grpc.ServerStream, ctx context.Context) *WrappedStream {
+	return &WrappedStream{ServerStream: ss, ctx: ctx}
+}
+
+func (w *WrappedStream) Context() context.Context {
+	return w.ctx
+}

--- a/internal/server/logfields.go
+++ b/internal/server/logfields.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/grpcutil"
 	"github.com/opendecree/decree/internal/telemetry"
 )
 
@@ -30,7 +31,7 @@ func logFieldsUnaryInterceptor() grpc.UnaryServerInterceptor {
 // logFieldsStreamInterceptor is the streaming counterpart to logFieldsUnaryInterceptor.
 func logFieldsStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		return handler(srv, &logFieldsStream{ServerStream: ss, ctx: enrichLogFields(ss.Context())})
+		return handler(srv, grpcutil.NewWrappedStream(ss, enrichLogFields(ss.Context())))
 	}
 }
 
@@ -57,10 +58,3 @@ func newRequestID() string {
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
-
-type logFieldsStream struct {
-	grpc.ServerStream
-	ctx context.Context
-}
-
-func (s *logFieldsStream) Context() context.Context { return s.ctx }


### PR DESCRIPTION
## Summary

- Three packages (`auth/jwt`, `auth/metadata`, `server`) each defined a private struct to override a gRPC `ServerStream`'s context. All three were structurally identical — embed `grpc.ServerStream`, store a `context.Context`, override `Context()`.
- Consolidating into a single `grpcutil.WrappedStream` (with a `NewWrappedStream` constructor) eliminates the duplication and gives future interceptors a single well-known type to use or extend.

## Test plan

- [x] All existing `make test` tests pass — the change is purely structural, with no behavioral difference.
- [x] `make lint` passes (gofumpt, golangci-lint).

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)