### PR TITLE
feat(validation): add OTEL metric for JSON-Schema compile timeouts

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -254,14 +254,19 @@ func run() int {
 	cacheMetrics := telemetry.NewCacheMetrics(otelCfg)
 	configMetrics := telemetry.NewConfigMetrics(otelCfg)
 	schemaMetrics := telemetry.NewSchemaMetrics(otelCfg)
+	validationMetrics := telemetry.NewValidationMetrics(otelCfg)
 
 	// Validator factory (shared between schema + config services).
-	validatorFactory := validation.NewValidatorFactory(validatorStore,
+	validatorOpts := []validation.Option{
 		validation.WithLimits(validation.Limits{
 			CompileTimeout: cfg.SchemaCompileTimeout,
 			MaxDepth:       cfg.SchemaMaxRefDepth,
 		}),
-	)
+	}
+	if counter, ok := validationMetrics.TimeoutCounter(); ok {
+		validatorOpts = append(validatorOpts, validation.WithTimeoutCounter(counter))
+	}
+	validatorFactory := validation.NewValidatorFactory(validatorStore, validatorOpts...)
 
 	// Usage recorder — async batched read tracking for audit stats.
 	var recorder *audit.UsageRecorder

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -24,26 +24,29 @@ type Config struct {
 	MetricsSchema bool
 	// MetricsRateLimit enables the rate-limit rejection counter (role + method attributes).
 	MetricsRateLimit bool
+	// MetricsValidation enables validation counters (e.g. JSON-Schema compile timeouts).
+	MetricsValidation bool
 }
 
 // AnyMetrics returns true if any metric flag is enabled.
 func (c Config) AnyMetrics() bool {
-	return c.MetricsGRPC || c.MetricsDBPool || c.MetricsCache || c.MetricsConfig || c.MetricsSchema || c.MetricsRateLimit
+	return c.MetricsGRPC || c.MetricsDBPool || c.MetricsCache || c.MetricsConfig || c.MetricsSchema || c.MetricsRateLimit || c.MetricsValidation
 }
 
 // ConfigFromEnv parses telemetry configuration from environment variables.
 func ConfigFromEnv() Config {
 	return Config{
-		Enabled:          envBool("OTEL_ENABLED"),
-		TracesGRPC:       envBool("OTEL_TRACES_GRPC"),
-		TracesDB:         envBool("OTEL_TRACES_DB"),
-		TracesRedis:      envBool("OTEL_TRACES_REDIS"),
-		MetricsGRPC:      envBool("OTEL_METRICS_GRPC"),
-		MetricsDBPool:    envBool("OTEL_METRICS_DB_POOL"),
-		MetricsCache:     envBool("OTEL_METRICS_CACHE"),
-		MetricsConfig:    envBool("OTEL_METRICS_CONFIG"),
-		MetricsSchema:    envBool("OTEL_METRICS_SCHEMA"),
-		MetricsRateLimit: envBool("OTEL_METRICS_RATE_LIMIT"),
+		Enabled:           envBool("OTEL_ENABLED"),
+		TracesGRPC:        envBool("OTEL_TRACES_GRPC"),
+		TracesDB:          envBool("OTEL_TRACES_DB"),
+		TracesRedis:       envBool("OTEL_TRACES_REDIS"),
+		MetricsGRPC:       envBool("OTEL_METRICS_GRPC"),
+		MetricsDBPool:     envBool("OTEL_METRICS_DB_POOL"),
+		MetricsCache:      envBool("OTEL_METRICS_CACHE"),
+		MetricsConfig:     envBool("OTEL_METRICS_CONFIG"),
+		MetricsSchema:     envBool("OTEL_METRICS_SCHEMA"),
+		MetricsRateLimit:  envBool("OTEL_METRICS_RATE_LIMIT"),
+		MetricsValidation: envBool("OTEL_METRICS_VALIDATION"),
 	}
 }
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -131,6 +131,31 @@ func (m *RateLimitMetrics) Counter() (metric.Int64Counter, bool) {
 	return m.rejected, true
 }
 
+// ValidationMetrics records validation-related counters.
+type ValidationMetrics struct {
+	compileTimeouts metric.Int64Counter
+}
+
+// NewValidationMetrics creates validation metrics. Returns nil if not enabled.
+func NewValidationMetrics(cfg Config) *ValidationMetrics {
+	if !cfg.Enabled || !cfg.MetricsValidation {
+		return nil
+	}
+	meter := otel.Meter(meterName)
+	timeouts, _ := meter.Int64Counter("validation.json_schema_compile_timeouts_total",
+		metric.WithDescription("Number of JSON-Schema compile goroutines that exceeded their deadline"))
+	return &ValidationMetrics{compileTimeouts: timeouts}
+}
+
+// TimeoutCounter returns the underlying Int64Counter and true when metrics are
+// enabled, or a nil interface and false when disabled.
+func (m *ValidationMetrics) TimeoutCounter() (metric.Int64Counter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.compileTimeouts, true
+}
+
 // StartDBPoolMetrics starts a background goroutine that periodically records
 // DB connection pool statistics. Returns immediately if not enabled.
 func StartDBPoolMetrics(ctx context.Context, cfg Config, writePool, readPool *pgxpool.Pool) {

--- a/internal/validation/json_schema.go
+++ b/internal/validation/json_schema.go
@@ -1,10 +1,13 @@
 package validation
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
@@ -17,13 +20,21 @@ type jsonSchemaValidator struct {
 // newJSONSchemaValidator compiles a JSON Schema document for validation.
 // limits.MaxDepth bounds structural nesting before compile;
 // limits.CompileTimeout caps the wall-clock duration of the compile call.
+// timeoutCounter, if non-nil, is incremented when the deadline fires.
 //
-// Note: jsonschema/v6 has no CompileContext, so a compile that exceeds the
-// deadline will continue running in its goroutine until it finishes (or
-// the process exits). The pre-compile depth check and upstream document-
-// size cap (schema.Limits.MaxDocBytes) bound the worst-case work; the
-// timeout is a defense-in-depth backstop against unanticipated pathologies.
-func newJSONSchemaValidator(schemaDoc string, limits Limits) (*jsonSchemaValidator, error) {
+// Goroutine leak: jsonschema/v6 has no CompileContext, so a compile that
+// exceeds the deadline will continue running until it finishes or the
+// process exits. This is acceptable because:
+//   - The pre-compile depth check (MaxDepth) rejects deeply-nested bombs
+//     before the goroutine is started.
+//   - The upstream document-size cap (schema.Limits.MaxDocBytes) bounds
+//     the total input the compiler can process.
+//
+// Together these make the worst-case work finite. The timeout is a
+// defence-in-depth backstop against unanticipated compiler pathologies.
+// When it fires, the counter "validation.json_schema_compile_timeouts_total"
+// is incremented so operators can alert on sustained activity.
+func newJSONSchemaValidator(schemaDoc string, limits Limits, timeoutCounter metric.Int64Counter) (*jsonSchemaValidator, error) {
 	if limits.MaxDepth > 0 {
 		if err := scanJSONDepth(schemaDoc, limits.MaxDepth); err != nil {
 			return nil, err
@@ -64,6 +75,9 @@ func newJSONSchemaValidator(schemaDoc string, limits Limits) (*jsonSchemaValidat
 	case r := <-ch:
 		return r.v, r.err
 	case <-timer.C:
+		if timeoutCounter != nil {
+			timeoutCounter.Add(context.Background(), 1)
+		}
 		return nil, fmt.Errorf("compile json schema: timeout after %s", limits.CompileTimeout)
 	}
 }

--- a/internal/validation/json_schema_test.go
+++ b/internal/validation/json_schema_test.go
@@ -1,13 +1,28 @@
 package validation
 
 import (
+	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// countingCounter wraps noop.Int64Counter to track Add calls.
+type countingCounter struct {
+	noop.Int64Counter
+	n atomic.Int64
+}
+
+func (c *countingCounter) Add(_ context.Context, incr int64, _ ...metric.AddOption) {
+	c.n.Add(incr)
+}
 
 func TestDefaultLimits(t *testing.T) {
 	l := DefaultLimits()
@@ -17,7 +32,7 @@ func TestDefaultLimits(t *testing.T) {
 
 func TestNewJSONSchemaValidator_Compiles(t *testing.T) {
 	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
-	v, err := newJSONSchemaValidator(doc, DefaultLimits())
+	v, err := newJSONSchemaValidator(doc, DefaultLimits(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, v)
 	require.NoError(t, v.validate(`{"name":"x"}`))
@@ -27,28 +42,28 @@ func TestNewJSONSchemaValidator_Compiles(t *testing.T) {
 func TestNewJSONSchemaValidator_DepthExceeded(t *testing.T) {
 	// Build a schema with nesting depth 10, then cap MaxDepth to 5.
 	doc := strings.Repeat(`{"properties":{"x":`, 10) + `{"type":"string"}` + strings.Repeat(`}}`, 10)
-	_, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 5})
+	_, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 5}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nesting depth exceeds limit of 5")
 }
 
 func TestNewJSONSchemaValidator_DepthDisabled(t *testing.T) {
 	doc := strings.Repeat(`{"properties":{"x":`, 5) + `{"type":"string"}` + strings.Repeat(`}}`, 5)
-	v, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 0})
+	v, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 0}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, v)
 }
 
 func TestNewJSONSchemaValidator_MalformedJSONFallsThrough(t *testing.T) {
 	// Pre-scan ignores non-JSON; compiler reports the syntax error.
-	_, err := newJSONSchemaValidator(`not-json`, DefaultLimits())
+	_, err := newJSONSchemaValidator(`not-json`, DefaultLimits(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid json schema")
 }
 
 func TestNewJSONSchemaValidator_TimeoutZeroIsUnbounded(t *testing.T) {
 	doc := `{"type":"string"}`
-	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 0, MaxDepth: 0})
+	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 0, MaxDepth: 0}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, v)
 }
@@ -58,10 +73,30 @@ func TestNewJSONSchemaValidator_CompileTimeoutFires(t *testing.T) {
 	// scheduled, unmarshal the document, and push to the (buffered) result
 	// channel — the select therefore reaches the timeout branch.
 	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
-	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0})
+	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}, nil)
 	require.Error(t, err)
 	require.Nil(t, v)
 	assert.Contains(t, err.Error(), "compile json schema: timeout after")
