### PR TITLE
bench(storage,cache,pubsub): add hot-path benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,9 +625,9 @@ jobs:
       - name: Run chart render tests
         run: ./deploy/helm/decree/tests/template_test.sh
 
-  # Runs authz guard chain and server cold-start benchmarks and uploads results
-  # as a workflow artifact for tracking over time. Informational — does not gate
-  # the branch protection check.
+  # Runs hot-path and infrastructure benchmarks; uploads results as a workflow
+  # artifact for tracking over time. Informational — does not gate branch protection.
+  # Storage (dbstore) and Redis benchmarks are skipped: no DB/Redis services here.
   bench:
     name: Benchmarks
     runs-on: ubuntu-latest
@@ -635,7 +635,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -650,15 +650,21 @@ jobs:
 
       - name: Run benchmarks
         run: |
-          go test -bench=. -benchmem -run='^$' -benchtime=5s \
-            ./internal/authz/ ./cmd/server/ \
+          go test -bench=. -benchmem -run='^$' -benchtime=5s -count=5 \
+            ./internal/authz/ ./internal/cache/ ./internal/pubsub/ ./cmd/server/ \
             | tee bench.txt
+
+      - name: Compute p50/p95 with benchstat
+        run: |
+          go run golang.org/x/perf/cmd/benchstat@latest bench.txt | tee bench-stats.txt
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:
           name: bench-${{ github.sha }}
-          path: bench.txt
+          path: |
+            bench.txt
+            bench-stats.txt
 
   # Aggregates all job results for branch protection. A single required check
   # that passes iff every listed job passed or was legitimately skipped.

--- a/internal/cache/cache_bench_test.go
+++ b/internal/cache/cache_bench_test.go
@@ -1,0 +1,100 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func BenchmarkMemoryCache_Hit(b *testing.B) {
+	c := NewMemoryCache(0)
+	defer c.Stop()
+	ctx := context.Background()
+	_ = c.Set(ctx, "t1", 1, map[string]string{"a": "1", "b": "2", "c": "3"}, time.Minute)
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = c.Get(ctx, "t1", 1)
+	}
+}
+
+func BenchmarkMemoryCache_Miss(b *testing.B) {
+	c := NewMemoryCache(0)
+	defer c.Stop()
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = c.Get(ctx, "t1", 1)
+	}
+}
+
+func BenchmarkMemoryCache_SetEvictsOldest(b *testing.B) {
+	const cap = 100
+	c := NewMemoryCache(cap)
+	defer c.Stop()
+	ctx := context.Background()
+	for i := range cap {
+		_ = c.Set(ctx, fmt.Sprintf("seed%d", i), 1, map[string]string{"v": "x"}, time.Minute)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		_ = c.Set(ctx, fmt.Sprintf("new%d", i), 1, map[string]string{"v": "x"}, time.Minute)
+	}
+}
+
+func newRedisClient(b *testing.B) *redis.Client {
+	b.Helper()
+	addr := os.Getenv("REDIS_URL")
+	if addr == "" {
+		b.Skip("REDIS_URL not set")
+	}
+	opt, err := redis.ParseURL(addr)
+	if err != nil {
+		b.Fatalf("parse REDIS_URL: %v", err)
+	}
+	return redis.NewClient(opt)
+}
+
+func BenchmarkRedisCache_Get(b *testing.B) {
+	client := newRedisClient(b)
+	defer func() { _ = client.Close() }()
+	c := NewRedisCache(client)
+	ctx := context.Background()
+	_ = c.Set(ctx, "bench-t1", 1, map[string]string{"a": "1", "b": "2"}, time.Minute)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = c.Get(ctx, "bench-t1", 1)
+	}
+}
+
+func BenchmarkRedisCache_Set(b *testing.B) {
+	client := newRedisClient(b)
+	defer func() { _ = client.Close() }()
+	c := NewRedisCache(client)
+	ctx := context.Background()
+	vals := map[string]string{"a": "1", "b": "2", "c": "3"}
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		_ = c.Set(ctx, fmt.Sprintf("bench-t%d", i%10), 1, vals, time.Minute)
+	}
+}
+
+func BenchmarkRedisCache_Invalidate(b *testing.B) {
+	client := newRedisClient(b)
+	defer func() { _ = client.Close() }()
+	c := NewRedisCache(client)
+	ctx := context.Background()
+	vals := map[string]string{"a": "1"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		tid := fmt.Sprintf("bench-inv%d", i%5)
+		_ = c.Set(ctx, tid, 1, vals, time.Minute)
+		_ = c.Invalidate(ctx, tid)
+	}
+}

