### PR TITLE
security: add MustHaveClaims defense-in-depth to all read handlers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,21 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_foo_bar;
 - Proto files are linted with `buf lint` and checked for breaking changes with `buf breaking`
 - All public SDK methods must have godoc comments (docs will be generated)
 
+### gRPC Handler Auth Convention
+
+Every non-public gRPC handler must call `auth.MustHaveClaims(ctx)` as its first statement. This is a defense-in-depth guard — it catches cases where the auth interceptor is bypassed (e.g., internal callers, future test helpers, new interceptor chains).
+
+```go
+func (s *Service) GetFoo(ctx context.Context, req *pb.GetFooRequest) (*pb.GetFooResponse, error) {
+    if err := auth.MustHaveClaims(ctx); err != nil {
+        return nil, err
+    }
+    // ... rest of handler
+}
+```
+
+The only exemptions are RPCs explicitly documented as unauthenticated in the proto (currently `GetServerInfo` and the standard gRPC `Health` service). Exemptions are maintained in the `allowlist` map in `internal/authcheck/authcheck_test.go`, which is a CI-enforced AST scan that will fail the build if a handler is missing the call.
+
 ## Submitting Changes
 
 1. Fork the repository

--- a/internal/authcheck/authcheck_test.go
+++ b/internal/authcheck/authcheck_test.go
@@ -1,0 +1,139 @@
+// Package authcheck enforces the convention that every non-public gRPC handler
+// must call auth.MustHaveClaims(ctx) as a defense-in-depth guard.
+//
+// Public handlers (RPCs explicitly documented as unauthenticated in the proto)
+// are listed in the allowlist below.  The standard gRPC health service
+// (/grpc.health.v1.Health/*) and GetServerInfo are the only two such RPCs in
+// this codebase; they are handled separately and do not appear in the files
+// scanned here.
+package authcheck_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// allowlist contains exported method names that are intentionally exempt from
+// the MustHaveClaims requirement.  Every entry here must have a justification.
+var allowlist = map[string]string{
+	// GetServerInfo is documented as unauthenticated in server_service.proto and
+	// is handled by internal/server/server_info.go, which is a separate service
+	// type (ServerService, not Service) and is not scanned below.
+}
+
+// serviceFiles lists the Go source files whose exported Service methods must
+// all call auth.MustHaveClaims(ctx).  Only files containing RPCs that require
+// authentication belong here.  The ServerService (server/server_info.go) is
+// intentionally absent — GetServerInfo is the sole public RPC and the
+// ServerService type is kept separate for exactly that reason.
+var serviceFiles = []string{
+	"../schema/service.go",
+	"../config/service.go",
+	"../audit/service.go",
+}
+
+func TestAllHandlersHaveMustHaveClaims(t *testing.T) {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+
+	for _, rel := range serviceFiles {
+		path := filepath.Join(dir, rel)
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if !isServiceHandlerMethod(fn) {
+				continue
+			}
+			name := fn.Name.Name
+			if reason, exempt := allowlist[name]; exempt {
+				t.Logf("skip %s (allowlisted: %s)", name, reason)
+				continue
+			}
+			if !bodyCallsMustHaveClaims(fn.Body) {
+				t.Errorf("%s: %s missing auth.MustHaveClaims(ctx) — add it or add to the allowlist with justification",
+					filepath.Base(path), name)
+			}
+		}
+	}
+}
+
+// isServiceHandlerMethod returns true for exported methods on a *Service
+// receiver that match a gRPC unary or server-streaming handler signature:
+//
+//	func (s *Service) Foo(ctx context.Context, req *pb.FooRequest) (*pb.FooResponse, error)
+//	func (s *Service) Bar(req *pb.BarRequest, stream ...) error
+func isServiceHandlerMethod(fn *ast.FuncDecl) bool {
+	// Must be exported.
+	if !fn.Name.IsExported() {
+		return false
+	}
+	// Must have a pointer receiver named *Service.
+	if fn.Recv == nil || len(fn.Recv.List) != 1 {
+		return false
+	}
+	star, ok := fn.Recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := star.X.(*ast.Ident)
+	if !ok || ident.Name != "Service" {
+		return false
+	}
+	// Must return an error (last result).
+	if fn.Type.Results == nil || len(fn.Type.Results.List) == 0 {
+		return false
+	}
+	last := fn.Type.Results.List[len(fn.Type.Results.List)-1]
+	errIdent, ok := last.Type.(*ast.Ident)
+	if !ok || errIdent.Name != "error" {
+		return false
+	}
+	// Must take at least one parameter.
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return false
+	}
+	return true
+}
+
+// bodyCallsMustHaveClaims reports whether the function body contains a call to
+// auth.MustHaveClaims at any depth.
+func bodyCallsMustHaveClaims(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if pkg.Name == "auth" && sel.Sel.Name == "MustHaveClaims" {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -801,6 +801,9 @@ func (s *Service) ListFieldLocks(ctx context.Context, req *pb.ListFieldLocksRequ
 // --- Import/export ---
 
 func (s *Service) ExportSchema(ctx context.Context, req *pb.ExportSchemaRequest) (*pb.ExportSchemaResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
 	// Load the schema via GetSchema to reuse version resolution.
 	getResp, err := s.GetSchema(ctx, &pb.GetSchemaRequest{
 		Id:      req.Id,

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -316,6 +316,9 @@ func TestSchemaService_RequiresAuth(t *testing.T) {
 
 	_, err = svc.ListFieldLocks(ctx, &pb.ListFieldLocksRequest{})
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	_, err = svc.ExportSchema(ctx, &pb.ExportSchemaRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- `ExportSchema` was the only handler missing an explicit `auth.MustHaveClaims(ctx)` guard — it relied on delegation through `GetSchema`, which is fragile against interceptor bypasses or internal callers.
- Adds an AST-scanning CI test (`internal/authcheck`) that parses each service file at test time and fails the build if any exported `*Service` handler is missing the call, making the convention machine-enforced going forward.
- Documents the convention in `CONTRIBUTING.md` so contributors know the pattern before the scanner catches them.

## Test plan

- [x] `make test` passes — `internal/authcheck` test scans all three service files and reports zero violations
- [x] Verified scanner catches the gap: reverting `ExportSchema` with `git stash` causes the test to fail with a clear message
- [x] `make lint` passes — no new lint issues

Closes #423