### PR TITLE
test(cache,pubsub): add miniredis integration tests for Redis impls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,16 @@ site/
 /server
 cmd/decree/decree
 
+# Example binaries (compiled in-place by go build / go test -tags=example)
+examples/config-validation/config-validation
+examples/environment-bootstrap/environment-bootstrap
+examples/feature-flags/feature-flags
+examples/live-config/live-config
+examples/multi-tenant/multi-tenant
+examples/optimistic-concurrency/optimistic-concurrency
+examples/quickstart/quickstart
+examples/schema-lifecycle/schema-lifecycle
+examples/setup/setup
+
 # Coverage thresholds — only the root file is tracked
 sdk/**/coverage-thresholds.json

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/MicahParks/jwkset v0.11.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8g
 github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -152,6 +154,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +41,145 @@ func TestRedisCache_Key(t *testing.T) {
 func TestRedisCache_TenantPattern(t *testing.T) {
 	c := &RedisCache{prefix: "config:"}
 	require.Equal(t, "config:tenant-1:*", c.tenantPattern("tenant-1"))
+}
+
+// --- miniredis integration tests ---
+
+func newTestRedisCache(t *testing.T) (*RedisCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr:       mr.Addr(),
+		MaxRetries: 0,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewRedisCache(client), mr
+}
+
+func TestRedisCache_GetSet_Happy(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1", "b": "2"}, time.Minute))
+
+	got, err := c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+}
+
+func TestRedisCache_GetMiss(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	got, err := c.Get(context.Background(), "t1", 1)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestRedisCache_Invalidate_Happy(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+	require.NoError(t, c.Set(ctx, "t1", 2, map[string]string{"b": "2"}, time.Minute))
+	require.NoError(t, c.Set(ctx, "t2", 1, map[string]string{"c": "3"}, time.Minute))
+
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	got, err := c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	got, err = c.Get(ctx, "t1", 2)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// t2 must not be affected by t1 invalidation.
+	got, err = c.Get(ctx, "t2", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "3", got["c"])
+}
+
+func TestRedisCache_TTLBoundary(t *testing.T) {
+	c, mr := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Second))
+
+	got, err := c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	require.NotNil(t, got, "entry should exist before TTL expires")
+
+	mr.FastForward(2 * time.Second)
+
+	got, err = c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.Nil(t, got, "entry should be gone after TTL expires")
+}
+
+func TestRedisCache_RedisDownMidGet(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr:       mr.Addr(),
+		MaxRetries: 0,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+	c := NewRedisCache(client)
+	ctx := context.Background()
+
+	mr.Close()
+
+	_, err := c.Get(ctx, "t1", 1)
+	require.Error(t, err)
+}
+
+func TestRedisCache_StaleAfterRollback(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	// v1 active, then v2 deployed.
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"fee": "0.01"}, time.Minute))
+	require.NoError(t, c.Set(ctx, "t1", 2, map[string]string{"fee": "0.02"}, time.Minute))
+
+	// Rollback: invalidate the entire tenant to clear stale v2 data.
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	got, err := c.Get(ctx, "t1", 2)
+	require.NoError(t, err)
+	assert.Nil(t, got, "stale v2 must be evicted after rollback")
+
+	got, err = c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.Nil(t, got, "v1 also evicted; repopulated on next read-through")
+
+	// Re-warm cache with rolled-back version.
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"fee": "0.01"}, time.Minute))
+	got, err = c.Get(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "0.01", got["fee"])
+}
+
+func TestRedisCache_KeyCollisionAcrossTenants(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "tenant-a", 1, map[string]string{"x": "a"}, time.Minute))
+	require.NoError(t, c.Set(ctx, "tenant-b", 1, map[string]string{"x": "b"}, time.Minute))
+
+	gotA, err := c.Get(ctx, "tenant-a", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "a", gotA["x"])
+
+	gotB, err := c.Get(ctx, "tenant-b", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "b", gotB["x"])
+
+	// Invalidating tenant-a must not touch tenant-b.
+	require.NoError(t, c.Invalidate(ctx, "tenant-a"))
+
+	gotA, err = c.Get(ctx, "tenant-a", 1)
+	require.NoError(t, err)
+	assert.Nil(t, gotA)
+
+	gotB, err = c.Get(ctx, "tenant-b", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "b", gotB["x"])
 }

