### PR TITLE
fix(validation): replace MustCompile with safe Compile to prevent panic

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -269,6 +269,9 @@ func run() int {
 	if counter, ok := validationMetrics.TimeoutCounter(); ok {
 		validatorOpts = append(validatorOpts, validation.WithTimeoutCounter(counter))
 	}
+	if counter, ok := validationMetrics.RegexErrorCounter(); ok {
+		validatorOpts = append(validatorOpts, validation.WithRegexErrorCounter(counter))
+	}
 	validatorFactory := validation.NewValidatorFactory(validatorStore, validatorOpts...)
 
 	// Usage recorder — async batched read tracking for audit stats.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -133,7 +133,8 @@ func (m *RateLimitMetrics) Counter() (metric.Int64Counter, bool) {
 
 // ValidationMetrics records validation-related counters.
 type ValidationMetrics struct {
-	compileTimeouts metric.Int64Counter
+	compileTimeouts    metric.Int64Counter
+	regexCompileErrors metric.Int64Counter
 }
 
 // NewValidationMetrics creates validation metrics. Returns nil if not enabled.
@@ -144,7 +145,9 @@ func NewValidationMetrics(cfg Config) *ValidationMetrics {
 	meter := otel.Meter(meterName)
 	timeouts, _ := meter.Int64Counter("validation.json_schema_compile_timeouts_total",
 		metric.WithDescription("Number of JSON-Schema compile goroutines that exceeded their deadline"))
-	return &ValidationMetrics{compileTimeouts: timeouts}
+	regexErrors, _ := meter.Int64Counter("validator_regex_compile_errors_total",
+		metric.WithDescription("Number of regex constraint patterns that failed to compile"))
+	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors}
 }
 
 // TimeoutCounter returns the underlying Int64Counter and true when metrics are
@@ -154,6 +157,15 @@ func (m *ValidationMetrics) TimeoutCounter() (metric.Int64Counter, bool) {
 		return nil, false
 	}
 	return m.compileTimeouts, true
+}
+
+// RegexErrorCounter returns the underlying Int64Counter and true when metrics
+// are enabled, or a nil interface and false when disabled.
+func (m *ValidationMetrics) RegexErrorCounter() (metric.Int64Counter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.regexCompileErrors, true
 }
 
 // StartDBPoolMetrics starts a background goroutine that periodically records

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -121,11 +121,21 @@ func TestValidationMetrics_NilSafe(t *testing.T) {
 	counter, ok := m.TimeoutCounter()
 	assert.False(t, ok)
 	assert.Nil(t, counter)
+	counter, ok = m.RegexErrorCounter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
 }
 
 func TestValidationMetrics_TimeoutCounter(t *testing.T) {
 	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
 	counter, ok := m.TimeoutCounter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
+}
+
+func TestValidationMetrics_RegexErrorCounter(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.RegexErrorCounter()
 	assert.True(t, ok)
 	assert.NotNil(t, counter)
 }

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -38,12 +38,13 @@ func DefaultLimits() Limits {
 }
 
 // Option configures a [ValidatorFactory] or [FieldValidator]. See
-// [WithLimits] and [WithTimeoutCounter].
+// [WithLimits], [WithTimeoutCounter], and [WithRegexErrorCounter].
 type Option func(*options)
 
 type options struct {
-	limits         Limits
-	timeoutCounter metric.Int64Counter // nil when metrics are disabled
+	limits            Limits
+	timeoutCounter    metric.Int64Counter // nil when metrics are disabled
+	regexErrorCounter metric.Int64Counter // nil when metrics are disabled
 }
 
 // WithLimits sets the JSON-Schema compile limits. Defaults to
@@ -58,6 +59,13 @@ func WithLimits(l Limits) Option {
 // (no-op — equivalent to omitting the option).
 func WithTimeoutCounter(c metric.Int64Counter) Option {
 	return func(o *options) { o.timeoutCounter = c }
+}
+
+// WithRegexErrorCounter sets the OTEL counter incremented when a regex
+// constraint pattern stored in the DB fails to compile. The counter name
+// should be "validator_regex_compile_errors_total". Pass nil to disable.
+func WithRegexErrorCounter(c metric.Int64Counter) Option {
+	return func(o *options) { o.regexErrorCounter = c }
 }
 
 func resolveOptions(opts []Option) options {

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -4,7 +4,9 @@
 package validation
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"math"
 	"net/url"
 	"regexp"
@@ -146,20 +148,25 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			})
 		}
 		if constraints.Regex != nil {
-			// Regex constraints are validated at schema import time, so the
-			// pattern is guaranteed to compile here. MustCompile panics on
-			// invalid input, which would indicate a bug in the import path.
-			re := regexp.MustCompile(*constraints.Regex)
-			v.checks = append(v.checks, func(tv *pb.TypedValue) error {
-				val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
-				if !re.MatchString(val) {
-					if v.sensitive {
-						return fmt.Errorf("value does not match pattern %s", re.String())
-					}
-					return fmt.Errorf("value %q does not match pattern %s", val, re.String())
+			re, err := regexp.Compile(*constraints.Regex)
+			if err != nil {
+				slog.Default().Error("invalid regex constraint in schema; skipping check",
+					"field", fieldPath, "pattern", *constraints.Regex, "error", err)
+				if o.regexErrorCounter != nil {
+					o.regexErrorCounter.Add(context.Background(), 1)
 				}
-				return nil
-			})
+			} else {
+				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
+					val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
+					if !re.MatchString(val) {
+						if v.sensitive {
+							return fmt.Errorf("value does not match pattern %s", re.String())
+						}
+						return fmt.Errorf("value %q does not match pattern %s", val, re.String())
+					}
+					return nil
+				})
+			}
 		}
 
 	case pb.FieldType_FIELD_TYPE_DURATION:

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -131,6 +131,14 @@ func TestValidate_InvalidRegexInDB_DoesNotPanic(t *testing.T) {
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "any value"}}))
 }
 
+func TestValidate_InvalidRegex_IncrementsCounter(t *testing.T) {
+	ctr := &countingCounter{}
+	NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		Regex: ptr(`[invalid`),
+	}, WithRegexErrorCounter(ctr))
+	assert.Equal(t, int64(1), ctr.n.Load())
+}
+
 // --- Enum constraints ---
 
 func TestValidate_Enum(t *testing.T) {

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -120,6 +120,17 @@ func TestValidate_StringPattern(t *testing.T) {
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "not-an-email"}}))
 }
 
+func TestValidate_InvalidRegexInDB_DoesNotPanic(t *testing.T) {
+	// Simulates a bad pattern written directly to the DB bypassing schema validation.
+	// The validator must skip the regex check rather than panic.
+	v := NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+		Regex: ptr(`[invalid`),
+	})
+
+	// No panic; regex check is silently skipped so every value passes.
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "any value"}}))
+}
+
 // --- Enum constraints ---
 
 func TestValidate_Enum(t *testing.T) {


### PR DESCRIPTION
## Summary

- `regexp.MustCompile` panics on an invalid pattern, crashing the request goroutine if a bad regex reaches the DB (e.g. via direct write or a migration bug) — this removes that risk entirely.
- On compile failure the validator now logs the broken pattern, increments the `validator_regex_compile_errors_total` metric counter, and skips the regex check so reads continue unblocked.

## Test plan

- [x] `TestValidate_InvalidRegexInDB_DoesNotPanic` — constructs a validator with an invalid pattern and asserts no panic and no validation error (check is skipped)
- [x] `TestValidate_StringPattern` — existing test confirms valid regex still enforces the pattern correctly
- [x] Full test suite (`make test`) passes with `-race`

Closes #419