### PR TITLE
feat(auth): add WithLeeway option and JWT edge case tests

### DIFF
--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
@@ -69,6 +70,7 @@ type Interceptor struct {
 	jwks       keyfunc.Keyfunc
 	jwksCancel context.CancelFunc
 	issuer     string
+	leeway     time.Duration
 	logger     *slog.Logger
 }
 
@@ -77,6 +79,7 @@ type InterceptorOption func(*interceptorOptions)
 
 type interceptorOptions struct {
 	issuer string
+	leeway time.Duration
 	logger *slog.Logger
 }
 
@@ -84,6 +87,11 @@ type interceptorOptions struct {
 // When unset, the issuer claim is not checked.
 func WithIssuer(issuer string) InterceptorOption {
 	return func(o *interceptorOptions) { o.issuer = issuer }
+}
+
+// WithLeeway sets the clock-skew tolerance applied to exp, nbf, and iat claims.
+func WithLeeway(d time.Duration) InterceptorOption {
+	return func(o *interceptorOptions) { o.leeway = d }
 }
 
 // WithLogger sets the interceptor logger. Defaults to slog.Default() when unset.
@@ -110,6 +118,7 @@ func NewInterceptor(ctx context.Context, jwksURL string, opts ...InterceptorOpti
 		jwks:       jwks,
 		jwksCancel: jwksCancel,
 		issuer:     o.issuer,
+		leeway:     o.leeway,
 		logger:     o.logger,
 	}, nil
 }
@@ -155,6 +164,9 @@ func (i *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 	opts := []jwt.ParserOption{jwt.WithValidMethods([]string{"RS256", "ES256"})}
 	if i.issuer != "" {
 		opts = append(opts, jwt.WithIssuer(i.issuer))
+	}
+	if i.leeway > 0 {
+		opts = append(opts, jwt.WithLeeway(i.leeway))
 	}
 
 	parsed, err := jwt.ParseWithClaims(token, claims, i.jwks.KeyfuncCtx(ctx), opts...)

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,18 +40,17 @@ func init() {
 	}
 }
 
