### PR TITLE
fix(sdk): replace panicking TypedValue accessors with safe (T, bool) API

### DIFF
--- a/cmd/decree/config_integration_test.go
+++ b/cmd/decree/config_integration_test.go
@@ -73,11 +73,11 @@ func TestRunConfigSet_PicksTypedValueKindFromSchema(t *testing.T) {
 		wantKind configclient.ValueKind
 		check    func(*configclient.TypedValue) bool
 	}{
-		{"bool", adminclient.Field{Path: "x", Type: "bool"}, "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.BoolValue() }},
-		{"integer", adminclient.Field{Path: "x", Type: "integer"}, "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == 42 }},
-		{"number", adminclient.Field{Path: "x", Type: "number"}, "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.FloatValue() == 3.14 }},
-		{"duration", adminclient.Field{Path: "x", Type: "duration"}, "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.DurationValue().Seconds() == 15 }},
-		{"string", adminclient.Field{Path: "x", Type: "string"}, "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
+		{"bool", adminclient.Field{Path: "x", Type: "bool"}, "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.MustBoolValue() }},
+		{"integer", adminclient.Field{Path: "x", Type: "integer"}, "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.MustIntValue() == 42 }},
+		{"number", adminclient.Field{Path: "x", Type: "number"}, "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.MustFloatValue() == 3.14 }},
+		{"duration", adminclient.Field{Path: "x", Type: "duration"}, "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.MustDurationValue().Seconds() == 15 }},
+		{"string", adminclient.Field{Path: "x", Type: "string"}, "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.MustStringValue() == "hello" }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,14 +150,14 @@ func TestRunConfigSetMany_SendsTypedValuesMatchingSchema(t *testing.T) {
 	for _, u := range tr.setFields.Updates {
 		byPath[u.FieldPath] = u.Value
 	}
-	if byPath["a"].Kind() != configclient.KindInteger || byPath["a"].IntValue() != 100 {
-		t.Errorf("a: got kind=%v int=%d", byPath["a"].Kind(), byPath["a"].IntValue())
+	if byPath["a"].Kind() != configclient.KindInteger || byPath["a"].MustIntValue() != 100 {
+		t.Errorf("a: got kind=%v int=%d", byPath["a"].Kind(), byPath["a"].MustIntValue())
 	}
-	if byPath["b"].Kind() != configclient.KindBool || !byPath["b"].BoolValue() {
-		t.Errorf("b: got kind=%v bool=%v", byPath["b"].Kind(), byPath["b"].BoolValue())
+	if byPath["b"].Kind() != configclient.KindBool || !byPath["b"].MustBoolValue() {
+		t.Errorf("b: got kind=%v bool=%v", byPath["b"].Kind(), byPath["b"].MustBoolValue())
 	}
-	if byPath["c"].Kind() != configclient.KindDuration || byPath["c"].DurationValue().Minutes() != 2 {
-		t.Errorf("c: got kind=%v dur=%v", byPath["c"].Kind(), byPath["c"].DurationValue())
+	if byPath["c"].Kind() != configclient.KindDuration || byPath["c"].MustDurationValue().Minutes() != 2 {
+		t.Errorf("c: got kind=%v dur=%v", byPath["c"].Kind(), byPath["c"].MustDurationValue())
 	}
 }
 

--- a/cmd/decree/typed_test.go
+++ b/cmd/decree/typed_test.go
@@ -15,20 +15,20 @@ func TestParseTypedValue_Success(t *testing.T) {
 		wantKind  configclient.ValueKind
 		check     func(*configclient.TypedValue) bool
 	}{
-		{"string", "string", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
-		{"empty field type defaults to string", "", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.StringValue() == "hello" }},
-		{"integer", "integer", "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == 42 }},
-		{"integer negative", "integer", "-7", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.IntValue() == -7 }},
-		{"number", "number", "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.FloatValue() == 3.14 }},
-		{"bool true", "bool", "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.BoolValue() }},
-		{"bool false", "bool", "false", configclient.KindBool, func(v *configclient.TypedValue) bool { return !v.BoolValue() }},
+		{"string", "string", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.MustStringValue() == "hello" }},
+		{"empty field type defaults to string", "", "hello", configclient.KindString, func(v *configclient.TypedValue) bool { return v.MustStringValue() == "hello" }},
+		{"integer", "integer", "42", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.MustIntValue() == 42 }},
+		{"integer negative", "integer", "-7", configclient.KindInteger, func(v *configclient.TypedValue) bool { return v.MustIntValue() == -7 }},
+		{"number", "number", "3.14", configclient.KindNumber, func(v *configclient.TypedValue) bool { return v.MustFloatValue() == 3.14 }},
+		{"bool true", "bool", "true", configclient.KindBool, func(v *configclient.TypedValue) bool { return v.MustBoolValue() }},
+		{"bool false", "bool", "false", configclient.KindBool, func(v *configclient.TypedValue) bool { return !v.MustBoolValue() }},
 		{"time RFC3339", "time", "2026-03-30T12:00:00Z", configclient.KindTime, func(v *configclient.TypedValue) bool {
-			return v.TimeValue().Equal(time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC))
+			return v.MustTimeValue().Equal(time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC))
 		}},
-		{"duration", "duration", "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.DurationValue() == 15*time.Second }},
-		{"url", "url", "https://example.com", configclient.KindURL, func(v *configclient.TypedValue) bool { return v.URLValue() == "https://example.com" }},
-		{"json object", "json", `{"a":1}`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.JSONValue() == `{"a":1}` }},
-		{"json array", "json", `[1,2,3]`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.JSONValue() == `[1,2,3]` }},
+		{"duration", "duration", "15s", configclient.KindDuration, func(v *configclient.TypedValue) bool { return v.MustDurationValue() == 15*time.Second }},
+		{"url", "url", "https://example.com", configclient.KindURL, func(v *configclient.TypedValue) bool { return v.MustURLValue() == "https://example.com" }},
+		{"json object", "json", `{"a":1}`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.MustJSONValue() == `{"a":1}` }},
+		{"json array", "json", `[1,2,3]`, configclient.KindJSON, func(v *configclient.TypedValue) bool { return v.MustJSONValue() == `[1,2,3]` }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/e2e/type_matrix_test.go
+++ b/e2e/type_matrix_test.go
@@ -54,9 +54,9 @@ func typeCases() []typeCase {
 		{
 			name: "string", fieldType: "FIELD_TYPE_STRING",
 			sample:    func() *configclient.TypedValue { return configclient.StringVal("hello-" + randSuffix()) },
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.StringValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustStringValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.Equal(t, want.StringValue(), got.StringValue())
+				assert.Equal(t, want.MustStringValue(), got.MustStringValue())
 			},
 		},
 		{
@@ -64,9 +64,9 @@ func typeCases() []typeCase {
 			sample: func() *configclient.TypedValue {
 				return configclient.IntVal(atomic.AddInt64(&sampleSeq, 1))
 			},
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%d", tv.IntValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%d", tv.MustIntValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.Equal(t, want.IntValue(), got.IntValue())
+				assert.Equal(t, want.MustIntValue(), got.MustIntValue())
 			},
 		},
 		{
@@ -74,9 +74,9 @@ func typeCases() []typeCase {
 			sample: func() *configclient.TypedValue {
 				return configclient.FloatVal(float64(atomic.AddInt64(&sampleSeq, 1)) / 100)
 			},
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%g", tv.FloatValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%g", tv.MustFloatValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.InEpsilon(t, want.FloatValue(), got.FloatValue(), 1e-9)
+				assert.InEpsilon(t, want.MustFloatValue(), got.MustFloatValue(), 1e-9)
 			},
 		},
 		{
@@ -84,9 +84,9 @@ func typeCases() []typeCase {
 			sample: func() *configclient.TypedValue {
 				return configclient.BoolVal(atomic.AddInt64(&sampleSeq, 1)%2 == 0)
 			},
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%t", tv.BoolValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%t", tv.MustBoolValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.Equal(t, want.BoolValue(), got.BoolValue())
+				assert.Equal(t, want.MustBoolValue(), got.MustBoolValue())
 			},
 		},
 		{
@@ -95,11 +95,11 @@ func typeCases() []typeCase {
 				return configclient.TimeVal(time.Unix(atomic.AddInt64(&sampleSeq, 1), 0).UTC())
 			},
 			yamlValue: func(tv *configclient.TypedValue) string {
-				return fmt.Sprintf("%q", tv.TimeValue().Format(time.RFC3339Nano))
+				return fmt.Sprintf("%q", tv.MustTimeValue().Format(time.RFC3339Nano))
 			},
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.True(t, want.TimeValue().Equal(got.TimeValue()),
-					"time mismatch: want=%s got=%s", want.TimeValue(), got.TimeValue())
+				assert.True(t, want.MustTimeValue().Equal(got.MustTimeValue()),
+					"time mismatch: want=%s got=%s", want.MustTimeValue(), got.MustTimeValue())
 			},
 		},
 		{
@@ -107,17 +107,17 @@ func typeCases() []typeCase {
 			sample: func() *configclient.TypedValue {
 				return configclient.DurationVal(time.Duration(atomic.AddInt64(&sampleSeq, 1)) * time.Second)
 			},
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.DurationValue().String()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustDurationValue().String()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.Equal(t, want.DurationValue(), got.DurationValue())
+				assert.Equal(t, want.MustDurationValue(), got.MustDurationValue())
 			},
 		},
 		{
 			name: "url", fieldType: "FIELD_TYPE_URL",
 			sample:    func() *configclient.TypedValue { return configclient.URLVal("https://example.com/" + randSuffix()) },
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.URLValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustURLValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.Equal(t, want.URLValue(), got.URLValue())
+				assert.Equal(t, want.MustURLValue(), got.MustURLValue())
 			},
 		},
 		{
@@ -125,9 +125,9 @@ func typeCases() []typeCase {
 			sample: func() *configclient.TypedValue {
 				return configclient.JSONVal(fmt.Sprintf(`{"k":"v-%d"}`, atomic.AddInt64(&sampleSeq, 1)))
 			},
-			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.JSONValue()) },
+			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustJSONValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
-				assert.JSONEq(t, want.JSONValue(), got.JSONValue())
+				assert.JSONEq(t, want.MustJSONValue(), got.MustJSONValue())
 			},
 		},
 	}

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -221,8 +221,8 @@ func TestSetManyTyped_Success(t *testing.T) {
 		for _, u := range r.Updates {
 			byPath[u.FieldPath] = u.Value
 		}
-		return byPath["count"] != nil && byPath["count"].Kind() == KindInteger && byPath["count"].IntValue() == 42 &&
-			byPath["enabled"] != nil && byPath["enabled"].Kind() == KindBool && byPath["enabled"].BoolValue()
+		return byPath["count"] != nil && byPath["count"].Kind() == KindInteger && byPath["count"].MustIntValue() == 42 &&
+			byPath["enabled"] != nil && byPath["enabled"].Kind() == KindBool && byPath["enabled"].MustBoolValue()
 	}, &SetFieldsResponse{}, nil)
 
 	err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{
@@ -598,7 +598,7 @@ func TestSetInt_Success(t *testing.T) {
 
 	tr.on("SetField", func(args ...any) bool {
 		r := args[0].(*SetFieldRequest)
-		return r.Value != nil && r.Value.Kind() == KindInteger && r.Value.IntValue() == 42
+		return r.Value != nil && r.Value.Kind() == KindInteger && r.Value.MustIntValue() == 42
 	}, &SetFieldResponse{}, nil)
 
 	if err := client.SetInt(ctx, "t1", "retries", 42); err != nil {
@@ -613,7 +613,7 @@ func TestSetBool_Success(t *testing.T) {
 
 	tr.on("SetField", func(args ...any) bool {
 		r := args[0].(*SetFieldRequest)
-		return r.Value != nil && r.Value.Kind() == KindBool && r.Value.BoolValue()
+		return r.Value != nil && r.Value.Kind() == KindBool && r.Value.MustBoolValue()
 	}, &SetFieldResponse{}, nil)
 
 	if err := client.SetBool(ctx, "t1", "enabled", true); err != nil {
@@ -628,7 +628,7 @@ func TestSetFloat_Success(t *testing.T) {
 
 	tr.on("SetField", func(args ...any) bool {
 		r := args[0].(*SetFieldRequest)
-		return r.Value != nil && r.Value.Kind() == KindNumber && r.Value.FloatValue() == 3.14
+		return r.Value != nil && r.Value.Kind() == KindNumber && r.Value.MustFloatValue() == 3.14
 	}, &SetFieldResponse{}, nil)
 
 	if err := client.SetFloat(ctx, "t1", "rate", 3.14); err != nil {

--- a/sdk/configclient/typed_test.go
+++ b/sdk/configclient/typed_test.go
@@ -32,7 +32,7 @@ func TestSetDuration_Success(t *testing.T) {
 
 	tr.on("SetField", func(args ...any) bool {
 		r := args[0].(*SetFieldRequest)
-		return r.Value != nil && r.Value.Kind() == KindDuration && r.Value.DurationValue() == 30*time.Second
+		return r.Value != nil && r.Value.Kind() == KindDuration && r.Value.MustDurationValue() == 30*time.Second
 	}, &SetFieldResponse{}, nil)
 
 	if err := client.SetDuration(ctx, "t1", "x", 30*time.Second); err != nil {
@@ -240,22 +240,76 @@ func TestTypedValue_StringTime(t *testing.T) {
 // --- TypedValue accessors ---
 
 func TestTypedValue_Accessors(t *testing.T) {
-	if got := StringVal("hello").StringValue(); got != "hello" {
-		t.Errorf("StringValue: got %v, want hello", got)
-	}
 	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	if got := TimeVal(ts).TimeValue(); !got.Equal(ts) {
-		t.Errorf("TimeValue: got %v, want %v", got, ts)
+
+	// (T, bool) — matching kind returns value + true
+	if s, ok := StringVal("hello").StringValue(); !ok || s != "hello" {
+		t.Errorf("StringValue: got (%v, %v), want (hello, true)", s, ok)
 	}
-	if got := URLVal("https://x.com").URLValue(); got != "https://x.com" {
-		t.Errorf("URLValue: got %v, want https://x.com", got)
+	if n, ok := IntVal(42).IntValue(); !ok || n != 42 {
+		t.Errorf("IntValue: got (%v, %v), want (42, true)", n, ok)
 	}
-	if got := JSONVal(`{}`).JSONValue(); got != "{}" {
-		t.Errorf("JSONValue: got %v, want {}", got)
+	if f, ok := FloatVal(3.14).FloatValue(); !ok || f != 3.14 {
+		t.Errorf("FloatValue: got (%v, %v), want (3.14, true)", f, ok)
+	}
+	if b, ok := BoolVal(true).BoolValue(); !ok || !b {
+		t.Errorf("BoolValue: got (%v, %v), want (true, true)", b, ok)
+	}
+	if tv, ok := TimeVal(ts).TimeValue(); !ok || !tv.Equal(ts) {
+		t.Errorf("TimeValue: got (%v, %v), want (%v, true)", tv, ok, ts)
+	}
+	if d, ok := DurationVal(time.Hour).DurationValue(); !ok || d != time.Hour {
+		t.Errorf("DurationValue: got (%v, %v), want (1h0m0s, true)", d, ok)
+	}
+	if u, ok := URLVal("https://x.com").URLValue(); !ok || u != "https://x.com" {
+		t.Errorf("URLValue: got (%v, %v), want (https://x.com, true)", u, ok)
+	}
+	if j, ok := JSONVal(`{}`).JSONValue(); !ok || j != "{}" {
+		t.Errorf("JSONValue: got (%v, %v), want ({}, true)", j, ok)
+	}
+
+	// (T, bool) — mismatched kind returns zero + false
+	if s, ok := IntVal(1).StringValue(); ok || s != "" {
+		t.Errorf("StringValue mismatch: got (%v, %v), want ('', false)", s, ok)
+	}
+	if n, ok := StringVal("x").IntValue(); ok || n != 0 {
+		t.Errorf("IntValue mismatch: got (%v, %v), want (0, false)", n, ok)
+	}
+	if f, ok := BoolVal(true).FloatValue(); ok || f != 0 {
+		t.Errorf("FloatValue mismatch: got (%v, %v), want (0, false)", f, ok)
+	}
+	if b, ok := IntVal(1).BoolValue(); ok || b {
+		t.Errorf("BoolValue mismatch: got (%v, %v), want (false, false)", b, ok)
+	}
+	if tv, ok := StringVal("x").TimeValue(); ok || !tv.IsZero() {
+		t.Errorf("TimeValue mismatch: got (%v, %v), want (zero, false)", tv, ok)
+	}
+	if d, ok := StringVal("x").DurationValue(); ok || d != 0 {
+		t.Errorf("DurationValue mismatch: got (%v, %v), want (0, false)", d, ok)
+	}
+	if u, ok := BoolVal(true).URLValue(); ok || u != "" {
+		t.Errorf("URLValue mismatch: got (%v, %v), want ('', false)", u, ok)
+	}
+	if j, ok := IntVal(1).JSONValue(); ok || j != "" {
+		t.Errorf("JSONValue mismatch: got (%v, %v), want ('', false)", j, ok)
+	}
+
+	// Must variants — correct kind
+	if got := StringVal("hello").MustStringValue(); got != "hello" {
+		t.Errorf("MustStringValue: got %v, want hello", got)
+	}
+	if got := TimeVal(ts).MustTimeValue(); !got.Equal(ts) {
+		t.Errorf("MustTimeValue: got %v, want %v", got, ts)
+	}
+	if got := URLVal("https://x.com").MustURLValue(); got != "https://x.com" {
+		t.Errorf("MustURLValue: got %v, want https://x.com", got)
+	}
+	if got := JSONVal(`{}`).MustJSONValue(); got != "{}" {
+		t.Errorf("MustJSONValue: got %v, want {}", got)
 	}
 }
 
-func TestTypedValue_AccessorPanics(t *testing.T) {
+func TestTypedValue_MustAccessorPanics(t *testing.T) {
 	assertPanics := func(t *testing.T, name string, fn func()) {
 		t.Helper()
 		defer func() {
@@ -265,17 +319,17 @@ func TestTypedValue_AccessorPanics(t *testing.T) {
 		}()
 		fn()
 	}
-	t.Run("StringValue on int", func(t *testing.T) {
-		assertPanics(t, "StringValue", func() { IntVal(1).StringValue() })
+	t.Run("MustStringValue on int", func(t *testing.T) {
+		assertPanics(t, "MustStringValue", func() { IntVal(1).MustStringValue() })
 	})
-	t.Run("TimeValue on string", func(t *testing.T) {
-		assertPanics(t, "TimeValue", func() { StringVal("x").TimeValue() })
+	t.Run("MustTimeValue on string", func(t *testing.T) {
+		assertPanics(t, "MustTimeValue", func() { StringVal("x").MustTimeValue() })
 	})
-	t.Run("URLValue on bool", func(t *testing.T) {
-		assertPanics(t, "URLValue", func() { BoolVal(true).URLValue() })
+	t.Run("MustURLValue on bool", func(t *testing.T) {
+		assertPanics(t, "MustURLValue", func() { BoolVal(true).MustURLValue() })
 	})
-	t.Run("JSONValue on int", func(t *testing.T) {
-		assertPanics(t, "JSONValue", func() { IntVal(1).JSONValue() })
+	t.Run("MustJSONValue on int", func(t *testing.T) {
+		assertPanics(t, "MustJSONValue", func() { IntVal(1).MustJSONValue() })
 	})
 }
 

--- a/sdk/configclient/typed_value.go
+++ b/sdk/configclient/typed_value.go
@@ -35,66 +35,130 @@ type TypedValue struct {
 // Kind returns the value's type.
 func (tv *TypedValue) Kind() ValueKind { return tv.kind }
 
-// StringValue returns the string value. Panics if Kind is not KindString.
-func (tv *TypedValue) StringValue() string {
+// StringValue returns the string value and true if Kind is KindString, otherwise "", false.
+func (tv *TypedValue) StringValue() (string, bool) {
 	if tv.kind != KindString {
-		panic("TypedValue.StringValue called on non-string value")
+		return "", false
+	}
+	return tv.str, true
+}
+
+// MustStringValue returns the string value. Panics if Kind is not KindString.
+func (tv *TypedValue) MustStringValue() string {
+	if tv.kind != KindString {
+		panic("TypedValue.MustStringValue called on non-string value")
 	}
 	return tv.str
 }
 
-// IntValue returns the int64 value. Panics if Kind is not KindInteger.
-func (tv *TypedValue) IntValue() int64 {
+// IntValue returns the int64 value and true if Kind is KindInteger, otherwise 0, false.
+func (tv *TypedValue) IntValue() (int64, bool) {
 	if tv.kind != KindInteger {
-		panic("TypedValue.IntValue called on non-integer value")
+		return 0, false
+	}
+	return tv.i, true
+}
+
+// MustIntValue returns the int64 value. Panics if Kind is not KindInteger.
+func (tv *TypedValue) MustIntValue() int64 {
+	if tv.kind != KindInteger {
+		panic("TypedValue.MustIntValue called on non-integer value")
 	}
 	return tv.i
 }
 
-// FloatValue returns the float64 value. Panics if Kind is not KindNumber.
-func (tv *TypedValue) FloatValue() float64 {
+// FloatValue returns the float64 value and true if Kind is KindNumber, otherwise 0, false.
+func (tv *TypedValue) FloatValue() (float64, bool) {
 	if tv.kind != KindNumber {
-		panic("TypedValue.FloatValue called on non-number value")
+		return 0, false
+	}
+	return tv.num, true
+}
+
+// MustFloatValue returns the float64 value. Panics if Kind is not KindNumber.
+func (tv *TypedValue) MustFloatValue() float64 {
+	if tv.kind != KindNumber {
+		panic("TypedValue.MustFloatValue called on non-number value")
 	}
 	return tv.num
 }
 
-// BoolValue returns the bool value. Panics if Kind is not KindBool.
-func (tv *TypedValue) BoolValue() bool {
+// BoolValue returns the bool value and true if Kind is KindBool, otherwise false, false.
+func (tv *TypedValue) BoolValue() (bool, bool) {
 	if tv.kind != KindBool {
-		panic("TypedValue.BoolValue called on non-bool value")
+		return false, false
+	}
+	return tv.b, true
+}
+
+// MustBoolValue returns the bool value. Panics if Kind is not KindBool.
+func (tv *TypedValue) MustBoolValue() bool {
+	if tv.kind != KindBool {
+		panic("TypedValue.MustBoolValue called on non-bool value")
 	}
 	return tv.b
 }
 
-// TimeValue returns the time.Time value. Panics if Kind is not KindTime.
-func (tv *TypedValue) TimeValue() time.Time {
+// TimeValue returns the time.Time value and true if Kind is KindTime, otherwise zero time, false.
+func (tv *TypedValue) TimeValue() (time.Time, bool) {
 	if tv.kind != KindTime {
-		panic("TypedValue.TimeValue called on non-time value")
+		return time.Time{}, false
+	}
+	return tv.t, true
+}
+
+// MustTimeValue returns the time.Time value. Panics if Kind is not KindTime.
+func (tv *TypedValue) MustTimeValue() time.Time {
+	if tv.kind != KindTime {
+		panic("TypedValue.MustTimeValue called on non-time value")
 	}
 	return tv.t
 }
 
-// DurationValue returns the time.Duration value. Panics if Kind is not KindDuration.
-func (tv *TypedValue) DurationValue() time.Duration {
+// DurationValue returns the time.Duration value and true if Kind is KindDuration, otherwise 0, false.
+func (tv *TypedValue) DurationValue() (time.Duration, bool) {
 	if tv.kind != KindDuration {
-		panic("TypedValue.DurationValue called on non-duration value")
+		return 0, false
+	}
+	return tv.d, true
+}
+
+// MustDurationValue returns the time.Duration value. Panics if Kind is not KindDuration.
+func (tv *TypedValue) MustDurationValue() time.Duration {
+	if tv.kind != KindDuration {
+		panic("TypedValue.MustDurationValue called on non-duration value")
 	}
 	return tv.d
 }
 
-// URLValue returns the URL string value. Panics if Kind is not KindURL.
-func (tv *TypedValue) URLValue() string {
+// URLValue returns the URL string value and true if Kind is KindURL, otherwise "", false.
+func (tv *TypedValue) URLValue() (string, bool) {
 	if tv.kind != KindURL {
-		panic("TypedValue.URLValue called on non-url value")
+		return "", false
+	}
+	return tv.str, true
+}
+
+// MustURLValue returns the URL string value. Panics if Kind is not KindURL.
+func (tv *TypedValue) MustURLValue() string {
+	if tv.kind != KindURL {
+		panic("TypedValue.MustURLValue called on non-url value")
 	}
 	return tv.str
 }
 
-// JSONValue returns the JSON string value. Panics if Kind is not KindJSON.
-func (tv *TypedValue) JSONValue() string {
+// JSONValue returns the JSON string value and true if Kind is KindJSON, otherwise "", false.
+func (tv *TypedValue) JSONValue() (string, bool) {
 	if tv.kind != KindJSON {
-		panic("TypedValue.JSONValue called on non-json value")
+		return "", false
+	}
+	return tv.str, true
+}
+
+// MustJSONValue returns the JSON string value. Panics if Kind is not KindJSON.
+func (tv *TypedValue) MustJSONValue() string {
+	if tv.kind != KindJSON {
+		panic("TypedValue.MustJSONValue called on non-json value")
 	}
 	return tv.str
 }

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -51,21 +51,21 @@ func typedValueToProto(tv *configclient.TypedValue) *pb.TypedValue {
 	}
 	switch tv.Kind() {
 	case configclient.KindInteger:
-		return &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: tv.IntValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: tv.MustIntValue()}}
 	case configclient.KindNumber:
-		return &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: tv.FloatValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: tv.MustFloatValue()}}
 	case configclient.KindString:
-		return &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: tv.StringValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: tv.MustStringValue()}}
 	case configclient.KindBool:
-		return &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: tv.BoolValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: tv.MustBoolValue()}}
 	case configclient.KindTime:
-		return &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(tv.TimeValue())}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(tv.MustTimeValue())}}
 	case configclient.KindDuration:
-		return &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(tv.DurationValue())}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(tv.MustDurationValue())}}
 	case configclient.KindURL:
-		return &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: tv.URLValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: tv.MustURLValue()}}
 	case configclient.KindJSON:
-		return &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: tv.JSONValue()}}
+		return &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: tv.MustJSONValue()}}
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Summary

- SDKs must not panic on user input — every typed accessor in `TypedValue` previously panicked on a kind mismatch, which could crash a caller who received a value of unexpected type from the server.
- The eight accessors (`StringValue`, `IntValue`, `FloatValue`, `BoolValue`, `TimeValue`, `DurationValue`, `URLValue`, `JSONValue`) now follow the comma-ok idiom, returning `(T, bool)` where `false` signals a kind mismatch.
- `MustXxx` variants (`MustStringValue`, `MustIntValue`, etc.) are added for callers that have already verified the kind and want the original panic-on-mismatch behaviour.

## Test plan

- [x] `TestTypedValue_Accessors` extended to cover all eight types × correct-kind and mismatch-kind paths for the new `(T, bool)` API.
- [x] `TestTypedValue_MustAccessorPanics` verifies that the `Must` variants still panic on mismatch.
- [x] All internal callers in `grpctransport/convert.go`, `sdk/configclient`, `cmd/decree`, and `e2e` updated to `Must` variants (they confirm kind before calling).
- [x] `make test` passes (all packages, `-race`).
- [x] `make lint` passes (0 issues).

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)