### PR TITLE
docs(sdk): add README and ExampleXxx tests for all SDK modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
           cd sdk/configclient && go test ./... -count=1 -coverprofile=../../cov-configclient.out -covermode=atomic &
           cd sdk/adminclient && go test ./... -count=1 -coverprofile=../../cov-adminclient.out -covermode=atomic &
           cd sdk/configwatcher && go test ./... -count=1 -coverprofile=../../cov-configwatcher.out -covermode=atomic &
+          cd sdk/grpctransport && go test ./... -count=1 -coverprofile=../../cov-grpctransport.out -covermode=atomic &
           cd sdk/tools && go test ./... -count=1 -coverprofile=../../cov-tools.out -covermode=atomic &
           cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic &
           wait
@@ -243,13 +244,14 @@ jobs:
             --profile sdk/configclient=cov-configclient.out \
             --profile sdk/adminclient=cov-adminclient.out \
             --profile sdk/configwatcher=cov-configwatcher.out \
+            --profile sdk/grpctransport=cov-grpctransport.out \
             --profile sdk/tools=cov-tools.out \
             --profile cmd/decree=cov-decree.out
 
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage.out
-          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-tools.out cov-decree.out; do
+          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-decree.out; do
             [ -f "$f" ] && grep -v "^mode:" "$f" >> coverage.out || true
           done
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SERVER_LDFLAGS := -X github.com/opendecree/decree/internal/version.Version=$(GIT
 CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 
 # Module list for multi-module operations.
-SDK_MODULES := sdk/configclient sdk/adminclient sdk/configwatcher sdk/tools
+SDK_MODULES := sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools
 
 .PHONY: all generate generate-proto generate-sqlc test lint build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -4,5 +4,6 @@
   "sdk/adminclient": 98.0,
   "sdk/configclient": 87.1,
   "sdk/configwatcher": 90.9,
+  "sdk/grpctransport": 8.0,
   "sdk/tools": 96.1
 }

