### PR TITLE
chore(configwatcher): delete unused mockSubscriptionBlocking

### DIFF
--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -142,4 +142,3 @@ func TestWatcher_ConcurrentStartAndClose(t *testing.T) {
 	cancel()
 	_ = w.Close()
 }
-

--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -3,7 +3,6 @@ package configwatcher
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"sync"
 	"testing"
@@ -144,13 +143,3 @@ func TestWatcher_ConcurrentStartAndClose(t *testing.T) {
 	_ = w.Close()
 }
 
-// mockSubscriptionBlocking is a subscription that blocks until context is cancelled.
-// Used by race tests that don't need actual stream data.
-type mockSubscriptionBlocking struct {
-	ctx context.Context
-}
-
-func (s *mockSubscriptionBlocking) Recv() (*configclient.ConfigChange, error) {
-	<-s.ctx.Done()
-	return nil, io.EOF
-}


### PR DESCRIPTION
## Summary

- `mockSubscriptionBlocking` was defined in `race_test.go` but never instantiated in any test — it was dead code from the start.
- Removing it along with the now-orphaned `"io"` import keeps the test file honest about what it actually exercises.

## Test plan

- [x] `make test` passes, including the race detector (`go test -race` via `make test`).
- [x] `make lint` passes.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)