### PR TITLE
feat(configwatcher): bound reconnect loadSnapshot with explicit timeout

### DIFF
--- a/sdk/configwatcher/options_test.go
+++ b/sdk/configwatcher/options_test.go
@@ -18,6 +18,9 @@ func TestNew_Defaults(t *testing.T) {
 	if got := w.opts.maxBackoff; got != 30*time.Second {
 		t.Errorf("got %v, want %v", got, 30*time.Second)
 	}
+	if got := w.opts.snapshotTimeout; got != 10*time.Second {
+		t.Errorf("got %v, want %v", got, 10*time.Second)
+	}
 	if w.opts.logger == nil {
 		t.Fatal("expected non-nil logger")
 	}
@@ -33,6 +36,13 @@ func TestWithReconnectBackoff(t *testing.T) {
 	}
 	if got := w.opts.maxBackoff; got != 1*time.Minute {
 		t.Errorf("got %v, want %v", got, 1*time.Minute)
+	}
+}
+
+func TestWithSnapshotTimeout(t *testing.T) {
+	w := New(nil, "t1", WithSnapshotTimeout(5*time.Second))
+	if got := w.opts.snapshotTimeout; got != 5*time.Second {
+		t.Errorf("got %v, want %v", got, 5*time.Second)
 	}
 }
 

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -54,9 +54,10 @@ type fieldEntry struct {
 }
 
 type options struct {
-	minBackoff time.Duration
-	maxBackoff time.Duration
-	logger     *slog.Logger
+	minBackoff      time.Duration
+	maxBackoff      time.Duration
+	snapshotTimeout time.Duration
+	logger          *slog.Logger
 }
 
 // New creates a new watcher for the given tenant's configuration.
@@ -66,9 +67,10 @@ type options struct {
 // Use grpctransport.NewConfigTransport to create a gRPC-backed transport.
 func New(transport configclient.Transport, tenantID string, opts ...Option) *Watcher {
 	o := options{
-		minBackoff: 500 * time.Millisecond,
-		maxBackoff: 30 * time.Second,
-		logger:     slog.Default(),
+		minBackoff:      500 * time.Millisecond,
+		maxBackoff:      30 * time.Second,
+		snapshotTimeout: 10 * time.Second,
+		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -98,6 +100,12 @@ func WithReconnectBackoff(min, max time.Duration) Option {
 // WithLogger sets a custom logger. Defaults to slog.Default().
 func WithLogger(logger *slog.Logger) Option {
 	return func(o *options) { o.logger = logger }
+}
+
+// WithSnapshotTimeout sets the deadline applied to each loadSnapshot call
+// inside the reconnect loop. Defaults to 10s.
+func WithSnapshotTimeout(d time.Duration) Option {
+	return func(o *options) { o.snapshotTimeout = d }
 }
 
 // --- Field registration ---
@@ -263,8 +271,12 @@ func (w *Watcher) subscriptionLoop(ctx context.Context) {
 		backoff = min(backoff*2, w.opts.maxBackoff)
 
 		// Re-load snapshot on reconnect to catch changes missed during disconnect.
-		if err := w.loadSnapshot(ctx); err != nil {
-			w.opts.logger.WarnContext(ctx, "failed to reload snapshot on reconnect", "error", err)
+		// Use an explicit timeout so a slow server cannot stall the reconnect loop.
+		snapCtx, snapCancel := context.WithTimeout(ctx, w.opts.snapshotTimeout)
+		snapErr := w.loadSnapshot(snapCtx)
+		snapCancel()
+		if snapErr != nil {
+			w.opts.logger.WarnContext(ctx, "failed to reload snapshot on reconnect", "error", snapErr)
 		} else {
 			backoff = w.opts.minBackoff // Reset backoff on successful snapshot.
 		}

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -323,6 +325,68 @@ func TestWatcher_NullField(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	if got := name.Get(); got != "fallback" {
 		t.Errorf("got %v, want %v after null update", got, "fallback")
+	}
+
+	cancel()
+	_ = w.Close()
+}
+
+func TestWatcher_ReconnectSnapshotTimeout(t *testing.T) {
+	// Verify that a slow loadSnapshot during reconnect times out and does not
+	// stall the reconnect loop indefinitely.
+	var callCount atomic.Int32
+	blocked := make(chan struct{})
+	unblocked := make(chan struct{})
+
+	tr := &mockTransport{
+		getConfigFn: func(ctx context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			n := int(callCount.Add(1))
+			if n == 1 {
+				return &configclient.GetConfigResponse{TenantID: "t1"}, nil
+			}
+			if n == 2 {
+				close(blocked)
+				<-ctx.Done() // blocks until snapshotTimeout fires
+				close(unblocked)
+				return nil, ctx.Err()
+			}
+			return nil, fmt.Errorf("stream error")
+		},
+		subscribeFn: func(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			return nil, fmt.Errorf("stream error")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := &Watcher{
+		transport: tr,
+		tenantID:  "t1",
+		opts: options{
+			minBackoff:      5 * time.Millisecond,
+			maxBackoff:      10 * time.Millisecond,
+			snapshotTimeout: 30 * time.Millisecond,
+			logger:          slog.Default(),
+		},
+		fields: make(map[string]*fieldEntry),
+		done:   make(chan struct{}),
+	}
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	select {
+	case <-blocked:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("reconnect snapshot was not called")
+	}
+
+	select {
+	case <-unblocked:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("snapshot did not time out within snapshotTimeout + margin")
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

- The reconnect loop in `subscriptionLoop` called `loadSnapshot` with no deadline, relying solely on the gRPC transport timeout. A slow or unresponsive server could stall the loop indefinitely, preventing backoff from making progress.
- This change wraps the reconnect snapshot call in `context.WithTimeout` (default 10s, configurable via `WithSnapshotTimeout`) so the loop resumes on a predictable schedule regardless of transport behavior.

## Test plan

- `TestWatcher_ReconnectSnapshotTimeout`: asserts that when a reconnect snapshot blocks longer than `snapshotTimeout`, the context deadline fires and the loop continues — verified via channel synchronization.
- `TestWithSnapshotTimeout`: asserts the option sets `opts.snapshotTimeout` correctly.
- `TestNew_Defaults`: updated to assert the default `snapshotTimeout` is 10s.
- Full test suite passes: `make test`.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)