### PR TITLE
ci: shallow clone in Lint job, fetch main tip for buf breaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       image: ${{ env.TOOLS_IMAGE }}:${{ steps.hash.outputs.tag }}
 
   # Runs golangci-lint against Go code and buf lint/breaking against protos.
-  # buf breaking needs main fetched so it can diff the current branch.
+  # buf breaking needs the tip of main, fetched explicitly in the next step.
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -165,11 +165,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Fetch main branch for buf breaking
         if: github.ref != 'refs/heads/main'
-        run: git fetch origin main:main
+        run: git fetch origin main:main --depth=1
 
       - name: Check supply-chain pins
         run: ./scripts/check-supply-chain-pins.sh


### PR DESCRIPTION
## Summary

- The Lint job was fetching the full git history (`fetch-depth: 0`) on every PR, even though `buf breaking` only needs the tip of `main` to compare proto files against.
- The explicit `git fetch origin main:main` step already provides exactly what `buf breaking` needs, making the full history fetch wasteful.
- Switching to the default shallow clone (depth=1) and adding `--depth=1` to the main fetch eliminates unnecessary history transfer on every lint run.

## Test plan

- [ ] CI passes on this PR — Lint job completes, including `buf lint` and `buf breaking`
- [ ] Go lint and format check pass
- [ ] Proto lint + breaking check pass (confirms shallow main fetch is sufficient)

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)