--- a/internal/pubsub/redis_test.go
+++ b/internal/pubsub/redis_test.go
@@ -1,10 +1,15 @@
 package pubsub
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +36,161 @@ func TestNewRedisSubscriber(t *testing.T) {
 func TestRedisSubscriber_Close(t *testing.T) {
 	s := NewRedisSubscriber(nil, discardLogger)
 	require.NoError(t, s.Close())
+}
+
+// --- miniredis integration tests ---
+
+func newTestRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr:       mr.Addr(),
+		MaxRetries: 0,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func TestRedisPubSub_PublishSubscribe_Happy(t *testing.T) {
+	client := newTestRedisClient(t)
+	pub := NewRedisPublisher(client)
+	sub := NewRedisSubscriber(client, discardLogger)
+	ctx := context.Background()
+
+	ch, cancel, err := sub.Subscribe(ctx, "t1")
+	require.NoError(t, err)
+	defer cancel()
+
+	event := ConfigChangeEvent{TenantID: "t1", FieldPath: "app.fee", NewValue: "0.02"}
+	require.NoError(t, pub.Publish(ctx, event))
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "app.fee", got.FieldPath)
+		assert.Equal(t, "0.02", got.NewValue)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestRedisPubSub_TenantIsolation(t *testing.T) {
+	client := newTestRedisClient(t)
+	pub := NewRedisPublisher(client)
+	sub := NewRedisSubscriber(client, discardLogger)
+	ctx := context.Background()
+
+	ch1, cancel1, err := sub.Subscribe(ctx, "t1")
+	require.NoError(t, err)
+	defer cancel1()
+
+	ch2, cancel2, err := sub.Subscribe(ctx, "t2")
+	require.NoError(t, err)
+	defer cancel2()
+
+	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "a"}))
+
+	select {
+	case <-ch1:
+	case <-time.After(time.Second):
+		t.Fatal("t1 should receive event")
+	}
+	select {
+	case <-ch2:
+		t.Fatal("t2 should not receive t1 event")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestRedisPubSub_SlowSubscriber(t *testing.T) {
+	client := newTestRedisClient(t)
+	pub := NewRedisPublisher(client)
+	sub := NewRedisSubscriber(client, discardLogger)
+	ctx := context.Background()
+
+	ch, cancel, err := sub.Subscribe(ctx, "t1")
+	require.NoError(t, err)
+	defer cancel()
+
+	// Publish several messages without reading; the 64-slot buffer absorbs them.
+	const n = 5
+	for range n {
+		require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "x"}))
+	}
+
+	// Slow consumer reads all messages after a delay.
+	time.Sleep(50 * time.Millisecond)
+	received := 0
+	for received < n {
+		select {
+		case _, ok := <-ch:
+			require.True(t, ok)
+			received++
+		case <-time.After(time.Second):
+			t.Fatalf("timed out after receiving %d/%d events", received, n)
+		}
+	}
+	assert.Equal(t, n, received)
+}
+
+func TestRedisPubSub_SubscribeFailsWhenRedisDown(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr:       mr.Addr(),
+		MaxRetries: 0,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+	sub := NewRedisSubscriber(client, discardLogger)
+
+	mr.Close()
+
+	_, _, err := sub.Subscribe(context.Background(), "t1")
+	require.Error(t, err, "subscribe must fail when Redis is unreachable")
+}
+
+func TestRedisPubSub_CancelClosesChannel(t *testing.T) {
+	client := newTestRedisClient(t)
+	sub := NewRedisSubscriber(client, discardLogger)
+	ctx := context.Background()
+
+	ch, cancel, err := sub.Subscribe(ctx, "t1")
+	require.NoError(t, err)
+
+	cancel()
+
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "channel must be closed after cancel")
+	case <-time.After(time.Second):
+		t.Fatal("channel did not close after cancel")
+	}
+}
+
+func TestRedisPubSub_DuplicateDeliverySemantics(t *testing.T) {
+	client := newTestRedisClient(t)
+	pub := NewRedisPublisher(client)
+	sub := NewRedisSubscriber(client, discardLogger)
+	ctx := context.Background()
+
+	ch, cancel, err := sub.Subscribe(ctx, "t1")
+	require.NoError(t, err)
+	defer cancel()
+
+	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "x"}))
+
+	select {
+	case got := <-ch:
+		assert.Equal(t, "x", got.FieldPath)
+	case <-time.After(time.Second):
+		t.Fatal("no event received")
+	}
+
+	// Redis pub/sub is at-most-once: exactly one delivery per publish.
+	select {
+	case extra, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected duplicate delivery: %+v", extra)
+		}
+	case <-time.After(50 * time.Millisecond):
+		// Good: no duplicate.
+	}
 }


### PR DESCRIPTION
## Summary

- `internal/cache/redis` Get/Invalidate and `internal/pubsub/redis` Publish/Subscribe had 0% integration coverage; as external-dependency wrappers they cannot be meaningfully tested with nil clients.
- Added `github.com/alicebob/miniredis/v2` as a test-only dependency, enabling real Redis-protocol testing against an in-process server without Docker.
- Cache coverage goes from ~50% → 96%; pubsub from ~51% → 90%, covering TTL expiry (FastForward), tenant key isolation, Redis-down error paths, stale-after-rollback invalidation, slow subscriber buffering, and at-most-once delivery semantics.

## Test plan

- [x] New miniredis tests pass under `-race` flag
- [x] Full `make test` green across all modules
- [x] `golangci-lint` clean

Closes #464