--- a/internal/pubsub/pubsub_bench_test.go
+++ b/internal/pubsub/pubsub_bench_test.go
@@ -1,0 +1,106 @@
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var benchEvent = ConfigChangeEvent{
+	TenantID:  "bench-t1",
+	Version:   1,
+	FieldPath: "app.rate_limit",
+	OldValue:  "100",
+	NewValue:  "200",
+	ChangedBy: "bench",
+	ChangedAt: time.Now(),
+}
+
+func BenchmarkMemoryPubSub_Publish_NoSubscribers(b *testing.B) {
+	ps := NewMemoryPubSub()
+	defer func() { _ = ps.Close() }()
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ps.Publish(ctx, benchEvent)
+	}
+}
+
+func BenchmarkMemoryPubSub_FanOut(b *testing.B) {
+	for _, subs := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("%dsubs", subs), func(b *testing.B) {
+			ps := NewMemoryPubSub()
+			// Register Close first (LIFO: cancel runs before Close, preventing double-close).
+			b.Cleanup(func() { _ = ps.Close() })
+			ctx := context.Background()
+			for range subs {
+				_, cancel, _ := ps.Subscribe(ctx, benchEvent.TenantID)
+				b.Cleanup(cancel)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = ps.Publish(ctx, benchEvent)
+			}
+		})
+	}
+}
+
+func newRedisPubSubClient(b *testing.B) *redis.Client {
+	b.Helper()
+	addr := os.Getenv("REDIS_URL")
+	if addr == "" {
+		b.Skip("REDIS_URL not set")
+	}
+	opt, err := redis.ParseURL(addr)
+	if err != nil {
+		b.Fatalf("parse REDIS_URL: %v", err)
+	}
+	return redis.NewClient(opt)
+}
+
+func BenchmarkRedisPubSub_Publish(b *testing.B) {
+	client := newRedisPubSubClient(b)
+	defer func() { _ = client.Close() }()
+	p := NewRedisPublisher(client)
+	defer func() { _ = p.Close() }()
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = p.Publish(ctx, benchEvent)
+	}
+}
+
+func BenchmarkRedisPubSub_FanOut(b *testing.B) {
+	for _, subs := range []int{1, 5, 20} {
+		b.Run(fmt.Sprintf("%dsubs", subs), func(b *testing.B) {
+			client := newRedisPubSubClient(b)
+			defer func() { _ = client.Close() }()
+			p := NewRedisPublisher(client)
+			defer func() { _ = p.Close() }()
+			subClient := newRedisPubSubClient(b)
+			defer func() { _ = subClient.Close() }()
+			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 10}))
+			subscriber := NewRedisSubscriber(subClient, logger)
+			defer func() { _ = subscriber.Close() }()
+			ctx := context.Background()
+			for range subs {
+				_, cancel, err := subscriber.Subscribe(ctx, benchEvent.TenantID)
+				if err != nil {
+					b.Skip("redis subscribe failed:", err)
+				}
+				b.Cleanup(cancel)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_ = p.Publish(ctx, benchEvent)
+			}
+		})
+	}
+}

