### PR TITLE
feat(server): embed admin UI via embed.FS, serve at /admin/

### DIFF
--- a/.agents/context/completed.md
+++ b/.agents/context/completed.md
@@ -191,3 +191,18 @@ SHA-256 hash chain over `audit_write_log` closes the silently-rewritable history
 - **Audit coverage** — schema (create/update/delete/publish/import), tenant (create/update/delete), and lock (lock/unlock) mutations now all write audit entries with correct `object_kind`.
 - **VerifyChain RPC** — new gRPC method `VerifyChain` (proto + generated stubs). Server handler in `internal/audit/service.go`: per-tenant (resolve + access check) or global chain (superadmin only). `internal/audit/verify.go`: fetches ordered entries, recomputes each hash, reports breaks. CLI: `decree audit verify [--tenant <id>]`. Client-side: `adminclient.VerifyChain` + `computeClientHash`.
 - **Bug fixed** — `schema/service.go` `RunInTx` error handlers were converting all errors to `codes.Internal`, swallowing `codes.InvalidArgument` validation errors from `createFieldsOn`. Fixed by checking `status.FromError(err)` and propagating gRPC status errors directly.
+
+## Stress Tests (#27–#29)
+
+Separate `stress/` Go module (`github.com/opendecree/decree/stress`, build tag `stress`) with three test files:
+- **cache_test.go** — `BenchmarkManyTenants_GetAll`, `BenchmarkManyFields_GetAll`, `BenchmarkRapidInvalidation`, `TestCacheEviction` (concurrent readers + writers, asserts zero errors and zero empty reads).
+- **connection_test.go** — `TestConnectionPool_ConcurrentLoad`, `TestConnectionPool_LeakDetection`, `BenchmarkConcurrentGetAll`, `BenchmarkLargePayload_GetAll`, `BenchmarkBulkTenants_List`, `TestLargeSchema_CreateAndFetch`, `TestLargePayload_SetAndGet`.
+- **memory_test.go** — `TestMemoryGrowth_BoundedUnderLoad`, `TestGoroutineLeak`, `TestConcurrentTenants_Isolation`, `BenchmarkMemoryGrowth_Sustained`. Heap snapshot via pprof.
+
+`testing.Short()` halves counts/durations for CI. `testing.TB` shared helpers. `CI=true make stress` injects `-short`. New `stress` CI job in `ci.yml` (20 min timeout, `needs: [tools, changes]`).
+
+## Admin GUI Embed (#24)
+
+`internal/ui/` package with `//go:embed dist` exposes `ui.FS`. Placeholder `dist/index.html` committed; real assets copied by `make ui` (runs `npm ci + npm run build` in `../decree-ui`, copies output into `dist/`). Built `assets/` directory excluded from git.
+
+`server.WithUI(fs.FS)` option adds SPA handler at `/admin/` with client-side routing fallback (`spaHandler`). `top` ServeMux created when either `openAPISpec` or `uiFS` is present. `ENABLE_UI=1` env var activates it; `fs.Sub(ui.FS, "dist")` resolves the subpath before passing to the option. `gatewayOptionsBuild.HasUI` bool for testability. Two new unit tests (`TestBuildGatewayOptions_UIWired`, `TestBuildGatewayOptions_UIAbsent`).

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 go.work
 go.work.sum
 bin/
-dist/
+/dist/
+internal/ui/dist/assets/
 *.exe
 *.exe~
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 # Module list for multi-module operations.
 SDK_MODULES := sdk/configclient sdk/adminclient sdk/configwatcher sdk/tools
 
-.PHONY: all generate generate-proto generate-sqlc test lint build image migrate e2e examples bench bench-e2e stress docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
+.PHONY: all generate generate-proto generate-sqlc test lint build image ui migrate e2e examples bench bench-e2e stress docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 
 all: generate lint test build
 
@@ -62,6 +62,13 @@ build:
 ## image: Build the Docker image
 image:
 	docker build -t $(BINARY_NAME) -f build/Dockerfile .
+
+## ui: Copy admin UI dist from ../decree-ui into internal/ui/dist (local dev). Requires decree-ui checked out at ../decree-ui.
+ui:
+	npm --prefix ../decree-ui ci
+	npm --prefix ../decree-ui run build
+	rm -rf internal/ui/dist/assets
+	cp -r ../decree-ui/dist/. internal/ui/dist/
 
 # --- Quality ---
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -33,6 +34,7 @@ import (
 	"github.com/opendecree/decree/internal/storage"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/telemetry"
+	ui "github.com/opendecree/decree/internal/ui"
 	"github.com/opendecree/decree/internal/validation"
 	"github.com/opendecree/decree/internal/version"
 
@@ -341,7 +343,16 @@ func run() int {
 			}
 		}
 
