### PR TITLE
ci: collapse e2e, examples, stress into integration matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # CI pipeline for OpenDecree server, SDKs, and CLI.
 #
-# Jobs: changes ──┬── tools → e2e, examples, stress ──────────────────→ check (alls-green gate)
+# Jobs: changes ──┬── tools → integration (e2e|examples|stress) ──────→ check (alls-green gate)
 #                 ├── lint, docs ──────────────────────────────────────────────┘
 #                 └── test, sdk-compat, govulncheck, deps-review ──────────────┘
 #
@@ -340,135 +340,11 @@ jobs:
             exit 1
           fi
 
-  # Boots the service via docker compose and runs the e2e Go test suite
-  # against it. Pre-builds the server image locally using the ghcr layer cache.
-  e2e:
-    name: E2E
-    runs-on: ubuntu-latest
-    needs: [tools, changes]
-    if: needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-      packages: read
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull tools image
-        run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
-
-      - name: Pre-build server image with layer cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: build/Dockerfile
-          load: true
-          tags: decree-service
-          # Two-tier cache:
-          #   - registry buildcache (read-only; main.yml is canonical writer)
-          #     supplies stable layers like base image + go mod download.
-          #   - GHA cache (read/write, shared scope) carries warm layers
-          #     forward from previous PR runs without round-tripping ghcr.
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
-            type=gha,scope=server-build
-          cache-to: type=gha,scope=server-build,mode=max
-
-      - name: Run E2E tests
-        run: |
-          docker compose up -d --wait service
-          cd e2e && go test -tags=e2e -v -race -count=1 ./... || (cd .. && docker compose down -v && exit 1)
-          docker compose down -v
-        env:
-          TOOLS_IMAGE: ${{ needs.tools.outputs.image }}
-
-  # Runs the hands-on example programs against the freshly-built server image,
-  # catching SDK regressions that only surface in real integration scenarios.
-  examples:
-    name: Examples
-    runs-on: ubuntu-latest
-    needs: [tools, changes]
-    if: needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-      packages: read
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pull tools image
-        run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
-
-      - name: Pre-build server image with layer cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: build/Dockerfile
-          load: true
-          tags: decree-service
-          # Two-tier cache:
-          #   - registry buildcache (read-only; main.yml is canonical writer)
-          #     supplies stable layers like base image + go mod download.
-          #   - GHA cache (read/write, shared scope) carries warm layers
-          #     forward from previous PR runs without round-tripping ghcr.
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
-            type=gha,scope=server-build
-          cache-to: type=gha,scope=server-build,mode=max
-
-      - name: Run examples
-        run: make examples
-        env:
-          TOOLS_IMAGE: ${{ needs.tools.outputs.image }}
-
-  # Runs cache pressure, connection pool, and memory growth stress tests in
-  # short mode (-short flag) against the freshly-built server image.
-  stress:
-    name: Stress tests
+  # E2E, examples, and stress share identical setup (checkout, Go, Docker,
+  # tools image, server image prebuild). Collapsed into one matrix job to
+  # eliminate the 3× YAML duplication. Legs run in parallel by default.
+  integration:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     needs: [tools, changes]
     if: needs.changes.outputs.code == 'true'
@@ -476,6 +352,16 @@ jobs:
       contents: read
       packages: read
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: e2e
+            name: E2E
+          - suite: examples
+            name: Examples
+          - suite: stress
+            name: Stress tests
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -511,13 +397,31 @@ jobs:
           file: build/Dockerfile
           load: true
           tags: decree-service
+          # Two-tier cache:
+          #   - registry buildcache (read-only; main.yml is canonical writer)
+          #     supplies stable layers like base image + go mod download.
+          #   - GHA cache (read/write, shared scope) carries warm layers
+          #     forward from previous PR runs without round-tripping ghcr.
           cache-from: |
             type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
             type=gha,scope=server-build
           cache-to: type=gha,scope=server-build,mode=max
 
-      - name: Run stress tests (short mode)
-        run: CI=true make stress
+      - name: Run ${{ matrix.name }}
+        run: |
+          case "${{ matrix.suite }}" in
+            e2e)
+              docker compose up -d --wait service
+              cd e2e && go test -tags=e2e -v -race -count=1 ./... || (cd .. && docker compose down -v && exit 1)
+              docker compose down -v
+              ;;
+            examples)
+              make examples
+              ;;
+            stress)
+              CI=true make stress
+              ;;
+          esac
         env:
           TOOLS_IMAGE: ${{ needs.tools.outputs.image }}
 
@@ -736,7 +640,7 @@ jobs:
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, meta-schemas, helm, bench, upgrade]
+    needs: [lint, test, sdk-compat, docs, integration, govulncheck, deps-review, meta-schemas, helm, bench, upgrade]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -745,4 +649,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, e2e, examples, stress, govulncheck, deps-review, helm, bench, upgrade
+          allowed-skips: lint, test, sdk-compat, docs, integration, govulncheck, deps-review, helm, bench, upgrade


### PR DESCRIPTION
## Summary

- Three jobs (`e2e`, `examples`, `stress`) had identical setup: checkout, Go install, Docker login, tools image pull, and server image prebuild — duplicating ~180 lines of YAML and ~4× setup compute cost per PR.
- Collapsed into a single `integration` matrix job with three parallel legs so wall-clock is unchanged, but the shared setup is defined once. YAML drops from ~180 to ~55 lines.
- Updated the `check` gate to reference `integration` instead of the three individual job IDs; `fail-fast: false` preserves independent failure behavior per leg.

## Test plan

- [ ] CI passes — all three matrix legs (E2E, Examples, Stress tests) run and complete
- [ ] Matrix legs run in parallel (no wall-clock regression vs. three separate jobs)
- [ ] `CI check` gate passes when all legs pass or when the entire matrix is skipped (`code == 'false'`)
- [ ] Individual leg failure causes the matrix job to fail and the `CI check` gate to block the PR

Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)