### PR TITLE
fix(migrations): enforce CREATE INDEX CONCURRENTLY convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,30 @@ make bench
 make bench-e2e
 ```
 
+## Database Migrations
+
+Migrations live in `db/migrations/` and are applied by [goose](https://github.com/pressly/goose).
+
+### Index convention
+
+`CREATE INDEX` (blocking) holds an `ACCESS EXCLUSIVE` lock for the full build duration, blocking all writes. Always use `CREATE INDEX CONCURRENTLY` for any index added against a table that may already contain data.
+
+Because `CREATE INDEX CONCURRENTLY` cannot run inside a transaction, every migration that creates an index must opt out of the goose transaction wrapper:
+
+```sql
+-- +goose NO TRANSACTION
+
+-- +goose Up
+CREATE INDEX CONCURRENTLY idx_foo_bar ON foo(bar);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_foo_bar;
+```
+
+**Exception:** indexes created in the initial schema migration (on an empty table) may use plain `CREATE INDEX`. Annotate each such line with `-- decree:index-lock-ok <reason>` to suppress the lint check.
+
+`make lint` (via `make lint-migrations`) enforces this convention. The script `scripts/check-concurrent-indexes.sh` can also be run standalone.
+
 ## Code Style
 
 - Follow standard Go conventions

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 # Module list for multi-module operations.
 SDK_MODULES := sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools
 
-.PHONY: all generate generate-proto generate-sqlc test lint build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
+.PHONY: all generate generate-proto generate-sqlc test lint lint-go lint-proto lint-migrations build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 
 all: generate lint test build
 
@@ -72,12 +72,16 @@ ui:
 
 # --- Quality ---
 
-## lint: Run all linters (Go + protobuf)
-lint: lint-go lint-proto
+## lint: Run all linters (Go + protobuf + migrations)
+lint: lint-go lint-proto lint-migrations
 
 ## lint-go: Run golangci-lint
 lint-go:
 	golangci-lint run ./...
+
+## lint-migrations: Check migrations for blocking CREATE INDEX (requires CONCURRENTLY or suppression annotation)
+lint-migrations:
+	./scripts/check-concurrent-indexes.sh
 
 ## lint-proto: Run buf lint + breaking change detection (Docker)
 ## buf breaking is skipped in git worktrees (Docker cannot traverse worktree .git files).

--- a/db/migrations/001_initial_schema.sql
+++ b/db/migrations/001_initial_schema.sql
@@ -117,8 +117,8 @@ CREATE TABLE audit_write_log (
     created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_audit_write_log_tenant ON audit_write_log(tenant_id, created_at);
-CREATE INDEX idx_audit_write_log_actor ON audit_write_log(actor, created_at);
+CREATE INDEX idx_audit_write_log_tenant ON audit_write_log(tenant_id, created_at); -- decree:index-lock-ok initial schema runs on empty table
+CREATE INDEX idx_audit_write_log_actor ON audit_write_log(actor, created_at); -- decree:index-lock-ok initial schema runs on empty table
 
 -- Audit: read usage aggregation
 CREATE TABLE usage_stats (

--- a/scripts/check-concurrent-indexes.sh
+++ b/scripts/check-concurrent-indexes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Enforce CREATE INDEX CONCURRENTLY convention in goose migration files.
+#
+# Rules:
+#   1. Any file containing CREATE INDEX CONCURRENTLY must have -- +goose NO TRANSACTION.
+#   2. Any file containing CREATE INDEX (blocking) must annotate each such line with
+#      -- decree:index-lock-ok <reason> or fail the check.
+#
+# Usage: ./scripts/check-concurrent-indexes.sh [migrations-dir]
+#   Default migrations-dir: db/migrations
+
+set -euo pipefail
+
+MIGRATIONS_DIR="${1:-db/migrations}"
+ERRORS=0
+
+while IFS= read -r -d '' f; do
+    # Check rule 1: CONCURRENTLY without NO TRANSACTION header.
+    if grep -qiE 'CREATE (UNIQUE )?INDEX CONCURRENTLY' "$f"; then
+        if ! grep -q '^\-\- +goose NO TRANSACTION' "$f"; then
+            echo "ERROR: $f uses CREATE INDEX CONCURRENTLY but is missing '-- +goose NO TRANSACTION'" >&2
+            ERRORS=$((ERRORS + 1))
+        fi
+    fi
+
+    # Check rule 2: blocking CREATE INDEX without suppression annotation.
+    while IFS= read -r line; do
+        if echo "$line" | grep -qiE 'CREATE (UNIQUE )?INDEX [^C]' && \
+           ! echo "$line" | grep -qiE 'CREATE (UNIQUE )?INDEX CONCURRENTLY'; then
+            if ! echo "$line" | grep -q 'decree:index-lock-ok'; then
+                echo "ERROR: $f: blocking CREATE INDEX missing annotation (add -- decree:index-lock-ok <reason> or use CONCURRENTLY):" >&2
+                echo "  $line" >&2
+                ERRORS=$((ERRORS + 1))
+            fi
+        fi
+    done < "$f"
+done < <(find "$MIGRATIONS_DIR" -name '*.sql' -print0 | sort -z)
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "" >&2
+    echo "Fix: use CREATE INDEX CONCURRENTLY with '-- +goose NO TRANSACTION', or add '-- decree:index-lock-ok <reason>' for intentional blocking indexes." >&2
+    exit 1
+fi
+
+echo "check-concurrent-indexes: OK ($(find "$MIGRATIONS_DIR" -name '*.sql' | wc -l | tr -d ' ') migrations checked)"


### PR DESCRIPTION
## Summary

- Blocking `CREATE INDEX` holds an `ACCESS EXCLUSIVE` lock for the full build, stalling all writes on a populated table — any future backfill migration would have caused production downtime.
- Establishes a project-wide convention: new index migrations must use `CREATE INDEX CONCURRENTLY` with `-- +goose NO TRANSACTION`.
- Adds a lint script (`scripts/check-concurrent-indexes.sh`) wired into `make lint` to enforce the convention automatically on every CI run.

## Test plan

- [x] `make lint-migrations` passes on the current migrations
- [x] Verified the script catches a blocking `CREATE INDEX` without annotation (exits 1)
- [x] Verified `CREATE INDEX CONCURRENTLY` without `-- +goose NO TRANSACTION` is flagged (exits 1)
- [x] Verified `CREATE INDEX CONCURRENTLY` + `-- +goose NO TRANSACTION` passes cleanly
- [x] Verified `-- decree:index-lock-ok` annotation suppresses the blocking-index error

Closes #421