### PR TITLE
fix(auth): deny unauthenticated requests by default

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -133,6 +133,9 @@ func (s *Service) QueryWriteLog(ctx context.Context, req *pb.QueryWriteLogReques
 }
 
 func (s *Service) GetFieldUsage(ctx context.Context, req *pb.GetFieldUsageRequest) (*pb.GetFieldUsageResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
@@ -183,6 +186,9 @@ func (s *Service) GetFieldUsage(ctx context.Context, req *pb.GetFieldUsageReques
 }
 
 func (s *Service) GetTenantUsage(ctx context.Context, req *pb.GetTenantUsageRequest) (*pb.GetTenantUsageResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
@@ -264,6 +270,9 @@ func (s *Service) VerifyChain(ctx context.Context, req *pb.VerifyChainRequest) (
 }
 
 func (s *Service) GetUnusedFields(ctx context.Context, req *pb.GetUnusedFieldsRequest) (*pb.GetUnusedFieldsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -395,3 +395,17 @@ func TestAuditEntryToProto(t *testing.T) {
 	assert.Equal(t, "0.02", *pb.NewValue)
 	assert.Equal(t, int32(3), *pb.ConfigVersion)
 }
+
+func TestAuditService_RequiresAuth(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := context.Background()
+
+	_, err := svc.GetFieldUsage(ctx, &pb.GetFieldUsageRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetTenantUsage(ctx, &pb.GetTenantUsageRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetUnusedFields(ctx, &pb.GetUnusedFieldsRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -155,7 +155,7 @@ func TestQueryWriteLog_InvalidPageToken(t *testing.T) {
 
 func TestGetFieldUsage_Success(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	lastReadBy := "reader"
 	now := time.Now()
@@ -175,7 +175,7 @@ func TestGetFieldUsage_Success(t *testing.T) {
 
 func TestGetFieldUsage_InvalidTenantID(t *testing.T) {
 	svc, _ := newTestService()
-	_, err := svc.GetFieldUsage(context.Background(), &pb.GetFieldUsageRequest{TenantId: "bad"})
+	_, err := svc.GetFieldUsage(auth.WithoutAuth(context.Background()), &pb.GetFieldUsageRequest{TenantId: "bad"})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -183,7 +183,7 @@ func TestGetFieldUsage_InvalidTenantID(t *testing.T) {
 
 func TestGetTenantUsage_Success(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetTenantUsage", ctx, mock.Anything).Return([]domain.TenantUsageRow{
 		{FieldPath: "app.fee", ReadCount: 10},
@@ -199,7 +199,7 @@ func TestGetTenantUsage_Success(t *testing.T) {
 
 func TestGetTenantUsage_InvalidTenantID(t *testing.T) {
 	svc, _ := newTestService()
-	_, err := svc.GetTenantUsage(context.Background(), &pb.GetTenantUsageRequest{TenantId: "bad"})
+	_, err := svc.GetTenantUsage(auth.WithoutAuth(context.Background()), &pb.GetTenantUsageRequest{TenantId: "bad"})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -207,7 +207,7 @@ func TestGetTenantUsage_InvalidTenantID(t *testing.T) {
 
 func TestGetUnusedFields_Success(t *testing.T) {
 	svc, store := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetUnusedFields", ctx, mock.Anything).Return([]string{"old.field", "unused.flag"}, nil)
 
@@ -221,7 +221,7 @@ func TestGetUnusedFields_Success(t *testing.T) {
 
 func TestGetUnusedFields_InvalidTenantID(t *testing.T) {
 	svc, _ := newTestService()
-	_, err := svc.GetUnusedFields(context.Background(), &pb.GetUnusedFieldsRequest{
+	_, err := svc.GetUnusedFields(auth.WithoutAuth(context.Background()), &pb.GetUnusedFieldsRequest{
 		TenantId: "bad",
 		Since:    timestamppb.Now(),
 	})

--- a/internal/auth/access.go
+++ b/internal/auth/access.go
@@ -7,22 +7,31 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Access functions in this file are permissive when no auth claims are present in the
-// context. The interceptor layer (MetadataInterceptor or JWTInterceptor) is the gate
-// that requires authentication before claims are set.
-//
-// Consequence: any method accidentally added to skipAuth bypasses not just
-// authentication but all authz checks too. Handlers for RPCs that must never be
-// reachable without auth should call MustHaveClaims first as a defense-in-depth guard.
+type withoutAuthKey struct{}
+
+// WithoutAuth marks ctx as explicitly bypassing auth checks. Use only for
+// legitimate internal callers (server-internal goroutines, test setup helpers).
+// Every call site should be auditable — do not use to silence unexpected failures.
+func WithoutAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, withoutAuthKey{}, true)
+}
+
+func isWithoutAuth(ctx context.Context) bool {
+	v, _ := ctx.Value(withoutAuthKey{}).(bool)
+	return v
+}
 
 // CheckTenantAccess verifies the caller has access to the given tenant.
 // Returns nil for superadmins. Returns PermissionDenied if the tenant is
-// not in the caller's tenant_ids list.
+// not in the caller's tenant_ids list. Returns Unauthenticated when no claims
+// are present unless WithoutAuth(ctx) is set.
 func CheckTenantAccess(ctx context.Context, tenantID string) error {
 	claims, ok := ClaimsFromContext(ctx)
 	if !ok {
-		// No auth context — permissive (tests, internal calls).
-		return nil
+		if isWithoutAuth(ctx) {
+			return nil
+		}
+		return status.Error(codes.Unauthenticated, "authentication required")
 	}
 	if claims.HasTenantAccess(tenantID) {
 		return nil
@@ -31,11 +40,14 @@ func CheckTenantAccess(ctx context.Context, tenantID string) error {
 }
 
 // RequireSuperAdmin returns PermissionDenied if the caller is not superadmin.
-// No-ops when no auth context is present (internal/test calls).
+// Returns Unauthenticated when no claims are present unless WithoutAuth(ctx) is set.
 func RequireSuperAdmin(ctx context.Context) error {
 	claims, ok := ClaimsFromContext(ctx)
 	if !ok {
-		return nil
+		if isWithoutAuth(ctx) {
+			return nil
+		}
+		return status.Error(codes.Unauthenticated, "authentication required")
 	}
 	if claims.IsSuperAdmin() {
 		return nil
@@ -44,11 +56,14 @@ func RequireSuperAdmin(ctx context.Context) error {
 }
 
 // RequireAdminOrAbove returns PermissionDenied for the user (read-only) role.
-// No-ops when no auth context is present (internal/test calls).
+// Returns Unauthenticated when no claims are present unless WithoutAuth(ctx) is set.
 func RequireAdminOrAbove(ctx context.Context) error {
 	claims, ok := ClaimsFromContext(ctx)
 	if !ok {
-		return nil
+		if isWithoutAuth(ctx) {
+			return nil
+		}
+		return status.Error(codes.Unauthenticated, "authentication required")
 	}
 	if claims.Role == RoleUser {
 		return status.Error(codes.PermissionDenied, "admin or superadmin required")
@@ -57,31 +72,36 @@ func RequireAdminOrAbove(ctx context.Context) error {
 }
 
 // AllowedTenantIDs returns the caller's allowed tenant IDs.
-// Returns nil for superadmins (meaning all tenants).
+// Returns nil for superadmins (meaning all tenants), and for internal callers
+// marked with WithoutAuth. Callers without auth are blocked by auth guards
+// before this function is typically reached.
 func AllowedTenantIDs(ctx context.Context) []string {
 	claims, ok := ClaimsFromContext(ctx)
 	if !ok {
 		return nil
 	}
 	if claims.IsSuperAdmin() {
-		return nil // nil = all tenants
+		return nil
 	}
 	return claims.TenantIDs
 }
 
 // IsSuperAdmin reports whether the caller has the superadmin role.
-// Returns true when no auth context is present (permissive, consistent with other access helpers).
+// Returns true for internal callers marked with WithoutAuth.
 func IsSuperAdmin(ctx context.Context) bool {
 	claims, ok := ClaimsFromContext(ctx)
-	return !ok || claims.IsSuperAdmin()
+	if !ok {
+		return isWithoutAuth(ctx)
+	}
+	return claims.IsSuperAdmin()
 }
 
-// MustHaveClaims returns codes.Unauthenticated if no auth claims are present in ctx.
-// Use in handler bodies as a defense-in-depth guard for RPCs that must never be
-// reachable without authentication, even if the method is accidentally added to skipAuth.
+// MustHaveClaims returns codes.Unauthenticated if no auth claims are present in ctx
+// and ctx is not marked with WithoutAuth. Use in handler bodies as a defense-in-depth
+// guard for RPCs that must never be reachable without authentication.
 func MustHaveClaims(ctx context.Context) error {
 	_, ok := ClaimsFromContext(ctx)
-	if !ok {
+	if !ok && !isWithoutAuth(ctx) {
 		return status.Error(codes.Unauthenticated, "authentication required")
 	}
 	return nil

--- a/internal/auth/access_test.go
+++ b/internal/auth/access_test.go
@@ -10,9 +10,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func TestCheckTenantAccess_NoClaims_Permissive(t *testing.T) {
-	// No claims in context — permissive (tests, internal calls).
-	assert.NoError(t, CheckTenantAccess(context.Background(), "t1"))
+func TestCheckTenantAccess_NoClaims_Denied(t *testing.T) {
+	err := CheckTenantAccess(context.Background(), "t1")
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestCheckTenantAccess_WithoutAuth_Allowed(t *testing.T) {
+	assert.NoError(t, CheckTenantAccess(WithoutAuth(context.Background()), "t1"))
 }
 
 func TestCheckTenantAccess_Superadmin_AllowsAny(t *testing.T) {
@@ -80,6 +85,10 @@ func TestMustHaveClaims_NoClaims(t *testing.T) {
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
+func TestMustHaveClaims_WithoutAuth(t *testing.T) {
+	assert.NoError(t, MustHaveClaims(WithoutAuth(context.Background())))
+}
+
 func TestMustHaveClaims_WithClaims(t *testing.T) {
 	ctx := ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin})
 	assert.NoError(t, MustHaveClaims(ctx))
@@ -88,21 +97,18 @@ func TestMustHaveClaims_WithClaims(t *testing.T) {
 func TestRequireSuperAdmin(t *testing.T) {
 	tests := []struct {
 		name    string
-		claims  *Claims
+		ctx     context.Context
 		wantErr codes.Code
 	}{
-		{"no claims — permissive", nil, codes.OK},
-		{"superadmin — allowed", &Claims{Role: RoleSuperAdmin}, codes.OK},
-		{"admin — denied", &Claims{Role: RoleAdmin}, codes.PermissionDenied},
-		{"user — denied", &Claims{Role: RoleUser}, codes.PermissionDenied},
+		{"no claims — denied", context.Background(), codes.Unauthenticated},
+		{"WithoutAuth — allowed", WithoutAuth(context.Background()), codes.OK},
+		{"superadmin — allowed", ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin}), codes.OK},
+		{"admin — denied", ContextWithClaims(context.Background(), &Claims{Role: RoleAdmin}), codes.PermissionDenied},
+		{"user — denied", ContextWithClaims(context.Background(), &Claims{Role: RoleUser}), codes.PermissionDenied},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			if tc.claims != nil {
-				ctx = ContextWithClaims(ctx, tc.claims)
-			}
-			err := RequireSuperAdmin(ctx)
+			err := RequireSuperAdmin(tc.ctx)
 			if tc.wantErr == codes.OK {
 				assert.NoError(t, err)
 			} else {
@@ -116,21 +122,18 @@ func TestRequireSuperAdmin(t *testing.T) {
 func TestRequireAdminOrAbove(t *testing.T) {
 	tests := []struct {
 		name    string
-		claims  *Claims
+		ctx     context.Context
 		wantErr codes.Code
 	}{
-		{"no claims — permissive", nil, codes.OK},
-		{"superadmin — allowed", &Claims{Role: RoleSuperAdmin}, codes.OK},
-		{"admin — allowed", &Claims{Role: RoleAdmin}, codes.OK},
-		{"user — denied", &Claims{Role: RoleUser}, codes.PermissionDenied},
+		{"no claims — denied", context.Background(), codes.Unauthenticated},
+		{"WithoutAuth — allowed", WithoutAuth(context.Background()), codes.OK},
+		{"superadmin — allowed", ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin}), codes.OK},
+		{"admin — allowed", ContextWithClaims(context.Background(), &Claims{Role: RoleAdmin}), codes.OK},
+		{"user — denied", ContextWithClaims(context.Background(), &Claims{Role: RoleUser}), codes.PermissionDenied},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			if tc.claims != nil {
-				ctx = ContextWithClaims(ctx, tc.claims)
-			}
-			err := RequireAdminOrAbove(ctx)
+			err := RequireAdminOrAbove(tc.ctx)
 			if tc.wantErr == codes.OK {
 				assert.NoError(t, err)
 			} else {
@@ -142,7 +145,8 @@ func TestRequireAdminOrAbove(t *testing.T) {
 }
 
 func TestIsSuperAdmin(t *testing.T) {
-	assert.True(t, IsSuperAdmin(context.Background()), "no claims — permissive")
+	assert.False(t, IsSuperAdmin(context.Background()), "no claims — denied")
+	assert.True(t, IsSuperAdmin(WithoutAuth(context.Background())), "WithoutAuth — allowed")
 	assert.True(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleSuperAdmin})))
 	assert.False(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleAdmin})))
 	assert.False(t, IsSuperAdmin(ContextWithClaims(context.Background(), &Claims{Role: RoleUser})))

--- a/internal/authz/guard_test.go
+++ b/internal/authz/guard_test.go
@@ -37,7 +37,7 @@ func userCtx() context.Context {
 	})
 }
 
-func noAuthCtx() context.Context { return context.Background() }
+func noAuthCtx() context.Context { return auth.WithoutAuth(context.Background()) }
 
 const (
 	tenant1 = "00000001-0000-0000-0000-000000000001"

--- a/internal/config/concurrency_test.go
+++ b/internal/config/concurrency_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
 
@@ -87,7 +88,7 @@ func TestGetFieldsFanOut_RunsConcurrently(t *testing.T) {
 
 	// Wire up the mockStore embedded in gateStore for everything except
 	// GetConfigValueAtVersion (which gateStore overrides).
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	gs.mockStore.On("GetLatestConfigVersion", mock.Anything, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -185,6 +185,9 @@ func errToStatus(err error, notFoundMsg, failedMsg string) error {
 // --- Read operations ---
 
 func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.GetConfigResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err
@@ -289,6 +292,9 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 }
 
 func (s *Service) GetField(ctx context.Context, req *pb.GetFieldRequest) (*pb.GetFieldResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err
@@ -327,6 +333,9 @@ func (s *Service) GetField(ctx context.Context, req *pb.GetFieldRequest) (*pb.Ge
 }
 
 func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.GetFieldsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err
@@ -679,6 +688,9 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 // --- Version operations ---
 
 func (s *Service) ListVersions(ctx context.Context, req *pb.ListVersionsRequest) (*pb.ListVersionsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err
@@ -717,6 +729,9 @@ func (s *Service) ListVersions(ctx context.Context, req *pb.ListVersionsRequest)
 }
 
 func (s *Service) GetVersion(ctx context.Context, req *pb.GetVersionRequest) (*pb.GetVersionResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err
@@ -838,6 +853,9 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamingServer[pb.SubscribeResponse]) error {
 	ctx := stream.Context()
 
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return err
@@ -941,6 +959,9 @@ func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamin
 // --- Import/export ---
 
 func (s *Service) ExportConfig(ctx context.Context, req *pb.ExportConfigRequest) (*pb.ExportConfigResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
 		return nil, err

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/pubsub"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
@@ -22,7 +23,7 @@ import (
 
 func TestGetFields_Success(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	cache.On("Get", mock.Anything, tenantID1, mock.Anything).Return(nil, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
@@ -44,7 +45,7 @@ func TestGetFields_Success(t *testing.T) {
 
 func TestGetFields_SkipsMissing(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	cache.On("Get", mock.Anything, tenantID1, mock.Anything).Return(nil, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
@@ -60,7 +61,7 @@ func TestGetFields_SkipsMissing(t *testing.T) {
 
 func TestGetFields_InvalidTenantID(t *testing.T) {
 	svc, _, _, _ := newTestService()
-	_, err := svc.GetFields(context.Background(), &pb.GetFieldsRequest{TenantId: ""})
+	_, err := svc.GetFields(auth.WithoutAuth(context.Background()), &pb.GetFieldsRequest{TenantId: ""})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -69,7 +70,7 @@ func TestGetFields_InvalidTenantID(t *testing.T) {
 // assert each value lands in the right slot.
 func TestGetFields_PreservesOrder(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	cache.On("Get", mock.Anything, tenantID1, mock.Anything).Return(nil, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
@@ -97,7 +98,7 @@ func TestGetFields_PreservesOrder(t *testing.T) {
 // dropped while present rows retain their request order.
 func TestGetFields_MixedMissingAndPresent(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	cache.On("Get", mock.Anything, tenantID1, mock.Anything).Return(nil, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
@@ -127,7 +128,7 @@ func TestGetFields_MixedMissingAndPresent(t *testing.T) {
 // surfaces as Internal and aborts the group.
 func TestGetFields_PropagatesError(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	cache.On("Get", mock.Anything, tenantID1, mock.Anything).Return(nil, nil)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
@@ -151,7 +152,7 @@ func TestGetFields_PropagatesError(t *testing.T) {
 
 func TestGetConfig_ByTenantName(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	// Resolve "acme" slug → tenant UUID
 	store.On("GetTenantByName", mock.Anything, "acme").Return(domain.Tenant{
@@ -172,7 +173,7 @@ func TestGetConfig_ByTenantName(t *testing.T) {
 
 func TestGetConfig_ByTenantUUID(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	// UUID goes directly to version lookup — no name resolution
 	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{
@@ -191,7 +192,7 @@ func TestGetConfig_TenantNameNotFound(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	store.On("GetTenantByName", mock.Anything, "nonexistent").Return(domain.Tenant{}, domain.ErrNotFound)
 
-	_, err := svc.GetConfig(context.Background(), &pb.GetConfigRequest{TenantId: "nonexistent"})
+	_, err := svc.GetConfig(auth.WithoutAuth(context.Background()), &pb.GetConfigRequest{TenantId: "nonexistent"})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
@@ -291,7 +292,7 @@ func TestSetFields_VersionConflictReturnsAborted(t *testing.T) {
 
 func TestListVersions_Success(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("ListConfigVersions", ctx, mock.Anything).Return([]domain.ConfigVersion{
 		{ID: versionID2, Version: 2, CreatedAt: time.Now()},
@@ -305,7 +306,7 @@ func TestListVersions_Success(t *testing.T) {
 
 func TestListVersions_InvalidTenantID(t *testing.T) {
 	svc, _, _, _ := newTestService()
-	_, err := svc.ListVersions(context.Background(), &pb.ListVersionsRequest{TenantId: ""})
+	_, err := svc.ListVersions(auth.WithoutAuth(context.Background()), &pb.ListVersionsRequest{TenantId: ""})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -313,7 +314,7 @@ func TestListVersions_InvalidTenantID(t *testing.T) {
 
 func TestGetVersion_Success(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetConfigVersion", ctx, mock.Anything).Return(domain.ConfigVersion{
 		ID: versionID2, Version: 2, CreatedBy: "admin", CreatedAt: time.Now(),
@@ -326,7 +327,7 @@ func TestGetVersion_Success(t *testing.T) {
 
 func TestGetVersion_NotFound(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetConfigVersion", ctx, mock.Anything).Return(domain.ConfigVersion{}, domain.ErrNotFound)
 
@@ -388,7 +389,7 @@ func (m *mockServerStream) RecvMsg(any) error            { return nil }
 func TestSubscribe_InvalidTenantID(t *testing.T) {
 	svc, _, _, _ := newTestService()
 
-	stream := &mockServerStream{ctx: context.Background()}
+	stream := &mockServerStream{ctx: auth.WithoutAuth(context.Background())}
 	err := svc.Subscribe(&pb.SubscribeRequest{TenantId: ""}, stream)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
@@ -398,7 +399,7 @@ func TestSubscribe_SubscribeError(t *testing.T) {
 	sub := &mockSubscriber{}
 	svc.subscriber = sub
 
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", ctx, tenantID1).
@@ -416,7 +417,7 @@ func TestSubscribe_ForwardsEvents(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent, 2)
 	cancel := func() {}
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithCancel(auth.WithoutAuth(context.Background()))
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
@@ -467,7 +468,7 @@ func TestSubscribe_FiltersByFieldPaths(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent, 3)
 	cancel := func() {}
 
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
@@ -500,7 +501,7 @@ func TestSubscribe_ContextCancellation(t *testing.T) {
 	cancelCalled := false
 	cancel := func() { cancelCalled = true }
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithCancel(auth.WithoutAuth(context.Background()))
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
@@ -523,7 +524,7 @@ func TestSubscribe_SendError(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent, 1)
 	cancel := func() {}
 
-	stream := &errServerStream{ctx: context.Background(), sendErr: errors.New("stream broken")}
+	stream := &errServerStream{ctx: auth.WithoutAuth(context.Background()), sendErr: errors.New("stream broken")}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
 		Return((<-chan pubsub.ConfigChangeEvent)(ch), context.CancelFunc(cancel), nil)
@@ -560,7 +561,7 @@ func TestSubscribe_ReplayStoreError(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent)
 	cancel := func() {}
 
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
@@ -587,7 +588,7 @@ func TestSubscribe_ReplaysMissedEvents(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent) // never sends — only replay matters
 	cancel := func() {}
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithCancel(auth.WithoutAuth(context.Background()))
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).
@@ -639,7 +640,7 @@ func TestSubscribe_WatermarkDeduplicatesReplayedVersions(t *testing.T) {
 	ch := make(chan pubsub.ConfigChangeEvent, 2)
 	cancel := func() {}
 
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 	stream := &mockServerStream{ctx: ctx}
 
 	sub.On("Subscribe", mock.Anything, tenantID1).

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -65,7 +65,7 @@ func newTestServiceWithValidation() (*Service, *mockStore) {
 
 func TestGetConfig_CacheHit(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 5}, nil)
@@ -85,7 +85,7 @@ func TestGetConfig_CacheHit(t *testing.T) {
 
 func TestGetConfig_CacheMiss(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 3}, nil)
@@ -108,7 +108,7 @@ func TestGetConfig_CacheMiss(t *testing.T) {
 
 func TestGetConfig_IncludeDescriptions_BypassesCache(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	desc := "fee per transaction"
 
@@ -375,7 +375,7 @@ func TestSetField_LockedField(t *testing.T) {
 
 func TestGetField_NotFound(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -445,7 +445,7 @@ func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 
 func TestExportConfig_Success(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 3}, nil)
@@ -772,7 +772,7 @@ func TestGetField_RecordsUsage(t *testing.T) {
 		WithLogger(testLogger),
 		WithRecorder(recorder),
 	)
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -805,7 +805,7 @@ func TestGetConfig_RecordsUsage(t *testing.T) {
 		WithLogger(testLogger),
 		WithRecorder(recorder),
 	)
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -847,7 +847,7 @@ func TestGetFields_RecordsUsage(t *testing.T) {
 		WithLogger(testLogger),
 		WithRecorder(recorder),
 	)
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -884,7 +884,7 @@ func TestGetConfig_CacheHit_RecordsUsage(t *testing.T) {
 		WithLogger(testLogger),
 		WithRecorder(recorder),
 	)
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 5}, nil)
@@ -906,7 +906,7 @@ func TestGetConfig_CacheHit_RecordsUsage(t *testing.T) {
 func TestGetField_NilRecorder_NoPanic(t *testing.T) {
 	// Default test service has nil recorder — verify reads don't panic.
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -924,7 +924,7 @@ func TestGetField_NilRecorder_NoPanic(t *testing.T) {
 // rather than silently skipping validation (fail-open).
 func TestValidateField_ValidatorLookupError(t *testing.T) {
 	svc, store := newTestServiceWithValidation()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	storeErr := errors.New("db connection lost")
 	store.On("GetTenantByID", ctx, tenantID1).Return(domain.Tenant{}, storeErr)
@@ -941,7 +941,7 @@ func TestValidateField_ValidatorLookupError(t *testing.T) {
 // coerce all response types to STRING).
 func TestFieldTypeMap_ValidatorLookupError(t *testing.T) {
 	svc, store := newTestServiceWithValidation()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	storeErr := errors.New("db connection lost")
 	store.On("GetTenantByID", ctx, tenantID1).Return(domain.Tenant{}, storeErr)
@@ -990,7 +990,7 @@ func sensitiveSchemaSetup(store *mockStore, ctx context.Context) {
 
 func TestGetConfig_RedactsSensitiveFields(t *testing.T) {
 	svc, store, cache, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
@@ -1099,7 +1099,7 @@ func TestSetField_PublishRedactsSensitiveField(t *testing.T) {
 
 func TestExportConfig_RedactsSensitiveFields(t *testing.T) {
 	svc, store, _, _ := newTestService()
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1174,4 +1174,14 @@ func TestConfigService_RequiresAuth(t *testing.T) {
 
 	_, err = svc.ListVersions(ctx, &pb.ListVersionsRequest{})
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetVersion(ctx, &pb.GetVersionRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.ExportConfig(ctx, &pb.ExportConfigRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	stream := &mockServerStream{ctx: ctx}
+	err = svc.Subscribe(&pb.SubscribeRequest{}, stream)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1158,3 +1158,20 @@ func TestWithMetrics_Option(t *testing.T) {
 		WithMetrics(nil))
 	assert.NotNil(t, svc)
 }
+
+func TestConfigService_RequiresAuth(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	ctx := context.Background()
+
+	_, err := svc.GetConfig(ctx, &pb.GetConfigRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetField(ctx, &pb.GetFieldRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetFields(ctx, &pb.GetFieldsRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.ListVersions(ctx, &pb.ListVersionsRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}

--- a/internal/config/withguard_test.go
+++ b/internal/config/withguard_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/authz"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
@@ -37,7 +38,7 @@ func TestNewService_WithGuard_ReplacesDefaultGuard(t *testing.T) {
 	store.On("GetTenantByID", mock.Anything, tenantID1).
 		Return(domain.Tenant{ID: tenantID1}, nil)
 
-	_, err := svc.GetConfig(context.Background(), &pb.GetConfigRequest{TenantId: tenantID1})
+	_, err := svc.GetConfig(auth.WithoutAuth(context.Background()), &pb.GetConfigRequest{TenantId: tenantID1})
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, status.Code(err))
 }
@@ -61,6 +62,6 @@ func TestNewService_WithGuard_AllowAll(t *testing.T) {
 		Return(map[string]string{}, nil)
 	setupNoSensitiveFields(store)
 
-	_, err := svc.GetConfig(context.Background(), &pb.GetConfigRequest{TenantId: tenantID1})
+	_, err := svc.GetConfig(auth.WithoutAuth(context.Background()), &pb.GetConfigRequest{TenantId: tenantID1})
 	require.NoError(t, err)
 }

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -209,6 +209,9 @@ func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest)
 }
 
 func (s *Service) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (*pb.GetSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "schema id or name required")
 	}
@@ -242,6 +245,9 @@ func (s *Service) GetSchema(ctx context.Context, req *pb.GetSchemaRequest) (*pb.
 }
 
 func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (*pb.ListSchemasResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	pageSize := pagination.ClampPageSize(req.PageSize, 50, 100)
 
 	offset, err := pagination.DecodePageToken(req.PageToken)
@@ -523,6 +529,9 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 }
 
 func (s *Service) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (*pb.GetTenantResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.Id)
 	if err != nil {
 		return nil, err
@@ -531,6 +540,9 @@ func (s *Service) GetTenant(ctx context.Context, req *pb.GetTenantRequest) (*pb.
 }
 
 func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (*pb.ListTenantsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	pageSize := pagination.ClampPageSize(req.PageSize, 50, 500)
 
 	offset, err := pagination.DecodePageToken(req.PageToken)
@@ -763,6 +775,9 @@ func (s *Service) UnlockField(ctx context.Context, req *pb.UnlockFieldRequest) (
 }
 
 func (s *Service) ListFieldLocks(ctx context.Context, req *pb.ListFieldLocksRequest) (*pb.ListFieldLocksResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -49,7 +49,7 @@ func TestListSchemas_Success(t *testing.T) {
 	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
 	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, nil)
 
-	resp, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageSize: 10})
+	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 10})
 	require.NoError(t, err)
 	assert.Len(t, resp.Schemas, 1)
 }
@@ -74,7 +74,7 @@ func TestListSchemas_Pagination(t *testing.T) {
 	store.On("GetLatestSchemaVersion", mock.Anything, s1.ID).Return(v1, nil)
 	store.On("GetSchemaFields", mock.Anything, v1.ID).Return([]domain.SchemaField{}, nil)
 
-	resp, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageSize: 1})
+	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 1})
 	require.NoError(t, err)
 	assert.Len(t, resp.Schemas, 1)
 	assert.NotEmpty(t, resp.NextPageToken, "expected next_page_token for full page")
@@ -86,7 +86,7 @@ func TestListSchemas_Pagination(t *testing.T) {
 	store.On("GetLatestSchemaVersion", mock.Anything, s2.ID).Return(v2, nil)
 	store.On("GetSchemaFields", mock.Anything, v2.ID).Return([]domain.SchemaField{}, nil)
 
-	resp, err = svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{
+	resp, err = svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{
 		PageSize:  1,
 		PageToken: resp.NextPageToken,
 	})
@@ -98,7 +98,7 @@ func TestListSchemas_Pagination(t *testing.T) {
 func TestListSchemas_InvalidPageToken(t *testing.T) {
 	svc := NewService(&mockStore{}, WithLogger(testLogger))
 
-	_, err := svc.ListSchemas(context.Background(), &pb.ListSchemasRequest{PageToken: "garbage"})
+	_, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageToken: "garbage"})
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
@@ -133,7 +133,7 @@ func TestGetTenant_Success(t *testing.T) {
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
 
-	resp, err := svc.GetTenant(context.Background(), &pb.GetTenantRequest{Id: testTenantID})
+	resp, err := svc.GetTenant(auth.WithoutAuth(context.Background()), &pb.GetTenantRequest{Id: testTenantID})
 	require.NoError(t, err)
 	assert.Equal(t, "acme", resp.Tenant.Name)
 }
@@ -145,7 +145,7 @@ func TestGetTenant_NotFound(t *testing.T) {
 	missingID := "99999999-9999-9999-9999-999999999999"
 	store.On("GetTenantByID", mock.Anything, missingID).Return(domain.Tenant{}, domain.ErrNotFound)
 
-	_, err := svc.GetTenant(context.Background(), &pb.GetTenantRequest{Id: missingID})
+	_, err := svc.GetTenant(auth.WithoutAuth(context.Background()), &pb.GetTenantRequest{Id: missingID})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
@@ -158,7 +158,7 @@ func TestListTenants_BySchema(t *testing.T) {
 	schemaID := testSchemaID
 	store.On("ListTenantsBySchema", mock.Anything, mock.Anything).Return([]domain.Tenant{testTenant()}, nil)
 
-	resp, err := svc.ListTenants(context.Background(), &pb.ListTenantsRequest{SchemaId: &schemaID, PageSize: 10})
+	resp, err := svc.ListTenants(auth.WithoutAuth(context.Background()), &pb.ListTenantsRequest{SchemaId: &schemaID, PageSize: 10})
 	require.NoError(t, err)
 	assert.Len(t, resp.Tenants, 1)
 }
@@ -169,7 +169,7 @@ func TestListTenants_All(t *testing.T) {
 
 	store.On("ListTenants", mock.Anything, mock.Anything).Return([]domain.Tenant{testTenant()}, nil)
 
-	resp, err := svc.ListTenants(context.Background(), &pb.ListTenantsRequest{PageSize: 10})
+	resp, err := svc.ListTenants(auth.WithoutAuth(context.Background()), &pb.ListTenantsRequest{PageSize: 10})
 	require.NoError(t, err)
 	assert.Len(t, resp.Tenants, 1)
 }
@@ -239,7 +239,7 @@ func TestListFieldLocks_Success(t *testing.T) {
 		{TenantID: testTenantID, FieldPath: "app.fee"},
 	}, nil)
 
-	resp, err := svc.ListFieldLocks(context.Background(), &pb.ListFieldLocksRequest{TenantId: testTenantID})
+	resp, err := svc.ListFieldLocks(auth.WithoutAuth(context.Background()), &pb.ListFieldLocksRequest{TenantId: testTenantID})
 	require.NoError(t, err)
 	assert.Len(t, resp.Locks, 1)
 	assert.Equal(t, "app.fee", resp.Locks[0].FieldPath)
@@ -502,7 +502,7 @@ func TestGetTenant_ByName(t *testing.T) {
 
 	store.On("GetTenantByName", mock.Anything, "acme").Return(testTenant(), nil)
 
-	resp, err := svc.GetTenant(context.Background(), &pb.GetTenantRequest{Id: "acme"})
+	resp, err := svc.GetTenant(auth.WithoutAuth(context.Background()), &pb.GetTenantRequest{Id: "acme"})
 	require.NoError(t, err)
 	assert.Equal(t, testTenantID, resp.Tenant.Id)
 }
@@ -515,7 +515,7 @@ func TestGetSchema_ByName(t *testing.T) {
 	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
 	store.On("GetSchemaFields", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
-	resp, err := svc.GetSchema(context.Background(), &pb.GetSchemaRequest{Id: "test-schema"})
+	resp, err := svc.GetSchema(auth.WithoutAuth(context.Background()), &pb.GetSchemaRequest{Id: "test-schema"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-schema", resp.Schema.Name)
 }
@@ -585,10 +585,10 @@ func TestListTenants_BySchemaFiltered(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-func TestListTenants_NoAuthContext_SeesAll(t *testing.T) {
+func TestListTenants_WithoutAuth_SeesAll(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background() // No auth claims — permissive.
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("ListTenants", ctx, ListTenantsParams{
 		Limit: 51, AllowedTenantIDs: nil,
@@ -598,6 +598,14 @@ func TestListTenants_NoAuthContext_SeesAll(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, resp.Tenants, 1)
 	store.AssertExpectations(t)
+}
+
+func TestListTenants_NoAuthContext_Denied(t *testing.T) {
+	svc := NewService(&mockStore{}, WithLogger(testLogger))
+
+	_, err := svc.ListTenants(context.Background(), &pb.ListTenantsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
 func TestListTenants_InvalidPageToken(t *testing.T) {
@@ -613,7 +621,7 @@ func TestListTenants_InvalidPageToken(t *testing.T) {
 func TestExportSchema_LatestVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(domain.Schema{ID: testSchemaID, Name: "test-schema"}, nil)
@@ -636,7 +644,7 @@ func TestExportSchema_LatestVersion(t *testing.T) {
 func TestExportSchema_SpecificVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 	v := int32(2)
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
@@ -658,7 +666,7 @@ func TestExportSchema_SpecificVersion(t *testing.T) {
 func TestExportSchema_SchemaNotFound(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetSchemaByID", ctx, testSchemaID).Return(domain.Schema{}, domain.ErrNotFound)
 
@@ -671,7 +679,7 @@ func TestExportSchema_InvalidID(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetSchemaByName", mock.Anything, "bad").Return(domain.Schema{}, domain.ErrNotFound)
-	_, err := svc.ExportSchema(context.Background(), &pb.ExportSchemaRequest{Id: "bad"})
+	_, err := svc.ExportSchema(auth.WithoutAuth(context.Background()), &pb.ExportSchemaRequest{Id: "bad"})
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -291,6 +291,33 @@ func TestCreateSchema_FieldTagsNotPersisted(t *testing.T) {
 	assert.True(t, got.Sensitive, "sensitive lost in round-trip")
 }
 
+func TestSchemaService_RequiresAuth(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := context.Background()
+
+	_, err := svc.CreateSchema(ctx, &pb.CreateSchemaRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetSchema(ctx, &pb.GetSchemaRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.CreateTenant(ctx, &pb.CreateTenantRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.GetTenant(ctx, &pb.GetTenantRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.UnlockField(ctx, &pb.UnlockFieldRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.ListSchemas(ctx, &pb.ListSchemasRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.ListFieldLocks(ctx, &pb.ListFieldLocksRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
 // --- helpers ---
 
 func ptrInt32(v int32) *int32 {

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -72,7 +72,7 @@ func TestCreateSchema_EmptyName(t *testing.T) {
 func TestGetSchema_LatestVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(domain.Schema{ID: testSchemaID, Name: "test"}, nil)
@@ -91,7 +91,7 @@ func TestGetSchema_LatestVersion(t *testing.T) {
 func TestGetSchema_SpecificVersion(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	v := int32(2)
 
@@ -112,7 +112,7 @@ func TestGetSchema_SpecificVersion(t *testing.T) {
 func TestGetSchema_NotFound(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
-	ctx := context.Background()
+	ctx := auth.WithoutAuth(context.Background())
 
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(domain.Schema{}, domain.ErrNotFound)


### PR DESCRIPTION
## Summary

- Read handlers in config, schema, and audit services now reject requests with no auth context via auth.MustHaveClaims()
- Adds auth.WithoutAuth(ctx) marker for legitimate internal callers that bypass auth (replaces the old permissive no-claims default)
- Updates authz guard tests to reflect that no-claims contexts are unauthenticated, not permissive

## Test plan

- [x] All service unit tests updated to use auth.WithoutAuth(ctx) for internal calls
- [x] Tests that intentionally lack auth (e.g. TestVerifyChain_NoClaims) assert Unauthenticated
- [x] authz guard tests updated — noAuthCtx() now uses WithoutAuth
- [x] make test passes

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)