### PR TITLE
fix(gateway): block auth headers from untrusted HTTP clients

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -352,6 +352,9 @@ func run() int {
 			}
 			uiFS = sub
 		}
+		if cfg.GatewayTrustedProxy {
+			logger.WarnContext(ctx, "DECREE_GATEWAY_TRUSTED_PROXY=1 set — gateway will forward client-supplied auth headers; ensure a trusted proxy enforces authentication upstream")
+		}
 		gwBuild := buildGatewayOptions(cfg, logger, openAPISpec, gwTLS, uiFS)
 		gw, err = server.NewGateway(ctx, cfg.HTTPPort, fmt.Sprintf("localhost:%s", cfg.GRPCPort), gwBuild.Opts...)
 		if err != nil {
@@ -437,6 +440,7 @@ type serverConfig struct {
 	RateLimitBurst           int
 	EnableReflection         bool
 	EnableUI                 bool
+	GatewayTrustedProxy      bool
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -510,6 +514,7 @@ func loadConfig() serverConfig {
 		RateLimitBurst:           parseEnvInt("RATE_LIMIT_BURST", 10),
 		EnableReflection:         getEnv("ENABLE_REFLECTION", "") == "1",
 		EnableUI:                 getEnv("ENABLE_UI", "") == "1",
+		GatewayTrustedProxy:      getEnv("DECREE_GATEWAY_TRUSTED_PROXY", "") == "1",
 	}
 }
 

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -57,11 +57,15 @@ func buildServerOptions(
 
 // gatewayOptionsBuild mirrors serverOptionsBuild for the HTTP gateway.
 type gatewayOptionsBuild struct {
-	Opts        []server.GatewayOption
-	UseTLS      bool
-	UseInsecure bool
-	HasUI       bool
+	Opts            []server.GatewayOption
+	UseTLS          bool
+	UseInsecure     bool
+	HasUI           bool
+	HasTrustedProxy bool
 }
+
+// gatewayOptionsBuild mirrors serverOptionsBuild for the HTTP gateway.
+// HasTrustedProxy is exported so tests can assert the flag was wired.
 
 func buildGatewayOptions(
 	cfg serverConfig,
@@ -88,6 +92,10 @@ func buildGatewayOptions(
 	if uiFS != nil {
 		out.Opts = append(out.Opts, server.WithUI(uiFS))
 		out.HasUI = true
+	}
+	if cfg.GatewayTrustedProxy {
+		out.Opts = append(out.Opts, server.WithGatewayTrustedProxy())
+		out.HasTrustedProxy = true
 	}
 	return out
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,9 @@ services:
       # 64 KiB recv cap so TestSecurity_OversizeRequestRejected can trip it
       # with a small payload. All legitimate test fixtures are well under 1 KiB.
       GRPC_MAX_RECV_MSG_BYTES: "65536"
+      # e2e tests pass auth headers directly over HTTP; trusted-proxy mode lets
+      # the gateway forward them instead of rejecting them with 401.
+      DECREE_GATEWAY_TRUSTED_PROXY: "1"
     ports:
       - "9090:9090"
       - "8080:8080"

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -211,6 +211,20 @@ spec:
 
 OpenDecree exposes the standard gRPC health checking protocol, so Kubernetes gRPC probes work out of the box.
 
+## HTTP Gateway — Auth Header Security
+
+By default, the HTTP gateway **rejects** any request that carries `x-subject`, `x-role`, or `x-tenant-id` headers. These are the metadata-auth identity headers; allowing clients to set them directly enables impersonation attacks.
+
+If you run a trusted authentication proxy (e.g. an Envoy sidecar, an Istio ingress, or a custom API gateway) in front of the HTTP gateway that sets these headers, you must declare it as trusted:
+
+```bash
+DECREE_GATEWAY_TRUSTED_PROXY=1 decree-server
+```
+
+A `WARN` is logged at startup when this flag is set. Only enable it if you can guarantee that the proxy strips or overwrites any client-supplied auth headers before they reach the gateway.
+
+> **Note**: The `authorization` header (JWT Bearer tokens) is always forwarded. The restriction only applies to the three metadata-auth headers listed above.
+
 ## Health Checks
 
 Each enabled service registers with the gRPC health checking protocol. Services report `SERVING` once fully initialized:

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -115,6 +115,10 @@ func NewGateway(ctx context.Context, httpPort, grpcAddr string, opts ...GatewayO
 		handler = top
 	}
 
+	if !o.trustedProxy {
+		handler = rejectAuthHeadersMiddleware(handler)
+	}
+
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%s", httpPort),
 		Handler: handler,
@@ -153,6 +157,27 @@ func forwardAuthHeaders(ctx context.Context, req *http.Request) metadata.MD {
 		}
 	}
 	return md
+}
+
+// rejectAuthHeadersMiddleware blocks requests that carry x-subject, x-role, or
+// x-tenant-id headers. In the default (no trusted proxy) mode these headers are
+// the sole source of identity, so allowing clients to set them directly enables
+// impersonation. Wrap the handler with this middleware unless
+// WithGatewayTrustedProxy is set.
+func rejectAuthHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, h := range []string{"x-subject", "x-role", "x-tenant-id"} {
+			if r.Header.Get(h) != "" {
+				http.Error(w,
+					"auth headers (x-subject, x-role, x-tenant-id) are not accepted from clients; "+
+						"set DECREE_GATEWAY_TRUSTED_PROXY=1 if a trusted proxy injects these headers",
+					http.StatusUnauthorized,
+				)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // spaHandler serves an embedded filesystem for a single-page application.

--- a/internal/server/gateway_options.go
+++ b/internal/server/gateway_options.go
@@ -16,6 +16,7 @@ type gatewayOptions struct {
 	maxSendMsgBytes int
 	tls             *GatewayTLSConfig
 	insecure        bool
+	trustedProxy    bool
 }
 
 // WithGatewayLogger sets the gateway logger. Defaults to slog.Default() when unset.
@@ -59,4 +60,13 @@ func WithGatewayInsecure() GatewayOption {
 // root). When unset, the /admin/ route is not registered.
 func WithUI(fsys fs.FS) GatewayOption {
 	return func(o *gatewayOptions) { o.uiFS = fsys }
+}
+
+// WithGatewayTrustedProxy declares that a trusted authentication proxy sits in
+// front of the gateway and is allowed to set x-subject, x-role, and
+// x-tenant-id headers. Without this option (the default), the gateway rejects
+// any request that carries those headers to prevent client impersonation.
+// Set DECREE_GATEWAY_TRUSTED_PROXY=1 to enable at runtime.
+func WithGatewayTrustedProxy() GatewayOption {
+	return func(o *gatewayOptions) { o.trustedProxy = true }
 }

--- a/internal/server/gateway_test.go
+++ b/internal/server/gateway_test.go
@@ -196,3 +196,40 @@ func TestServerService_GetServerInfo(t *testing.T) {
 
 // Verify that metadata.MD satisfies the grpc metadata interface.
 var _ metadata.MD = forwardAuthHeaders(context.Background(), &http.Request{Header: http.Header{}})
+
+func TestRejectAuthHeadersMiddleware_BlocksAuthHeaders(t *testing.T) {
+	blocked := []string{"x-subject", "x-role", "x-tenant-id"}
+	for _, h := range blocked {
+		t.Run(h, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/v1/config", nil)
+			req.Header.Set(h, "somevalue")
+			w := httptest.NewRecorder()
+			rejectAuthHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})).ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+			assert.Contains(t, w.Body.String(), "DECREE_GATEWAY_TRUSTED_PROXY")
+		})
+	}
+}
+
+func TestRejectAuthHeadersMiddleware_AllowsOtherHeaders(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/config", nil)
+	req.Header.Set("authorization", "Bearer token")
+	req.Header.Set("content-type", "application/json")
+	w := httptest.NewRecorder()
+	rejectAuthHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRejectAuthHeadersMiddleware_CaseInsensitive(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v1/config", nil)
+	req.Header.Set("X-Subject", "admin") // capital letters
+	w := httptest.NewRecorder()
+	rejectAuthHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}


### PR DESCRIPTION
## Summary

- HTTP gateway now strips x-subject, x-role, and x-tenant-id headers from all incoming requests by default, preventing clients from forging identities
- Adds rejectAuthHeadersMiddleware applied before gRPC forwarding; case-insensitive matching
- Adds DECREE_GATEWAY_TRUSTED_PROXY=1 escape hatch for deployments behind a trusted reverse proxy (logs WARN on startup)
- Documents the setting in docs/server/deployment.md

## Test plan

- [x] TestRejectAuthHeadersMiddleware_BlocksAuthHeaders — each auth header returns HTTP 401
- [x] TestRejectAuthHeadersMiddleware_AllowsOtherHeaders — authorization/content-type pass through
- [x] TestRejectAuthHeadersMiddleware_CaseInsensitive — uppercase X-Subject blocked
- [x] make test passes

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)