### PR TITLE
fix(validation): count string length in runes, reject NaN/Inf for numbers

### DIFF
--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -5,8 +5,10 @@ package validation
 
 import (
 	"fmt"
+	"math"
 	"net/url"
 	"regexp"
+	"unicode/utf8"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/storage/domain"
@@ -78,6 +80,17 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 		sensitive:       sensitive,
 	}
 
+	// Number finiteness check is always applied (not constraint-dependent).
+	if fieldType == pb.FieldType_FIELD_TYPE_NUMBER {
+		v.checks = append(v.checks, func(tv *pb.TypedValue) error {
+			n := tv.Kind.(*pb.TypedValue_NumberValue).NumberValue
+			if math.IsNaN(n) || math.IsInf(n, 0) {
+				return fmt.Errorf("value is not a finite number")
+			}
+			return nil
+		})
+	}
+
 	// URL validity check is always applied (not constraint-dependent).
 	if fieldType == pb.FieldType_FIELD_TYPE_URL {
 		v.checks = append(v.checks, func(tv *pb.TypedValue) error {
@@ -114,8 +127,9 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			min := int(*constraints.MinLength)
 			v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 				val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
-				if len(val) < min {
-					return fmt.Errorf("string length %d is less than minimum %d", len(val), min)
+				n := utf8.RuneCountInString(val)
+				if n < min {
+					return fmt.Errorf("string length %d is less than minimum %d", n, min)
 				}
 				return nil
 			})
@@ -124,8 +138,9 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			max := int(*constraints.MaxLength)
 			v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 				val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
-				if len(val) > max {
-					return fmt.Errorf("string length %d is greater than maximum %d", len(val), max)
+				n := utf8.RuneCountInString(val)
+				if n > max {
+					return fmt.Errorf("string length %d is greater than maximum %d", n, max)
 				}
 				return nil
 			})

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,4 +317,133 @@ func TestValidatorCache_UpdateExistingDoesNotGrow(t *testing.T) {
 
 	_, ok = c.Get("t2")
 	assert.True(t, ok, "t2 should not be evicted by update")
+}
+
+// --- Unicode / rune-based string length ---
+
+func TestValidate_StringLength_Unicode(t *testing.T) {
+	v := NewFieldValidator("label", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		MinLength: ptr(int32(2)),
+		MaxLength: ptr(int32(3)),
+	})
+
+	// Each emoji is 1 rune but 4 bytes — byte count would produce wrong results.
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "🎉🎉"}}))  // 2 runes, 8 bytes
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "🎉🎉🎉"}})) // 3 runes, 12 bytes
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "🎉"}}))      // 1 rune  — below min
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "🎉🎉🎉🎉"}}))   // 4 runes — above max
+
+	// Multi-byte Unicode: "日本語" = 3 runes, 9 bytes.
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "日本語"}}))
+
+	// Accented ASCII: "héllo" = 5 runes, 6 bytes — above max.
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "héllo"}}))
+}
+
+// --- String exactly at MaxLength boundary ---
+
+func TestValidate_StringLength_ExactBoundary(t *testing.T) {
+	v := NewFieldValidator("desc", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		MaxLength: ptr(int32(5)),
+	})
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}})) // exactly 5
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "helloo"}}))   // 6 — one over
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hell"}}))  // 4 — one under
+}
+
+// --- math.MaxInt64 / MaxFloat64 / very small floats ---
+
+func TestValidate_Integer_MaxInt64(t *testing.T) {
+	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MaxInt64}}))
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MinInt64}}))
+}
+
+func TestValidate_Integer_MaxInt64_WithMax(t *testing.T) {
+	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+		Max: ptr(float64(math.MaxInt64)),
+	})
+	// MaxInt64 as float64 rounds up slightly, so the integer MaxInt64 satisfies the constraint.
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MaxInt64}}))
+}
+
+func TestValidate_Number_MaxFloat64(t *testing.T) {
+	v := NewFieldValidator("big", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.MaxFloat64}}))
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: -math.MaxFloat64}}))
+}
+
+func TestValidate_Number_SmallFloat(t *testing.T) {
+	v := NewFieldValidator("tiny", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.SmallestNonzeroFloat64}}))
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: -math.SmallestNonzeroFloat64}}))
+}
+
+// --- NaN / Inf ---
+
+func TestValidate_Number_NaN_Rejected(t *testing.T) {
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.NaN()}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "finite")
+}
+
+func TestValidate_Number_PosInf_Rejected(t *testing.T) {
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.Inf(1)}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "finite")
+}
+
+func TestValidate_Number_NegInf_Rejected(t *testing.T) {
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.Inf(-1)}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "finite")
+}
+
+func TestValidate_Number_NaN_WithConstraints_Rejected(t *testing.T) {
+	// NaN must be rejected even when min/max constraints are present, because
+	// NaN comparisons are always false and would otherwise silently pass.
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+		Min: ptr(float64(0)),
+		Max: ptr(float64(1)),
+	})
+	require.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.NaN()}}))
+}
+
+// --- Nil TypedValue oneof ---
+
+func TestValidate_NilKindOnNullable(t *testing.T) {
+	// A TypedValue with no oneof set (Kind==nil) is treated as null for nullable fields.
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, true, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{}))
+}
+
+func TestValidate_NilKindOnNullable_Number(t *testing.T) {
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_NUMBER, true, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{}))
+}
+
+func TestValidate_NilKindOnNullable_String(t *testing.T) {
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, true, false, nil)
+	require.NoError(t, v.Validate(&pb.TypedValue{}))
+}
+
+// --- String at large boundary (doc-size scale) ---
+
+func TestValidate_StringLength_LargeBoundary(t *testing.T) {
+	// Verify boundary behaviour at a doc-size-scale length (5 MiB = 5242880 bytes).
+	// All ASCII, so rune count == byte count.
+	const limit = 5 * 1024 * 1024
+	v := NewFieldValidator("blob", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		MaxLength: ptr(int32(limit)),
+	})
+
+	atLimit := strings.Repeat("a", limit)
+	overLimit := atLimit + "a"
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: atLimit}}))
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: overLimit}}))
 }


### PR DESCRIPTION
## Summary

- String min/max length constraints were measured in bytes, causing multi-byte characters (emoji, CJK, accented Latin) to fail or pass incorrectly; switched to rune counting to match user-visible character semantics.
- NaN and ±Inf values silently bypassed all numeric constraint checks because IEEE 754 comparisons against NaN always evaluate to false; added an unconditional finiteness check for number fields.

## Test plan

- [ ] Unicode/emoji strings: 2-rune emoji passes a min=2/max=3 constraint; 4-rune emoji fails; CJK and accented Latin behave correctly
- [ ] Exact MaxLength boundary: string at N accepted, N+1 rejected
- [ ] `math.MaxInt64` / `math.MinInt64` accepted without constraints and with a `Max: float64(math.MaxInt64)` constraint
- [ ] `math.MaxFloat64` and `math.SmallestNonzeroFloat64` accepted without constraints
- [ ] NaN rejected with and without min/max constraints
- [ ] +Inf and -Inf rejected
- [ ] Nil `TypedValue` oneof (unset Kind) accepted on nullable int, number, and string fields
- [ ] 5 MiB string at exactly `MaxLength` accepted; at `MaxLength+1` rejected
- [ ] Full test suite passes with `-race`: `make test`

Closes #468