### PR TITLE
ci: path-filter Docs check, replace tools image with go install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,14 @@
 # CI pipeline for OpenDecree server, SDKs, and CLI.
 #
-# Jobs: changes ──┬── tools → docs, e2e, examples, stress ──→ check (alls-green gate)
-#                 ├── lint ──────────────────────────────────────────────────────┘
-#                 └── test, sdk-compat, govulncheck, deps-review ───────────────┘
+# Jobs: changes ──┬── tools → e2e, examples, stress ──────────────────→ check (alls-green gate)
+#                 ├── lint, docs ──────────────────────────────────────────────┘
+#                 └── test, sdk-compat, govulncheck, deps-review ──────────────┘
 #
-# The changes job runs dorny/paths-filter; all downstream jobs (tools, lint,
-# test, sdk-compat, docs, e2e, examples, stress, govulncheck) skip on docs-only PRs —
-# zero-cost CI for top-level Markdown edits.
+# The changes job runs dorny/paths-filter; code jobs skip on docs-only PRs;
+# the docs job additionally skips unless proto/CLI/mkdocs files changed.
 #
-# The tools job builds/caches the Docker image used by docs, e2e, examples,
-# and stress, with a registry-backed buildx cache (:buildcache tag) so unchanged
+# The tools job builds/caches the Docker image used by e2e, examples, and
+# stress, with a registry-backed buildx cache (:buildcache tag) so unchanged
 # layers are pulled from ghcr and only modified layers rebuild.
 #
 # Security posture (issue #8):
@@ -63,6 +62,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       helm: ${{ steps.filter.outputs.helm }}
       migrations: ${{ steps.filter.outputs.migrations }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -90,6 +90,12 @@ jobs:
               - '.github/workflows/ci.yml'
             migrations:
               - 'db/migrations/**'
+            docs:
+              - 'proto/**'
+              - 'cmd/decree/**'
+              - 'internal/version/**'
+              - 'Makefile'
+              - 'mkdocs.yml'
 
   # Builds/pushes the shared decree-tools Docker image used by downstream jobs.
   # Skips the build if an image tagged with the Dockerfile hash already exists
@@ -290,16 +296,17 @@ jobs:
           cd sdk/configwatcher && go test ./... -count=1 &
           wait
 
-  # Regenerates docs + OpenAPI spec and fails if the generated output differs
-  # from what's committed. Catches forgotten `make generate docs` runs.
+  # Regenerates docs and fails if the output differs from what's committed.
+  # Catches forgotten `make generate docs` runs. Gated on docs-relevant paths
+  # (proto, cmd/decree, internal/version, Makefile, mkdocs.yml) so pure Go
+  # or config-only PRs skip this job entirely.
   docs:
     name: Docs check
     runs-on: ubuntu-latest
-    needs: [tools, changes]
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes]
+    if: needs.changes.outputs.docs == 'true'
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -313,26 +320,23 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: "**/go.sum"
 
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install buf
+        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
+        env:
+          GOTOOLCHAIN: auto
 
-      - name: Pull tools image
+      - name: Install protoc-gen-doc
+        run: go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+      - name: Regenerate docs
         run: |
-          docker pull "${{ needs.tools.outputs.image }}"
-          docker tag "${{ needs.tools.outputs.image }}" decree-tools
-          touch .tools-image-built
-
-      - name: Regenerate docs and OpenAPI spec
-        run: make generate docs
+          buf generate --template buf.gen.doc.yaml
+          make docs-cli docs-man
 
       - name: Check docs are up-to-date
         run: |
-          if ! git diff --exit-code docs/ cmd/server/openapi.json; then
-            echo "::error::Generated docs or OpenAPI spec are out of date. Run 'make generate docs' and commit."
+          if ! git diff --exit-code docs/; then
+            echo "::error::Generated docs are out of date. Run 'make generate docs' and commit."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- The Docs check ran on every code PR (~81 s wall-clock) even when no doc-relevant file changed. A new `docs` path filter (`proto/**`, `cmd/decree/**`, `internal/version/**`, `Makefile`, `mkdocs.yml`) gates the job so pure Go and config-only PRs skip it entirely.
- The Docker image pull (~20 s on cache hit) is replaced with `go install` for `buf` and `protoc-gen-doc`. The job now runs independently of the tools build instead of waiting behind it.
- The regeneration step changes from `make generate docs` (which also regenerates Go proto code and sqlc) to `buf generate --template buf.gen.doc.yaml && make docs-cli docs-man` — just the doc artifacts. The diff check narrows to `docs/` accordingly.

## Test plan

- [ ] CI passes on a PR that touches proto files — Docs check runs, `buf generate --template buf.gen.doc.yaml` produces up-to-date output, diff check passes
- [ ] CI passes on a PR that only touches Go files — Docs check is skipped (filter output `docs == 'false'`)
- [ ] `buf lint` and docs generation work without the tools Docker image
- [ ] `make docs-cli docs-man` builds the CLI and generates reference docs
- [ ] `check` gate still passes (docs in `allowed-skips`)

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)