--- a/sdk/adminclient/README.md
+++ b/sdk/adminclient/README.md
@@ -1,0 +1,73 @@
+# adminclient
+
+> **Alpha** — API subject to change.
+
+Go client for administrative operations on OpenDecree: schema management, tenant management, field locks, audit queries, and config versioning.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/opendecree/decree/sdk/adminclient.svg)](https://pkg.go.dev/github.com/opendecree/decree/sdk/adminclient)
+
+## Quickstart
+
+```go
+import "github.com/opendecree/decree/sdk/grpctransport"
+
+conn, _ := grpctransport.Dial("localhost:50051", grpctransport.WithInsecure())
+client, _ := grpctransport.NewAdminClient(conn,
+    grpctransport.WithSubject("admin"),
+    grpctransport.WithRole("superadmin"),
+)
+
+ctx := context.Background()
+```
+
+## Schema management
+
+```go
+// Import a schema from YAML and auto-publish it.
+schema, _ := client.ImportSchema(ctx, yamlContent, true)
+
+// Or build one programmatically.
+schema, _ = client.CreateSchema(ctx, "app-config", []adminclient.Field{
+    {Path: "app.name", Type: "string"},
+    {Path: "app.debug", Type: "bool", Default: "false"},
+}, "initial schema")
+schema, _ = client.PublishSchema(ctx, schema.ID, schema.Version)
+```
+
+## Tenant management
+
+```go
+tenant, _ := client.CreateTenant(ctx, "acme-corp", schema.ID, schema.Version)
+tenants, _ := client.ListTenants(ctx, schema.ID)
+```
+
+## Field locks
+
+Locks prevent tenants from overriding a field beyond a set of allowed values:
+
+```go
+// Lock app.tier to "free" — prevents runtime override above the free plan.
+_ = client.LockField(ctx, tenant.ID, "app.tier", "free")
+
+locks, _ := client.ListFieldLocks(ctx, tenant.ID)
+```
+
+## Config versioning
+
+```go
+versions, _ := client.ListConfigVersions(ctx, tenant.ID)
+_ = client.RollbackConfig(ctx, tenant.ID, versions[1].Version, "revert bad deploy")
+```
+
+## Config import/export
+
+```go
+yaml, _ := client.ExportConfig(ctx, tenant.ID, nil) // nil = latest
+_, _ = client.ImportConfig(ctx, tenant.ID, yaml, "seed", adminclient.ImportModeMerge)
+```
+
+## Related packages
+
+- [`configclient`](../configclient) — runtime reads and writes for application code
+- [`configwatcher`](../configwatcher) — live, auto-refreshing values
+- [`grpctransport`](../grpctransport) — gRPC transport and `Dial` helper

--- a/sdk/adminclient/example_test.go
+++ b/sdk/adminclient/example_test.go
@@ -1,0 +1,138 @@
+package adminclient_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+)
+
+// fakeSchemaTransport implements SchemaTransport for documentation examples.
+type fakeSchemaTransport struct{}
+
+func (f *fakeSchemaTransport) CreateSchema(_ context.Context, req *adminclient.CreateSchemaRequest) (*adminclient.Schema, error) {
+	return &adminclient.Schema{ID: "schema-1", Name: req.Name, Version: 1}, nil
+}
+
+func (f *fakeSchemaTransport) GetSchema(_ context.Context, id string, _ *int32) (*adminclient.Schema, error) {
+	return &adminclient.Schema{ID: id, Name: "app-config", Version: 1}, nil
+}
+
+func (f *fakeSchemaTransport) ListSchemas(_ context.Context, _ int32, _ string) (*adminclient.ListSchemasResponse, error) {
+	return &adminclient.ListSchemasResponse{}, nil
+}
+
+func (f *fakeSchemaTransport) UpdateSchema(_ context.Context, _ *adminclient.UpdateSchemaRequest) (*adminclient.Schema, error) {
+	return &adminclient.Schema{ID: "schema-1", Version: 2}, nil
+}
+
+func (f *fakeSchemaTransport) PublishSchema(_ context.Context, id string, version int32) (*adminclient.Schema, error) {
+	return &adminclient.Schema{ID: id, Version: version, Published: true}, nil
+}
+
+func (f *fakeSchemaTransport) DeleteSchema(_ context.Context, _ string) error { return nil }
+
+func (f *fakeSchemaTransport) ExportSchema(_ context.Context, _ string, _ *int32) ([]byte, error) {
+	return []byte("fields: []"), nil
+}
+
+func (f *fakeSchemaTransport) ImportSchema(_ context.Context, _ []byte, _ bool) (*adminclient.Schema, error) {
+	return &adminclient.Schema{ID: "schema-1", Name: "app-config", Version: 1, Published: true}, nil
+}
+
+func (f *fakeSchemaTransport) CreateTenant(_ context.Context, req *adminclient.CreateTenantRequest) (*adminclient.Tenant, error) {
+	return &adminclient.Tenant{ID: "tenant-1", Name: req.Name, SchemaID: req.SchemaID}, nil
+}
+
+func (f *fakeSchemaTransport) GetTenant(_ context.Context, id string) (*adminclient.Tenant, error) {
+	return &adminclient.Tenant{ID: id, Name: "acme-corp"}, nil
+}
+
+func (f *fakeSchemaTransport) ListTenants(_ context.Context, _ *string, _ int32, _ string) (*adminclient.ListTenantsResponse, error) {
+	return &adminclient.ListTenantsResponse{}, nil
+}
+
+func (f *fakeSchemaTransport) UpdateTenant(_ context.Context, req *adminclient.UpdateTenantRequest) (*adminclient.Tenant, error) {
+	return &adminclient.Tenant{ID: req.ID}, nil
+}
+
+func (f *fakeSchemaTransport) DeleteTenant(_ context.Context, _ string) error { return nil }
+
+func (f *fakeSchemaTransport) LockField(_ context.Context, _ string, fieldPath string, _ []string) error {
+	_ = fieldPath
+	return nil
+}
+
+func (f *fakeSchemaTransport) UnlockField(_ context.Context, _ string, _ string) error { return nil }
+
+func (f *fakeSchemaTransport) ListFieldLocks(_ context.Context, _ string) ([]adminclient.FieldLock, error) {
+	return []adminclient.FieldLock{
+		{TenantID: "tenant-1", FieldPath: "app.tier", LockedValues: []string{"free"}},
+	}, nil
+}
+
+// fakeAuditTransport implements AuditTransport for documentation examples.
+type fakeAuditTransport struct{}
+
+func (f *fakeAuditTransport) QueryWriteLog(_ context.Context, _ *adminclient.QueryWriteLogRequest) (*adminclient.QueryWriteLogResponse, error) {
+	return &adminclient.QueryWriteLogResponse{}, nil
+}
+
+func (f *fakeAuditTransport) GetFieldUsage(_ context.Context, _, _ string, _, _ *time.Time) (*adminclient.UsageStats, error) {
+	return &adminclient.UsageStats{}, nil
+}
+
+func (f *fakeAuditTransport) GetTenantUsage(_ context.Context, _ string, _, _ *time.Time) ([]*adminclient.UsageStats, error) {
+	return nil, nil
+}
+
+func (f *fakeAuditTransport) GetUnusedFields(_ context.Context, _ string, _ time.Time) ([]string, error) {
+	return nil, nil
+}
+
+func newClient() *adminclient.Client {
+	return adminclient.New(
+		adminclient.WithSchemaTransport(&fakeSchemaTransport{}),
+		adminclient.WithAuditTransport(&fakeAuditTransport{}),
+	)
+}
+
+func ExampleClient_ImportSchema() {
+	client := newClient()
+	ctx := context.Background()
+
+	yaml := []byte(`
+name: app-config
+fields:
+  - path: app.environment
+    type: string
+`)
+	schema, err := client.ImportSchema(ctx, yaml, true)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(schema.Name)
+	// Output: app-config
+}
+
+func ExampleClient_LockField() {
+	client := newClient()
+	ctx := context.Background()
+
+	// Lock app.tier to "free" for tenant-1 — prevents runtime overrides.
+	err := client.LockField(ctx, "tenant-1", "app.tier", "free")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	locks, err := client.ListFieldLocks(ctx, "tenant-1")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(len(locks), "lock(s)")
+	// Output: 1 lock(s)
+}