-// jwksJSON returns a JWKS JSON document for the test RSA public key.
-func jwksJSON() []byte {
-	n := testKey.N
-	e := big.NewInt(int64(testKey.E))
+// makeJWKS returns a JWKS JSON document for the given RSA private key and kid.
+func makeJWKS(key *rsa.PrivateKey, kid string) []byte {
+	e := big.NewInt(int64(key.E))
 	jwks := map[string]any{
 		"keys": []map[string]any{
 			{
 				"kty": "RSA",
 				"use": "sig",
-				"kid": testKID,
+				"kid": kid,
 				"alg": "RS256",
-				"n":   base64.RawURLEncoding.EncodeToString(n.Bytes()),
+				"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
 				"e":   base64.RawURLEncoding.EncodeToString(e.Bytes()),
 			},
 		},
@@ -59,8 +59,14 @@ func jwksJSON() []byte {
 	return b
 }
 
+// jwksJSON returns a JWKS JSON document for the test RSA public key.
+func jwksJSON() []byte {
+	return makeJWKS(testKey, testKID)
+}
+
 // newTestInterceptor starts an httptest JWKS server and returns an Interceptor.
-func newTestInterceptor(t *testing.T, issuer string) *Interceptor {
+// extraOpts are appended after WithIssuer and WithLogger.
+func newTestInterceptor(t *testing.T, issuer string, extraOpts ...InterceptorOption) *Interceptor {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -68,11 +74,9 @@ func newTestInterceptor(t *testing.T, issuer string) *Interceptor {
 	}))
 	t.Cleanup(srv.Close)
 
+	opts := append([]InterceptorOption{WithIssuer(issuer), WithLogger(testLogger)}, extraOpts...)
 	ctx := context.Background()
-	interceptor, err := NewInterceptor(ctx, srv.URL,
-		WithIssuer(issuer),
-		WithLogger(testLogger),
-	)
+	interceptor, err := NewInterceptor(ctx, srv.URL, opts...)
 	require.NoError(t, err)
 	t.Cleanup(interceptor.Close)
 	return interceptor
@@ -417,6 +421,209 @@ func TestUnaryInterceptor_WrongSigningKey(t *testing.T) {
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	token.Header["kid"] = testKID // same kid, wrong key
 	signed, err := token.SignedString(otherKey)
+	require.NoError(t, err)
+
+	ctx := ctxWithBearer(signed)
+	_, err = unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// --- Expiry boundary / leeway ---
+
+func TestUnaryInterceptor_ExpiryBoundaryRejected(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Second)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_ExpiryWithinLeeway(t *testing.T) {
+	interceptor := newTestInterceptor(t, "", WithLeeway(30*time.Second))
+	unary := interceptor.UnaryInterceptor()
+
+	// Expired 10s ago — within the 30s leeway window.
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-10 * time.Second)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestUnaryInterceptor_ExpiryBeyondLeeway(t *testing.T) {
+	interceptor := newTestInterceptor(t, "", WithLeeway(5*time.Second))
+	unary := interceptor.UnaryInterceptor()
+
+	// Expired 60s ago — beyond the 5s leeway.
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-60 * time.Second)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// --- JWKS rotation ---
+
+func TestUnaryInterceptor_JWKSRotation(t *testing.T) {
+	rotatedKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	const rotatedKID = "test-key-rotated"
+
+	var mu sync.Mutex
+	currentJWKS := jwksJSON()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		body := currentJWKS
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	interceptor, err := NewInterceptor(context.Background(), srv.URL, WithLogger(testLogger))
+	require.NoError(t, err)
+	t.Cleanup(interceptor.Close)
+	unary := interceptor.UnaryInterceptor()
+
+	// Original key works before rotation.
+	ctx := ctxWithBearer(signToken(t, validClaims(RoleAdmin, "t1")))
+	_, err = unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+
+	// Rotate: JWKS now serves only the new key.
+	mu.Lock()
+	currentJWKS = makeJWKS(rotatedKey, rotatedKID)
+	mu.Unlock()
+
+	// Token signed with rotated key — keyfunc refetches on unknown kid.
+	rotatedClaims := validClaims(RoleAdmin, "t1")
+	rotatedToken := jwt.NewWithClaims(jwt.SigningMethodRS256, rotatedClaims)
+	rotatedToken.Header["kid"] = rotatedKID
+	rotatedSigned, err := rotatedToken.SignedString(rotatedKey)
+	require.NoError(t, err)
+
+	ctx = ctxWithBearer(rotatedSigned)
+	_, err = unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err, "new key after rotation should validate")
+
+	// Old token (original kid, no longer in JWKS) must be rejected.
+	ctx = ctxWithBearer(signToken(t, validClaims(RoleAdmin, "t1")))
+	_, err = unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err, "old kid after rotation must be rejected")
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// --- Clock skew (nbf) ---
+
+func TestUnaryInterceptor_ClockSkew_NBF_Rejected(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	// nbf 10s in the future — no leeway configured.
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(10 * time.Second)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_ClockSkew_NBF_WithinLeeway(t *testing.T) {
+	interceptor := newTestInterceptor(t, "", WithLeeway(30*time.Second))
+	unary := interceptor.UnaryInterceptor()
+
+	// nbf 10s in the future — within 30s leeway.
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(10 * time.Second)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// --- Malformed tokens ---
+
+func TestUnaryInterceptor_MalformedToken_TruncatedHeader(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithBearer("eyJhbGci")
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_MalformedToken_NonBase64Segments(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithBearer("abc.!!!.xyz")
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_MalformedToken_AlgNone(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"role":"superadmin","exp":9999999999}`))
+	noneToken := header + "." + payload + "."
+
+	ctx := ctxWithBearer(noneToken)
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_MalformedToken_UnsupportedAlgorithm(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := validClaims(RoleAdmin, "t1")
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := tok.SignedString([]byte("some-hmac-secret"))
 	require.NoError(t, err)
 
 	ctx := ctxWithBearer(signed)

--- a/internal/grpcutil/stream_test.go
+++ b/internal/grpcutil/stream_test.go
@@ -1,0 +1,20 @@
+package grpcutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"github.com/opendecree/decree/internal/grpcutil"
+)
+
+type fakeStream struct{ grpc.ServerStream }
+
+func TestWrappedStream_Context(t *testing.T) {
+	type key struct{}
+	ctx := context.WithValue(context.Background(), key{}, "sentinel")
+	ws := grpcutil.NewWrappedStream(fakeStream{}, ctx)
+	assert.Equal(t, ctx, ws.Context())
+}

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -1,0 +1,15 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/internal/storage"
+)
+
+func TestNewDB_InvalidDSN(t *testing.T) {
+	_, err := storage.NewDB(context.Background(), "not-a-dsn", "")
+	require.Error(t, err)
+}

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/opendecree/decree/internal/storage"
 )
 
-func TestNewDB_InvalidDSN(t *testing.T) {
+func TestNewDB_MalformedDSN(t *testing.T) {
 	_, err := storage.NewDB(context.Background(), "not-a-dsn", "")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary

- JWT validation lacked tests for important boundary conditions required before beta, leaving clock-skew tolerance, key rotation, and malformed-token handling unverified.
- Adds `WithLeeway(time.Duration)` interceptor option so callers can configure exp/nbf tolerance without forking the parser.
- Fixes a pre-existing coverage pipeline failure where `go tool covdata` was absent for packages with no runnable test files under `-cover`.

## Test plan

- [x] Expiry boundary: token expired 1 s ago rejected without leeway; expired 10 s ago accepted within 30 s leeway; expired 60 s ago rejected beyond 5 s leeway
- [x] JWKS rotation: token signed with new key and kid accepted after JWKS server rotates; token with old kid rejected post-rotation
- [x] Clock skew (nbf): token with nbf 10 s in the future rejected without leeway; accepted within 30 s leeway
- [x] Malformed tokens: truncated header, non-base64 segments, `alg=none`, and HS256 against RS256-only config all return `Unauthenticated`
- [x] `internal/grpcutil` and `internal/storage` now have unit tests; coverage pipeline exits 0 end-to-end

Closes #465