### PR TITLE
test(ratelimit): cover WithInterceptorLogger and WithRejectedCounter

### DIFF
--- a/internal/ratelimit/options_test.go
+++ b/internal/ratelimit/options_test.go
@@ -1,0 +1,59 @@
+package ratelimit_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/internal/ratelimit"
+)
+
+// countingCounter wraps noop.Int64Counter to track Add calls.
+type countingCounter struct {
+	noop.Int64Counter
+	n atomic.Int64
+}
+
+func (c *countingCounter) Add(_ context.Context, incr int64, _ ...metric.AddOption) {
+	c.n.Add(incr)
+}
+
+func TestWithInterceptorLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	denying := ratelimit.NewInProcess(rate.Limit(0), 0)
+	i := ratelimit.New(ratelimit.Config{Anonymous: denying},
+		ratelimit.WithInterceptorLogger(logger),
+	)
+
+	// Health-check methods emit a debug log via the configured logger.
+	err := invokeUnary(t, i, context.Background(), "/grpc.health.v1.Health/Check")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "rate limit exempt")
+}
+
+func TestWithRejectedCounter(t *testing.T) {
+	counter := &countingCounter{}
+
+	denying := ratelimit.NewInProcess(rate.Limit(0), 0)
+	i := ratelimit.New(ratelimit.Config{Anonymous: denying},
+		ratelimit.WithRejectedCounter(counter),
+	)
+
+	err := invokeUnary(t, i, context.Background(), testMethod)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Equal(t, int64(1), counter.n.Load())
+}


### PR DESCRIPTION
## Summary

- Both `WithInterceptorLogger` and `WithRejectedCounter` had no tests — they could be silently dropped from the wiring without any failure catching it.
- `WithInterceptorLogger` is exercised by confirming that a health-check call writes the expected debug log entry to the supplied logger.
- `WithRejectedCounter` is exercised by confirming that a rejected unary call increments the counter exactly once, using a lightweight `noop`-embedded stub that captures `Add` calls without pulling in the full OTel SDK.

## Test plan

- [x] `TestWithInterceptorLogger` — health-check call with a zero-capacity limiter passes (exempt), and the custom logger receives the `"rate limit exempt"` debug entry.
- [x] `TestWithRejectedCounter` — non-exempt call with a zero-capacity limiter is rejected with `ResourceExhausted`, and the counter records exactly 1 increment.
- [x] Both tests pass under `go test ./internal/ratelimit/...`.
- [x] `make lint` passes.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)