--- a/sdk/configclient/README.md
+++ b/sdk/configclient/README.md
@@ -1,0 +1,72 @@
+# configclient
+
+> **Alpha** — API subject to change.
+
+Go client for reading and writing OpenDecree configuration values at application runtime. Wraps a pluggable `Transport` with typed accessors and optimistic concurrency helpers.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/opendecree/decree/sdk/configclient.svg)](https://pkg.go.dev/github.com/opendecree/decree/sdk/configclient)
+
+## Quickstart
+
+```go
+import (
+    "github.com/opendecree/decree/sdk/grpctransport"
+)
+
+conn, _ := grpctransport.Dial("localhost:50051", grpctransport.WithInsecure())
+client, _ := grpctransport.NewConfigClient(conn,
+    grpctransport.WithSubject("myapp"),
+    grpctransport.WithRole("user"),
+)
+
+ctx := context.Background()
+
+// Typed reads — no string parsing needed.
+name, _     := client.GetString(ctx, tenantID, "app.name")
+debug, _    := client.GetBool(ctx, tenantID, "app.debug")
+timeout, _  := client.GetDuration(ctx, tenantID, "jobs.timeout")
+
+// Typed writes.
+_ = client.SetBool(ctx, tenantID, "app.debug", true)
+
+// Batch write.
+_ = client.SetMany(ctx, tenantID, map[string]string{
+    "app.name":  "MyApp",
+    "app.debug": "false",
+}, "initial seed")
+```
+
+## Typed accessors
+
+| Method | Go type |
+|--------|---------|
+| `GetString` / `SetString` | `string` |
+| `GetInt` / `SetInt` | `int64` |
+| `GetFloat` / `SetFloat` | `float64` |
+| `GetBool` / `SetBool` | `bool` |
+| `GetTime` / `SetTime` | `time.Time` |
+| `GetDuration` / `SetDuration` | `time.Duration` |
+
+## Optimistic concurrency
+
+Use `GetForUpdate` + `LockedValue.Set` to perform a read-modify-write without losing concurrent updates:
+
+```go
+lv, _ := client.GetForUpdate(ctx, tenantID, "counters.visits")
+_ = lv.Set(ctx, client, strconv.Itoa(visits+1))
+```
+
+Or use the higher-level helper that retries on conflict:
+
+```go
+_ = client.Update(ctx, tenantID, "counters.visits", func(cur string) (string, error) {
+    n, _ := strconv.Atoi(cur)
+    return strconv.Itoa(n+1), nil
+})
+```
+
+## Related packages
+
+- [`configwatcher`](../configwatcher) — live, auto-refreshing values via subscription stream
+- [`adminclient`](../adminclient) — schema management, tenant ops, locks, audit
+- [`grpctransport`](../grpctransport) — gRPC `Transport` implementation and `Dial` helper

--- a/sdk/configclient/example_test.go
+++ b/sdk/configclient/example_test.go
@@ -1,0 +1,104 @@
+package configclient_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+// fakeTransport is a minimal Transport for documentation examples.
+type fakeTransport struct{}
+
+func (f *fakeTransport) GetField(_ context.Context, req *configclient.GetFieldRequest) (*configclient.GetFieldResponse, error) {
+	return &configclient.GetFieldResponse{
+		FieldPath: req.FieldPath,
+		Value:     configclient.StringVal("production"),
+	}, nil
+}
+
+func (f *fakeTransport) GetConfig(_ context.Context, req *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+	return &configclient.GetConfigResponse{
+		TenantID: req.TenantID,
+		Version:  1,
+		Values: []configclient.ConfigValue{
+			{FieldPath: "app.name", Value: configclient.StringVal("MyApp")},
+			{FieldPath: "app.debug", Value: configclient.BoolVal(false)},
+		},
+	}, nil
+}
+
+func (f *fakeTransport) GetFields(_ context.Context, req *configclient.GetFieldsRequest) (*configclient.GetFieldsResponse, error) {
+	values := make([]configclient.ConfigValue, len(req.FieldPaths))
+	for i, p := range req.FieldPaths {
+		values[i] = configclient.ConfigValue{FieldPath: p, Value: configclient.StringVal("value")}
+	}
+	return &configclient.GetFieldsResponse{Values: values}, nil
+}
+
+func (f *fakeTransport) SetField(_ context.Context, _ *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
+	return &configclient.SetFieldResponse{}, nil
+}
+
+func (f *fakeTransport) SetFields(_ context.Context, _ *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
+	return &configclient.SetFieldsResponse{}, nil
+}
+
+func (f *fakeTransport) Subscribe(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func ExampleClient_Get() {
+	client := configclient.New(&fakeTransport{})
+	ctx := context.Background()
+
+	env, err := client.GetString(ctx, "tenant-1", "app.environment")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(env)
+	// Output: production
+}
+
+func ExampleClient_Set() {
+	client := configclient.New(&fakeTransport{})
+	ctx := context.Background()
+
+	err := client.Set(ctx, "tenant-1", "app.environment", "staging")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output: ok
+}
+
+func ExampleClient_GetAll() {
+	client := configclient.New(&fakeTransport{})
+	ctx := context.Background()
+
+	values, err := client.GetAll(ctx, "tenant-1")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(len(values), "fields")
+	// Output: 2 fields
+}
+
+func ExampleClient_SetMany() {
+	client := configclient.New(&fakeTransport{})
+	ctx := context.Background()
+
+	err := client.SetMany(ctx, "tenant-1", map[string]string{
+		"app.name":  "MyApp",
+		"app.debug": "false",
+	}, "bulk update")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output: ok
+}

--- a/sdk/configwatcher/README.md
+++ b/sdk/configwatcher/README.md
@@ -1,0 +1,61 @@
+# configwatcher
+
+> **Alpha** — API subject to change.
+
+Live, auto-refreshing configuration values for Go applications. Registers typed `Value` handles before start, loads a full snapshot on `Start`, then streams server-pushed updates in the background.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/opendecree/decree/sdk/configwatcher.svg)](https://pkg.go.dev/github.com/opendecree/decree/sdk/configwatcher)
+
+## Quickstart
+
+```go
+import "github.com/opendecree/decree/sdk/grpctransport"
+
+conn, _ := grpctransport.Dial("localhost:50051", grpctransport.WithInsecure())
+w, _ := grpctransport.NewWatcher(conn, tenantID,
+    grpctransport.WithSubject("myapp"),
+    grpctransport.WithRole("user"),
+)
+
+// Register fields before Start — each returns a live *Value[T].
+maxConn := w.Int("limits.max_connections", 100)
+debug   := w.Bool("app.debug", false)
+timeout := w.Duration("jobs.timeout", 30*time.Second)
+
+// Start loads the snapshot and begins streaming updates.
+if err := w.Start(ctx); err != nil {
+    log.Fatal(err)
+}
+defer w.Close()
+
+// Get never blocks and is safe for concurrent use.
+fmt.Println(maxConn.Get())   // → 100 (or server value)
+fmt.Println(timeout.Get())   // → 30s (or server value)
+```
+
+## Observing changes
+
+```go
+for change := range debug.Changes() {
+    log.Printf("app.debug changed: %v → %v", change.Old, change.New)
+}
+```
+
+The `Changes()` channel is closed when `Close` is called.
+
+## Typed field methods
+
+| Method | Go type |
+|--------|---------|
+| `String(path, default)` | `string` |
+| `Int(path, default)` | `int64` |
+| `Float(path, default)` | `float64` |
+| `Bool(path, default)` | `bool` |
+| `Duration(path, default)` | `time.Duration` |
+| `Time(path, default)` | `time.Time` |
+
+## Related packages
+
+- [`configclient`](../configclient) — one-shot reads/writes without a persistent stream
+- [`adminclient`](../adminclient) — schema management, tenant ops, locks, audit
+- [`grpctransport`](../grpctransport) — gRPC transport and `Dial` helper

--- a/sdk/configwatcher/example_test.go
+++ b/sdk/configwatcher/example_test.go
@@ -1,0 +1,69 @@
+package configwatcher_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opendecree/decree/sdk/configclient"
+	"github.com/opendecree/decree/sdk/configwatcher"
+)
+
+// fakeTransport implements configclient.Transport for documentation examples.
+type fakeTransport struct{}
+
+func (f *fakeTransport) GetField(_ context.Context, _ *configclient.GetFieldRequest) (*configclient.GetFieldResponse, error) {
+	return &configclient.GetFieldResponse{Value: configclient.StringVal("production")}, nil
+}
+
+func (f *fakeTransport) GetConfig(_ context.Context, req *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+	return &configclient.GetConfigResponse{TenantID: req.TenantID, Version: 1}, nil
+}
+
+func (f *fakeTransport) GetFields(_ context.Context, _ *configclient.GetFieldsRequest) (*configclient.GetFieldsResponse, error) {
+	return &configclient.GetFieldsResponse{}, nil
+}
+
+func (f *fakeTransport) SetField(_ context.Context, _ *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
+	return &configclient.SetFieldResponse{}, nil
+}
+
+func (f *fakeTransport) SetFields(_ context.Context, _ *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
+	return &configclient.SetFieldsResponse{}, nil
+}
+
+func (f *fakeTransport) Subscribe(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func ExampleWatcher() {
+	w := configwatcher.New(&fakeTransport{}, "tenant-1")
+
+	// Register typed fields before calling Start.
+	maxConn := w.Int("limits.max_connections", 100)
+	debug := w.Bool("app.debug", false)
+
+	// Before Start is called, Get returns the registered default.
+	fmt.Println(maxConn.Get())
+	fmt.Println(debug.Get())
+	// Output:
+	// 100
+	// false
+}
+
+func ExampleWatcher_Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w := configwatcher.New(&fakeTransport{}, "tenant-1")
+	timeout := w.String("jobs.timeout", "30s")
+
+	// Start loads a snapshot and streams live updates in the background.
+	if err := w.Start(ctx); err != nil {
+		fmt.Println("start error:", err)
+	}
+	defer w.Close()
+
+	// Get returns the current value; defaults are returned until the first snapshot.
+	fmt.Println(timeout.Get())
+	// Output: 30s
+}

