### PR TITLE
ci: drop redundant Build server + CLI step from Test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,6 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: "**/go.sum"
 
-      - name: Build server + CLI
-        run: |
-          go build -o bin/decree-server ./cmd/server
-          cd cmd/decree && go build -o ../../bin/decree .
-
       - name: Unit tests
         run: go test ./internal/... -race -count=1 -coverprofile=coverage-internal.out -covermode=atomic
 


### PR DESCRIPTION
## Summary
- The explicit `go build` step in the Test job compiled the same packages that `go test` was about to compile anyway — pure duplicate work adding ~42s to the job.
- The produced binaries (`bin/decree-server`, `bin/decree`) were never uploaded as artifacts and are not consumed by any downstream job; e2e/examples/stress all build their own Docker images independently.

## Test plan
- [ ] Verify the Test job completes successfully without the build step
- [ ] Confirm unit tests and SDK tests still pass
- [ ] Confirm downstream jobs (e2e, examples, stress) still build and pass

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)