### PR TITLE
feat(storage): make pgxpool sizing configurable with sensible defaults

### DIFF
--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEnvDuration_Unset(t *testing.T) {
+	t.Setenv("_TEST_DUR_UNSET", "")
+	assert.Equal(t, 5*time.Second, parseEnvDuration("_TEST_DUR_UNSET", 5*time.Second))
+}
+
+func TestParseEnvDuration_Valid(t *testing.T) {
+	t.Setenv("_TEST_DUR_VALID", "2m30s")
+	assert.Equal(t, 2*time.Minute+30*time.Second, parseEnvDuration("_TEST_DUR_VALID", 0))
+}
+
+func TestLoadConfig_DBPoolEnvVars(t *testing.T) {
+	t.Setenv("DB_MAX_CONNS", "50")
+	t.Setenv("DB_MIN_CONNS", "5")
+	t.Setenv("DB_MAX_CONN_LIFETIME", "1h")
+	t.Setenv("DB_MAX_CONN_IDLE_TIME", "15m")
+	t.Setenv("DB_HEALTH_CHECK_PERIOD", "2m")
+
+	cfg := loadConfig()
+
+	assert.Equal(t, 50, cfg.DBMaxConns)
+	assert.Equal(t, 5, cfg.DBMinConns)
+	assert.Equal(t, time.Hour, cfg.DBMaxConnLifetime)
+	assert.Equal(t, 15*time.Minute, cfg.DBMaxConnIdleTime)
+	assert.Equal(t, 2*time.Minute, cfg.DBHealthCheckPeriod)
+}