--- a/sdk/grpctransport/README.md
+++ b/sdk/grpctransport/README.md
@@ -1,0 +1,55 @@
+# grpctransport
+
+> **Alpha** — API subject to change.
+
+gRPC transport implementations for the OpenDecree Go SDK. Provides `Dial`, `NewConfigClient`, `NewAdminClient`, and `NewWatcher` — the usual entry points for connecting to an OpenDecree server.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/opendecree/decree/sdk/grpctransport.svg)](https://pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport)
+
+## Quickstart
+
+```go
+import "github.com/opendecree/decree/sdk/grpctransport"
+
+// Production: TLS with system roots.
+conn, err := grpctransport.Dial("api.example.com:443")
+
+// Local dev: insecure (plaintext).
+conn, err := grpctransport.Dial("localhost:50051", grpctransport.WithInsecure())
+
+// Read config values.
+client, err := grpctransport.NewConfigClient(conn,
+    grpctransport.WithSubject("myapp"),
+    grpctransport.WithRole("user"),
+)
+
+// Admin operations (schema, tenants, locks).
+admin, err := grpctransport.NewAdminClient(conn,
+    grpctransport.WithSubject("admin"),
+    grpctransport.WithRole("superadmin"),
+)
+
+// Live-updating config values.
+watcher, err := grpctransport.NewWatcher(conn, tenantID,
+    grpctransport.WithSubject("myapp"),
+    grpctransport.WithRole("user"),
+)
+```
+
+## TLS options
+
+| Option | Use case |
+|--------|----------|
+| _(none)_ | Production — TLS with system certificate roots |
+| `WithCustomCA(pool)` | Private CA or internal mTLS |
+| `WithInsecure()` | Local development / testing only |
+
+## Auth options
+
+| Option | Use case |
+|--------|----------|
+| `WithRole(r)` | Metadata-header auth (default mode) |
+| `WithSubject(s)` | Identifies the calling service |
+| `WithBearerToken(t)` | JWT auth (opt-in) |
+
+`WithRole` or `WithBearerToken` is required; construction returns an error if omitted.

--- a/sdk/grpctransport/example_test.go
+++ b/sdk/grpctransport/example_test.go
@@ -1,0 +1,91 @@
+package grpctransport_test
+
+import (
+	"fmt"
+
+	"github.com/opendecree/decree/sdk/grpctransport"
+)
+
+func ExampleDial() {
+	// TLS with system roots — production default.
+	conn, err := grpctransport.Dial("passthrough:///localhost:50051")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer conn.Close()
+	fmt.Println("ok")
+	// Output: ok
+}
+
+func ExampleDial_insecure() {
+	// Insecure — local development and testing only.
+	conn, err := grpctransport.Dial("passthrough:///localhost:50051", grpctransport.WithInsecure())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer conn.Close()
+	fmt.Println("ok")
+	// Output: ok
+}
+
+func ExampleNewConfigClient() {
+	conn, err := grpctransport.Dial("passthrough:///localhost:50051", grpctransport.WithInsecure())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer conn.Close()
+
+	_, err = grpctransport.NewConfigClient(conn,
+		grpctransport.WithSubject("myapp"),
+		grpctransport.WithRole("user"),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output: ok
+}
+
+func ExampleNewAdminClient() {
+	conn, err := grpctransport.Dial("passthrough:///localhost:50051", grpctransport.WithInsecure())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer conn.Close()
+
+	_, err = grpctransport.NewAdminClient(conn,
+		grpctransport.WithSubject("admin"),
+		grpctransport.WithRole("superadmin"),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output: ok
+}
+
+func ExampleNewWatcher() {
+	conn, err := grpctransport.Dial("passthrough:///localhost:50051", grpctransport.WithInsecure())
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer conn.Close()
+
+	_, err = grpctransport.NewWatcher(conn, "tenant-uuid",
+		grpctransport.WithSubject("myapp"),
+		grpctransport.WithRole("user"),
+	)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("ok")
+	// Output: ok
+}


### PR DESCRIPTION
## Summary

- Every SDK module was missing a README and runnable examples, which made the Go SDK undiscoverable — `go doc -examples` returned nothing and new users had no quickstart.
- Adds a `README.md` to each of the four SDK modules (`adminclient`, `configclient`, `configwatcher`, `grpctransport`) with a quickstart, typed API reference, and alpha-stability disclaimer.
- Adds `example_test.go` files with `ExampleXxx` functions covering all top-level APIs: Get/Set (configclient), ImportSchema/LockField (adminclient), Watcher/Watcher_Start (configwatcher), and Dial/NewConfigClient/NewAdminClient/NewWatcher (grpctransport). Examples use fake in-process transports so they compile and pass without a live server.

## Test plan

- [ ] `make test` passes — all 11 new examples run and produce expected output
- [ ] `go doc -examples github.com/opendecree/decree/sdk/configclient` returns examples
- [ ] CI test job now includes `sdk/grpctransport` with coverage ratchet at 8.0%
- [ ] `SDK_MODULES` in Makefile updated so `make test` covers grpctransport locally

Closes #479