### PR TITLE
Soft-delete tenants and schemas to preserve audit references

### DIFF
--- a/db/migrations/004_soft_delete.sql
+++ b/db/migrations/004_soft_delete.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+ALTER TABLE schemas ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE tenants ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Replace table-level UNIQUE with partial indexes so names can be reused after soft-delete.
+ALTER TABLE schemas DROP CONSTRAINT schemas_name_key;
+ALTER TABLE tenants DROP CONSTRAINT tenants_name_key;
+
+CREATE UNIQUE INDEX schemas_name_unique ON schemas(name) WHERE deleted_at IS NULL; -- decree:index-lock-ok alpha migration, tables are small
+CREATE UNIQUE INDEX tenants_name_unique ON tenants(name) WHERE deleted_at IS NULL; -- decree:index-lock-ok alpha migration, tables are small
+
+-- +goose Down
+
+DROP INDEX IF EXISTS schemas_name_unique;
+DROP INDEX IF EXISTS tenants_name_unique;
+
+ALTER TABLE schemas ADD CONSTRAINT schemas_name_key UNIQUE (name);
+ALTER TABLE tenants ADD CONSTRAINT tenants_name_key UNIQUE (name);
+
+ALTER TABLE tenants DROP COLUMN deleted_at;
+ALTER TABLE schemas DROP COLUMN deleted_at;

--- a/db/queries/schemas.sql
+++ b/db/queries/schemas.sql
@@ -4,18 +4,19 @@ VALUES ($1, $2)
 RETURNING *;
 
 -- name: GetSchemaByID :one
-SELECT * FROM schemas WHERE id = $1;
+SELECT * FROM schemas WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: GetSchemaByName :one
-SELECT * FROM schemas WHERE name = $1;
+SELECT * FROM schemas WHERE name = $1 AND deleted_at IS NULL;
 
 -- name: ListSchemas :many
 SELECT * FROM schemas
+WHERE deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
 
--- name: DeleteSchema :exec
-DELETE FROM schemas WHERE id = $1;
+-- name: SoftDeleteSchema :exec
+UPDATE schemas SET deleted_at = now() WHERE id = $1;
 
 -- name: CreateSchemaVersion :one
 INSERT INTO schema_versions (schema_id, version, parent_version, description, checksum, dependent_required, validations)

--- a/db/queries/tenants.sql
+++ b/db/queries/tenants.sql
@@ -4,46 +4,47 @@ VALUES ($1, $2, $3)
 RETURNING *;
 
 -- name: GetTenantByID :one
-SELECT * FROM tenants WHERE id = $1;
+SELECT * FROM tenants WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: GetTenantByName :one
-SELECT * FROM tenants WHERE name = $1;
+SELECT * FROM tenants WHERE name = $1 AND deleted_at IS NULL;
 
 -- name: ListTenants :many
 SELECT * FROM tenants
+WHERE deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
 
 -- name: ListTenantsByIDs :many
 SELECT * FROM tenants
-WHERE id = ANY(@allowed_ids::uuid[])
+WHERE id = ANY(@allowed_ids::uuid[]) AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
 
 -- name: ListTenantsBySchema :many
 SELECT * FROM tenants
-WHERE schema_id = $1
+WHERE schema_id = $1 AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListTenantsBySchemaAndIDs :many
 SELECT * FROM tenants
-WHERE schema_id = $1 AND id = ANY(@allowed_ids::uuid[])
+WHERE schema_id = $1 AND id = ANY(@allowed_ids::uuid[]) AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: UpdateTenantName :one
 UPDATE tenants SET name = $2, updated_at = now()
-WHERE id = $1
+WHERE id = $1 AND deleted_at IS NULL
 RETURNING *;
 
 -- name: UpdateTenantSchemaVersion :one
 UPDATE tenants SET schema_version = $2, updated_at = now()
-WHERE id = $1
+WHERE id = $1 AND deleted_at IS NULL
 RETURNING *;
 
