### PR TITLE
test: expand unit test coverage across five packages

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,7 +1,7 @@
 {
-  "cmd/decree": 86.6,
-  "internal": 81.9,
-  "sdk/adminclient": 97.2,
+  "cmd/decree": 86.7,
+  "internal": 83.0,
+  "sdk/adminclient": 98.0,
   "sdk/configclient": 87.1,
   "sdk/configwatcher": 90.9,
   "sdk/tools": 96.1

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -22,3 +22,20 @@ func TestRedisCache_SetEmptyValuesIsNoOp(t *testing.T) {
 	err = c.Set(context.Background(), "t1", 1, nil, time.Minute)
 	require.NoError(t, err)
 }
+
+func TestNewRedisCache(t *testing.T) {
+	c := NewRedisCache(nil)
+	require.NotNil(t, c)
+	require.Equal(t, "config:", c.prefix)
+}
+
+func TestRedisCache_Key(t *testing.T) {
+	c := &RedisCache{prefix: "config:"}
+	require.Equal(t, "config:tenant-1:v7", c.key("tenant-1", 7))
+	require.Equal(t, "config:t:v0", c.key("t", 0))
+}
+
+func TestRedisCache_TenantPattern(t *testing.T) {
+	c := &RedisCache{prefix: "config:"}
+	require.Equal(t, "config:tenant-1:*", c.tenantPattern("tenant-1"))
+}

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -916,3 +916,30 @@ func TestExportConfig_RedactsSensitiveFields(t *testing.T) {
 	assert.Contains(t, yaml, redactedSentinel)
 	assert.Contains(t, yaml, "myapp")
 }
+
+func TestDependentRequiredError(t *testing.T) {
+	inner := errors.New("inner error")
+	e := &dependentRequiredError{err: inner}
+	assert.Equal(t, "inner error", e.Error())
+	assert.Equal(t, inner, e.Unwrap())
+}
+
+func TestValidationError_Error(t *testing.T) {
+	inner := errors.New("cel rule failed")
+	e := &validationError{err: inner}
+	assert.Equal(t, "cel rule failed", e.Error())
+}
+
+func TestWithCacheMetrics_Option(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, &mockCache{}, &mockPublisher{}, &mockSubscriber{},
+		WithCacheMetrics(nil))
+	assert.NotNil(t, svc)
+}
+
+func TestWithMetrics_Option(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, &mockCache{}, &mockPublisher{}, &mockSubscriber{},
+		WithMetrics(nil))
+	assert.NotNil(t, svc)
+}

--- a/internal/pubsub/redis_test.go
+++ b/internal/pubsub/redis_test.go
@@ -1,0 +1,34 @@
+package pubsub
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var discardLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 10}))
+
+// Tests below use nil Redis clients. Only the constructor and Close paths are
+// exercised — no actual Redis calls are made.
+
+func TestNewRedisPublisher(t *testing.T) {
+	p := NewRedisPublisher(nil)
+	require.NotNil(t, p)
+}
+
+func TestRedisPublisher_Close(t *testing.T) {
+	p := NewRedisPublisher(nil)
+	require.NoError(t, p.Close())
+}
+
+func TestNewRedisSubscriber(t *testing.T) {
+	s := NewRedisSubscriber(nil, discardLogger)
+	require.NotNil(t, s)
+}
+
+func TestRedisSubscriber_Close(t *testing.T) {
+	s := NewRedisSubscriber(nil, discardLogger)
+	require.NoError(t, s.Close())
+}

--- a/internal/schema/cel/lint_test.go
+++ b/internal/schema/cel/lint_test.go
@@ -209,3 +209,40 @@ func TestLintValidations_Rule4_EqualityLiteralOnLeft(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "use enum: [true]")
 }
