### PR TITLE
Cap unbounded repeated request fields with configurable limits

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -52,6 +52,7 @@ external deployment, not the alpha cluster.
 | — | Tracked | Supply chain | Release-artifact attestations (Docker + Go binaries) | #159 | ✅ resolved |
 | — | Tracked | Auth | Role-based RPC policy + pluggable PermissionGuard | #205, #206, #269, #270 | ✅ resolved |
 | — | By design | Auth | Metadata mode defaults to `superadmin` when no `x-role` header — see `memory/feedback_auth_defaults.md` | — | — |
+| — | Tracked | Input | Unbounded repeated request fields (SetFields.updates, GetFields.field_paths, Subscribe.field_paths, UpdateSchema.remove_fields) are a DoS amplifier | #434 | ✅ resolved |
 
 ## Findings detail
 

--- a/api/centralconfig/v1/config_service.pb.go
+++ b/api/centralconfig/v1/config_service.pb.go
@@ -313,7 +313,8 @@ type GetFieldsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Tenant ID (UUID).
 	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
-	// Dot-separated field paths to retrieve.
+	// Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable
+	// via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument.
 	FieldPaths []string `protobuf:"bytes,2,rep,name=field_paths,json=fieldPaths,proto3" json:"field_paths,omitempty"`
 	// Config version to read from. If omitted, reads from the latest version.
 	Version *int32 `protobuf:"varint,3,opt,name=version,proto3,oneof" json:"version,omitempty"`