--- a/internal/storage/dbstore/store_bench_test.go
+++ b/internal/storage/dbstore/store_bench_test.go
@@ -1,0 +1,136 @@
+package dbstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func newBenchPool(b *testing.B) *pgxpool.Pool {
+	b.Helper()
+	dsn := os.Getenv("DB_WRITE_URL")
+	if dsn == "" {
+		b.Skip("DB_WRITE_URL not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		b.Fatalf("connect db: %v", err)
+	}
+	b.Cleanup(pool.Close)
+	return pool
+}
+
+// benchFixture sets up a minimal schema → schema_version → tenant →
+// config_version chain and returns the IDs needed by the benchmarks.
+// All rows are deleted on b.Cleanup.
+type benchFixture struct {
+	tenantID        pgtype.UUID
+	configVersionID pgtype.UUID
+}
+
+func setupBenchFixture(b *testing.B, q *Queries, ctx context.Context) benchFixture {
+	b.Helper()
+
+	schema, err := q.CreateSchema(ctx, CreateSchemaParams{Name: fmt.Sprintf("bench-schema-%d", b.N)})
+	if err != nil {
+		b.Fatalf("create schema: %v", err)
+	}
+
+	sv, err := q.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID:          schema.ID,
+		Version:           1,
+		Checksum:          "bench",
+		DependentRequired: []byte("[]"),
+		Validations:       []byte("[]"),
+	})
+	if err != nil {
+		b.Fatalf("create schema version: %v", err)
+	}
+
+	tenant, err := q.CreateTenant(ctx, CreateTenantParams{
+		Name:          fmt.Sprintf("bench-tenant-%d", b.N),
+		SchemaID:      schema.ID,
+		SchemaVersion: sv.Version,
+	})
+	if err != nil {
+		b.Fatalf("create tenant: %v", err)
+	}
+
+	cv, err := q.CreateConfigVersion(ctx, CreateConfigVersionParams{
+		TenantID:  tenant.ID,
+		Version:   1,
+		CreatedBy: "bench",
+	})
+	if err != nil {
+		b.Fatalf("create config version: %v", err)
+	}
+
+	b.Cleanup(func() {
+		// Cascade deletes handle child rows; order matters for FK constraints.
+		_, _ = q.db.Exec(ctx, "DELETE FROM tenants WHERE id = $1", tenant.ID)
+		_, _ = q.db.Exec(ctx, "DELETE FROM schema_versions WHERE id = $1", sv.ID)
+		_, _ = q.db.Exec(ctx, "DELETE FROM schemas WHERE id = $1", schema.ID)
+	})
+
+	return benchFixture{tenantID: tenant.ID, configVersionID: cv.ID}
+}
+
+func BenchmarkSetConfigValue(b *testing.B) {
+	pool := newBenchPool(b)
+	q := New(pool)
+	ctx := context.Background()
+	fix := setupBenchFixture(b, q, ctx)
+	val := "bench-value"
+	chk := "abc123"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		_ = q.SetConfigValue(ctx, SetConfigValueParams{
+			ConfigVersionID: fix.configVersionID,
+			FieldPath:       fmt.Sprintf("bench.field_%d", i%50),
+			Value:           &val,
+			Checksum:        &chk,
+		})
+	}
+}
+
+func BenchmarkGetFullConfigAtVersion(b *testing.B) {
+	pool := newBenchPool(b)
+	q := New(pool)
+	ctx := context.Background()
+	fix := setupBenchFixture(b, q, ctx)
+
+	// Pre-populate 20 fields so the query scans a realistic result set.
+	val := "bench-v"
+	for i := range 20 {
+		fp := fmt.Sprintf("bench.field_%d", i)
+		_ = q.SetConfigValue(ctx, SetConfigValueParams{
+			ConfigVersionID: fix.configVersionID,
+			FieldPath:       fp,
+			Value:           &val,
+		})
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = q.GetFullConfigAtVersion(ctx, GetFullConfigAtVersionParams{
+			TenantID: fix.tenantID,
+			Version:  1,
+		})
+	}
+}
+
+func BenchmarkListTenants(b *testing.B) {
+	pool := newBenchPool(b)
+	q := New(pool)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = q.ListTenants(ctx, ListTenantsParams{Limit: 50, Offset: 0})
+	}
+}


### PR DESCRIPTION
## Summary

- Hot paths (cache, pubsub, storage queries) had no benchmarks, making it impossible to detect regressions or measure optimization impact.
- Adds `BenchmarkMemoryCache_Hit/Miss/SetEvictsOldest` and `BenchmarkRedisCache_Get/Set/Invalidate` (Redis skipped when `REDIS_URL` unset).
- Adds `BenchmarkMemoryPubSub_Publish/FanOut` (0–50 subscribers) and `BenchmarkRedisPubSub_Publish/FanOut` (Redis skipped when `REDIS_URL` unset).
- Adds `BenchmarkSetConfigValue`, `BenchmarkGetFullConfigAtVersion`, and `BenchmarkListTenants` against a real Postgres pool, with full schema→tenant→config_version fixture setup and cleanup (skipped when `DB_WRITE_URL` unset).
- CI bench job extended: adds new packages, runs `-count=5` for benchstat, and uploads both raw results and percentile summary as artifacts.

## Test plan

- [ ] `go test -bench=^BenchmarkMemoryCache -benchmem -benchtime=500ms ./internal/cache/` — three benchmarks run and complete cleanly.
- [ ] `go test -bench=^BenchmarkMemoryPubSub -benchmem -benchtime=500ms ./internal/pubsub/` — publish and fan-out (1/10/50 subs) benchmarks run cleanly.
- [ ] `go test -bench=. -benchmem -run='^$' -benchtime=500ms ./internal/storage/dbstore/` — skips cleanly when `DB_WRITE_URL` is unset.
- [ ] Redis benchmarks skip (not fail) when `REDIS_URL` is unset.
- [ ] CI bench job produces `bench.txt` and `bench-stats.txt` artifacts.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)