### PR TITLE
fix(config): close TOCTOU in checksum-guarded writes

### DIFF
--- a/internal/config/concurrency_test.go
+++ b/internal/config/concurrency_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/storage/domain"
@@ -262,4 +264,89 @@ values:
 	case <-time.After(testTimeout):
 		t.Fatal("timeout waiting for ImportConfig to complete after unblocking")
 	}
+}
+
+// TestChecksumGuardedWrites_ChecksumMismatchInTx verifies that a concurrent
+// write that changes the latest version before our tx commits causes an Aborted
+// error. It simulates the race with successive mock return values:
+//   - Outside-tx GetLatestConfigVersion returns v1 (pre-race state).
+//   - Inside-tx GetLatestConfigVersion returns v2 (post-concurrent-write state).
+//   - The checksum at v2 differs from the client's expectedChecksum.
+//
+// This proves the checksum check is bound to the tx and detects the race (fix for #417).
+func TestChecksumGuardedWrites_ChecksumMismatchInTx(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{}
+	c := &mockCache{}
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	svc := NewService(store, c, pub, sub, WithLogger(testLogger))
+
+	ctx := superadminCtx()
+	expectedChecksum := "checksum-at-v1"
+	differentChecksum := "checksum-at-v2"
+
+	// First call: getOrCreateVersion outside the tx sees v1.
+	// Second call: txLatestVersion inside the tx sees v2 (concurrent write committed).
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil).Once()
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 2}, nil).Once()
+
+	// getCurrentValue (v1, outside tx) then checkChecksumAtVersion (v2, inside tx).
+	// Both return a row but with different checksums across calls.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{Value: strPtr("old"), Checksum: &expectedChecksum}, nil).Once()
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{Value: strPtr("newer"), Checksum: &differentChecksum}, nil).Once()
+
+	setupNoSensitiveFields(store)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:         tenantID1,
+		FieldPath:        "app.env",
+		Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}},
+		ExpectedChecksum: &expectedChecksum,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "checksum mismatch due to concurrent write must return Aborted")
+}
+
+// TestChecksumGuardedWrites_VersionConflictReturnsAborted verifies that when
+// CreateConfigVersion returns ErrVersionConflict (two writers racing to create
+// the same version slot), the service returns codes.Aborted rather than
+// codes.Internal. This proves the UNIQUE constraint collision is surfaced as a
+// retriable error, not an unexpected internal failure.
+func TestChecksumGuardedWrites_VersionConflictReturnsAborted(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{}
+	c := &mockCache{}
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	svc := NewService(store, c, pub, sub, WithLogger(testLogger))
+
+	ctx := superadminCtx()
+
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	// getCurrentValue outside tx: field not found.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	setupNoSensitiveFields(store)
+	// No ExpectedChecksum → checkChecksumAtVersion is skipped; CreateConfigVersion
+	// fails immediately with ErrVersionConflict (simulating the UNIQUE collision).
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.env",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict must return Aborted, not Internal")
 }

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -424,12 +424,7 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 
 	actor := s.getActor(ctx)
 
-	// Pre-transaction validation (reads only).
-	if req.ExpectedChecksum != nil {
-		if err := s.checkChecksum(ctx, tenantID, req.FieldPath, *req.ExpectedChecksum); err != nil {
-			return nil, err
-		}
-	}
+	// Pre-transaction validation (schema/lock checks only).
 	if err := s.validateField(ctx, tenantID, req.FieldPath, req.Value); err != nil {
 		return nil, err
 	}
@@ -451,12 +446,25 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	}
 
 	// Transaction: version + value + audit + dependentRequired check.
+	// Re-reading the latest version inside the tx and verifying the checksum
+	// there closes the TOCTOU window: concurrent writers must serialise through
+	// the UNIQUE(tenant_id, version) constraint on CreateConfigVersion, so at
+	// most one writer succeeds per version slot.
 	var newVersion domain.ConfigVersion
 	if err := s.store.RunInTx(ctx, func(tx Store) error {
 		var txErr error
+		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
+		if txErr != nil {
+			return txErr
+		}
+		if req.ExpectedChecksum != nil {
+			if txErr = checkChecksumAtVersion(ctx, tx, tenantID, req.FieldPath, *req.ExpectedChecksum, txLockedVersion); txErr != nil {
+				return txErr
+			}
+		}
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,
-			Version:     latestVersion + 1,
+			Version:     txLockedVersion + 1,
 			Description: ptrString(req.GetDescription()),
 			CreatedBy:   actor,
 		})
