### PR TITLE
ci: drop Go 1.23 from SDK compat matrix, test floor only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,9 @@ jobs:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Proves the SDK core modules still build and test against older Go versions
-  # we advertise support for (1.22 is the lowest SDK-supported minor).
+  # Proves the SDK core modules still build and test against the floor Go
+  # version we advertise support for (1.22). Testing 1.23+ is redundant:
+  # if 1.22 passes, later versions pass too. Only the floor matters.
   sdk-compat:
     name: SDK compat (Go ${{ matrix.go }})
     runs-on: ubuntu-latest
@@ -270,7 +271,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.22"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- The SDK compat matrix tested both Go 1.22 and Go 1.23, but per the version policy in `CLAUDE.md` the SDK floor is Go 1.22. Testing an intermediate version adds a runner per PR without catching anything the floor test doesn't already catch.
- Removing Go 1.23 from the matrix keeps the meaningful boundary check (the floor) while eliminating one runner's worth of compute per code PR.

## Test plan

- [ ] CI passes with only the `SDK compat (Go 1.22)` leg
- [ ] SDK core modules build and test against Go 1.22
- [ ] No `SDK compat (Go 1.23)` job appears in the run

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)