### PR TITLE
test(schema): add parameterized table test for errToStatus

### DIFF
--- a/internal/schema/errtostatus_test.go
+++ b/internal/schema/errtostatus_test.go
@@ -1,0 +1,60 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+func TestErrToStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		notFoundMsg string
+		failedMsg   string
+		wantCode    codes.Code
+		wantMsgPart string
+	}{
+		{
+			name:        "ErrNotFound maps to NotFound",
+			err:         domain.ErrNotFound,
+			notFoundMsg: "thing not found",
+			failedMsg:   "failed to get thing",
+			wantCode:    codes.NotFound,
+			wantMsgPart: "thing not found",
+		},
+		{
+			name:        "wrapped ErrNotFound maps to NotFound",
+			err:         fmt.Errorf("db: %w", domain.ErrNotFound),
+			notFoundMsg: "record not found",
+			failedMsg:   "internal error",
+			wantCode:    codes.NotFound,
+			wantMsgPart: "record not found",
+		},
+		{
+			name:        "other error maps to Internal",
+			err:         errors.New("connection reset"),
+			notFoundMsg: "not found",
+			failedMsg:   "operation failed",
+			wantCode:    codes.Internal,
+			wantMsgPart: "operation failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errToStatus(tc.err, tc.notFoundMsg, tc.failedMsg)
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantCode, st.Code())
+			assert.Contains(t, st.Message(), tc.wantMsgPart)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `errToStatus` had no direct tests — only implicit coverage when service RPCs hit error paths.
- A dedicated table test pins the gRPC code and message routing for each case at the lowest level, making regressions immediately visible without needing to trace through a full RPC call.
- The wrapped-error case explicitly verifies that `errors.Is` semantics are honoured, not just pointer equality.

## Test plan

- [x] `TestErrToStatus/ErrNotFound_maps_to_NotFound` — direct sentinel.
- [x] `TestErrToStatus/wrapped_ErrNotFound_maps_to_NotFound` — verifies `errors.Is` unwrapping.
- [x] `TestErrToStatus/other_error_maps_to_Internal` — any non-NotFound error → Internal.
- [x] All tests pass under `go test ./internal/schema/...`.
- [x] `make lint` passes.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)