### PR TITLE
feat(e2e): upgrade safety test — old binary → migrate → new binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       helm: ${{ steps.filter.outputs.helm }}
+      migrations: ${{ steps.filter.outputs.migrations }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -85,6 +86,8 @@ jobs:
             helm:
               - 'deploy/helm/**'
               - '.github/workflows/ci.yml'
+            migrations:
+              - 'db/migrations/**'
 
   # Builds/pushes the shared decree-tools Docker image used by downstream jobs.
   # Skips the build if an image tagged with the Dockerfile hash already exists
@@ -740,12 +743,73 @@ jobs:
             bench-e2e.txt
             bench-e2e-stats.txt
 
+  # Upgrade safety: runs the previous-release binary against a fresh DB,
+  # populates fixture data, applies new migrations, then asserts the new binary
+  # can read the old data and accept new writes. Only runs on PRs that touch
+  # db/migrations/, so it's zero-cost for non-migration changes.
+  upgrade:
+    name: Upgrade test
+    runs-on: ubuntu-latest
+    needs: [tools, changes]
+    if: needs.changes.outputs.migrations == 'true'
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/go.sum"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull tools image
+        run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker-container
+          driver-opts: network=host
+
+      - name: Pre-build server image with layer cache
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: build/Dockerfile
+          load: true
+          tags: decree-service
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
+            type=gha,scope=server-build
+          cache-to: type=gha,scope=server-build,mode=max
+
+      - name: Run upgrade test
+        run: ./scripts/run-upgrade-test.sh
+        env:
+          TOOLS_IMAGE: decree-tools
+          SERVICE_IMAGE: decree-service
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Aggregates all job results for branch protection. A single required check
   # that passes iff every listed job passed or was legitimately skipped.
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, meta-schemas, helm, bench, bench-e2e]
+    needs: [lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, meta-schemas, helm, bench, bench-e2e, upgrade]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -754,4 +818,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, helm, bench, bench-e2e
+          allowed-skips: lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, helm, bench, bench-e2e, upgrade

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ e2e:
 e2e-coverage:
 	./scripts/e2e-coverage.sh
 
+## upgrade-test: Run upgrade safety test (old binary → goose up → new binary). Requires TOOLS_IMAGE and SERVICE_IMAGE.
+upgrade-test:
+	./scripts/run-upgrade-test.sh
+
 ## examples: Run SDK examples (docker compose lifecycle)
 examples:
 	docker compose up -d --wait service

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -1,0 +1,81 @@
+//go:build e2e && upgrade
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+)
+
+const (
+	upgradeSchemaName = "upgrade-e2e-schema"
+	upgradeTenantName = "upgrade-e2e-tenant"
+)
+
+// TestUpgrade_Populate writes fixture data via the previous-release binary.
+// Run before goose migrations and before switching to the new binary.
+func TestUpgrade_Populate(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	cfg := newConfigClient(conn)
+	ctx := context.Background()
+
+	s, err := admin.CreateSchema(ctx, upgradeSchemaName, []adminclient.Field{
+		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "app.region", Type: "FIELD_TYPE_STRING"},
+	}, "upgrade e2e fixture")
+	require.NoError(t, err)
+
+	_, err = admin.PublishSchema(ctx, s.ID, 1)
+	require.NoError(t, err)
+
+	tenant, err := admin.CreateTenant(ctx, upgradeTenantName, s.ID, 1)
+	require.NoError(t, err)
+
+	require.NoError(t, cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second))
+	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.region", "us-east-1"))
+}
+
+// TestUpgrade_Assert verifies fixture data is intact after goose migrations,
+// and that the new binary accepts new writes on the migrated schema.
+func TestUpgrade_Assert(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	cfg := newConfigClient(conn)
+	ctx := context.Background()
+
+	// Locate schema by name.
+	schemaID, schemaVersion, err := admin.GetLatestPublishedSchemaVersion(ctx, upgradeSchemaName)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), schemaVersion)
+
+	// Locate tenant by name.
+	tenants, err := admin.ListTenants(ctx, schemaID)
+	require.NoError(t, err)
+	var tenantID string
+	for _, tnt := range tenants {
+		if tnt.Name == upgradeTenantName {
+			tenantID = tnt.ID
+			break
+		}
+	}
+	require.NotEmpty(t, tenantID, "tenant %q not found after migration", upgradeTenantName)
+
+	// Verify config values survived migration.
+	vals, err := cfg.GetAll(ctx, tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "30s", vals["app.timeout"])
+	assert.Equal(t, "us-east-1", vals["app.region"])
+
+	// Verify new writes succeed on the migrated server.
+	require.NoError(t, cfg.Set(ctx, tenantID, "app.region", "eu-west-1"))
+	updated, err := cfg.Get(ctx, tenantID, "app.region")
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", updated)
+}

