### PR TITLE
fix(auth): change default role from superadmin to user

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,20 @@
 # Migration Guide
 
+## next — metadata auth default role changed to `user`
+
+The default role assigned when `x-role` is missing from a metadata-auth request has changed from `superadmin` to `user`. Any caller that omits `x-role` now needs an `x-tenant-id` header and will be treated as a read-only user instead of a superadmin.
+
+### What breaks
+
+Callers that sent only `x-subject` (relying on the implicit superadmin grant) will receive `codes.PermissionDenied` with message `x-tenant-id required for non-superadmin`.
+
+### How to migrate
+
+- **To keep superadmin access**: add `x-role: superadmin` to the request.
+- **To keep the old default temporarily** (migration window only): set `DECREE_INSECURE_DEFAULT_SUPERADMIN=1` on the server. A `WARN` is logged on every request that uses this fallback. Remove the flag before going to production.
+
+
+
 OpenDecree is **alpha** — the API is unstable and breaking changes ship without backward-compatibility shims. This document records the breaks so SDK consumers and embedders know what to update when bumping versions.
 
 ## v0.10.0-alpha.2 — functional options for service constructors

--- a/e2e/security_test.go
+++ b/e2e/security_test.go
@@ -112,7 +112,7 @@ func TestSecurity_SensitiveFieldRedacted(t *testing.T) {
 	// Subscribe before the write so the event is captured.
 	subCtx, subCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer subCancel()
-	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-security-sensitive")
+	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-security-sensitive", "x-role", "superadmin")
 	stream, err := cfgSvc.Subscribe(subCtx, &pb.SubscribeRequest{
 		TenantId:   tenant.ID,
 		FieldPaths: []string{"auth.token"},
@@ -272,7 +272,7 @@ func TestSecurity_AuditChainIntegrity(t *testing.T) {
 	cfg := newConfigClient(conn)
 	auditSvc := pb.NewAuditServiceClient(conn)
 
-	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-subject", "e2e-security-audit")
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-subject", "e2e-security-audit", "x-role", "superadmin")
 
 	// Lay down several config writes to build up a multi-entry chain.
 	require.NoError(t, cfg.Set(ctx, fixture.tenantID, "app.name", "alpha"))

--- a/e2e/security_test.go
+++ b/e2e/security_test.go
@@ -320,7 +320,7 @@ func TestSecurity_ReflectionEnabled(t *testing.T) {
 
 	// Reflection is registered as a regular gRPC service and goes through the
 	// same auth interceptor, so x-subject is required.
-	ctx = metadata.AppendToOutgoingContext(ctx, "x-subject", "e2e-security-reflection")
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-subject", "e2e-security-reflection", "x-role", "superadmin")
 
 	client := reflpb.NewServerReflectionClient(conn)
 	stream, err := client.ServerReflectionInfo(ctx)
@@ -363,7 +363,7 @@ func TestSecurity_ImportConfigSensitiveFieldRedacted(t *testing.T) {
 	// Subscribe before the import so we capture the event.
 	subCtx, subCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer subCancel()
-	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-security-import-sensitive")
+	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-security-import-sensitive", "x-role", "superadmin")
 	stream, err := cfgSvc.Subscribe(subCtx, &pb.SubscribeRequest{
 		TenantId:   tenant.ID,
 		FieldPaths: []string{"auth.token"},

--- a/e2e/stream_test.go
+++ b/e2e/stream_test.go
@@ -41,7 +41,7 @@ func TestConfigSubscription(t *testing.T) {
 	defer cancel()
 
 	// Add auth metadata (required by server).
-	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-test")
+	subCtx = metadata.AppendToOutgoingContext(subCtx, "x-subject", "e2e-test", "x-role", "superadmin")
 
 	stream, err := configSvc.Subscribe(subCtx, &pb.SubscribeRequest{
 		TenantId:   tenant.ID,

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -49,15 +50,17 @@ type TenantResolver func(ctx context.Context, idOrName string) (string, error)
 // MetadataInterceptor extracts identity from gRPC metadata headers
 // instead of JWT tokens. Used when JWT auth is disabled.
 type MetadataInterceptor struct {
-	resolveTenant TenantResolver
-	logger        *slog.Logger
+	resolveTenant             TenantResolver
+	logger                    *slog.Logger
+	insecureDefaultSuperadmin bool
 }
 
 // MetadataInterceptorOption configures a MetadataInterceptor.
 type MetadataInterceptorOption func(*metadataInterceptorOptions)
 
 type metadataInterceptorOptions struct {
-	logger *slog.Logger
+	logger                    *slog.Logger
+	insecureDefaultSuperadmin bool
 }
 
 // WithMetadataLogger sets the logger used for sanitised server-side errors.
@@ -66,15 +69,34 @@ func WithMetadataLogger(l *slog.Logger) MetadataInterceptorOption {
 	return func(o *metadataInterceptorOptions) { o.logger = l }
 }
 
+// WithInsecureDefaultSuperadmin restores the pre-v0.10 behaviour where a
+// missing x-role header defaults to superadmin. Only for migration windows;
+// never use in production. Set DECREE_INSECURE_DEFAULT_SUPERADMIN=1 to enable
+// at runtime without code changes.
+func WithInsecureDefaultSuperadmin() MetadataInterceptorOption {
+	return func(o *metadataInterceptorOptions) { o.insecureDefaultSuperadmin = true }
+}
+
 // NewMetadataInterceptor creates a new metadata-based auth interceptor.
 // If resolver is non-nil, tenant IDs in x-tenant-id headers are resolved
 // from name slugs to UUIDs before storing in the auth context.
 func NewMetadataInterceptor(resolver TenantResolver, opts ...MetadataInterceptorOption) *MetadataInterceptor {
 	o := metadataInterceptorOptions{logger: slog.Default()}
+	if os.Getenv("DECREE_INSECURE_DEFAULT_SUPERADMIN") == "1" {
+		o.insecureDefaultSuperadmin = true
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return &MetadataInterceptor{resolveTenant: resolver, logger: o.logger}
+	m := &MetadataInterceptor{
+		resolveTenant:             resolver,
+		logger:                    o.logger,
+		insecureDefaultSuperadmin: o.insecureDefaultSuperadmin,
+	}
+	if m.insecureDefaultSuperadmin {
+		m.logger.Warn("DECREE_INSECURE_DEFAULT_SUPERADMIN enabled — clients without x-role get superadmin; do not use in production")
+	}
+	return m
 }
 
 // UnaryInterceptor returns a gRPC unary server interceptor.
@@ -126,7 +148,12 @@ func (m *MetadataInterceptor) extractClaims(ctx context.Context) (context.Contex
 	}
 	role := Role(rawRole)
 	if role == "" {
-		role = RoleSuperAdmin
+		if m.insecureDefaultSuperadmin {
+			role = RoleSuperAdmin
+			m.logger.WarnContext(ctx, "insecure default superadmin role assigned", "subject", subject)
+		} else {
+			role = RoleUser
+		}
 	}
 	switch role {
 	case RoleSuperAdmin, RoleAdmin, RoleUser:

--- a/internal/auth/metadata_test.go
+++ b/internal/auth/metadata_test.go
@@ -26,15 +26,50 @@ func TestMetadata_ValidSuperadmin(t *testing.T) {
 	interceptor := NewMetadataInterceptor(nil)
 	unary := interceptor.UnaryInterceptor()
 
-	ctx := ctxWithMetadata(map[string]string{"x-subject": "admin@example.com"})
+	ctx := ctxWithMetadata(map[string]string{"x-subject": "admin@example.com", "x-role": "superadmin"})
 	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
 
 	require.NoError(t, err)
 	assert.Equal(t, "ok", resp)
 }
 
-func TestMetadata_DefaultsToSuperadmin(t *testing.T) {
+func TestMetadata_DefaultsToUser(t *testing.T) {
 	interceptor := NewMetadataInterceptor(nil)
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithMetadata(map[string]string{
+		"x-subject":   "user@example.com",
+		"x-tenant-id": "tenant-123",
+	})
+
+	var captured *Claims
+	handler := func(ctx context.Context, _ any) (any, error) {
+		captured, _ = ClaimsFromContext(ctx)
+		return "ok", nil
+	}
+
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	assert.Equal(t, "user@example.com", captured.Subject)
+	assert.Equal(t, RoleUser, captured.Role)
+	assert.Equal(t, []string{"tenant-123"}, captured.TenantIDs)
+}
+
+func TestMetadata_DefaultRole_MissingTenant_Denied(t *testing.T) {
+	interceptor := NewMetadataInterceptor(nil)
+	unary := interceptor.UnaryInterceptor()
+
+	// No x-role and no x-tenant-id: defaults to RoleUser which requires a tenant.
+	ctx := ctxWithMetadata(map[string]string{"x-subject": "user@example.com"})
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+func TestMetadata_InsecureDefaultSuperadmin(t *testing.T) {
+	interceptor := NewMetadataInterceptor(nil, WithInsecureDefaultSuperadmin())
 	unary := interceptor.UnaryInterceptor()
 
 	ctx := ctxWithMetadata(map[string]string{"x-subject": "user@example.com"})
@@ -48,7 +83,6 @@ func TestMetadata_DefaultsToSuperadmin(t *testing.T) {
 	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, handler)
 	require.NoError(t, err)
 	require.NotNil(t, captured)
-	assert.Equal(t, "user@example.com", captured.Subject)
 	assert.Equal(t, RoleSuperAdmin, captured.Role)
 	assert.Empty(t, captured.TenantIDs)
 }

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -28,7 +28,7 @@ import (
 // and verifies the core schema→tenant→config flow works end-to-end.
 func TestMemoryBackend_Integration(t *testing.T) {
 	ctx := context.Background()
-	authCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-subject", "integration-test"))
+	authCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("x-subject", "integration-test", "x-role", "superadmin"))
 
 	// Create server.
 	srv, err := New("0", auth.NewMetadataInterceptor(nil),


### PR DESCRIPTION
## Summary

- Removes insecure default superadmin role for unauthenticated metadata requests
- Default role when x-role header is missing is now RoleUser; no x-tenant-id → PermissionDenied  
- Adds WithInsecureDefaultSuperadmin() opt-in (DECREE_INSECURE_DEFAULT_SUPERADMIN=1) with startup/per-request WARN logs
- Updates e2e/security tests to pass x-role: superadmin explicitly

## Breaking change

Callers relying on missing x-role defaulting to superadmin must now pass it explicitly, or set DECREE_INSECURE_DEFAULT_SUPERADMIN=1. See MIGRATION.md.

## Test plan

- [x] TestMetadata_DefaultsToUser — no x-role → RoleUser
- [x] TestMetadata_DefaultRole_MissingTenant_Denied — no tenant → PermissionDenied
- [x] TestMetadata_InsecureDefaultSuperadmin — opt-in flag → RoleSuperAdmin
- [x] make test passes
- [x] e2e tests updated to pass x-role: superadmin explicitly

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)