### PR TITLE
fix(ci): sync golangci-lint version — Makefile to v2.11.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_DIR := bin
 TOOLS_IMAGE := decree-tools
 TOOLS_SENTINEL := .tools-image-built
 DOCKER_RUN_TOOLS := docker run --rm -u $(shell id -u):$(shell id -g) -e HOME=/tmp -v $(CURDIR):/workspace -w /workspace $(TOOLS_IMAGE)
-GOLANGCI_LINT_VERSION := v2.8.0
+GOLANGCI_LINT_VERSION := v2.11.4
 
 # Version injection for binaries.
 GIT_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)


### PR DESCRIPTION
## Summary

- `GOLANGCI_LINT_VERSION` in the Makefile was pinned to `v2.8.0` while the CI workflow uses `v2.11.4`, so developers running `golangci-lint` locally could get different results than CI — lint issues that CI catches would pass locally and vice versa.
- One-line fix: update the Makefile pin to `v2.11.4` to match the workflow.

## Test plan

- [ ] CI passes (lint job uses `v2.11.4` unchanged)
- [ ] `GOLANGCI_LINT_VERSION` in Makefile matches `version:` in `.github/workflows/ci.yml`

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)