--- name: DeleteTenant :exec
-DELETE FROM tenants WHERE id = $1;
+-- name: SoftDeleteTenant :exec
+UPDATE tenants SET deleted_at = now() WHERE id = $1;
 
 -- name: CreateFieldLock :exec
 INSERT INTO tenant_field_locks (tenant_id, field_path, locked_values)

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -73,9 +73,9 @@ func (m *MemoryStore) CreateSchema(_ context.Context, arg CreateSchemaParams) (d
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Check name uniqueness.
+	// Check name uniqueness among non-deleted schemas.
 	for _, s := range m.schemas {
-		if s.Name == arg.Name {
+		if s.Name == arg.Name && s.DeletedAt == nil {
 			return domain.Schema{}, fmt.Errorf("schema with name %q already exists", arg.Name)
 		}
 	}
@@ -97,7 +97,7 @@ func (m *MemoryStore) GetSchemaByID(_ context.Context, id string) (domain.Schema
 	defer m.mu.RUnlock()
 
 	s, ok := m.schemas[id]
-	if !ok {
+	if !ok || s.DeletedAt != nil {
 		return domain.Schema{}, domain.ErrNotFound
 	}
 	return s, nil
@@ -108,7 +108,7 @@ func (m *MemoryStore) GetSchemaByName(_ context.Context, name string) (domain.Sc
 	defer m.mu.RUnlock()
 
 	for _, s := range m.schemas {
-		if s.Name == name {
+		if s.Name == name && s.DeletedAt == nil {
 			return s, nil
 		}
 	}
@@ -121,7 +121,9 @@ func (m *MemoryStore) ListSchemas(_ context.Context, arg ListSchemasParams) ([]d
 
 	all := make([]domain.Schema, 0, len(m.schemas))
 	for _, s := range m.schemas {
-		all = append(all, s)
+		if s.DeletedAt == nil {
+			all = append(all, s)
+		}
 	}
 	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
 
@@ -132,27 +134,13 @@ func (m *MemoryStore) DeleteSchema(_ context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.schemas[id]; !ok {
+	s, ok := m.schemas[id]
+	if !ok || s.DeletedAt != nil {
 		return domain.ErrNotFound
 	}
-
-	// Cascade: delete versions + their fields.
-	for vid, sv := range m.schemaVersions {
-		if sv.SchemaID == id {
-			delete(m.schemaFields, vid)
-			delete(m.schemaVersions, vid)
-		}
-	}
-
-	// Cascade: delete tenants + their locks.
-	for tid, t := range m.tenants {
-		if t.SchemaID == id {
-			delete(m.fieldLocks, tid)
-			delete(m.tenants, tid)
-		}
-	}
-
-	delete(m.schemas, id)
+	now := time.Now()
+	s.DeletedAt = &now
+	m.schemas[id] = s
 	return nil
 }
 
@@ -322,7 +310,7 @@ func (m *MemoryStore) GetTenantByID(_ context.Context, id string) (domain.Tenant
 	defer m.mu.RUnlock()
 
 	t, ok := m.tenants[id]
-	if !ok {
+	if !ok || t.DeletedAt != nil {
 		return domain.Tenant{}, domain.ErrNotFound
 	}
 	return t, nil
@@ -333,7 +321,7 @@ func (m *MemoryStore) GetTenantByName(_ context.Context, name string) (domain.Te
 	defer m.mu.RUnlock()
 
 	for _, t := range m.tenants {
-		if t.Name == name {
+		if t.Name == name && t.DeletedAt == nil {
 			return t, nil
 		}
 	}
@@ -346,6 +334,9 @@ func (m *MemoryStore) ListTenants(_ context.Context, arg ListTenantsParams) ([]d
 
 	all := make([]domain.Tenant, 0, len(m.tenants))
 	for _, t := range m.tenants {
+		if t.DeletedAt != nil {
+			continue
+		}
 		if arg.AllowedTenantIDs != nil && !slices.Contains(arg.AllowedTenantIDs, t.ID) {
 			continue
 		}
@@ -362,7 +353,7 @@ func (m *MemoryStore) ListTenantsBySchema(_ context.Context, arg ListTenantsBySc
 
 	var filtered []domain.Tenant
 	for _, t := range m.tenants {
-		if t.SchemaID != arg.SchemaID {
+		if t.DeletedAt != nil || t.SchemaID != arg.SchemaID {
 			continue
 		}
 		if arg.AllowedTenantIDs != nil && !slices.Contains(arg.AllowedTenantIDs, t.ID) {
@@ -380,7 +371,7 @@ func (m *MemoryStore) UpdateTenantName(_ context.Context, arg UpdateTenantNamePa
 	defer m.mu.Unlock()
 
 	t, ok := m.tenants[arg.ID]
-	if !ok {
+	if !ok || t.DeletedAt != nil {
 		return domain.Tenant{}, domain.ErrNotFound
 	}
 	t.Name = arg.Name
@@ -394,7 +385,7 @@ func (m *MemoryStore) UpdateTenantSchemaVersion(_ context.Context, arg UpdateTen
 	defer m.mu.Unlock()
 
 	t, ok := m.tenants[arg.ID]
-	if !ok {
+	if !ok || t.DeletedAt != nil {
 		return domain.Tenant{}, domain.ErrNotFound
 	}
 	t.SchemaVersion = arg.SchemaVersion
@@ -407,11 +398,13 @@ func (m *MemoryStore) DeleteTenant(_ context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.tenants[id]; !ok {
+	t, ok := m.tenants[id]
+	if !ok || t.DeletedAt != nil {
 		return domain.ErrNotFound
 	}
-	delete(m.fieldLocks, id)
-	delete(m.tenants, id)
+	now := time.Now()
+	t.DeletedAt = &now
+	m.tenants[id] = t
 	return nil
 }
 
@@ -421,7 +414,8 @@ func (m *MemoryStore) CreateFieldLock(_ context.Context, arg CreateFieldLockPara
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.tenants[arg.TenantID]; !ok {
+	t, ok := m.tenants[arg.TenantID]
+	if !ok || t.DeletedAt != nil {
 		return domain.ErrNotFound
 	}
 

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -378,11 +378,11 @@ func TestMemoryStore_Pagination(t *testing.T) {
 	assert.Len(t, bySchema, 1)
 }
 
-func TestMemoryStore_DeleteSchemaCascade(t *testing.T) {
+func TestMemoryStore_DeleteSchema_SoftDelete(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()
 
-	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "cascade"})
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "soft-delete-schema"})
 	require.NoError(t, err)
 
 	sv, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
@@ -396,7 +396,7 @@ func TestMemoryStore_DeleteSchemaCascade(t *testing.T) {
 	require.NoError(t, err)
 
 	tenant, err := store.CreateTenant(ctx, CreateTenantParams{
-		Name: "cascade-tenant", SchemaID: s.ID, SchemaVersion: 1,
+		Name: "soft-delete-tenant", SchemaID: s.ID, SchemaVersion: 1,
 	})
 	require.NoError(t, err)
 
@@ -405,27 +405,82 @@ func TestMemoryStore_DeleteSchemaCascade(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Delete schema cascades everything.
+	// Soft-delete schema.
 	err = store.DeleteSchema(ctx, s.ID)
 	require.NoError(t, err)
 
-	// Version gone.
-	_, err = store.GetSchemaVersion(ctx, GetSchemaVersionParams{SchemaID: s.ID, Version: 1})
+	// Schema inaccessible via normal lookups.
+	_, err = store.GetSchemaByID(ctx, s.ID)
+	assert.True(t, errors.Is(err, domain.ErrNotFound))
+	_, err = store.GetSchemaByName(ctx, "soft-delete-schema")
 	assert.True(t, errors.Is(err, domain.ErrNotFound))
 
-	// Fields gone.
-	fields, err := store.GetSchemaFields(ctx, sv.ID)
+	// Schema absent from list.
+	schemas, err := store.ListSchemas(ctx, ListSchemasParams{Limit: 10})
 	require.NoError(t, err)
-	assert.Empty(t, fields)
+	assert.Empty(t, schemas)
 
-	// Tenant gone.
+	// Double-delete returns ErrNotFound.
+	assert.True(t, errors.Is(store.DeleteSchema(ctx, s.ID), domain.ErrNotFound))
+
+	// Name can be reused after soft-delete.
+	_, err = store.CreateSchema(ctx, CreateSchemaParams{Name: "soft-delete-schema"})
+	require.NoError(t, err)
+
+	// Tenant remains accessible (has its own deleted_at lifecycle).
 	_, err = store.GetTenantByID(ctx, tenant.ID)
-	assert.True(t, errors.Is(err, domain.ErrNotFound))
+	require.NoError(t, err)
 
-	// Locks gone.
+	// Field locks remain.
 	locks, err := store.GetFieldLocks(ctx, tenant.ID)
 	require.NoError(t, err)
-	assert.Empty(t, locks)
+	assert.Len(t, locks, 1)
+}
+
+func TestMemoryStore_DeleteTenant_SoftDelete(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "sd-schema"})
+	require.NoError(t, err)
+
+	tenant, err := store.CreateTenant(ctx, CreateTenantParams{
+		Name: "sd-tenant", SchemaID: s.ID, SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateFieldLock(ctx, CreateFieldLockParams{
+		TenantID: tenant.ID, FieldPath: "x", LockedValues: []byte(`["v"]`),
+	})
+	require.NoError(t, err)
+
+	// Soft-delete tenant.
+	require.NoError(t, store.DeleteTenant(ctx, tenant.ID))
+
+	// Tenant inaccessible via normal lookups.
+	_, err = store.GetTenantByID(ctx, tenant.ID)
+	assert.True(t, errors.Is(err, domain.ErrNotFound))
+	_, err = store.GetTenantByName(ctx, "sd-tenant")
+	assert.True(t, errors.Is(err, domain.ErrNotFound))
+
+	// Tenant absent from list.
+	list, err := store.ListTenants(ctx, ListTenantsParams{Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, list)
+
+	// Double-delete returns ErrNotFound.
+	assert.True(t, errors.Is(store.DeleteTenant(ctx, tenant.ID), domain.ErrNotFound))
+
+	// Name can be reused after soft-delete.
+	_, err = store.CreateTenant(ctx, CreateTenantParams{
+		Name: "sd-tenant", SchemaID: s.ID, SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+
+	// Field locks remain in storage (accessible by ID, not via normal tenant lookup).
+	locks, err := store.GetFieldLocks(ctx, tenant.ID)
+	require.NoError(t, err)
+	assert.Len(t, locks, 1)
 }
 
 func TestMemoryStore_ListTenants_FilteredByAllowedIDs(t *testing.T) {

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -170,7 +170,7 @@ func (s *PGStore) DeleteSchema(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	return s.write.DeleteSchema(ctx, pgID)
+	return s.write.SoftDeleteSchema(ctx, pgID)
 }
 
 // --- Schema versions ---
@@ -436,7 +436,7 @@ func (s *PGStore) DeleteTenant(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	return s.write.DeleteTenant(ctx, pgID)
+	return s.write.SoftDeleteTenant(ctx, pgID)
 }
 
 // --- Field locks ---
@@ -493,6 +493,7 @@ func schemaFromDB(r dbstore.Schema) domain.Schema {
 		Description: r.Description,
 		CreatedAt:   pgconv.TimestamptzToTime(r.CreatedAt),
 		UpdatedAt:   pgconv.TimestamptzToTime(r.UpdatedAt),
+		DeletedAt:   pgconv.TimestamptzToOptionalTime(r.DeletedAt),
 	}
 }
 
@@ -543,6 +544,7 @@ func tenantFromDB(r dbstore.Tenant) domain.Tenant {
 		SchemaVersion: r.SchemaVersion,
 		CreatedAt:     pgconv.TimestamptzToTime(r.CreatedAt),
 		UpdatedAt:     pgconv.TimestamptzToTime(r.UpdatedAt),
+		DeletedAt:     pgconv.TimestamptzToOptionalTime(r.DeletedAt),
 	}
 }
 

--- a/internal/storage/dbstore/models.gen.go
+++ b/internal/storage/dbstore/models.gen.go
@@ -99,6 +99,7 @@ type Schema struct {
 	Description *string            `json:"description"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt   pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type SchemaField struct {
@@ -143,6 +144,7 @@ type Tenant struct {
 	SchemaVersion int32              `json:"schema_version"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt     pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type TenantFieldLock struct {

--- a/internal/storage/dbstore/schemas.sql.gen.go
+++ b/internal/storage/dbstore/schemas.sql.gen.go
@@ -14,7 +14,7 @@ import (
 const createSchema = `-- name: CreateSchema :one
 INSERT INTO schemas (name, description)
 VALUES ($1, $2)
-RETURNING id, name, description, created_at, updated_at
+RETURNING id, name, description, created_at, updated_at, deleted_at
 `
 
 type CreateSchemaParams struct {
@@ -31,6 +31,7 @@ func (q *Queries) CreateSchema(ctx context.Context, arg CreateSchemaParams) (Sch
 		&i.Description,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -154,15 +155,6 @@ func (q *Queries) CreateSchemaVersion(ctx context.Context, arg CreateSchemaVersi
 	return i, err
 }
 
-const deleteSchema = `-- name: DeleteSchema :exec
-DELETE FROM schemas WHERE id = $1
-`
-
-func (q *Queries) DeleteSchema(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteSchema, id)
-	return err
-}
-
 const deleteSchemaField = `-- name: DeleteSchemaField :exec
 DELETE FROM schema_fields
 WHERE schema_version_id = $1 AND path = $2
@@ -204,7 +196,7 @@ func (q *Queries) GetLatestSchemaVersion(ctx context.Context, schemaID pgtype.UU
 }
 
 const getSchemaByID = `-- name: GetSchemaByID :one
-SELECT id, name, description, created_at, updated_at FROM schemas WHERE id = $1
+SELECT id, name, description, created_at, updated_at, deleted_at FROM schemas WHERE id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) GetSchemaByID(ctx context.Context, id pgtype.UUID) (Schema, error) {
@@ -216,12 +208,13 @@ func (q *Queries) GetSchemaByID(ctx context.Context, id pgtype.UUID) (Schema, er
 		&i.Description,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const getSchemaByName = `-- name: GetSchemaByName :one
-SELECT id, name, description, created_at, updated_at FROM schemas WHERE name = $1
+SELECT id, name, description, created_at, updated_at, deleted_at FROM schemas WHERE name = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) GetSchemaByName(ctx context.Context, name string) (Schema, error) {
@@ -233,6 +226,7 @@ func (q *Queries) GetSchemaByName(ctx context.Context, name string) (Schema, err
 		&i.Description,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -312,7 +306,8 @@ func (q *Queries) GetSchemaVersion(ctx context.Context, arg GetSchemaVersionPara
 }
 
 const listSchemas = `-- name: ListSchemas :many
-SELECT id, name, description, created_at, updated_at FROM schemas
+SELECT id, name, description, created_at, updated_at, deleted_at FROM schemas
+WHERE deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -337,6 +332,7 @@ func (q *Queries) ListSchemas(ctx context.Context, arg ListSchemasParams) ([]Sch
 			&i.Description,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -375,4 +371,13 @@ func (q *Queries) PublishSchemaVersion(ctx context.Context, arg PublishSchemaVer
 		&i.CreatedAt,
 	)
 	return i, err
+}
+
+const softDeleteSchema = `-- name: SoftDeleteSchema :exec
+UPDATE schemas SET deleted_at = now() WHERE id = $1
+`
+
+func (q *Queries) SoftDeleteSchema(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, softDeleteSchema, id)
+	return err
 }

--- a/internal/storage/dbstore/tenants.sql.gen.go
+++ b/internal/storage/dbstore/tenants.sql.gen.go
@@ -31,7 +31,7 @@ func (q *Queries) CreateFieldLock(ctx context.Context, arg CreateFieldLockParams
 const createTenant = `-- name: CreateTenant :one
 INSERT INTO tenants (name, schema_id, schema_version)
 VALUES ($1, $2, $3)
-RETURNING id, name, schema_id, schema_version, created_at, updated_at
+RETURNING id, name, schema_id, schema_version, created_at, updated_at, deleted_at
 `
 
 type CreateTenantParams struct {
@@ -50,6 +50,7 @@ func (q *Queries) CreateTenant(ctx context.Context, arg CreateTenantParams) (Ten
 		&i.SchemaVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -66,15 +67,6 @@ type DeleteFieldLockParams struct {
 
 func (q *Queries) DeleteFieldLock(ctx context.Context, arg DeleteFieldLockParams) error {
 	_, err := q.db.Exec(ctx, deleteFieldLock, arg.TenantID, arg.FieldPath)
-	return err
-}
-
-const deleteTenant = `-- name: DeleteTenant :exec
-DELETE FROM tenants WHERE id = $1
-`
-
-func (q *Queries) DeleteTenant(ctx context.Context, id pgtype.UUID) error {
-	_, err := q.db.Exec(ctx, deleteTenant, id)
 	return err
 }
 
@@ -105,7 +97,7 @@ func (q *Queries) GetFieldLocks(ctx context.Context, tenantID pgtype.UUID) ([]Te
 }
 
 const getTenantByID = `-- name: GetTenantByID :one
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants WHERE id = $1
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants WHERE id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) GetTenantByID(ctx context.Context, id pgtype.UUID) (Tenant, error) {
@@ -118,12 +110,13 @@ func (q *Queries) GetTenantByID(ctx context.Context, id pgtype.UUID) (Tenant, er
 		&i.SchemaVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const getTenantByName = `-- name: GetTenantByName :one
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants WHERE name = $1
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants WHERE name = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) GetTenantByName(ctx context.Context, name string) (Tenant, error) {
@@ -136,12 +129,14 @@ func (q *Queries) GetTenantByName(ctx context.Context, name string) (Tenant, err
 		&i.SchemaVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const listTenants = `-- name: ListTenants :many
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
+WHERE deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -167,6 +162,7 @@ func (q *Queries) ListTenants(ctx context.Context, arg ListTenantsParams) ([]Ten
 			&i.SchemaVersion,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -179,8 +175,8 @@ func (q *Queries) ListTenants(ctx context.Context, arg ListTenantsParams) ([]Ten
 }
 
 const listTenantsByIDs = `-- name: ListTenantsByIDs :many
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants
-WHERE id = ANY($3::uuid[])
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
+WHERE id = ANY($3::uuid[]) AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -207,6 +203,7 @@ func (q *Queries) ListTenantsByIDs(ctx context.Context, arg ListTenantsByIDsPara
 			&i.SchemaVersion,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -219,8 +216,8 @@ func (q *Queries) ListTenantsByIDs(ctx context.Context, arg ListTenantsByIDsPara
 }
 
 const listTenantsBySchema = `-- name: ListTenantsBySchema :many
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants
-WHERE schema_id = $1
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
+WHERE schema_id = $1 AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -247,6 +244,7 @@ func (q *Queries) ListTenantsBySchema(ctx context.Context, arg ListTenantsBySche
 			&i.SchemaVersion,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -259,8 +257,8 @@ func (q *Queries) ListTenantsBySchema(ctx context.Context, arg ListTenantsBySche
 }
 
 const listTenantsBySchemaAndIDs = `-- name: ListTenantsBySchemaAndIDs :many
-SELECT id, name, schema_id, schema_version, created_at, updated_at FROM tenants
-WHERE schema_id = $1 AND id = ANY($4::uuid[])
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
+WHERE schema_id = $1 AND id = ANY($4::uuid[]) AND deleted_at IS NULL
 ORDER BY created_at DESC
 LIMIT $2 OFFSET $3
 `
@@ -293,6 +291,7 @@ func (q *Queries) ListTenantsBySchemaAndIDs(ctx context.Context, arg ListTenants
 			&i.SchemaVersion,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -304,10 +303,19 @@ func (q *Queries) ListTenantsBySchemaAndIDs(ctx context.Context, arg ListTenants
 	return items, nil
 }
 
+const softDeleteTenant = `-- name: SoftDeleteTenant :exec
+UPDATE tenants SET deleted_at = now() WHERE id = $1
+`
+
+func (q *Queries) SoftDeleteTenant(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, softDeleteTenant, id)
+	return err
+}
+
 const updateTenantName = `-- name: UpdateTenantName :one
 UPDATE tenants SET name = $2, updated_at = now()
-WHERE id = $1
-RETURNING id, name, schema_id, schema_version, created_at, updated_at
+WHERE id = $1 AND deleted_at IS NULL
+RETURNING id, name, schema_id, schema_version, created_at, updated_at, deleted_at
 `
 
 type UpdateTenantNameParams struct {
@@ -325,14 +333,15 @@ func (q *Queries) UpdateTenantName(ctx context.Context, arg UpdateTenantNamePara
 		&i.SchemaVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const updateTenantSchemaVersion = `-- name: UpdateTenantSchemaVersion :one
 UPDATE tenants SET schema_version = $2, updated_at = now()
-WHERE id = $1
-RETURNING id, name, schema_id, schema_version, created_at, updated_at
+WHERE id = $1 AND deleted_at IS NULL
+RETURNING id, name, schema_id, schema_version, created_at, updated_at, deleted_at
 `
 
 type UpdateTenantSchemaVersionParams struct {
@@ -350,6 +359,7 @@ func (q *Queries) UpdateTenantSchemaVersion(ctx context.Context, arg UpdateTenan
 		&i.SchemaVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return i, err
 }

--- a/internal/storage/domain/types.go
+++ b/internal/storage/domain/types.go
@@ -33,6 +33,7 @@ type Schema struct {
 	Description *string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	DeletedAt   *time.Time
 }
 
 // SchemaVersion represents a specific version of a schema.
@@ -87,6 +88,7 @@ type Tenant struct {
 	SchemaVersion int32
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
+	DeletedAt     *time.Time
 }
 
 // TenantFieldLock represents a locked field for a tenant.


### PR DESCRIPTION
## Summary

- Preserves audit integrity by replacing hard `DELETE` on tenants and schemas with soft-delete (`deleted_at` timestamp), so `audit_write_log` references remain resolvable even after deletion.
- All `SELECT` queries on `tenants` and `schemas` now filter `WHERE deleted_at IS NULL`, keeping deleted records invisible to normal API operations.
- Partial unique indexes (`WHERE deleted_at IS NULL`) replace table-level `UNIQUE` constraints, allowing deleted names to be reused.

## Test plan

- [x] All existing unit tests pass (`make test`)
- [x] New `TestMemoryStore_DeleteSchema_SoftDelete` verifies: schema inaccessible after delete, absent from list, name reusable, tenant survives independently
- [x] New `TestMemoryStore_DeleteTenant_SoftDelete` verifies: tenant inaccessible after delete, absent from list, name reusable, field locks preserved
- [x] `CreateFieldLock` rejects soft-deleted tenants
- [x] Pre-commit checks pass (build, vet, lint, race-test, coverage thresholds)

Closes #453