+
+// The following two tests exercise the flipOp branches for _>_ and _>=_ by
+// placing the literal on the left side of the comparison. Without the flip,
+// the operand order would map to the wrong bound direction.
+
+func TestLintValidations_Rule4_ComparisonLiteralOnLeft_GT(t *testing.T) {
+	// `100.0 > self.payments.max_amount` flips to `self.x < 100.0` → exclusiveMaximum
+	rules := []*pb.ValidationRule{
+		{Rule: "100.0 > self.payments.max_amount", Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use exclusiveMaximum: 100 on the field")
+}
+
+func TestLintValidations_Rule4_ComparisonLiteralOnLeft_GTE(t *testing.T) {
+	// `100.0 >= self.payments.max_amount` flips to `self.x <= 100.0` → maximum
+	rules := []*pb.ValidationRule{
+		{Rule: "100.0 >= self.payments.max_amount", Message: "x"},
+	}
+	err := LintValidations(rules, showcaseFields())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use maximum: 100 on the field")
+}
+
+func TestLintValidations_InOperatorTraversesListAndComprehensionNodes(t *testing.T) {
+	// The `in` macro compiles to a comprehension over a list literal. This
+	// exercises the ListKind and ComprehensionKind branches in the visit
+	// function, which collectSelfChains relies on to find all self.* references.
+	fields := []*pb.SchemaField{
+		{Path: "mode", Type: pb.FieldType_FIELD_TYPE_STRING},
+	}
+	rules := []*pb.ValidationRule{
+		{Rule: `self.mode in ["a", "b", "c"]`, Message: "valid modes"},
+	}
+	require.NoError(t, LintValidations(rules, fields))
+}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -76,3 +76,51 @@ func TestStartDBPoolMetrics_Disabled(t *testing.T) {
 	StartDBPoolMetrics(context.Background(), Config{}, nil, nil)
 	StartDBPoolMetrics(context.Background(), Config{Enabled: true, MetricsDBPool: false}, nil, nil)
 }
+
+func TestNewRateLimitMetrics_Disabled(t *testing.T) {
+	assert.Nil(t, NewRateLimitMetrics(Config{}))
+	assert.Nil(t, NewRateLimitMetrics(Config{Enabled: true, MetricsRateLimit: false}))
+}
+
+func TestNewRateLimitMetrics_Enabled(t *testing.T) {
+	m := NewRateLimitMetrics(Config{Enabled: true, MetricsRateLimit: true})
+	assert.NotNil(t, m)
+}
+
+func TestRateLimitMetrics_NilSafe(t *testing.T) {
+	var m *RateLimitMetrics
+	counter, ok := m.Counter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
+}
+
+func TestRateLimitMetrics_Counter(t *testing.T) {
+	m := NewRateLimitMetrics(Config{Enabled: true, MetricsRateLimit: true})
+	counter, ok := m.Counter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
+}
+
+func TestNewValidationMetrics_Disabled(t *testing.T) {
+	assert.Nil(t, NewValidationMetrics(Config{}))
+	assert.Nil(t, NewValidationMetrics(Config{Enabled: true, MetricsValidation: false}))
+}
+
+func TestNewValidationMetrics_Enabled(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	assert.NotNil(t, m)
+}
+
+func TestValidationMetrics_NilSafe(t *testing.T) {
+	var m *ValidationMetrics
+	counter, ok := m.TimeoutCounter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
+}
+
+func TestValidationMetrics_TimeoutCounter(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.TimeoutCounter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for previously uncovered functions that require no external dependencies (no live Redis or database), ensuring regressions in pure-Go logic are caught at the unit level
- Covers `RateLimitMetrics`, `ValidationMetrics`, Redis constructor/close paths, CEL lint `flipOp` branches, `visit` traversal of list and comprehension nodes, and config service error type methods
- Ratchets coverage thresholds: `internal` 81.9 → 83.0, `cmd/decree` 86.6 → 86.7, `sdk/adminclient` 97.2 → 98.0

## Test plan
- [x] All new tests pass: `make test`
- [x] Coverage thresholds verified: `./scripts/check-coverage.sh`
- [x] Ran with `-race` — no data races detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)