### PR TITLE
fix(audit): include payload fields in chain hash (epoch 1)

### DIFF
--- a/db/migrations/003_audit_chain_epoch.sql
+++ b/db/migrations/003_audit_chain_epoch.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Add chain_epoch to distinguish legacy entries (epoch 0, structural-only hash)
+-- from post-migration entries (epoch 1+, full payload included in hash).
+-- Existing rows keep epoch 0 so VerifyChain can still validate them using the
+-- original hash scheme. New inserts always use epoch 1.
+ALTER TABLE audit_write_log
+    ADD COLUMN chain_epoch INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+
+ALTER TABLE audit_write_log
+    DROP COLUMN IF EXISTS chain_epoch;

--- a/db/queries/audit.sql
+++ b/db/queries/audit.sql
@@ -1,6 +1,6 @@
 -- name: InsertAuditWriteLog :exec
-INSERT INTO audit_write_log (id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, object_kind, previous_hash, entry_hash, created_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);
+INSERT INTO audit_write_log (id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, object_kind, previous_hash, entry_hash, created_at, chain_epoch)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);
 
 -- name: GetLastAuditHashForTenant :one
 SELECT COALESCE(entry_hash, '')

--- a/internal/audit/chain.go
+++ b/internal/audit/chain.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -16,13 +17,40 @@ type ChainInput struct {
 	Action       string
 	ObjectKind   string
 	CreatedAt    time.Time
+
+	// Epoch 0 = legacy (structural fields only).
+	// Epoch 1+ = full payload included.
+	Epoch int
+
+	// Payload fields (included in epoch 1+ hashes).
+	FieldPath     *string
+	OldValue      *string
+	NewValue      *string
+	ConfigVersion *int32
+	Metadata      []byte
 }
 
 // ComputeEntryHash produces a SHA-256 hash over the immutable fields of an
 // audit entry, chaining it to the previous entry via PreviousHash.
+// Epoch 0 uses only structural fields (backward compat for pre-migration rows).
+// Epoch 1+ includes all payload fields so tampering with content is detectable.
 func ComputeEntryHash(in ChainInput) string {
 	h := sha256.New()
-	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d",
+	if in.Epoch == 0 {
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d",
+			in.PreviousHash,
+			in.ID,
+			in.TenantID,
+			in.Actor,
+			in.Action,
+			in.ObjectKind,
+			in.CreatedAt.UnixNano(),
+		)
+		return hex.EncodeToString(h.Sum(nil))
+	}
+	// Epoch 1+: structural fields followed by payload fields.
+	// Payload fields use a 1-byte presence marker: 0x00=nil, 0x01=non-nil.
+	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d\x00",
 		in.PreviousHash,
 		in.ID,
 		in.TenantID,
@@ -31,5 +59,32 @@ func ComputeEntryHash(in ChainInput) string {
 		in.ObjectKind,
 		in.CreatedAt.UnixNano(),
 	)
+	writeNullableStr(h, in.FieldPath)
+	writeNullableStr(h, in.OldValue)
+	writeNullableStr(h, in.NewValue)
+	writeNullableI32(h, in.ConfigVersion)
+	if len(in.Metadata) == 0 {
+		_, _ = h.Write([]byte{0x00})
+	} else {
+		_, _ = h.Write([]byte{0x01})
+		_, _ = fmt.Fprint(h, hex.EncodeToString(in.Metadata))
+	}
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func writeNullableStr(h io.Writer, s *string) {
+	if s == nil {
+		_, _ = h.Write([]byte{0x00})
+	} else {
+		_, _ = h.Write([]byte{0x01})
+		_, _ = fmt.Fprintf(h, "%s\x00", *s)
+	}
+}
+
+func writeNullableI32(h io.Writer, v *int32) {
+	if v == nil {
+		_, _ = h.Write([]byte{0x00})
+	} else {
+		_, _ = fmt.Fprintf(h, "\x01%d\x00", *v)
+	}
 }

--- a/internal/audit/chain_test.go
+++ b/internal/audit/chain_test.go
@@ -52,3 +52,77 @@ func TestComputeEntryHash_ChainSensitivity(t *testing.T) {
 	modified.ObjectKind = "schema"
 	assert.NotEqual(t, h1, ComputeEntryHash(modified))
 }
