### PR TITLE
feat(release): expand GoReleaser with Homebrew, deb/rpm/apk, Docker, SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,16 +127,26 @@ jobs:
           ## Install
 
           \`\`\`bash
-          # CLI
+          # Homebrew (macOS / Linux)
+          brew install opendecree/tap/decree
+
+          # CLI via go install
           go install github.com/opendecree/decree/cmd/decree@${TAG}
+
+          # Debian / Ubuntu
+          # Download decree_linux_amd64.deb from Assets below
+          dpkg -i decree_linux_amd64.deb
+
+          # RPM (RHEL / Fedora)
+          # Download decree_linux_amd64.rpm from Assets below
+          rpm -i decree_linux_amd64.rpm
 
           # SDK (grpctransport pulls in configclient + configwatcher)
           go get github.com/opendecree/decree/sdk/grpctransport@${TAG}
           go get github.com/opendecree/decree/sdk/adminclient@${TAG}
 
-          # Docker
+          # Docker (multi-arch: amd64 + arm64)
           docker pull ghcr.io/opendecree/decree:${VERSION}
-          docker pull ghcr.io/opendecree/decree-cli:${VERSION}
           \`\`\`
 
           ## Verify provenance
@@ -179,6 +189,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -191,6 +202,19 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run goreleaser
         # goreleaser/goreleaser-action@v7
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8
@@ -199,6 +223,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Attest binary provenance
         uses: actions/attest-build-provenance@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,95 @@ archives:
         formats:
           - zip
 
+# Linux packages for the decree CLI (deb, rpm, apk).
+nfpms:
+  - id: decree
+    package_name: decree
+    ids:
+      - decree
+    vendor: OpenDecree
+    homepage: https://github.com/opendecree/decree
+    maintainer: OpenDecree <noreply@opendecree.dev>
+    description: decree — the OpenDecree configuration CLI
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/doc/decree/copyright
+
+# Homebrew tap — auto-updates opendecree/homebrew-tap on release.
+# Prerequisites: create opendecree/homebrew-tap (public, empty) and set
+# HOMEBREW_TAP_TOKEN repository secret (classic PAT with repo scope on tap repo).
+brews:
+  - name: decree
+    ids:
+      - decree
+    repository:
+      owner: opendecree
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/opendecree/decree
+    description: decree — the OpenDecree configuration CLI
+    license: Apache-2.0
+    install: |
+      bin.install "decree"
+    test: |
+      system "#{bin}/decree", "version"
+
+# Multi-arch Docker images for decree-server published to ghcr.io.
+dockers:
+  - id: decree-server-amd64
+    ids:
+      - decree-server
+    image_templates:
+      - "ghcr.io/opendecree/decree:{{ .Tag }}-amd64"
+      - "ghcr.io/opendecree/decree:latest-amd64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/opendecree/decree"
+    dockerfile: build/Dockerfile
+    goarch: amd64
+    goos: linux
+
+  - id: decree-server-arm64
+    ids:
+      - decree-server
+    image_templates:
+      - "ghcr.io/opendecree/decree:{{ .Tag }}-arm64"
+      - "ghcr.io/opendecree/decree:latest-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source=https://github.com/opendecree/decree"
+    dockerfile: build/Dockerfile
+    goarch: arm64
+    goos: linux
+
+docker_manifests:
+  - name_template: "ghcr.io/opendecree/decree:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/opendecree/decree:{{ .Tag }}-amd64"
+      - "ghcr.io/opendecree/decree:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/opendecree/decree:latest"
+    image_templates:
+      - "ghcr.io/opendecree/decree:latest-amd64"
+      - "ghcr.io/opendecree/decree:latest-arm64"
+
+# SBOM for all binaries.
+sboms:
+  - artifacts: binary
+
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
## Summary

- Expands the existing GoReleaser config to add Homebrew tap auto-update, Linux packages (deb/rpm/apk for the CLI), multi-arch Docker manifests pushed to `ghcr.io/opendecree/decree`, and SBOM generation.
- Updates the `binaries` release job with `packages: write`, QEMU, Docker Buildx, ghcr.io login, and `HOMEBREW_TAP_TOKEN` env so goreleaser can push Docker images and update the tap.
- Updates the release body template to include Homebrew, dpkg, and rpm install instructions.

## Prerequisites (manual steps before next release)

- [ ] Create `opendecree/homebrew-tap` repo (public, empty — goreleaser will populate it)
- [ ] Add `HOMEBREW_TAP_TOKEN` as a repository secret (classic PAT with `repo` scope on the homebrew-tap repo)

## Test plan

- [x] `.goreleaser.yaml` is syntactically valid YAML
- [x] `release.yml` YAML is valid and all existing jobs are untouched
- [ ] Run `goreleaser check` locally (requires goreleaser installed) to validate the config
- [ ] Next tag push produces: multi-arch binaries + Linux packages + Homebrew formula + Docker manifests + SBOM

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)