-		gwBuild := buildGatewayOptions(cfg, logger, openAPISpec, gwTLS)
+		var uiFS fs.FS
+		if cfg.EnableUI {
+			sub, subErr := fs.Sub(ui.FS, "dist")
+			if subErr != nil {
+				logger.ErrorContext(ctx, "failed to prepare UI filesystem", "error", subErr)
+				return 1
+			}
+			uiFS = sub
+		}
+		gwBuild := buildGatewayOptions(cfg, logger, openAPISpec, gwTLS, uiFS)
 		gw, err = server.NewGateway(ctx, cfg.HTTPPort, fmt.Sprintf("localhost:%s", cfg.GRPCPort), gwBuild.Opts...)
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create HTTP gateway", "error", err)
@@ -425,6 +436,7 @@ type serverConfig struct {
 	RateLimitSuperAdminRPS   float64 // 0 = unlimited
 	RateLimitBurst           int
 	EnableReflection         bool
+	EnableUI                 bool
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -497,6 +509,7 @@ func loadConfig() serverConfig {
 		RateLimitSuperAdminRPS:   parseEnvFloat("RATE_LIMIT_SUPERADMIN_RPS", 0),
 		RateLimitBurst:           parseEnvInt("RATE_LIMIT_BURST", 10),
 		EnableReflection:         getEnv("ENABLE_REFLECTION", "") == "1",
+		EnableUI:                 getEnv("ENABLE_UI", "") == "1",
 	}
 }
 

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"log/slog"
 
 	"google.golang.org/grpc"
@@ -59,6 +60,7 @@ type gatewayOptionsBuild struct {
 	Opts        []server.GatewayOption
 	UseTLS      bool
 	UseInsecure bool
+	HasUI       bool
 }
 
 func buildGatewayOptions(
@@ -66,6 +68,7 @@ func buildGatewayOptions(
 	logger *slog.Logger,
 	openAPISpec []byte,
 	gwTLS *server.GatewayTLSConfig,
+	uiFS fs.FS,
 ) gatewayOptionsBuild {
 	out := gatewayOptionsBuild{
 		Opts: []server.GatewayOption{
@@ -81,6 +84,10 @@ func buildGatewayOptions(
 	} else {
 		out.Opts = append(out.Opts, server.WithGatewayTLS(gwTLS))
 		out.UseTLS = true
+	}
+	if uiFS != nil {
+		out.Opts = append(out.Opts, server.WithUI(uiFS))
+		out.HasUI = true
 	}
 	return out
 }

--- a/cmd/server/options_test.go
+++ b/cmd/server/options_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"io"
+	"io/fs"
 	"log/slog"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
@@ -111,10 +113,11 @@ func TestBuildGatewayOptions_TLS(t *testing.T) {
 	cfg.InsecureListen = false
 	gwTLS := &server.GatewayTLSConfig{CAFile: "ca.pem"}
 
-	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), gwTLS)
+	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), gwTLS, nil)
 
 	assert.True(t, got.UseTLS)
 	assert.False(t, got.UseInsecure)
+	assert.False(t, got.HasUI)
 	assert.Len(t, got.Opts, 5, "4 base options + TLS option")
 }
 
@@ -122,9 +125,31 @@ func TestBuildGatewayOptions_Insecure(t *testing.T) {
 	cfg := baseServerCfg()
 	cfg.InsecureListen = true
 
-	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), nil)
+	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), nil, nil)
 
 	assert.False(t, got.UseTLS)
 	assert.True(t, got.UseInsecure)
+	assert.False(t, got.HasUI)
 	assert.Len(t, got.Opts, 5, "4 base options + Insecure option")
+}
+
+func TestBuildGatewayOptions_UIWired(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+	testFS := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("<html/>")}}
+
+	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), nil, fs.FS(testFS))
+
+	assert.True(t, got.HasUI, "non-nil uiFS must be wired into the option slice")
+	assert.Len(t, got.Opts, 6, "4 base options + Insecure + UI")
+}
+
+func TestBuildGatewayOptions_UIAbsent(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+
+	got := buildGatewayOptions(cfg, discardLogger(), []byte(`{}`), nil, nil)
+
+	assert.False(t, got.HasUI, "nil uiFS must not produce a WithUI option")
+	assert.Len(t, got.Opts, 5)
 }

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -93,18 +94,23 @@ func NewGateway(ctx context.Context, httpPort, grpcAddr string, opts ...GatewayO
 		}
 	}
 
-	// Wrap gateway mux with docs routes.
+	// Wrap gateway mux with docs and UI routes.
 	handler := http.Handler(mux)