@@ -572,7 +573,8 @@ type SetFieldsRequest struct {
 	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	// Field updates to apply. All updates are applied atomically in a single
 	// config version. If any update fails validation (checksum, field lock),
-	// no changes are committed.
+	// no changes are committed. Maximum 1 000 entries (configurable via
+	// CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument.
 	Updates []*FieldUpdate `protobuf:"bytes,2,rep,name=updates,proto3" json:"updates,omitempty"`
 	// Version-level description explaining why these changes were made.
 	Description   *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
@@ -1081,7 +1083,9 @@ type SubscribeRequest struct {
 	// Tenant ID (UUID) to subscribe to.
 	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
 	// Field paths to filter on. If empty, receives changes for all fields.
-	// Changes to fields not in this list are silently dropped.
+	// Changes to fields not in this list are silently dropped. Maximum 1 000
+	// entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns
+	// InvalidArgument.
 	FieldPaths []string `protobuf:"bytes,2,rep,name=field_paths,json=fieldPaths,proto3" json:"field_paths,omitempty"`
 	// Resume the stream from this config version (inclusive). When set, the
 	// server replays all changes at versions >= start_version before streaming

--- a/api/centralconfig/v1/schema_service.pb.go
+++ b/api/centralconfig/v1/schema_service.pb.go
@@ -355,7 +355,9 @@ type UpdateSchemaRequest struct {
 	// Fields to add or modify. Existing fields not listed here are carried
 	// forward unchanged from the latest version.
 	Fields []*SchemaField `protobuf:"bytes,3,rep,name=fields,proto3" json:"fields,omitempty"`
-	// Dot-separated paths of fields to remove from the new version.
+	// Dot-separated paths of fields to remove from the new version. Maximum
+	// 1 000 entries (configurable via SCHEMA_MAX_REMOVE_FIELDS). Exceeds
+	// returns InvalidArgument.
 	RemoveFields  []string `protobuf:"bytes,4,rep,name=remove_fields,json=removeFields,proto3" json:"remove_fields,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -305,8 +305,9 @@ func run() int {
 			schema.WithMetrics(schemaMetrics),
 			schema.WithValidators(validatorFactory),
 			schema.WithLimits(schema.Limits{
-				MaxFields:   cfg.SchemaMaxFields,
-				MaxDocBytes: cfg.SchemaMaxDocBytes,
+				MaxFields:       cfg.SchemaMaxFields,
+				MaxDocBytes:     cfg.SchemaMaxDocBytes,
+				MaxRemoveFields: cfg.SchemaMaxRemoveFields,
 			}),
 		)
 		pb.RegisterSchemaServiceServer(srv.GRPCServer(), schemaSvc)
@@ -320,6 +321,9 @@ func run() int {
 			config.WithMetrics(configMetrics),
 			config.WithValidators(validatorFactory),
 			config.WithRecorder(recorder),
+			config.WithLimits(config.Limits{
+				MaxListLen: cfg.ConfigMaxListLen,
+			}),
 		)
 		pb.RegisterConfigServiceServer(srv.GRPCServer(), configSvc)
 		srv.SetServiceHealthy("centralconfig.v1.ConfigService")
@@ -432,8 +436,10 @@ type serverConfig struct {
 	GRPCMaxSendMsgBytes      int
 	SchemaMaxFields          int
 	SchemaMaxDocBytes        int
+	SchemaMaxRemoveFields    int
 	SchemaCompileTimeout     time.Duration
 	SchemaMaxRefDepth        int
+	ConfigMaxListLen         int
 	InsecureListen           bool
 	TLSCertFile              string
 	TLSKeyFile               string
@@ -524,8 +530,10 @@ func loadConfig() serverConfig {
 		GRPCMaxSendMsgBytes:      parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
 		SchemaMaxFields:          parseEnvInt("SCHEMA_MAX_FIELDS", 10_000),
 		SchemaMaxDocBytes:        parseEnvInt("SCHEMA_MAX_DOC_BYTES", 5*1024*1024),
+		SchemaMaxRemoveFields:    parseEnvInt("SCHEMA_MAX_REMOVE_FIELDS", 1_000),
 		SchemaCompileTimeout:     compileTimeout,
 		SchemaMaxRefDepth:        parseEnvInt("SCHEMA_MAX_REF_DEPTH", 64),
+		ConfigMaxListLen:         parseEnvInt("CONFIG_MAX_LIST_LEN", 1_000),
 		InsecureListen:           getEnv("INSECURE_LISTEN", "") == "1",
 		TLSCertFile:              getEnv("TLS_CERT_FILE", ""),
 		TLSKeyFile:               getEnv("TLS_KEY_FILE", ""),

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -996,7 +996,7 @@
           },
           {
             "name": "fieldPaths",
-            "description": "Field paths to filter on. If empty, receives changes for all fields.\nChanges to fields not in this list are silently dropped.",
+            "description": "Field paths to filter on. If empty, receives changes for all fields.\nChanges to fields not in this list are silently dropped. Maximum 1 000\nentries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns\nInvalidArgument.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -1415,7 +1415,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Dot-separated field paths to retrieve."
+          "description": "Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable\nvia CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument."
         },
         "version": {
           "type": "integer",
@@ -1476,7 +1476,7 @@
             "type": "object",
             "$ref": "#/definitions/v1FieldUpdate"
           },
-          "description": "Field updates to apply. All updates are applied atomically in a single\nconfig version. If any update fails validation (checksum, field lock),\nno changes are committed."
+          "description": "Field updates to apply. All updates are applied atomically in a single\nconfig version. If any update fails validation (checksum, field lock),\nno changes are committed. Maximum 1 000 entries (configurable via\nCONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument."
         },
         "description": {
           "type": "string",
@@ -1530,7 +1530,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Dot-separated paths of fields to remove from the new version."
+          "description": "Dot-separated paths of fields to remove from the new version. Maximum\n1 000 entries (configurable via SCHEMA_MAX_REMOVE_FIELDS). Exceeds\nreturns InvalidArgument."
         }
       }
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       # few fields and small YAMLs (< 1 KiB), well under these caps.
       SCHEMA_MAX_FIELDS: "100"
       SCHEMA_MAX_DOC_BYTES: "4096"
+      SCHEMA_MAX_REMOVE_FIELDS: "5"
+      CONFIG_MAX_LIST_LEN: "5"
       # 64 KiB recv cap so TestSecurity_OversizeRequestRejected can trip it
       # with a small payload. All legitimate test fixtures are well under 1 KiB.
       GRPC_MAX_RECV_MSG_BYTES: "65536"
@@ -134,6 +136,8 @@ services:
       ENABLE_REFLECTION: "1"
       SCHEMA_MAX_FIELDS: "100"
       SCHEMA_MAX_DOC_BYTES: "4096"
+      SCHEMA_MAX_REMOVE_FIELDS: "5"
+      CONFIG_MAX_LIST_LEN: "5"
       GRPC_MAX_RECV_MSG_BYTES: "65536"
       DECREE_GATEWAY_TRUSTED_PROXY: "1"
       JWT_JWKS_URL: "http://jwks-server:8090/.well-known/jwks.json"

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -930,7 +930,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
-| field_paths | [string](#string) | repeated | Dot-separated field paths to retrieve. |
+| field_paths | [string](#string) | repeated | Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
 | version | [int32](#int32) | optional | Config version to read from. If omitted, reads from the latest version. |
 | include_descriptions | [bool](#bool) |  | When true, includes value-level descriptions. This bypasses the Redis cache and reads directly from the database. |
 
@@ -1127,7 +1127,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
-| updates | [FieldUpdate](#centralconfig-v1-FieldUpdate) | repeated | Field updates to apply. All updates are applied atomically in a single config version. If any update fails validation (checksum, field lock), no changes are committed. |
+| updates | [FieldUpdate](#centralconfig-v1-FieldUpdate) | repeated | Field updates to apply. All updates are applied atomically in a single config version. If any update fails validation (checksum, field lock), no changes are committed. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
 | description | [string](#string) | optional | Version-level description explaining why these changes were made. |
 
 
@@ -1159,7 +1159,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID) to subscribe to. |
-| field_paths | [string](#string) | repeated | Field paths to filter on. If empty, receives changes for all fields. Changes to fields not in this list are silently dropped. |
+| field_paths | [string](#string) | repeated | Field paths to filter on. If empty, receives changes for all fields. Changes to fields not in this list are silently dropped. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
 | start_version | [int32](#int32) | optional | Resume the stream from this config version (inclusive). When set, the server replays all changes at versions &gt;= start_version before streaming live events. Use snapshot_version &#43; 1 to close the gap between a GetConfig snapshot and the live subscription. |
 
 
@@ -1676,7 +1676,7 @@ Imported versions are created as drafts (unpublished) unless auto_publish is tru
 | id | [string](#string) |  | Schema ID (UUID). |
 | version_description | [string](#string) | optional | Description of what changed in this version. |
 | fields | [SchemaField](#centralconfig-v1-SchemaField) | repeated | Fields to add or modify. Existing fields not listed here are carried forward unchanged from the latest version. |
-| remove_fields | [string](#string) | repeated | Dot-separated paths of fields to remove from the new version. |
+| remove_fields | [string](#string) | repeated | Dot-separated paths of fields to remove from the new version. Maximum 1 000 entries (configurable via `SCHEMA_MAX_REMOVE_FIELDS`). Exceeding this limit returns `InvalidArgument`. |
 
 
 

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -930,7 +930,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
-| field_paths | [string](#string) | repeated | Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
+| field_paths | [string](#string) | repeated | Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument. |
 | version | [int32](#int32) | optional | Config version to read from. If omitted, reads from the latest version. |
 | include_descriptions | [bool](#bool) |  | When true, includes value-level descriptions. This bypasses the Redis cache and reads directly from the database. |
 
@@ -1127,7 +1127,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
-| updates | [FieldUpdate](#centralconfig-v1-FieldUpdate) | repeated | Field updates to apply. All updates are applied atomically in a single config version. If any update fails validation (checksum, field lock), no changes are committed. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
+| updates | [FieldUpdate](#centralconfig-v1-FieldUpdate) | repeated | Field updates to apply. All updates are applied atomically in a single config version. If any update fails validation (checksum, field lock), no changes are committed. Maximum 1 000 entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument. |
 | description | [string](#string) | optional | Version-level description explaining why these changes were made. |
 
 
@@ -1159,7 +1159,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID) to subscribe to. |
-| field_paths | [string](#string) | repeated | Field paths to filter on. If empty, receives changes for all fields. Changes to fields not in this list are silently dropped. Maximum 1 000 entries (configurable via `CONFIG_MAX_LIST_LEN`). Exceeding this limit returns `InvalidArgument`. |
+| field_paths | [string](#string) | repeated | Field paths to filter on. If empty, receives changes for all fields. Changes to fields not in this list are silently dropped. Maximum 1 000 entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument. |
 | start_version | [int32](#int32) | optional | Resume the stream from this config version (inclusive). When set, the server replays all changes at versions &gt;= start_version before streaming live events. Use snapshot_version &#43; 1 to close the gap between a GetConfig snapshot and the live subscription. |
 
 
@@ -1676,7 +1676,7 @@ Imported versions are created as drafts (unpublished) unless auto_publish is tru
 | id | [string](#string) |  | Schema ID (UUID). |
 | version_description | [string](#string) | optional | Description of what changed in this version. |
 | fields | [SchemaField](#centralconfig-v1-SchemaField) | repeated | Fields to add or modify. Existing fields not listed here are carried forward unchanged from the latest version. |
-| remove_fields | [string](#string) | repeated | Dot-separated paths of fields to remove from the new version. Maximum 1 000 entries (configurable via `SCHEMA_MAX_REMOVE_FIELDS`). Exceeding this limit returns `InvalidArgument`. |
+| remove_fields | [string](#string) | repeated | Dot-separated paths of fields to remove from the new version. Maximum 1 000 entries (configurable via SCHEMA_MAX_REMOVE_FIELDS). Exceeds returns InvalidArgument. |
 
 
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -996,7 +996,7 @@
           },
           {
             "name": "fieldPaths",
-            "description": "Field paths to filter on. If empty, receives changes for all fields.\nChanges to fields not in this list are silently dropped.",
+            "description": "Field paths to filter on. If empty, receives changes for all fields.\nChanges to fields not in this list are silently dropped. Maximum 1 000\nentries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns\nInvalidArgument.",
             "in": "query",
             "required": false,
             "type": "array",
@@ -1415,7 +1415,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Dot-separated field paths to retrieve."
+          "description": "Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable\nvia CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument."
         },
         "version": {
           "type": "integer",
@@ -1476,7 +1476,7 @@
             "type": "object",
             "$ref": "#/definitions/v1FieldUpdate"
           },
-          "description": "Field updates to apply. All updates are applied atomically in a single\nconfig version. If any update fails validation (checksum, field lock),\nno changes are committed."
+          "description": "Field updates to apply. All updates are applied atomically in a single\nconfig version. If any update fails validation (checksum, field lock),\nno changes are committed. Maximum 1 000 entries (configurable via\nCONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument."
         },
         "description": {
           "type": "string",
@@ -1530,7 +1530,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Dot-separated paths of fields to remove from the new version."
+          "description": "Dot-separated paths of fields to remove from the new version. Maximum\n1 000 entries (configurable via SCHEMA_MAX_REMOVE_FIELDS). Exceeds\nreturns InvalidArgument."
         }
       }
     },

--- a/e2e/validation_limits_test.go
+++ b/e2e/validation_limits_test.go
@@ -11,7 +11,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/sdk/adminclient"
 )
 
@@ -19,12 +23,22 @@ import (
 //
 //	SCHEMA_MAX_FIELDS=100
 //	SCHEMA_MAX_DOC_BYTES=4096
+//	SCHEMA_MAX_REMOVE_FIELDS=5
+//	CONFIG_MAX_LIST_LEN=5
 //
 // so these tests can trip each limit with small payloads.
 const (
-	maxFields   = 100
-	maxDocBytes = 4096
+	maxFields        = 100
+	maxDocBytes      = 4096
+	maxRemoveFields  = 5
+	maxConfigListLen = 5
 )
+
+// superadminMD returns outgoing metadata that satisfies the server's auth
+// interceptor for e2e calls made directly via the proto client.
+func superadminMD(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, "x-subject", "e2e-limits", "x-role", "superadmin")
+}
 
 // TestValidationLimits_MaxFieldsRejected: CreateSchema with more fields
 // than the configured cap is rejected with InvalidArgument and a message
@@ -95,4 +109,140 @@ fields:
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, adminclient.ErrInvalidArgument))
 	assert.Contains(t, err.Error(), fmt.Sprintf("exceeds limit of %d", maxDocBytes))
+}
+
+// --- Config list-length limits (CONFIG_MAX_LIST_LEN=5 in docker-compose) ---
+
+// TestValidationLimits_GetFields_ExceedsListLen verifies that GetFields
+// rejects a request with more than CONFIG_MAX_LIST_LEN field_paths.
+func TestValidationLimits_GetFields_ExceedsListLen(t *testing.T) {
+	conn := dial(t)
+	cfgSvc := pb.NewConfigServiceClient(conn)
+	ctx := superadminMD(context.Background())
+
+	paths := make([]string, maxConfigListLen+1)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("f.field_%d", i)
+	}
+
+	_, err := cfgSvc.GetFields(ctx, &pb.GetFieldsRequest{
+		TenantId:   "00000000-0000-0000-0000-000000000099",
+		FieldPaths: paths,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxConfigListLen))
+}
+
+// TestValidationLimits_GetFields_AtLimitAccepted verifies that GetFields
+// accepts a request with exactly CONFIG_MAX_LIST_LEN field_paths.
+func TestValidationLimits_GetFields_AtLimitAccepted(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	cfgSvc := pb.NewConfigServiceClient(conn)
+	ctx := context.Background()
+	authCtx := superadminMD(ctx)
+
+	fields := make([]adminclient.Field, maxConfigListLen)
+	for i := range fields {
+		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: "FIELD_TYPE_STRING"}
+	}
+	s, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-get-%s", randSuffix()), fields, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.DeleteSchema(ctx, s.ID) })
+	require.NoError(t, admin.PublishSchema(ctx, s.ID))
+
+	tenant, err := admin.CreateTenant(ctx, fmt.Sprintf("limits-get-t-%s", randSuffix()), s.ID, 1)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.DeleteTenant(ctx, tenant.ID) })
+
+	paths := make([]string, maxConfigListLen)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("f.field_%d", i)
+	}
+	_, err = cfgSvc.GetFields(authCtx, &pb.GetFieldsRequest{TenantId: tenant.ID, FieldPaths: paths})
+	// Any error here is fine — but must NOT be InvalidArgument (limit not tripped).
+	if err != nil {
+		assert.NotEqual(t, codes.InvalidArgument, status.Code(err),
+			"limit guard must not fire at exactly %d paths", maxConfigListLen)
+	}
+}
+
+// TestValidationLimits_SetFields_ExceedsListLen verifies that SetFields
+// rejects a request with more than CONFIG_MAX_LIST_LEN updates.
+func TestValidationLimits_SetFields_ExceedsListLen(t *testing.T) {
+	conn := dial(t)
+	cfgSvc := pb.NewConfigServiceClient(conn)
+	ctx := superadminMD(context.Background())
+
+	updates := make([]*pb.FieldUpdate, maxConfigListLen+1)
+	for i := range updates {
+		updates[i] = &pb.FieldUpdate{FieldPath: fmt.Sprintf("f.field_%d", i)}
+	}
+
+	_, err := cfgSvc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: "00000000-0000-0000-0000-000000000099",
+		Updates:  updates,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxConfigListLen))
+}
+
+// TestValidationLimits_Subscribe_ExceedsListLen verifies that Subscribe
+// rejects a request with more than CONFIG_MAX_LIST_LEN field_paths.
+func TestValidationLimits_Subscribe_ExceedsListLen(t *testing.T) {
+	conn := dial(t)
+	cfgSvc := pb.NewConfigServiceClient(conn)
+	ctx := superadminMD(context.Background())
+
+	paths := make([]string, maxConfigListLen+1)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("f.field_%d", i)
+	}
+
+	stream, err := cfgSvc.Subscribe(ctx, &pb.SubscribeRequest{
+		TenantId:   "00000000-0000-0000-0000-000000000099",
+		FieldPaths: paths,
+	})
+	require.NoError(t, err, "Subscribe RPC setup must not fail before the first Recv")
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxConfigListLen))
+}
+
+// --- Schema remove_fields limit (SCHEMA_MAX_REMOVE_FIELDS=5 in docker-compose) ---
+
+// TestValidationLimits_UpdateSchema_RemoveFields_ExceedsListLen verifies
+// that UpdateSchema rejects a remove_fields list longer than
+// SCHEMA_MAX_REMOVE_FIELDS.
+func TestValidationLimits_UpdateSchema_RemoveFields_ExceedsListLen(t *testing.T) {
+	conn := dial(t)
+	admin := newAdminClient(conn)
+	schemaSvc := pb.NewSchemaServiceClient(conn)
+	ctx := context.Background()
+	authCtx := superadminMD(ctx)
+
+	fields := make([]adminclient.Field, maxRemoveFields+1)
+	for i := range fields {
+		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: "FIELD_TYPE_STRING"}
+	}
+	s, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-rm-%s", randSuffix()), fields, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = admin.DeleteSchema(ctx, s.ID) })
+
+	removePaths := make([]string, maxRemoveFields+1)
+	for i := range removePaths {
+		removePaths[i] = fmt.Sprintf("f.field_%d", i)
+	}
+
+	_, err = schemaSvc.UpdateSchema(authCtx, &pb.UpdateSchemaRequest{
+		Id:           s.ID,
+		RemoveFields: removePaths,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), fmt.Sprintf("exceeds limit of %d", maxRemoveFields))
 }

--- a/e2e/validation_limits_test.go
+++ b/e2e/validation_limits_test.go
@@ -150,7 +150,8 @@ func TestValidationLimits_GetFields_AtLimitAccepted(t *testing.T) {
 	s, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-get-%s", randSuffix()), fields, "")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = admin.DeleteSchema(ctx, s.ID) })
-	require.NoError(t, admin.PublishSchema(ctx, s.ID))
+	_, err = admin.PublishSchema(ctx, s.ID, 1)
+	require.NoError(t, err)
 
 	tenant, err := admin.CreateTenant(ctx, fmt.Sprintf("limits-get-t-%s", randSuffix()), s.ID, 1)
 	require.NoError(t, err)

--- a/internal/config/limits.go
+++ b/internal/config/limits.go
@@ -1,0 +1,17 @@
+package config
+
+// Limits caps the number of entries in repeated request fields accepted by
+// GetFields, SetFields, and Subscribe. Zero values mean "no limit". Use
+// [DefaultLimits] for safe defaults.
+type Limits struct {
+	// MaxListLen caps the number of entries in GetFields.field_paths,
+	// SetFields.updates, and Subscribe.field_paths.
+	MaxListLen int
+}
+
+// DefaultLimits returns a conservative default: 1 000 entries per list.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxListLen: 1_000,
+	}
+}

--- a/internal/config/limits_test.go
+++ b/internal/config/limits_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+func TestDefaultLimits(t *testing.T) {
+	l := DefaultLimits()
+	assert.Equal(t, 1_000, l.MaxListLen)
+}
+
+func newLimitedService(maxListLen int) *Service {
+	store := &mockStore{}
+	c := &mockCache{}
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	return NewService(store, c, pub, sub,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxListLen: maxListLen}),
+	)
+}
+
+func TestGetFields_ExceedsMaxListLen(t *testing.T) {
+	svc := newLimitedService(2)
+
+	_, err := svc.GetFields(superadminCtx(), &pb.GetFieldsRequest{
+		TenantId:   tenantID1,
+		FieldPaths: []string{"a", "b", "c"},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 2")
+}
+
+func TestSetFields_ExceedsMaxListLen(t *testing.T) {
+	svc := newLimitedService(2)
+
+	_, err := svc.SetFields(superadminCtx(), &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "a"},
+			{FieldPath: "b"},
+			{FieldPath: "c"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 2")
+}
+
+func TestSubscribe_ExceedsMaxListLen(t *testing.T) {
+	svc := newLimitedService(2)
+
+	stream := &mockServerStream{ctx: superadminCtx()}
+	err := svc.Subscribe(&pb.SubscribeRequest{
+		TenantId:   tenantID1,
+		FieldPaths: []string{"a", "b", "c"},
+	}, stream)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 2")
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -63,6 +63,7 @@ type serviceOptions struct {
 	validators   *validation.ValidatorFactory
 	recorder     *audit.UsageRecorder
 	guard        authz.Guard
+	limits       Limits
 }
 
 // WithLogger sets the service logger. Defaults to slog.Default() when unset.
@@ -96,6 +97,12 @@ func WithGuard(g authz.Guard) Option {
 	return func(o *serviceOptions) { o.guard = g }
 }
 
+// WithLimits caps the number of entries in repeated request fields.
+// Defaults to [DefaultLimits] when unset.
+func WithLimits(l Limits) Option {
+	return func(o *serviceOptions) { o.limits = l }
+}
+
 // Service implements the ConfigService gRPC server.
 type Service struct {
 	pb.UnimplementedConfigServiceServer
@@ -109,13 +116,14 @@ type Service struct {
 	validators   *validation.ValidatorFactory
 	recorder     *audit.UsageRecorder
 	guard        authz.Guard
+	limits       Limits
 }
 
 // NewService creates a new ConfigService. The four required dependencies
 // (store, cache, publisher, subscriber) are positional; everything else is
 // optional and may be passed via With...() options.
 func NewService(store Store, cache cache.ConfigCache, publisher pubsub.Publisher, subscriber pubsub.Subscriber, opts ...Option) *Service {
-	o := serviceOptions{logger: slog.Default()}
+	o := serviceOptions{logger: slog.Default(), limits: DefaultLimits()}
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -137,6 +145,7 @@ func NewService(store Store, cache cache.ConfigCache, publisher pubsub.Publisher
 		validators:   o.validators,
 		recorder:     o.recorder,
 		guard:        o.guard,
+		limits:       o.limits,
 	}
 }
 
@@ -335,6 +344,9 @@ func (s *Service) GetField(ctx context.Context, req *pb.GetFieldRequest) (*pb.Ge
 func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.GetFieldsResponse, error) {
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
+	}
+	if s.limits.MaxListLen > 0 && len(req.FieldPaths) > s.limits.MaxListLen {
+		return nil, status.Errorf(codes.InvalidArgument, "request has %d field_paths, exceeds limit of %d", len(req.FieldPaths), s.limits.MaxListLen)
 	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {
@@ -540,6 +552,9 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.SetFieldsResponse, error) {
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
+	}
+	if s.limits.MaxListLen > 0 && len(req.Updates) > s.limits.MaxListLen {
+		return nil, status.Errorf(codes.InvalidArgument, "request has %d updates, exceeds limit of %d", len(req.Updates), s.limits.MaxListLen)
 	}
 	// Upfront role + tenant check before the per-field loop (loop may be empty).
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionWrite)
@@ -855,6 +870,9 @@ func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamin
 
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return err
+	}
+	if s.limits.MaxListLen > 0 && len(req.FieldPaths) > s.limits.MaxListLen {
+		return status.Errorf(codes.InvalidArgument, "request has %d field_paths, exceeds limit of %d", len(req.FieldPaths), s.limits.MaxListLen)
 	}
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
 	if err != nil {

--- a/internal/schema/limits.go
+++ b/internal/schema/limits.go
@@ -13,13 +13,18 @@ type Limits struct {
 
 	// MaxDocBytes caps the serialized YAML document size at ImportSchema.
 	MaxDocBytes int
+
+	// MaxRemoveFields caps the number of entries in UpdateSchema.remove_fields.
+	MaxRemoveFields int
 }
 
-// DefaultLimits returns conservative defaults: 10 000 fields and 5 MiB
-// per document. Tune via env vars at the call site (cmd/server).
+// DefaultLimits returns conservative defaults: 10 000 fields, 5 MiB per
+// document, and 1 000 remove_fields entries per UpdateSchema request.
+// Tune via env vars at the call site (cmd/server).
 func DefaultLimits() Limits {
 	return Limits{
-		MaxFields:   10_000,
-		MaxDocBytes: 5 * 1024 * 1024,
+		MaxFields:       10_000,
+		MaxDocBytes:     5 * 1024 * 1024,
+		MaxRemoveFields: 1_000,
 	}
 }

--- a/internal/schema/limits_test.go
+++ b/internal/schema/limits_test.go
@@ -18,6 +18,25 @@ func TestDefaultLimits(t *testing.T) {
 	l := DefaultLimits()
 	assert.Equal(t, 10_000, l.MaxFields)
 	assert.Equal(t, 5*1024*1024, l.MaxDocBytes)
+	assert.Equal(t, 1_000, l.MaxRemoveFields)
+}
+
+func TestUpdateSchema_ExceedsMaxRemoveFields(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store,
+		WithLogger(testLogger),
+		WithLimits(Limits{MaxRemoveFields: 2}),
+	)
+
+	_, err := svc.UpdateSchema(superadminCtx(), &pb.UpdateSchemaRequest{
+		Id:           testSchemaID,
+		RemoveFields: []string{"a", "b", "c"},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "exceeds limit of 2")
+	store.AssertNotCalled(t, "GetLatestSchemaVersion")
 }
 
 func TestCreateSchema_ExceedsMaxFields(t *testing.T) {

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -298,6 +298,9 @@ func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest)
 	if req.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "schema id or name required")
 	}
+	if s.limits.MaxRemoveFields > 0 && len(req.RemoveFields) > s.limits.MaxRemoveFields {
+		return nil, status.Errorf(codes.InvalidArgument, "remove_fields has %d entries, exceeds limit of %d", len(req.RemoveFields), s.limits.MaxRemoveFields)
+	}
 
 	schema, err := s.resolveSchema(ctx, req.Id)
 	if err != nil {

--- a/proto/centralconfig/v1/config_service.proto
+++ b/proto/centralconfig/v1/config_service.proto
@@ -152,7 +152,8 @@ message GetFieldsRequest {
   // Tenant ID (UUID).
   string tenant_id = 1;
 
-  // Dot-separated field paths to retrieve.
+  // Dot-separated field paths to retrieve. Maximum 1 000 entries (configurable
+  // via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument.
   repeated string field_paths = 2;
 
   // Config version to read from. If omitted, reads from the latest version.
@@ -205,7 +206,8 @@ message SetFieldsRequest {
 
   // Field updates to apply. All updates are applied atomically in a single
   // config version. If any update fails validation (checksum, field lock),
-  // no changes are committed.
+  // no changes are committed. Maximum 1 000 entries (configurable via
+  // CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument.
   repeated FieldUpdate updates = 2;
 
   // Version-level description explaining why these changes were made.
@@ -292,7 +294,9 @@ message SubscribeRequest {
   string tenant_id = 1;
 
   // Field paths to filter on. If empty, receives changes for all fields.
-  // Changes to fields not in this list are silently dropped.
+  // Changes to fields not in this list are silently dropped. Maximum 1 000
+  // entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns
+  // InvalidArgument.
   repeated string field_paths = 2;
 
   // Resume the stream from this config version (inclusive). When set, the

--- a/proto/centralconfig/v1/schema_service.proto
+++ b/proto/centralconfig/v1/schema_service.proto
@@ -194,7 +194,9 @@ message UpdateSchemaRequest {
   // forward unchanged from the latest version.
   repeated SchemaField fields = 3;
 
-  // Dot-separated paths of fields to remove from the new version.
+  // Dot-separated paths of fields to remove from the new version. Maximum
+  // 1 000 entries (configurable via SCHEMA_MAX_REMOVE_FIELDS). Exceeds
+  // returns InvalidArgument.
   repeated string remove_fields = 4;
 }
 


### PR DESCRIPTION
## Summary

- Repeated fields on four RPCs (`SetFields.updates`, `GetFields.field_paths`, `Subscribe.field_paths`, `UpdateSchema.remove_fields`) had no upper bound, letting a single request carry 100k+ entries and amplify per-entry work (guard checks, validator calls) into a DoS vector.
- Adds a fast-path limit check before tenant resolution so oversized requests are rejected immediately with `InvalidArgument`.
- Defaults to 1 000 entries; tunable via `CONFIG_MAX_LIST_LEN` and `SCHEMA_MAX_REMOVE_FIELDS` env vars, following the same pattern as `SCHEMA_MAX_FIELDS`.

## Test plan

- [x] Unit tests: `TestGetFields_ExceedsMaxListLen`, `TestSetFields_ExceedsMaxListLen`, `TestSubscribe_ExceedsMaxListLen` (config package); `TestUpdateSchema_ExceedsMaxRemoveFields` (schema package)
- [x] `TestDefaultLimits` updated in both packages to assert new defaults
- [x] E2e tests added to `validation_limits_test.go`: exceeds-limit cases for all four RPCs; at-limit-accepted case for `GetFields`
- [x] docker-compose pins `CONFIG_MAX_LIST_LEN=5` and `SCHEMA_MAX_REMOVE_FIELDS=5` so e2e tests trip limits with tiny payloads
- [x] API reference and proto comments updated to document the limit and env var

Closes #434