+
+func TestComputeEntryHash_Epoch0_NoPayloadSensitivity(t *testing.T) {
+	fp := "app.name"
+	base := ChainInput{
+		PreviousHash: "prev",
+		ID:           "id-1",
+		TenantID:     "t-1",
+		Actor:        "a",
+		Action:       "set_field",
+		ObjectKind:   "field",
+		CreatedAt:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Epoch:        0,
+	}
+	withPayload := base
+	withPayload.FieldPath = &fp
+	withPayload.NewValue = func() *string { s := "hello"; return &s }()
+
+	// Epoch 0 must produce the same hash regardless of payload — backward compat.
+	assert.Equal(t, ComputeEntryHash(base), ComputeEntryHash(withPayload))
+}
+
+func TestComputeEntryHash_Epoch1_PayloadSensitivity(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	i32Ptr := func(i int32) *int32 { return &i }
+
+	base := ChainInput{
+		PreviousHash:  "prev",
+		ID:            "id-1",
+		TenantID:      "t-1",
+		Actor:         "a",
+		Action:        "set_field",
+		ObjectKind:    "field",
+		CreatedAt:     time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Epoch:         1,
+		FieldPath:     strPtr("app.name"),
+		OldValue:      strPtr("old"),
+		NewValue:      strPtr("new"),
+		ConfigVersion: i32Ptr(3),
+		Metadata:      []byte(`{"k":"v"}`),
+	}
+	h1 := ComputeEntryHash(base)
+	require.NotEmpty(t, h1)
+
+	mutate := func(fn func(*ChainInput)) {
+		m := base
+		fn(&m)
+		assert.NotEqual(t, h1, ComputeEntryHash(m), "mutation must change hash")
+	}
+
+	mutate(func(m *ChainInput) { m.FieldPath = strPtr("other.field") })
+	mutate(func(m *ChainInput) { m.FieldPath = nil })
+	mutate(func(m *ChainInput) { m.OldValue = strPtr("changed") })
+	mutate(func(m *ChainInput) { m.OldValue = nil })
+	mutate(func(m *ChainInput) { m.NewValue = strPtr("changed") })
+	mutate(func(m *ChainInput) { m.NewValue = nil })
+	mutate(func(m *ChainInput) { m.ConfigVersion = i32Ptr(99) })
+	mutate(func(m *ChainInput) { m.ConfigVersion = nil })
+	mutate(func(m *ChainInput) { m.Metadata = []byte(`{"k":"changed"}`) })
+	mutate(func(m *ChainInput) { m.Metadata = nil })
+}
+
+func TestComputeEntryHash_Epoch1_NilVsEmpty(t *testing.T) {
+	empty := ""
+	base := ChainInput{
+		Epoch: 1, ID: "id-1", Actor: "a", Action: "set_field", ObjectKind: "field",
+		CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	withNil := base
+	withEmpty := base
+	withEmpty.FieldPath = &empty
+
+	// nil and empty string must produce different hashes.
+	assert.NotEqual(t, ComputeEntryHash(withNil), ComputeEntryHash(withEmpty))
+}

--- a/internal/audit/store_memory.go
+++ b/internal/audit/store_memory.go
@@ -32,13 +32,19 @@ func (s *MemoryStore) InsertAuditWriteLog(_ context.Context, arg InsertAuditWrit
 	}
 	now := time.Now()
 	hash := ComputeEntryHash(ChainInput{
-		PreviousHash: prevHash,
-		ID:           id,
-		TenantID:     arg.TenantID,
-		Actor:        arg.Actor,
-		Action:       arg.Action,
-		ObjectKind:   kind,
-		CreatedAt:    now,
+		PreviousHash:  prevHash,
+		ID:            id,
+		TenantID:      arg.TenantID,
+		Actor:         arg.Actor,
+		Action:        arg.Action,
+		ObjectKind:    kind,
+		CreatedAt:     now,
+		Epoch:         1,
+		FieldPath:     arg.FieldPath,
+		OldValue:      arg.OldValue,
+		NewValue:      arg.NewValue,
+		ConfigVersion: arg.ConfigVersion,
+		Metadata:      arg.Metadata,
 	})
 
 	s.writeLogs = append(s.writeLogs, domain.AuditWriteLog{
@@ -54,6 +60,7 @@ func (s *MemoryStore) InsertAuditWriteLog(_ context.Context, arg InsertAuditWrit
 		Metadata:      arg.Metadata,
 		PreviousHash:  prevHash,
 		EntryHash:     hash,
+		ChainEpoch:    1,
 		CreatedAt:     now,
 	})
 	return nil

--- a/internal/audit/store_pg.go
+++ b/internal/audit/store_pg.go
@@ -70,13 +70,19 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 	// verification both use the same CreatedAt value.
 	now := time.Now().Truncate(time.Microsecond)
 	hash := ComputeEntryHash(ChainInput{
-		PreviousHash: prevHash,
-		ID:           pgconv.UUIDToString(id),
-		TenantID:     arg.TenantID,
-		Actor:        arg.Actor,
-		Action:       arg.Action,
-		ObjectKind:   kind,
-		CreatedAt:    now,
+		PreviousHash:  prevHash,
+		ID:            pgconv.UUIDToString(id),
+		TenantID:      arg.TenantID,
+		Actor:         arg.Actor,
+		Action:        arg.Action,
+		ObjectKind:    kind,
+		CreatedAt:     now,
+		Epoch:         1,
+		FieldPath:     arg.FieldPath,
+		OldValue:      arg.OldValue,
+		NewValue:      arg.NewValue,
+		ConfigVersion: arg.ConfigVersion,
+		Metadata:      arg.Metadata,
 	})
 
 	return s.write.InsertAuditWriteLog(ctx, dbstore.InsertAuditWriteLogParams{
@@ -93,6 +99,7 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		PreviousHash:  prevHash,
 		EntryHash:     hash,
 		CreatedAt:     pgconv.TimeToTimestamptz(now),
+		ChainEpoch:    1,
 	})
 }
 
@@ -235,6 +242,7 @@ func auditWriteLogFromDB(r dbstore.AuditWriteLog) domain.AuditWriteLog {
 		Metadata:      r.Metadata,
 		PreviousHash:  r.PreviousHash,
 		EntryHash:     r.EntryHash,
+		ChainEpoch:    r.ChainEpoch,
 		CreatedAt:     pgconv.TimestamptzToTime(r.CreatedAt),
 	}
 }

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -34,13 +34,19 @@ func VerifyChain(ctx context.Context, store Store, tenantID string) (VerifyResul
 	prev := ""
 	for i, e := range entries {
 		want := ComputeEntryHash(ChainInput{
-			PreviousHash: prev,
-			ID:           e.ID,
-			TenantID:     e.TenantID,
-			Actor:        e.Actor,
-			Action:       e.Action,
-			ObjectKind:   e.ObjectKind,
-			CreatedAt:    e.CreatedAt,
+			PreviousHash:  prev,
+			ID:            e.ID,
+			TenantID:      e.TenantID,
+			Actor:         e.Actor,
+			Action:        e.Action,
+			ObjectKind:    e.ObjectKind,
+			CreatedAt:     e.CreatedAt,
+			Epoch:         int(e.ChainEpoch),
+			FieldPath:     e.FieldPath,
+			OldValue:      e.OldValue,
+			NewValue:      e.NewValue,
+			ConfigVersion: e.ConfigVersion,
+			Metadata:      e.Metadata,
 		})
 		if e.EntryHash != want {
 			result.Breaks = append(result.Breaks, ChainBreak{

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -138,6 +138,44 @@ func TestVerifyChain_TriggerRollbackOnOldRow(t *testing.T) {
 	t.Skip("trigger tests run against real DB — see store_pg_test.go")
 }
 
+// TestVerifyChain_DetectsPayloadTampering asserts that mutating a payload field
+// (NewValue) is detected by VerifyChain on epoch-1 entries.
+func TestVerifyChain_DetectsPayloadTampering(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	tenantID := "pay10000-0000-0000-0000-000000000001"
+
+	for i := range 3 {
+		fp := "app.name"
+		val := string(rune('a' + i))
+		err := store.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+			TenantID:   tenantID,
+			Actor:      "actor",
+			Action:     "set_field",
+			ObjectKind: "field",
+			FieldPath:  &fp,
+			NewValue:   &val,
+		})
+		require.NoError(t, err)
+	}
+
+	// Mutate the NewValue of the first entry — payload tampered, hash unchanged.
+	store.mu.Lock()
+	for i, e := range store.writeLogs {
+		if e.TenantID == tenantID {
+			tampered := "TAMPERED"
+			store.writeLogs[i].NewValue = &tampered
+			break
+		}
+	}
+	store.mu.Unlock()
+
+	result, err := VerifyChain(ctx, store, tenantID)
+	require.NoError(t, err)
+	assert.False(t, result.OK, "chain should be broken after payload mutation")
+	assert.NotEmpty(t, result.Breaks, "should report at least one break")
+}
+
 // Helper for verify_test — avoids collision with store_memory_test.go's ptr.
 func verifyPtr(s string) *string { return &s }
 

--- a/internal/storage/dbstore/audit.sql.gen.go
+++ b/internal/storage/dbstore/audit.sql.gen.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getAuditWriteLogOrdered = `-- name: GetAuditWriteLogOrdered :many
-SELECT id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, created_at, object_kind, previous_hash, entry_hash FROM audit_write_log
+SELECT id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, created_at, object_kind, previous_hash, entry_hash, chain_epoch FROM audit_write_log
 WHERE tenant_id IS NOT DISTINCT FROM $1
 ORDER BY created_at ASC, id ASC
 `
@@ -40,6 +40,7 @@ func (q *Queries) GetAuditWriteLogOrdered(ctx context.Context, tenantID pgtype.U
 			&i.ObjectKind,
 			&i.PreviousHash,
 			&i.EntryHash,
+			&i.ChainEpoch,
 		); err != nil {
 			return nil, err
 		}
@@ -196,8 +197,8 @@ func (q *Queries) GetUnusedFields(ctx context.Context, arg GetUnusedFieldsParams
 }
 
 const insertAuditWriteLog = `-- name: InsertAuditWriteLog :exec
-INSERT INTO audit_write_log (id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, object_kind, previous_hash, entry_hash, created_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+INSERT INTO audit_write_log (id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, object_kind, previous_hash, entry_hash, created_at, chain_epoch)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 `
 
 type InsertAuditWriteLogParams struct {
@@ -214,6 +215,7 @@ type InsertAuditWriteLogParams struct {
 	PreviousHash  string             `json:"previous_hash"`
 	EntryHash     string             `json:"entry_hash"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ChainEpoch    int32              `json:"chain_epoch"`
 }
 
 func (q *Queries) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteLogParams) error {
@@ -231,12 +233,13 @@ func (q *Queries) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		arg.PreviousHash,
 		arg.EntryHash,
 		arg.CreatedAt,
+		arg.ChainEpoch,
 	)
 	return err
 }
 
 const queryAuditWriteLog = `-- name: QueryAuditWriteLog :many
-SELECT id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, created_at, object_kind, previous_hash, entry_hash FROM audit_write_log
+SELECT id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, created_at, object_kind, previous_hash, entry_hash, chain_epoch FROM audit_write_log
 WHERE ($1::UUID IS NULL OR tenant_id = $1)
   AND (NULLIF($2::TEXT, '') IS NULL OR actor = $2)
   AND (NULLIF($3::TEXT, '') IS NULL OR field_path = $3)
@@ -287,6 +290,7 @@ func (q *Queries) QueryAuditWriteLog(ctx context.Context, arg QueryAuditWriteLog
 			&i.ObjectKind,
 			&i.PreviousHash,
 			&i.EntryHash,
+			&i.ChainEpoch,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/storage/dbstore/models.gen.go
+++ b/internal/storage/dbstore/models.gen.go
@@ -73,6 +73,7 @@ type AuditWriteLog struct {
 	ObjectKind    string             `json:"object_kind"`
 	PreviousHash  string             `json:"previous_hash"`
 	EntryHash     string             `json:"entry_hash"`
+	ChainEpoch    int32              `json:"chain_epoch"`
 }
 
 type ConfigValue struct {

--- a/internal/storage/domain/types.go
+++ b/internal/storage/domain/types.go
@@ -136,7 +136,9 @@ type AuditWriteLog struct {
 	Metadata      []byte
 	PreviousHash  string
 	EntryHash     string
-	CreatedAt     time.Time
+	// ChainEpoch indicates the hash scheme. 0 = legacy (no payload), 1 = full payload.
+	ChainEpoch int32
+	CreatedAt  time.Time
 }
 
 // UsageStat represents read usage statistics for a field.

--- a/scripts/run-upgrade-test.sh
+++ b/scripts/run-upgrade-test.sh
@@ -67,7 +67,8 @@ mkdir -p "$OLD_MIGRATIONS_DIR"
 
 while IFS= read -r f; do
   [ -z "$f" ] && continue
-  git show "${PREV_TAG}:db/migrations/${f}" > "${OLD_MIGRATIONS_DIR}/${f}"
+  fname="${f##*/}"
+  git show "${PREV_TAG}:${f}" > "${OLD_MIGRATIONS_DIR}/${fname}"
 done < <(git ls-tree --name-only "$PREV_TAG" db/migrations/ 2>/dev/null || true)
 
 if [ -z "$(ls -A "$OLD_MIGRATIONS_DIR" 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary

- Payload fields (FieldPath, OldValue, NewValue, ConfigVersion, Metadata) were excluded from ComputeEntryHash, allowing content tampering without breaking the chain
- Epoch 1 adds all payload fields with nil/non-nil encoding using presence-byte markers
- Pre-migration rows retain epoch 0 (hash scheme unchanged) so VerifyChain remains valid for existing entries
- Migration 003_audit_chain_epoch.sql adds chain_epoch column (DEFAULT 0); new inserts use epoch 1

## Test plan

- [x] TestComputeEntryHash_Epoch0_NoPayloadSensitivity — epoch 0 hash ignores payload
- [x] TestComputeEntryHash_Epoch1_PayloadSensitivity — all payload field mutations change hash
- [x] TestComputeEntryHash_Epoch1_NilVsEmpty — nil and empty string produce different hashes
- [x] TestVerifyChain_DetectsPayloadTampering — mutating NewValue breaks the chain
- [x] make test passes

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)