### PR TITLE
ci: move bench job to push-only, remove from PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,13 +630,14 @@ jobs:
         run: ./deploy/helm/decree/tests/template_test.sh
 
   # Runs hot-path and infrastructure benchmarks; uploads results as a workflow
-  # artifact for tracking over time. Informational — does not gate branch protection.
-  # Storage (dbstore) and Redis benchmarks are skipped: no DB/Redis services here.
+  # artifact for tracking over time. Informational — push-to-main only, never
+  # blocks PRs. Storage (dbstore) and Redis benchmarks are skipped: no DB/Redis
+  # services here.
   bench:
     name: Benchmarks
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
     permissions:
       contents: read
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- The `bench` job was blocking every code PR for ~6 minutes despite a comment claiming it was informational — no regression gate existed, just an artifact upload.
- Adding `github.event_name == 'push'` to the job's `if:` condition makes it always skip on PRs; the existing `allowed-skips` entry in the `check` job means the gate passes immediately without any other changes.

## Test plan
- [ ] Verify CI on this PR completes without waiting for the bench job
- [ ] Confirm bench job shows as "skipped" in the check run, not "failed"
- [ ] Merge to main and confirm bench job does run on the push event

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)