### PR TITLE
ci: skip CodeQL Go analysis on PRs, move to push+schedule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,11 @@
 # CodeQL advanced setup. Replaces default-setup once disabled in repo settings.
 # Advanced unlocks paths-ignore (skip generated code) and Go module caching
 # across runs — projected ~1-2 min faster vs default-setup.
+#
+# Go analysis runs on push-to-main and weekly schedule only — not on PRs.
+# Per-PR vulnerability coverage is handled by govulncheck (ci.yml). This avoids
+# a ~5 min wall-clock hit from autobuild on every code PR.
+# Actions and Python analyzers still run on PRs (both are fast, < 1 min).
 name: CodeQL
 
 on:
@@ -27,6 +32,9 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Go autobuild takes ~5 min; skip it on PRs — govulncheck covers per-PR vuln
+    # scanning. Actions and Python are fast (< 1 min) and still run on PRs.
+    if: matrix.language != 'go' || github.event_name != 'pull_request'
     permissions:
       security-events: write
       packages: read


### PR DESCRIPTION
## Summary
- CodeQL Go (`autobuild`) was taking ~5 min on every code PR, making it the new wall-clock floor after #507 moved `bench` off the PR gate.
- Go analysis is now gated to push-to-main and the existing weekly schedule only; per-PR vulnerability scanning is already covered by `govulncheck` (33s, stays required via the CI check).
- `Analyze (go)` removed from required branch protection checks; Actions and Python analyzers remain on PR.

## Test plan
- [ ] Verify this PR's CI completes without waiting for `Analyze (go)`
- [ ] Confirm `Analyze (go)` is absent from this PR's check runs
- [ ] Merge to main and confirm all three languages run on the push event
- [ ] Confirm `govulncheck` still runs and passes on PRs

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)