### PR TITLE
fix(audit): require non-nil Since and cap lookback in GetUnusedFields

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -269,18 +270,30 @@ func (s *Service) VerifyChain(ctx context.Context, req *pb.VerifyChainRequest) (
 	}, nil
 }
 
+const unusedFieldsMaxLookback = 90 * 24 * time.Hour
+
 func (s *Service) GetUnusedFields(ctx context.Context, req *pb.GetUnusedFieldsRequest) (*pb.GetUnusedFieldsResponse, error) {
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
+	}
+	if req.Since == nil {
+		return nil, status.Error(codes.InvalidArgument, "since is required")
 	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
 		return nil, err
 	}
 
+	since := req.Since.AsTime()
+	if !auth.IsSuperAdmin(ctx) {
+		if earliest := time.Now().Add(-unusedFieldsMaxLookback); since.Before(earliest) {
+			since = earliest
+		}
+	}
+
 	paths, err := s.store.GetUnusedFields(ctx, GetUnusedFieldsParams{
 		TenantID: tenantID,
-		Since:    req.Since.AsTime(),
+		Since:    since,
 	})
 	if err != nil {
 		s.logger.ErrorContext(ctx, "get unused fields", "error", err)

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -228,6 +228,52 @@ func TestGetUnusedFields_InvalidTenantID(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func TestGetUnusedFields_NilSince(t *testing.T) {
+	svc, _ := newTestService()
+	_, err := svc.GetUnusedFields(auth.WithoutAuth(context.Background()), &pb.GetUnusedFieldsRequest{
+		TenantId: testTenantID,
+		Since:    nil,
+	})
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestGetUnusedFields_SinceCappedForNonSuperadmin(t *testing.T) {
+	svc, store := newTestService()
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleAdmin,
+		TenantIDs: []string{testTenantID},
+	})
+
+	store.On("GetUnusedFields", ctx, mock.MatchedBy(func(p GetUnusedFieldsParams) bool {
+		earliest := time.Now().Add(-unusedFieldsMaxLookback)
+		return !p.Since.Before(earliest.Add(-2*time.Second)) && !p.Since.After(time.Now())
+	})).Return([]string{}, nil)
+
+	_, err := svc.GetUnusedFields(ctx, &pb.GetUnusedFieldsRequest{
+		TenantId: testTenantID,
+		Since:    timestamppb.New(time.Now().Add(-200 * 24 * time.Hour)),
+	})
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+func TestGetUnusedFields_SuperadminBypassesCap(t *testing.T) {
+	svc, store := newTestService()
+	ctx := superadminCtx()
+	farBack := time.Now().Add(-200 * 24 * time.Hour)
+
+	store.On("GetUnusedFields", ctx, mock.MatchedBy(func(p GetUnusedFieldsParams) bool {
+		return p.Since.Before(time.Now().Add(-unusedFieldsMaxLookback))
+	})).Return([]string{}, nil)
+
+	_, err := svc.GetUnusedFields(ctx, &pb.GetUnusedFieldsRequest{
+		TenantId: testTenantID,
+		Since:    timestamppb.New(farBack),
+	})
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
 // --- Tenant access enforcement ---
 
 func TestQueryWriteLog_DeniedForOutOfScopeAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary

- Omitting `Since` silently fell back to Unix epoch, returning every field ever read on the tenant — a data exposure footgun.
- Non-superadmin callers are now capped to a 90-day lookback window to prevent bulk field enumeration even with valid credentials.
- Superadmins bypass the cap, preserving their ability to query full history.

## Test plan

- `TestGetUnusedFields_NilSince` — nil `Since` returns `InvalidArgument`
- `TestGetUnusedFields_SinceCappedForNonSuperadmin` — store receives a capped time when a non-superadmin passes a date >90 days ago
- `TestGetUnusedFields_SuperadminBypassesCap` — superadmin's far-back `Since` reaches the store unclamped
- All existing audit service tests pass

Closes #420