### PR TITLE
test(auth): add unit tests for RequireSuperAdmin and RequireAdminOrAbove

### DIFF
--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -84,3 +84,66 @@ func TestMustHaveClaims_WithClaims(t *testing.T) {
 	ctx := ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin})
 	assert.NoError(t, MustHaveClaims(ctx))
 }
+
+func TestRequireSuperAdmin(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  *Claims
+		wantErr codes.Code
+	}{
+		{"no claims — permissive", nil, codes.OK},
+		{"superadmin — allowed", &Claims{Role: RoleSuperAdmin}, codes.OK},
+		{"admin — denied", &Claims{Role: RoleAdmin}, codes.PermissionDenied},
+		{"user — denied", &Claims{Role: RoleUser}, codes.PermissionDenied},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.claims != nil {
+				ctx = ContextWithClaims(ctx, tc.claims)
+			}
+			err := RequireSuperAdmin(ctx)
+			if tc.wantErr == codes.OK {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, status.Code(err))
+			}
+		})
+	}
+}
+
+func TestRequireAdminOrAbove(t *testing.T) {
+	tests := []struct {
+		name    string
+		claims  *Claims
+		wantErr codes.Code
+	}{
+		{"no claims — permissive", nil, codes.OK},
+		{"superadmin — allowed", &Claims{Role: RoleSuperAdmin}, codes.OK},
+		{"admin — allowed", &Claims{Role: RoleAdmin}, codes.OK},
+		{"user — denied", &Claims{Role: RoleUser}, codes.PermissionDenied},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.claims != nil {
+				ctx = ContextWithClaims(ctx, tc.claims)
+			}
+			err := RequireAdminOrAbove(ctx)
+			if tc.wantErr == codes.OK {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, tc.wantErr, status.Code(err))
+			}
+		})
+	}
+}
+
+func TestIsSuperAdmin(t *testing.T) {
+	assert.True(t, IsSuperAdmin(context.Background()), "no claims — permissive")
+	assert.True(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin})))
+	assert.False(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleAdmin})))
+	assert.False(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleUser})))
+}


### PR DESCRIPTION
## Summary

- `RequireSuperAdmin`, `RequireAdminOrAbove`, and the package-level `IsSuperAdmin` had no direct unit tests — only indirect coverage through the service layer.
- Adding table-driven tests that cover every role (superadmin, admin, user) plus the no-claims permissive path for each function, making regressions immediately visible at the lowest possible level.

## Test plan

- [x] `TestRequireSuperAdmin` — 4 cases: no claims, superadmin, admin, user.
- [x] `TestRequireAdminOrAbove` — 4 cases: no claims, superadmin, admin, user.
- [x] `TestIsSuperAdmin` — 4 inline assertions covering no claims and all three roles.
- [x] All tests pass under `go test ./internal/auth/...`.
- [x] `make lint` passes.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)