@@ -493,6 +501,12 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 			ConfigVersion: &newVersion.Version,
 		})
 	}); err != nil {
+		if errors.Is(err, ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent write conflict; retry with the latest checksum")
+		}
+		if st, ok := status.FromError(err); ok {
+			return nil, st.Err()
+		}
 		return nil, mapDependentRequiredErr(err, func() error {
 			s.logger.ErrorContext(ctx, "set field transaction failed", "error", err)
 			return status.Error(codes.Internal, "failed to set field")
@@ -535,13 +549,8 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 		ctx = authz.WithFieldLockCache(ctx, locks)
 	}
 
-	// Pre-transaction validation (reads only).
+	// Pre-transaction validation (schema/lock checks only).
 	for _, update := range req.Updates {
-		if update.ExpectedChecksum != nil {
-			if err := s.checkChecksum(ctx, tenantID, update.FieldPath, *update.ExpectedChecksum); err != nil {
-				return nil, err
-			}
-		}
 		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: update.FieldPath}); err != nil {
 			return nil, err
 		}
@@ -581,12 +590,25 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 	}
 
 	// Transaction: version + all values + all audit entries + dependentRequired check.
+	// Checksums are verified inside the tx after re-reading the latest version so
+	// concurrent writes cannot bypass the check (TOCTOU fix for #417).
 	var newVersion domain.ConfigVersion
 	if err := s.store.RunInTx(ctx, func(tx Store) error {
 		var txErr error
+		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
+		if txErr != nil {
+			return txErr
+		}
+		for _, update := range req.Updates {
+			if update.ExpectedChecksum != nil {
+				if txErr = checkChecksumAtVersion(ctx, tx, tenantID, update.FieldPath, *update.ExpectedChecksum, txLockedVersion); txErr != nil {
+					return txErr
+				}
+			}
+		}
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,
-			Version:     latestVersion + 1,
+			Version:     txLockedVersion + 1,
 			Description: ptrString(req.GetDescription()),
 			CreatedBy:   actor,
 		})