-	if len(o.openAPISpec) > 0 {
+	if len(o.openAPISpec) > 0 || o.uiFS != nil {
 		top := http.NewServeMux()
-		top.HandleFunc("GET /docs/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(o.openAPISpec)
-		})
-		top.HandleFunc("GET /docs", func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			_, _ = w.Write([]byte(swaggerUIPage))
-		})
+		if len(o.openAPISpec) > 0 {
+			top.HandleFunc("GET /docs/openapi.json", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write(o.openAPISpec)
+			})
+			top.HandleFunc("GET /docs", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				_, _ = w.Write([]byte(swaggerUIPage))
+			})
+		}
+		if o.uiFS != nil {
+			top.Handle("/admin/", http.StripPrefix("/admin", spaHandler(o.uiFS)))
+		}
 		top.Handle("/", mux)
 		handler = top
 	}
@@ -147,6 +153,23 @@ func forwardAuthHeaders(ctx context.Context, req *http.Request) metadata.MD {
 		}
 	}
 	return md
+}
+
+// spaHandler serves an embedded filesystem for a single-page application.
+// Requests for files that exist are served directly; all other paths fall back
+// to index.html so client-side routing works correctly.
+func spaHandler(fsys fs.FS) http.Handler {
+	fileServer := http.FileServerFS(fsys)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path == "" {
+			path = "index.html"
+		}
+		if _, err := fsys.Open(path); err != nil {
+			r.URL.Path = "/"
+		}
+		fileServer.ServeHTTP(w, r)
+	})
 }
 
 // swaggerUIPage is a self-contained HTML page that renders the OpenAPI spec

--- a/internal/server/gateway_options.go
+++ b/internal/server/gateway_options.go
@@ -1,6 +1,9 @@
 package server
 
-import "log/slog"
+import (
+	"io/fs"
+	"log/slog"
+)
 
 // GatewayOption configures a Gateway.
 type GatewayOption func(*gatewayOptions)
@@ -8,6 +11,7 @@ type GatewayOption func(*gatewayOptions)
 type gatewayOptions struct {
 	logger          *slog.Logger
 	openAPISpec     []byte
+	uiFS            fs.FS
 	maxRecvMsgBytes int
 	maxSendMsgBytes int
 	tls             *GatewayTLSConfig
@@ -48,4 +52,11 @@ func WithGatewayTLS(cfg *GatewayTLSConfig) GatewayOption {
 // (INSECURE_LISTEN=1). Mutually exclusive with WithGatewayTLS.
 func WithGatewayInsecure() GatewayOption {
 	return func(o *gatewayOptions) { o.insecure = true }
+}
+
+// WithUI serves the given filesystem at /admin/ with SPA client-side routing
+// fallback. The FS must be rooted at the dist directory (index.html at its
+// root). When unset, the /admin/ route is not registered.
+func WithUI(fsys fs.FS) GatewayOption {
+	return func(o *gatewayOptions) { o.uiFS = fsys }
 }

--- a/internal/ui/dist/index.html
+++ b/internal/ui/dist/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenDecree Admin</title>
+  <style>
+    body { font-family: system-ui, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #f5f5f5; }
+    .msg { text-align: center; color: #333; }
+    .msg h2 { margin-bottom: 0.5rem; }
+    code { background: #e8e8e8; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <div class="msg">
+    <h2>Admin UI not built</h2>
+    <p>Run <code>make ui</code> to build the admin interface.</p>
+  </div>
+</body>
+</html>

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,6 @@
+package ui
+
+import "embed"
+
+//go:embed dist
+var FS embed.FS


### PR DESCRIPTION
## Summary

- Enables the server binary to serve the decree-ui React SPA directly at \`/admin/\` via Go's \`embed.FS\`, removing the need for a separate Nginx container or static file server in single-binary deployments.
- Adds \`ENABLE_UI=1\` as a clean opt-in so production deployments can enable the UI without breaking existing setups, and a placeholder page is served when the UI hasn't been built yet.
- Introduces \`make ui\` to copy a local decree-ui build into the embedded directory, keeping the local dev workflow self-contained without requiring Docker.

## Test plan

- [x] `make build` compiles clean with the embedded placeholder
- [x] `go test ./internal/server/... ./cmd/server/...` — all pass including 2 new gateway option tests (`TestBuildGatewayOptions_UIWired`, `TestBuildGatewayOptions_UIAbsent`)
- [x] Pre-commit checks pass (`make pre-commit`) — lint, vet, race tests, all coverage thresholds

## Implementation notes

- `//go:embed dist` in `internal/ui/ui.go` — placeholder `index.html` committed so the embed compiles without a real UI build; `assets/` is gitignored
- `server.WithUI(fs.FS)` mounts an SPA handler at `/admin/` with client-side routing fallback (unknown paths serve `index.html`)
- `top` ServeMux is now created when either `openAPISpec` or `uiFS` is present (previously only for docs)
- `gatewayOptionsBuild.HasUI` mirrors the existing `HasRateLimiter` pattern for testability

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)