### PR TITLE
ci: move bench-e2e to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@
 #   - main.yml  → ghcr.io/<owner>/decree:buildcache, decree-cli:buildcache
 #   - release.yml → same refs (shared with main.yml, mode=max)
 #   - tools job → ghcr.io/<owner>/decree-tools:buildcache
-# ci.yml e2e/examples are read-only consumers.
+# ci.yml e2e/examples/stress are read-only consumers.
+# E2E benchmarks moved to release.yml — too slow for per-PR CI.
 
 name: CI
 
@@ -669,80 +670,6 @@ jobs:
             bench.txt
             bench-stats.txt
 
-  # Runs e2e gRPC benchmarks for Schema and Audit services against the full
-  # server stack. Reports p50/p95/p99 per-op latency via custom bench metrics
-  # and uploads raw + benchstat output as workflow artifacts. Informational —
-  # does not gate branch protection.
-  bench-e2e:
-    name: E2E Benchmarks
-    runs-on: ubuntu-latest
-    needs: [tools, changes]
-    if: needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-      packages: read
-    timeout-minutes: 25
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull tools image
-        run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
-
-      - name: Pre-build server image with layer cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: build/Dockerfile
-          load: true
-          tags: decree-service
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
-            type=gha,scope=server-build
-          cache-to: type=gha,scope=server-build,mode=max
-
-      - name: Run e2e benchmarks
-        run: |
-          docker compose up -d --wait service
-          cd e2e && go test -tags=e2e -bench=. -benchmem -run='^$' -benchtime=3s -count=5 ./... \
-            | tee ../bench-e2e.txt || (cd .. && docker compose down -v && exit 1)
-          docker compose down -v
-        env:
-          TOOLS_IMAGE: ${{ needs.tools.outputs.image }}
-
-      - name: Compute p50/p95/p99 with benchstat
-        run: |
-          go run golang.org/x/perf/cmd/benchstat@latest bench-e2e.txt | tee bench-e2e-stats.txt
-
-      - name: Upload e2e benchmark results
-        uses: actions/upload-artifact@v4
-        with:
-          name: bench-e2e-${{ github.sha }}
-          path: |
-            bench-e2e.txt
-            bench-e2e-stats.txt
-
   # Upgrade safety: runs the previous-release binary against a fresh DB,
   # populates fixture data, applies new migrations, then asserts the new binary
   # can read the old data and accept new writes. Only runs on PRs that touch
@@ -809,7 +736,7 @@ jobs:
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, meta-schemas, helm, bench, bench-e2e, upgrade]
+    needs: [lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, meta-schemas, helm, bench, upgrade]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -818,4 +745,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, helm, bench, bench-e2e, upgrade
+          allowed-skips: lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, helm, bench, upgrade

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,3 +392,72 @@ jobs:
           subject-name: ${{ env.IMAGE_REF }}
           subject-digest: ${{ steps.manifest_digest.outputs.digest }}
           push-to-registry: true
+
+  # Runs e2e gRPC benchmarks against the just-released server image.
+  # Moved here from ci.yml — too slow for per-PR runs. Results are uploaded
+  # as release artifacts for latency tracking over versions.
+  bench-e2e:
+    name: E2E Benchmarks
+    runs-on: ubuntu-latest
+    needs: [images]
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: false
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull or build tools image
+        id: tools
+        run: |
+          TAG="ghcr.io/${{ github.repository_owner }}/decree-tools:sha-$(sha256sum build/Dockerfile.tools | cut -c1-12)"
+          if docker pull "$TAG" 2>/dev/null; then
+            docker tag "$TAG" decree-tools
+          else
+            docker build -f build/Dockerfile.tools -t decree-tools .
+          fi
+          echo "image=decree-tools" >> $GITHUB_OUTPUT
+
+      - name: Pull release server image
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          docker pull "ghcr.io/${{ github.repository_owner }}/decree:${VERSION}"
+          docker tag "ghcr.io/${{ github.repository_owner }}/decree:${VERSION}" decree-service
+
+      - name: Run e2e benchmarks
+        run: |
+          docker compose up -d --wait service
+          cd e2e && go test -tags=e2e -bench=. -benchmem -run='^$' -benchtime=3s -count=5 ./... \
+            | tee ../bench-e2e.txt || (cd .. && docker compose down -v && exit 1)
+          docker compose down -v
+        env:
+          TOOLS_IMAGE: decree-tools
+          SERVICE_IMAGE: decree-service
+
+      - name: Compute p50/p95/p99 with benchstat
+        run: |
+          go run golang.org/x/perf/cmd/benchstat@latest bench-e2e.txt | tee bench-e2e-stats.txt
+
+      - name: Upload e2e benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-e2e-${{ github.ref_name }}
+          path: |
+            bench-e2e.txt
+            bench-e2e-stats.txt


### PR DESCRIPTION
## Summary

- E2E gRPC benchmarks take ~25 minutes and are informational only — they don't gate branch protection. Running them on every PR adds significant queue time with no correctness benefit.
- Moves `bench-e2e` from `ci.yml` to `release.yml`, where it runs after the multi-arch images job and pulls the just-published server image from ghcr. Artifacts are named `bench-e2e-<tag>` so results are traceable per release.
- Removes `bench-e2e` from the `check` gate's `needs` and `allowed-skips` lists.

## Test plan

- [ ] Verify `bench-e2e` no longer appears in PR CI runs.
- [ ] Verify next release run includes a `bench-e2e` job after `images` completes.
- [ ] Confirm artifact named `bench-e2e-<tag>` is uploaded on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)