--- a/scripts/run-upgrade-test.sh
+++ b/scripts/run-upgrade-test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Upgrade test: old binary → goose up → new binary on same DB.
+#
+# Phases:
+#   1. Find previous release tag and pull its server image.
+#   2. Extract previous migrations from git.
+#   3. Start postgres + redis.
+#   4. Apply old migrations (goose).
+#   5. Start old server → TestUpgrade_Populate.
+#   6. Apply new migrations (goose up).
+#   7. Start new server → TestUpgrade_Assert.
+#
+# Env vars:
+#   TOOLS_IMAGE   goose image (default: decree-tools)
+#   SERVICE_IMAGE new server image (default: decree-service)
+#   GH_TOKEN      required for gh release list
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TOOLS_IMAGE="${TOOLS_IMAGE:-decree-tools}"
+SERVICE_IMAGE="${SERVICE_IMAGE:-decree-service}"
+NETWORK="decree-upgrade"
+PG_CONTAINER="decree-upgrade-pg"
+REDIS_CONTAINER="decree-upgrade-redis"
+OLD_SERVER="decree-upgrade-old"
+NEW_SERVER="decree-upgrade-new"
+DB_URL="postgres://centralconfig:localdev@${PG_CONTAINER}:5432/centralconfig?sslmode=disable"
+TMP_DIR=""
+
+cleanup() {
+  docker rm -f "$PG_CONTAINER" "$REDIS_CONTAINER" "$OLD_SERVER" "$NEW_SERVER" 2>/dev/null || true
+  docker network rm "$NETWORK" 2>/dev/null || true
+  [ -n "$TMP_DIR" ] && rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+wait_tcp() {
+  local host="$1" port="$2" label="$3" retries="${4:-30}"
+  echo "Waiting for $label on $host:$port ..."
+  for _ in $(seq 1 "$retries"); do
+    if nc -z "$host" "$port" 2>/dev/null; then
+      echo "$label is ready."
+      return 0
+    fi
+    sleep 1
+  done
+  echo "ERROR: $label did not become ready after ${retries}s" >&2
+  return 1
+}
+
+# ── 1. Find previous release tag ──────────────────────────────────────────────
+PREV_TAG=$(gh release list --repo opendecree/decree --limit 20 --json tagName,isDraft \
+  --jq '[.[] | select(.isDraft == false)] | .[0].tagName' 2>/dev/null || true)
+
+if [ -z "$PREV_TAG" ]; then
+  echo "No previous release found — skipping upgrade test."
+  exit 0
+fi
+echo "Previous release: $PREV_TAG"
+
+# ── 2. Extract previous migrations from git ───────────────────────────────────
+TMP_DIR=$(mktemp -d)
+OLD_MIGRATIONS_DIR="$TMP_DIR/migrations"
+mkdir -p "$OLD_MIGRATIONS_DIR"
+
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  git show "${PREV_TAG}:db/migrations/${f}" > "${OLD_MIGRATIONS_DIR}/${f}"
+done < <(git ls-tree --name-only "$PREV_TAG" db/migrations/ 2>/dev/null || true)
+
+if [ -z "$(ls -A "$OLD_MIGRATIONS_DIR" 2>/dev/null)" ]; then
+  echo "No migrations in $PREV_TAG — skipping upgrade test."
+  exit 0
+fi
+echo "Old migrations: $(ls "$OLD_MIGRATIONS_DIR" | tr '\n' ' ')"
+
+# ── 3. Pull previous server image ─────────────────────────────────────────────
+PREV_IMAGE="ghcr.io/opendecree/decree:${PREV_TAG}"
+if ! docker pull "$PREV_IMAGE"; then
+  echo "Image $PREV_IMAGE not available — skipping upgrade test."
+  exit 0
+fi
+
+# ── 4. Start postgres + redis ─────────────────────────────────────────────────
+docker network create "$NETWORK"
+
+docker run -d --name "$PG_CONTAINER" --network "$NETWORK" \
+  -p 5499:5432 \
+  -e POSTGRES_DB=centralconfig \
+  -e POSTGRES_USER=centralconfig \
+  -e POSTGRES_PASSWORD=localdev \
+  postgres:17
+
+docker run -d --name "$REDIS_CONTAINER" --network "$NETWORK" \
+  redis:7 redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru
+
+wait_tcp 127.0.0.1 5499 "postgres"
+until docker exec "$PG_CONTAINER" pg_isready -U centralconfig 2>/dev/null; do sleep 1; done
+
+# ── 5. Apply old migrations ───────────────────────────────────────────────────
+echo "--- applying old migrations ---"
+docker run --rm --network "$NETWORK" \
+  -v "${OLD_MIGRATIONS_DIR}:/migrations:ro" \
+  "$TOOLS_IMAGE" \
+  goose -dir /migrations postgres "$DB_URL" up
+
+# ── 6. Start old server, populate fixtures ────────────────────────────────────
+echo "--- starting old server ---"
+docker run -d --name "$OLD_SERVER" --network "$NETWORK" \
+  -p 19090:9090 \
+  -e GRPC_PORT=9090 \
+  -e DB_WRITE_URL="$DB_URL" \
+  -e DB_READ_URL="$DB_URL" \
+  -e REDIS_URL="redis://${REDIS_CONTAINER}:6379" \
+  -e ENABLE_SERVICES=schema,config,audit \
+  -e HTTP_PORT=8080 \
+  -e INSECURE_LISTEN=1 \
+  -e ENABLE_REFLECTION=1 \
+  -e SCHEMA_MAX_FIELDS=100 \
+  -e SCHEMA_MAX_DOC_BYTES=4096 \
+  "$PREV_IMAGE"
+
+wait_tcp 127.0.0.1 19090 "old server"
+
+echo "--- populating fixtures ---"
+(cd "$REPO_ROOT/e2e" && SERVICE_ADDR=localhost:19090 \
+  go test -tags=e2e,upgrade -run TestUpgrade_Populate -v -count=1 ./...)
+
+docker stop "$OLD_SERVER"
+docker rm "$OLD_SERVER"
+
+# ── 7. Apply new migrations ───────────────────────────────────────────────────
+echo "--- applying new migrations ---"
+docker run --rm --network "$NETWORK" \
+  -v "${REPO_ROOT}/db/migrations:/migrations:ro" \
+  "$TOOLS_IMAGE" \
+  goose -dir /migrations postgres "$DB_URL" up
+
+# ── 8. Start new server, assert data integrity ───────────────────────────────
+echo "--- starting new server ---"
+docker run -d --name "$NEW_SERVER" --network "$NETWORK" \
+  -p 29090:9090 \
+  -e GRPC_PORT=9090 \
+  -e DB_WRITE_URL="$DB_URL" \
+  -e DB_READ_URL="$DB_URL" \
+  -e REDIS_URL="redis://${REDIS_CONTAINER}:6379" \
+  -e ENABLE_SERVICES=schema,config,audit \
+  -e HTTP_PORT=8080 \
+  -e INSECURE_LISTEN=1 \
+  -e ENABLE_REFLECTION=1 \
+  -e SCHEMA_MAX_FIELDS=100 \
+  -e SCHEMA_MAX_DOC_BYTES=4096 \
+  "$SERVICE_IMAGE"
+
+wait_tcp 127.0.0.1 29090 "new server"
+
+echo "--- asserting data integrity ---"
+(cd "$REPO_ROOT/e2e" && SERVICE_ADDR=localhost:29090 \
+  go test -tags=e2e,upgrade -run TestUpgrade_Assert -v -count=1 ./...)
+
+echo "--- upgrade test passed ---"


### PR DESCRIPTION
## Summary

- Beta requires upgrade safety guarantees; there was no test that schema migrations preserve data written by a previous release binary.
- Adds an end-to-end upgrade test that runs the previous release server, populates fixture data, applies new goose migrations, then asserts the new server reads the old data and accepts new writes.
- The CI job is path-gated to `db/migrations/**`, so non-migration PRs pay zero cost.

## Test plan

- [ ] `e2e/upgrade_test.go` — `TestUpgrade_Populate` creates a schema, tenant, and config values against the old server; `TestUpgrade_Assert` reads them back after migration and writes a new value on the new server.
- [ ] `scripts/run-upgrade-test.sh` — orchestrates the full flow: pulls previous release image from ghcr.io, extracts old migrations from git tag, sequences old server → goose up → new server. Gracefully skips when no previous release or image exists.
- [ ] `make upgrade-test` runs the script locally.
- [ ] CI `upgrade` job in `ci.yml` triggers only on `db/migrations/**` changes and is included in the `check` gate with `allowed-skips`.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)