### PR TITLE
ci: add Codecov coverage upload across all repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,19 +227,33 @@ jobs:
           cd cmd/decree && go build -o ../../bin/decree .
 
       - name: Unit tests
-        run: go test ./internal/... -race -count=1
+        run: go test ./internal/... -race -count=1 -coverprofile=coverage-internal.out -covermode=atomic
 
       - name: SDK + CLI + tools tests
         run: |
-          cd sdk/configclient && go test ./... -count=1 &
-          cd sdk/adminclient && go test ./... -count=1 &
-          cd sdk/configwatcher && go test ./... -count=1 &
-          cd sdk/tools && go test ./... -count=1 &
-          cd cmd/decree && go test ./... -count=1 &
+          cd sdk/configclient && go test ./... -count=1 -coverprofile=../../cov-configclient.out -covermode=atomic &
+          cd sdk/adminclient && go test ./... -count=1 -coverprofile=../../cov-adminclient.out -covermode=atomic &
+          cd sdk/configwatcher && go test ./... -count=1 -coverprofile=../../cov-configwatcher.out -covermode=atomic &
+          cd sdk/tools && go test ./... -count=1 -coverprofile=../../cov-tools.out -covermode=atomic &
+          cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic &
           wait
 
       - name: Coverage ratchet
         run: ./scripts/check-coverage.sh
+
+      - name: Merge coverage profiles
+        run: |
+          echo "mode: atomic" > coverage.out
+          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-tools.out cov-decree.out; do
+            [ -f "$f" ] && grep -v "^mode:" "$f" >> coverage.out || true
+          done
+
+      - name: Upload coverage to Codecov
+        # codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # Proves the SDK core modules still build and test against older Go versions
   # we advertise support for (1.22 is the lowest SDK-supported minor).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://goreportcard.com/report/github.com/opendecree/decree"><img src="https://goreportcard.com/badge/github.com/opendecree/decree" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
   <a href="https://www.repostatus.org/#active"><img src="https://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active"></a>
+  <a href="https://codecov.io/gh/opendecree/decree"><img src="https://codecov.io/gh/opendecree/decree/graph/badge.svg" alt="Coverage"></a>
 </p>
 
 <p align="center"><strong>Define your config schema once. Get validation, APIs, type-safe SDKs, admin UI, and audit trail — automatically.</strong></p>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Codecov has no coverage data for any repo — this PR wires up uploads so the dashboard, PR delta comments, and badges all work from the first merge
- Adds per-module coverage merging for Go (six modules), XML report for Python (uploaded on 3.12 only to avoid duplicate reports), and JSON coverage for TypeScript and UI via vitest v8
- Enforces no-regression on the project and ≥80% patch coverage via \`codecov.yml\` policy

## Test plan
- [ ] Link Codecov account to opendecree org at codecov.io
- [ ] Add \`CODECOV_TOKEN\` as an org-level Actions + Dependabot secret via \`gh secret set\`
- [ ] Verify CI uploads land on the Codecov dashboard after this PR merges
- [ ] Confirm coverage badge renders in README

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)