+}
+
+func TestNewJSONSchemaValidator_TimeoutIncrementsCounter(t *testing.T) {
+	// Verify that the timeout branch increments the provided OTEL counter.
+	counter := &countingCounter{}
+	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
+	_, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}, counter)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compile json schema: timeout after")
+	assert.Equal(t, int64(1), counter.n.Load(), "timeout counter should be incremented exactly once")
+}
+
+func TestNewJSONSchemaValidator_SuccessDoesNotIncrementCounter(t *testing.T) {
+	// Successful compile must not increment the counter.
+	counter := &countingCounter{}
+	doc := `{"type":"string"}`
+	v, err := newJSONSchemaValidator(doc, DefaultLimits(), counter)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, int64(0), counter.n.Load(), "counter must not be incremented on success")
 }
 
 func TestScanJSONDepth(t *testing.T) {

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -1,6 +1,10 @@
 package validation
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+)
 
 // Limits caps JSON-Schema compilation cost. Zero values mean "no limit"
 // for that dimension. Use [DefaultLimits] for safe defaults.
@@ -34,17 +38,26 @@ func DefaultLimits() Limits {
 }
 
 // Option configures a [ValidatorFactory] or [FieldValidator]. See
-// [WithLimits].
+// [WithLimits] and [WithTimeoutCounter].
 type Option func(*options)
 
 type options struct {
-	limits Limits
+	limits         Limits
+	timeoutCounter metric.Int64Counter // nil when metrics are disabled
 }
 
 // WithLimits sets the JSON-Schema compile limits. Defaults to
 // [DefaultLimits] when unset.
 func WithLimits(l Limits) Option {
 	return func(o *options) { o.limits = l }
+}
+
+// WithTimeoutCounter sets the OTEL counter incremented when a JSON-Schema
+// compile goroutine exceeds its deadline. The counter name should be
+// "validation.json_schema_compile_timeouts_total". Pass nil to disable
+// (no-op — equivalent to omitting the option).
+func WithTimeoutCounter(c metric.Int64Counter) Option {
+	return func(o *options) { o.timeoutCounter = c }
 }
 
 func resolveOptions(opts []Option) options {

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -157,7 +157,7 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 
 	case pb.FieldType_FIELD_TYPE_JSON:
 		if constraints.JsonSchema != nil {
-			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o.limits)
+			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o.limits, o.timeoutCounter)
 			if err == nil {
 				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 					val := tv.Kind.(*pb.TypedValue_JsonValue).JsonValue


### PR DESCRIPTION
## Summary

- When JSON-Schema compilation times out, the goroutine leaks silently — there is no production signal that this is happening at scale.
- Adds `validation.json_schema_compile_timeouts_total` OTEL counter (enabled via `OTEL_METRICS_VALIDATION=true`) so operators can alert on sustained timeout activity.
- Updates the code comment on the goroutine to document why cancellation is not possible and what pre-scan bounds limit the worst-case work.

## Test plan

- [x] `TestNewJSONSchemaValidator_TimeoutIncrementsCounter` — triggers the 1ns timeout path and asserts the counter increments by 1
- [x] `TestNewJSONSchemaValidator_SuccessDoesNotIncrementCounter` — confirms counter stays at 0 on successful compile
- [x] `make test` passes (all packages, race detector enabled)
- [x] `make lint-go` passes (gofumpt + golangci-lint clean)
- [x] Counter name follows existing OTEL naming conventions in the codebase (`ratelimit.rejected`, `schema.publishes`, etc.)

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)