--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/opendecree/decree/internal/storage"
 )
 
 func TestParseEnvDuration_Unset(t *testing.T) {
@@ -31,4 +33,22 @@ func TestLoadConfig_DBPoolEnvVars(t *testing.T) {
 	assert.Equal(t, time.Hour, cfg.DBMaxConnLifetime)
 	assert.Equal(t, 15*time.Minute, cfg.DBMaxConnIdleTime)
 	assert.Equal(t, 2*time.Minute, cfg.DBHealthCheckPeriod)
+}
+
+func TestPoolConfigFromServerCfg(t *testing.T) {
+	cfg := serverConfig{
+		DBMaxConns:          10,
+		DBMinConns:          3,
+		DBMaxConnLifetime:   20 * time.Minute,
+		DBMaxConnIdleTime:   5 * time.Minute,
+		DBHealthCheckPeriod: 2 * time.Minute,
+	}
+	got := poolConfigFromServerCfg(cfg)
+	assert.Equal(t, storage.PoolConfig{
+		MaxConns:          10,
+		MinConns:          3,
+		MaxConnLifetime:   20 * time.Minute,
+		MaxConnIdleTime:   5 * time.Minute,
+		HealthCheckPeriod: 2 * time.Minute,
+	}, got)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,6 +127,13 @@ func run() int {
 		initG, initCtx := errgroup.WithContext(ctx)
 		initG.Go(func() error {
 			var dbOpts []storage.Option
+			dbOpts = append(dbOpts, storage.WithPoolConfig(storage.PoolConfig{
+				MaxConns:          int32(cfg.DBMaxConns),
+				MinConns:          int32(cfg.DBMinConns),
+				MaxConnLifetime:   cfg.DBMaxConnLifetime,
+				MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
+				HealthCheckPeriod: cfg.DBHealthCheckPeriod,
+			}))
 			if otelCfg.TracesDB {
 				dbOpts = append(dbOpts, storage.WithTracer(otelpgx.NewTracer()))
 			}
@@ -412,6 +419,11 @@ type serverConfig struct {
 	StorageBackend           string
 	DBWriteURL               string
 	DBReadURL                string
+	DBMaxConns               int
+	DBMinConns               int
+	DBMaxConnLifetime        time.Duration
+	DBMaxConnIdleTime        time.Duration
+	DBHealthCheckPeriod      time.Duration
 	RedisURL                 string
 	EnableServices           []string
 	JWTIssuer                string
@@ -462,6 +474,9 @@ func loadConfig() serverConfig {
 	enableServices := getEnv("ENABLE_SERVICES", "schema,config,audit")
 	dbWriteURL := getEnv("DB_WRITE_URL", "")
 	dbReadURL := getEnv("DB_READ_URL", dbWriteURL)
+	dbMaxConnLifetime := parseEnvDuration("DB_MAX_CONN_LIFETIME", 0)
+	dbMaxConnIdleTime := parseEnvDuration("DB_MAX_CONN_IDLE_TIME", 0)
+	dbHealthCheckPeriod := parseEnvDuration("DB_HEALTH_CHECK_PERIOD", 0)
 
 	flushInterval := 30 * time.Second
 	if v := getEnv("USAGE_FLUSH_INTERVAL", ""); v != "" {
@@ -486,6 +501,11 @@ func loadConfig() serverConfig {
 		StorageBackend:           getEnv("STORAGE_BACKEND", "postgres"),
 		DBWriteURL:               dbWriteURL,
 		DBReadURL:                dbReadURL,
+		DBMaxConns:               parseEnvInt("DB_MAX_CONNS", 0),
+		DBMinConns:               parseEnvInt("DB_MIN_CONNS", 0),
+		DBMaxConnLifetime:        dbMaxConnLifetime,
+		DBMaxConnIdleTime:        dbMaxConnIdleTime,
+		DBHealthCheckPeriod:      dbHealthCheckPeriod,
 		RedisURL:                 getEnv("REDIS_URL", ""),
 		EnableServices:           parseServices(enableServices),
 		JWTIssuer:                getEnv("JWT_ISSUER", ""),
@@ -541,6 +561,21 @@ func parseEnvFloat(key string, fallback float64) float64 {
 	v, err := strconv.ParseFloat(raw, 64)
 	if err != nil {
 		slog.Error("invalid float env var", "key", key, "value", raw, "error", err)
+		os.Exit(1)
+	}
+	return v
+}
+
+// parseEnvDuration parses a Go duration env var. Returns fallback (0 = use pool default) when unset;
+// exits on invalid so misconfiguration is loud.
+func parseEnvDuration(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := time.ParseDuration(raw)
+	if err != nil {
+		slog.Error("invalid duration env var", "key", key, "value", raw, "error", err)
 		os.Exit(1)
 	}
 	return v

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -127,13 +127,7 @@ func run() int {
 		initG, initCtx := errgroup.WithContext(ctx)
 		initG.Go(func() error {
 			var dbOpts []storage.Option
-			dbOpts = append(dbOpts, storage.WithPoolConfig(storage.PoolConfig{
-				MaxConns:          int32(cfg.DBMaxConns),
-				MinConns:          int32(cfg.DBMinConns),
-				MaxConnLifetime:   cfg.DBMaxConnLifetime,
-				MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
-				HealthCheckPeriod: cfg.DBHealthCheckPeriod,
-			}))
+			dbOpts = append(dbOpts, storage.WithPoolConfig(poolConfigFromServerCfg(cfg)))
 			if otelCfg.TracesDB {
 				dbOpts = append(dbOpts, storage.WithTracer(otelpgx.NewTracer()))
 			}
@@ -467,6 +461,16 @@ func tenantResolver(store schema.Store) auth.TenantResolver {
 			return "", err
 		}
 		return tenant.ID, nil
+	}
+}
+
+func poolConfigFromServerCfg(cfg serverConfig) storage.PoolConfig {
+	return storage.PoolConfig{
+		MaxConns:          int32(cfg.DBMaxConns),
+		MinConns:          int32(cfg.DBMinConns),
+		MaxConnLifetime:   cfg.DBMaxConnLifetime,
+		MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
+		HealthCheckPeriod: cfg.DBHealthCheckPeriod,
 	}
 }
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -11,6 +11,11 @@ OpenDecree is configured entirely through environment variables. No config files
 | `STORAGE_BACKEND` | Storage backend: `postgres` (default) or `memory` (no external deps, data not persisted). | `postgres` | No |
 | `DB_WRITE_URL` | PostgreSQL connection string for the primary (read-write) database. Format: `postgres://user:pass@host:5432/dbname?sslmode=disable` | -- | Yes (postgres mode) |
 | `DB_READ_URL` | PostgreSQL connection string for the read replica. Used for all read queries. Falls back to `DB_WRITE_URL` if not set. | `DB_WRITE_URL` | No |
+| `DB_MAX_CONNS` | Maximum number of connections in each pool. Raise if you see `connection pool exhausted` errors under load; lower if the database server connection limit is tight. | `25` | No |
+| `DB_MIN_CONNS` | Minimum number of idle connections the pool keeps open. Reduces cold-start latency for bursty traffic. | `2` | No |
+| `DB_MAX_CONN_LIFETIME` | Maximum wall-clock age of a connection before it is closed and replaced. Format: Go duration (e.g., `30m`, `1h`). Rotates connections away from a failover. | `30m` | No |
+| `DB_MAX_CONN_IDLE_TIME` | Maximum time a connection may sit idle before being closed. Format: Go duration (e.g., `10m`). Reduces idle load on the database server. | `10m` | No |
+| `DB_HEALTH_CHECK_PERIOD` | How often the pool pings idle connections to verify they are still alive. Format: Go duration (e.g., `1m`). | `1m` | No |
 | `REDIS_URL` | Redis connection string. Used for config caching and real-time change propagation (pub/sub). Format: `redis://host:6379` | -- | Yes (postgres mode) |
 | `ENABLE_SERVICES` | Comma-separated list of services to enable. Valid values: `schema`, `config`, `audit`. | `schema,config,audit` | No |
 | `LOG_LEVEL` | Log verbosity. One of: `debug`, `info`, `warn`, `error`. Logs are JSON-formatted to stdout. | `info` | No |

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -3,7 +3,10 @@ package storage_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/opendecree/decree/internal/storage"
@@ -12,4 +15,42 @@ import (
 func TestNewDB_MalformedDSN(t *testing.T) {
 	_, err := storage.NewDB(context.Background(), "not-a-dsn", "")
 	require.Error(t, err)
+}
+
+func TestWithPoolConfig_AppliesNonZeroFields(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://localhost/test")
+	require.NoError(t, err)
+
+	pc := storage.PoolConfig{
+		MaxConns:          10,
+		MinConns:          3,
+		MaxConnLifetime:   20 * time.Minute,
+		MaxConnIdleTime:   5 * time.Minute,
+		HealthCheckPeriod: 2 * time.Minute,
+	}
+	storage.WithPoolConfig(pc)(cfg)
+
+	assert.Equal(t, int32(10), cfg.MaxConns)
+	assert.Equal(t, int32(3), cfg.MinConns)
+	assert.Equal(t, 20*time.Minute, cfg.MaxConnLifetime)
+	assert.Equal(t, 5*time.Minute, cfg.MaxConnIdleTime)
+	assert.Equal(t, 2*time.Minute, cfg.HealthCheckPeriod)
+}
+
+func TestWithPoolConfig_ZeroValuesSkipped(t *testing.T) {
+	cfg, err := pgxpool.ParseConfig("postgres://localhost/test")
+	require.NoError(t, err)
+	cfg.MaxConns = 99
+	cfg.MinConns = 7
+	cfg.MaxConnLifetime = 60 * time.Minute
+	cfg.MaxConnIdleTime = 30 * time.Minute
+	cfg.HealthCheckPeriod = 5 * time.Minute
+
+	storage.WithPoolConfig(storage.PoolConfig{})(cfg)
+
+	assert.Equal(t, int32(99), cfg.MaxConns)
+	assert.Equal(t, int32(7), cfg.MinConns)
+	assert.Equal(t, 60*time.Minute, cfg.MaxConnLifetime)
+	assert.Equal(t, 30*time.Minute, cfg.MaxConnIdleTime)
+	assert.Equal(t, 5*time.Minute, cfg.HealthCheckPeriod)
 }

--- a/internal/storage/db_test.go
+++ b/internal/storage/db_test.go
@@ -17,6 +17,15 @@ func TestNewDB_MalformedDSN(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewDB_ConnectFailure(t *testing.T) {
+	// DSN parses successfully but 127.0.0.1:1 is immediately refused.
+	// This exercises the pool-defaults code path in newPool (between ParseConfig and connect).
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	_, err := storage.NewDB(ctx, "postgres://127.0.0.1:1/test", "")
+	require.Error(t, err)
+}
+
 func TestWithPoolConfig_AppliesNonZeroFields(t *testing.T) {
 	cfg, err := pgxpool.ParseConfig("postgres://localhost/test")
 	require.NoError(t, err)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -17,10 +18,40 @@ type DB struct {
 // Option configures the database connection pools.
 type Option func(*pgxpool.Config)
 
+// PoolConfig holds connection pool sizing parameters.
+type PoolConfig struct {
+	MaxConns          int32
+	MinConns          int32
+	MaxConnLifetime   time.Duration
+	MaxConnIdleTime   time.Duration
+	HealthCheckPeriod time.Duration
+}
+
 // WithTracer adds a pgx query tracer to the connection pool.
 func WithTracer(tracer pgx.QueryTracer) Option {
 	return func(cfg *pgxpool.Config) {
 		cfg.ConnConfig.Tracer = tracer
+	}
+}
+
+// WithPoolConfig overrides connection pool sizing defaults.
+func WithPoolConfig(pc PoolConfig) Option {
+	return func(cfg *pgxpool.Config) {
+		if pc.MaxConns > 0 {
+			cfg.MaxConns = pc.MaxConns
+		}
+		if pc.MinConns > 0 {
+			cfg.MinConns = pc.MinConns
+		}
+		if pc.MaxConnLifetime > 0 {
+			cfg.MaxConnLifetime = pc.MaxConnLifetime
+		}
+		if pc.MaxConnIdleTime > 0 {
+			cfg.MaxConnIdleTime = pc.MaxConnIdleTime
+		}
+		if pc.HealthCheckPeriod > 0 {
+			cfg.HealthCheckPeriod = pc.HealthCheckPeriod
+		}
 	}
 }
 
@@ -52,6 +83,11 @@ func newPool(ctx context.Context, dsn string, opts []Option) (*pgxpool.Pool, err
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
+	cfg.MaxConns = 25
+	cfg.MinConns = 2
+	cfg.MaxConnLifetime = 30 * time.Minute
+	cfg.MaxConnIdleTime = 10 * time.Minute
+	cfg.HealthCheckPeriod = 1 * time.Minute
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -169,6 +169,8 @@ func StartDBPoolMetrics(ctx context.Context, cfg Config, writePool, readPool *pg
 		metric.WithDescription("Number of currently acquired connections"))
 	idleConns, _ := meter.Int64ObservableGauge("db.pool.idle_connections",
 		metric.WithDescription("Number of idle connections in the pool"))
+	maxConns, _ := meter.Int64ObservableGauge("db.pool.max_connections",
+		metric.WithDescription("Maximum number of connections allowed in the pool"))
 
 	record := func(pool *pgxpool.Pool, poolName string) func(context.Context, metric.Observer) error {
 		return func(ctx context.Context, o metric.Observer) error {
@@ -177,11 +179,12 @@ func StartDBPoolMetrics(ctx context.Context, cfg Config, writePool, readPool *pg
 			o.ObserveInt64(totalConns, int64(stat.TotalConns()), attrs)
 			o.ObserveInt64(acquiredConns, int64(stat.AcquiredConns()), attrs)
 			o.ObserveInt64(idleConns, int64(stat.IdleConns()), attrs)
+			o.ObserveInt64(maxConns, int64(stat.MaxConns()), attrs)
 			return nil
 		}
 	}
 
-	callbacks := []metric.Observable{totalConns, acquiredConns, idleConns}
+	callbacks := []metric.Observable{totalConns, acquiredConns, idleConns, maxConns}
 	if writePool == readPool {
 		_, _ = meter.RegisterCallback(record(writePool, "write"), callbacks...)
 	} else {

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -72,9 +72,14 @@ func TestSchemaMetrics_RecordPublish(t *testing.T) {
 }
 
 func TestStartDBPoolMetrics_Disabled(t *testing.T) {
-	// Should return immediately without panic.
 	StartDBPoolMetrics(context.Background(), Config{}, nil, nil)
 	StartDBPoolMetrics(context.Background(), Config{Enabled: true, MetricsDBPool: false}, nil, nil)
+}
+
+func TestStartDBPoolMetrics_Enabled(t *testing.T) {
+	// nil pools: the registered callback is never invoked by the no-op global meter,
+	// so no nil dereference occurs. Exercises gauge registration and callback wiring.
+	StartDBPoolMetrics(context.Background(), Config{Enabled: true, MetricsDBPool: true}, nil, nil)
 }
 
 func TestNewRateLimitMetrics_Disabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- The pool was using pgxpool defaults (MaxConns = max(4, NumCPU), no MinConns, no lifetime caps), causing silent pool exhaustion under beta load with no operator-visible signal and no way to tune.
- Adds hardened defaults (MaxConns=25, MinConns=2, MaxConnLifetime=30m, MaxConnIdleTime=10m, HealthCheckPeriod=1m) applied before any option overrides.
- Surfaces five new env vars for operator tuning and adds a `db.pool.max_connections` OTel gauge to enable saturation alerting (acquired/max).

## Test plan

- [x] All existing unit and integration tests pass (`make test`)
- [x] Build clean (`make build`)
- [x] Lint clean (`make lint`, 0 issues)
- [x] `WithPoolConfig` zero-values skip the field so unset env vars fall through to defaults
- [x] `parseEnvDuration` exits loudly on malformed input (same pattern as `parseEnvInt`/`parseEnvFloat`)

Closes #418