@@ -625,6 +647,12 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 
 		return s.enforceDependentRequiredInTx(ctx, tx, tenantID, newVersion.Version, depRules)
 	}); err != nil {
+		if errors.Is(err, ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent write conflict; retry with the latest checksum")
+		}
+		if st, ok := status.FromError(err); ok {
+			return nil, st.Err()
+		}
 		return nil, mapDependentRequiredErr(err, func() error {
 			s.logger.ErrorContext(ctx, "set fields transaction failed", "error", err)
 			return status.Error(codes.Internal, "failed to set fields")
@@ -785,6 +813,9 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 			ConfigVersion: &newVersion.Version,
 		})
 	}); err != nil {
+		if errors.Is(err, ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent write conflict; retry the rollback")
+		}
 		return nil, mapDependentRequiredErr(err, func() error {
 			s.logger.ErrorContext(ctx, "rollback transaction failed", "error", err)
 			return status.Error(codes.Internal, "failed to rollback")
@@ -1117,6 +1148,9 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 
 		return s.enforceDependentRequiredInTx(ctx, tx, tenantID, newVersion.Version, depRules)
 	}); err != nil {
+		if errors.Is(err, ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "concurrent write conflict; retry the import")
+		}
 		return nil, mapDependentRequiredErr(err, func() error {
 			s.logger.ErrorContext(ctx, "import config transaction failed", "error", err)
 			return status.Error(codes.Internal, "failed to import config")
@@ -1297,22 +1331,36 @@ func (s *Service) getCurrentValue(ctx context.Context, tenantID string, fieldPat
 	return derefString(row.Value)
 }
 
-func (s *Service) checkChecksum(ctx context.Context, tenantID string, fieldPath, expected string) error {
-	latest, err := s.store.GetLatestConfigVersion(ctx, tenantID)
+// txLatestVersion returns the latest config version number for tenantID using
+// the provided Store (intended to be a tx-bound store). Returns 0 when no
+// versions exist yet. Must be called inside RunInTx so that the subsequent
+// CreateConfigVersion is in the same serialisable scope.
+func txLatestVersion(ctx context.Context, tx Store, tenantID string) (int32, error) {
+	latest, err := tx.GetLatestConfigVersion(ctx, tenantID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
-			return nil // No existing value — checksum check passes.
+			return 0, nil
 		}
-		return status.Error(codes.Internal, "failed to get latest version")
+		return 0, status.Error(codes.Internal, "failed to get latest version")
 	}
-	row, err := s.store.GetConfigValueAtVersion(ctx, GetConfigValueAtVersionParams{
+	return latest.Version, nil
+}
+
+// checkChecksumAtVersion verifies that the stored checksum for fieldPath at
+// version matches expected. Returns nil when version is 0 or the field does
+// not exist yet (first write is always allowed regardless of checksum).
+func checkChecksumAtVersion(ctx context.Context, tx Store, tenantID, fieldPath, expected string, version int32) error {
+	if version == 0 {
+		return nil
+	}
+	row, err := tx.GetConfigValueAtVersion(ctx, GetConfigValueAtVersionParams{
 		TenantID:  tenantID,
 		FieldPath: fieldPath,
-		Version:   latest.Version,
+		Version:   version,
 	})
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
-			return nil // Field doesn't exist yet.
+			return nil
 		}
 		return status.Error(codes.Internal, "failed to get current value for checksum")
 	}

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -232,6 +232,39 @@ func TestSetFields_InvalidTenantID(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func TestSetFields_ChecksumMismatch(t *testing.T) {
+	// Exercises the per-field checksum loop inside the SetFields transaction.
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	storedChecksum := "actual-stored"
+	clientChecksum := "client-expected-different"
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	// getOrCreateVersion + txLatestVersion (two calls to the same mock).
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	// getCurrentValue (outside tx) + checkChecksumAtVersion (inside tx): both
+	// return the stored checksum, which differs from the client's expectation.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{Value: strPtr("old"), Checksum: &storedChecksum}, nil)
+	setupNoSensitiveFields(store)
+
+	_, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{
+				FieldPath:        "app.name",
+				Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}},
+				ExpectedChecksum: &clientChecksum,
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+}
+
 // --- ListVersions ---
 
 func TestListVersions_Success(t *testing.T) {

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -265,6 +265,28 @@ func TestSetFields_ChecksumMismatch(t *testing.T) {
 	assert.Equal(t, codes.Aborted, status.Code(err))
 }
 
+func TestSetFields_VersionConflictReturnsAborted(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	setupNoSensitiveFields(store)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict)
+
+	_, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "app.name", Value: &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}}},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict must return Aborted, not Internal")
+}
+
 // --- ListVersions ---
 
 func TestListVersions_Success(t *testing.T) {

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -169,10 +169,13 @@ func TestSetField_ChecksumMismatch(t *testing.T) {
 
 	wrongChecksum := "wrong"
 
-	store.On("GetLatestConfigVersion", ctx, tenantID1).
+	// getOrCreateVersion (outside tx) + txLatestVersion (inside tx).
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
+	// getCurrentValue (outside tx) + checkChecksumAtVersion (inside tx).
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
 		Return(GetConfigValueAtVersionRow{Value: strPtr("old-value")}, nil)
+	setupNoSensitiveFields(store)
 
 	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
 		TenantId:         tenantID1,

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -188,6 +188,166 @@ func TestSetField_ChecksumMismatch(t *testing.T) {
 	assert.Equal(t, codes.Aborted, status.Code(err))
 }
 
+func TestSetField_ChecksumFirstWrite(t *testing.T) {
+	// When no versions exist yet (txLockedVersion == 0), an ExpectedChecksum
+	// is ignored and the write proceeds — there is nothing to mismatch against.
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	checksum := "any-value"
+
+	// Both outside-tx and inside-tx GetLatestConfigVersion return ErrNotFound.
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 1, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
+		Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
+		Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+	setupNoSensitiveFields(store)
+
+	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:         tenantID1,
+		FieldPath:        "app.name",
+		Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}},
+		ExpectedChecksum: &checksum,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), resp.ConfigVersion.Version)
+}
+
+func TestSetField_ChecksumDBError(t *testing.T) {
+	// When GetConfigValueAtVersion returns an unexpected error (not ErrNotFound),
+	// checkChecksumAtVersion surfaces it as codes.Internal.
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	checksum := "abc"
+	dbErr := errors.New("db exploded")
+
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	// Outside-tx getCurrentValue: ErrNotFound (field doesn't exist for audit).
+	// Inside-tx checkChecksumAtVersion: real db error.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound).Once()
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, dbErr).Once()
+	setupNoSensitiveFields(store)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:         tenantID1,
+		FieldPath:        "app.name",
+		Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}},
+		ExpectedChecksum: &checksum,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestSetField_TxLatestVersionDBError(t *testing.T) {
+	// When GetLatestConfigVersion fails inside the tx with a non-ErrNotFound
+	// error, SetField returns codes.Internal.
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	dbErr := errors.New("db exploded")
+
+	// Outside-tx: getOrCreateVersion succeeds.
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil).Once()
+	// Outside-tx: getCurrentValue.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	setupNoSensitiveFields(store)
+	// Inside-tx: txLatestVersion fails.
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{}, dbErr).Once()
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.name",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestSetField_ChecksumFieldNotYetWritten(t *testing.T) {
+	// When a version exists but the field has never been written, ErrNotFound
+	// from GetConfigValueAtVersion inside the tx means there is nothing to
+	// mismatch — the write proceeds regardless of ExpectedChecksum.
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	checksum := "any"
+
+	// Outside-tx: version 1 exists.
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	// getCurrentValue (outside tx): field not found.
+	// checkChecksumAtVersion (inside tx): field also not found → returns nil.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
+		Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
+		Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+	setupNoSensitiveFields(store)
+
+	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:         tenantID1,
+		FieldPath:        "app.name",
+		Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}},
+		ExpectedChecksum: &checksum,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), resp.ConfigVersion.Version)
+}
+
+func TestSetField_ChecksumMatchSucceeds(t *testing.T) {
+	// When the expected checksum matches the stored checksum, the write proceeds.
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	storedChecksum := "correct-checksum"
+
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{Value: strPtr("old"), Checksum: &storedChecksum}, nil)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
+		Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
+		Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+	setupNoSensitiveFields(store)
+
+	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:         tenantID1,
+		FieldPath:        "app.name",
+		Value:            &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "new"}},
+		ExpectedChecksum: &storedChecksum,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), resp.ConfigVersion.Version)
+}
+
 func TestSetField_LockedField(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	// Use admin context — lock checks only apply to non-superadmin.

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -422,6 +422,25 @@ func TestRollbackToVersion_Success(t *testing.T) {
 	store.AssertNumberOfCalls(t, "SetConfigValue", 2)
 }
 
+func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 5}, nil)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict)
+
+	_, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
+		TenantId: tenantID1,
+		Version:  2,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict during rollback must return Aborted, not Internal")
+}
+
 // --- ExportConfig ---
 
 func TestExportConfig_Success(t *testing.T) {
@@ -512,6 +531,39 @@ values:
 	store.AssertNumberOfCalls(t, "SetConfigValue", 2)
 	store.AssertNumberOfCalls(t, "InsertAuditWriteLog", 2)
 	cache.AssertCalled(t, "Invalidate", ctx, tenantID1)
+}
+
+func TestImportConfig_VersionConflictReturnsAborted(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	yamlContent := []byte(`spec_version: "v1"
+values:
+  app.env:
+    value: "prod"
+`)
+
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", mock.Anything, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", mock.Anything, schemaVersionID).
+		Return([]domain.SchemaField{{Path: "app.env", FieldType: domain.FieldTypeString}}, nil)
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict)
+
+	_, err := svc.ImportConfig(ctx, &pb.ImportConfigRequest{
+		TenantId:    tenantID1,
+		YamlContent: yamlContent,
+		Mode:        pb.ImportMode_IMPORT_MODE_REPLACE,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict during import must return Aborted, not Internal")
 }
 
 // --- ImportConfig with validation ---

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -2,10 +2,16 @@ package config
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/opendecree/decree/internal/storage/domain"
 )
+
+// ErrVersionConflict is returned by CreateConfigVersion when a concurrent
+// writer already committed the same version number (UNIQUE constraint violation).
+// Callers should surface this as codes.Aborted and advise a retry.
+var ErrVersionConflict = errors.New("version conflict")
 
 // --- Local param/result types ---
 

--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -75,6 +76,10 @@ func (s *PGStore) CreateConfigVersion(ctx context.Context, arg CreateConfigVersi
 		CreatedBy:   arg.CreatedBy,
 	})
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ConfigVersion{}, ErrVersionConflict
+		}
 		return domain.ConfigVersion{}, err
 	}
 	return configVersionFromDB(row), nil


### PR DESCRIPTION
## Summary

- The `ExpectedChecksum` check ran outside the write transaction, so a concurrent writer could commit a new version between the check and the INSERT — causing Writer A to silently overwrite Writer B's change.
- Moving the checksum re-read and comparison inside the transaction closes the window. The `UNIQUE(tenant_id, version)` constraint then acts as the final CAS: only one writer can create a given version slot.
- `ErrVersionConflict` (SQLSTATE 23505) and gRPC status errors emitted within the tx are now surfaced as `codes.Aborted` so callers know the conflict is retriable, not a server failure.

## Test plan

- [ ] `TestSetField_ChecksumMismatch` — checksum mismatch still returns `Aborted` (updated to match new in-tx call sequence)
- [ ] `TestChecksumGuardedWrites_ChecksumMismatchInTx` — simulates the race via successive mock returns; proves the check is bound to the tx
- [ ] `TestChecksumGuardedWrites_VersionConflictReturnsAborted` — proves `ErrVersionConflict` maps to `Aborted`, not `Internal`
- [ ] `make test` — full suite green
- [ ] `make lint` — zero issues

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)