### PR TITLE
Add WithTokenSource for per-RPC token refresh in grpctransport

### DIFF
--- a/sdk/grpctransport/audit_transport.go
+++ b/sdk/grpctransport/audit_transport.go
@@ -35,7 +35,10 @@ func NewAuditTransport(conn grpc.ClientConnInterface, opts ...Option) (*AuditTra
 }
 
 func (t *AuditTransport) QueryWriteLog(ctx context.Context, req *adminclient.QueryWriteLogRequest) (*adminclient.QueryWriteLogResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.QueryWriteLogRequest{
 		TenantId:  req.TenantID,
 		Actor:     req.Actor,
@@ -60,7 +63,10 @@ func (t *AuditTransport) QueryWriteLog(ctx context.Context, req *adminclient.Que
 }
 
 func (t *AuditTransport) GetFieldUsage(ctx context.Context, tenantID, fieldPath string, start, end *time.Time) (*adminclient.UsageStats, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetFieldUsage(ctx, &pb.GetFieldUsageRequest{
 		TenantId:  tenantID,
 		FieldPath: fieldPath,
@@ -74,7 +80,10 @@ func (t *AuditTransport) GetFieldUsage(ctx context.Context, tenantID, fieldPath 
 }
 
 func (t *AuditTransport) GetTenantUsage(ctx context.Context, tenantID string, start, end *time.Time) ([]*adminclient.UsageStats, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetTenantUsage(ctx, &pb.GetTenantUsageRequest{
 		TenantId:  tenantID,
 		StartTime: timeToProto(start),
@@ -91,7 +100,10 @@ func (t *AuditTransport) GetTenantUsage(ctx context.Context, tenantID string, st
 }
 
 func (t *AuditTransport) GetUnusedFields(ctx context.Context, tenantID string, since time.Time) ([]string, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetUnusedFields(ctx, &pb.GetUnusedFieldsRequest{
 		TenantId: tenantID,
 		Since:    timestamppb.New(since),

--- a/sdk/grpctransport/auth.go
+++ b/sdk/grpctransport/auth.go
@@ -29,6 +29,7 @@ type authConfig struct {
 	role        string
 	tenantID    string
 	bearerToken string
+	tokenSource func(context.Context) (string, error)
 }
 
 // WithSubject sets the x-subject metadata header.
@@ -50,6 +51,14 @@ func WithTenantID(id string) Option {
 // When set, the x-subject/x-role/x-tenant-id headers are not sent.
 func WithBearerToken(token string) Option {
 	return func(c *config) { c.auth.bearerToken = token }
+}
+
+// WithTokenSource sets a per-RPC token source. The function is called on
+// every RPC and its return value is used as the Bearer token. Use this
+// instead of [WithBearerToken] when tokens can expire (e.g. OAuth2,
+// short-lived JWTs).
+func WithTokenSource(fn func(context.Context) (string, error)) Option {
+	return func(c *config) { c.auth.tokenSource = fn }
 }
 
 // WithRetry passes a retry configuration through to configclient.
@@ -74,26 +83,33 @@ func WithLogger(l *slog.Logger) Option {
 }
 
 // ErrRoleRequired is returned by transport constructors when neither
-// WithRole nor WithBearerToken is provided.
-var ErrRoleRequired = errors.New("grpctransport: WithRole is required when not using WithBearerToken")
+// WithRole, WithBearerToken, nor WithTokenSource is provided.
+var ErrRoleRequired = errors.New("grpctransport: WithRole is required when not using WithBearerToken or WithTokenSource")
 
 func buildConfig(opts []Option) (config, error) {
 	var cfg config
 	for _, o := range opts {
 		o(&cfg)
 	}
-	if cfg.auth.bearerToken == "" && cfg.auth.role == "" {
+	if cfg.auth.bearerToken == "" && cfg.auth.tokenSource == nil && cfg.auth.role == "" {
 		return config{}, ErrRoleRequired
 	}
 	return cfg, nil
 }
 
 // applyAuth injects authentication metadata into the outgoing gRPC context.
-func applyAuth(ctx context.Context, auth authConfig) context.Context {
+func applyAuth(ctx context.Context, auth authConfig) (context.Context, error) {
 	md := metadata.MD{}
-	if auth.bearerToken != "" {
+	switch {
+	case auth.tokenSource != nil:
+		tok, err := auth.tokenSource(ctx)
+		if err != nil {
+			return ctx, err
+		}
+		md.Set("authorization", "Bearer "+tok)
+	case auth.bearerToken != "":
 		md.Set("authorization", "Bearer "+auth.bearerToken)
-	} else {
+	default:
 		if auth.subject != "" {
 			md.Set("x-subject", auth.subject)
 		}
@@ -104,5 +120,5 @@ func applyAuth(ctx context.Context, auth authConfig) context.Context {
 			md.Set("x-tenant-id", auth.tenantID)
 		}
 	}
-	return metadata.NewOutgoingContext(ctx, md)
+	return metadata.NewOutgoingContext(ctx, md), nil
 }

--- a/sdk/grpctransport/auth_test.go
+++ b/sdk/grpctransport/auth_test.go
@@ -1,6 +1,7 @@
 package grpctransport_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -54,5 +55,28 @@ func TestNewWatcher_NoRole_Errors(t *testing.T) {
 	_, err := grpctransport.NewWatcher(conn(), "tenant-id")
 	if !errors.Is(err, grpctransport.ErrRoleRequired) {
 		t.Fatalf("expected ErrRoleRequired, got %v", err)
+	}
+}
+
+func TestBuildConfig_WithTokenSource_NoRoleRequired(t *testing.T) {
+	_, err := grpctransport.NewConfigTransport(conn(),
+		grpctransport.WithTokenSource(func(context.Context) (string, error) {
+			return "tok", nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error with token source and no role: %v", err)
+	}
+}
+
+func TestBuildConfig_WithTokenSource_ErrorPropagates(t *testing.T) {
+	// Construction succeeds; token source errors surface on RPC calls, not at build time.
+	_, err := grpctransport.NewConfigTransport(conn(),
+		grpctransport.WithTokenSource(func(context.Context) (string, error) {
+			return "", errors.New("token refresh failed")
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected construction error: %v", err)
 	}
 }

--- a/sdk/grpctransport/config_admin_transport.go
+++ b/sdk/grpctransport/config_admin_transport.go
@@ -32,7 +32,10 @@ func NewAdminConfigTransport(conn grpc.ClientConnInterface, opts ...Option) (*Ad
 }
 
 func (t *AdminConfigTransport) ListVersions(ctx context.Context, tenantID string, pageSize int32, pageToken string) (*adminclient.ListVersionsResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ListVersions(ctx, &pb.ListVersionsRequest{
 		TenantId:  tenantID,
 		PageSize:  pageSize,
@@ -52,7 +55,10 @@ func (t *AdminConfigTransport) ListVersions(ctx context.Context, tenantID string
 }
 
 func (t *AdminConfigTransport) GetVersion(ctx context.Context, tenantID string, version int32) (*adminclient.Version, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetVersion(ctx, &pb.GetVersionRequest{
 		TenantId: tenantID,
 		Version:  version,
@@ -64,7 +70,10 @@ func (t *AdminConfigTransport) GetVersion(ctx context.Context, tenantID string, 
 }
 
 func (t *AdminConfigTransport) RollbackToVersion(ctx context.Context, tenantID string, version int32, description string) (*adminclient.Version, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.RollbackToVersionRequest{
 		TenantId: tenantID,
 		Version:  version,
@@ -80,7 +89,10 @@ func (t *AdminConfigTransport) RollbackToVersion(ctx context.Context, tenantID s
 }
 
 func (t *AdminConfigTransport) ExportConfig(ctx context.Context, tenantID string, version *int32) ([]byte, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ExportConfig(ctx, &pb.ExportConfigRequest{
 		TenantId: tenantID,
 		Version:  version,
@@ -92,7 +104,10 @@ func (t *AdminConfigTransport) ExportConfig(ctx context.Context, tenantID string
 }
 
 func (t *AdminConfigTransport) ImportConfig(ctx context.Context, req *adminclient.ImportConfigRequest) (*adminclient.Version, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.ImportConfigRequest{
 		TenantId:    req.TenantID,
 		YamlContent: req.YamlContent,

--- a/sdk/grpctransport/config_transport.go
+++ b/sdk/grpctransport/config_transport.go
@@ -32,7 +32,10 @@ func NewConfigTransport(conn grpc.ClientConnInterface, opts ...Option) (*ConfigT
 }
 
 func (t *ConfigTransport) GetField(ctx context.Context, req *configclient.GetFieldRequest) (*configclient.GetFieldResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetField(ctx, &pb.GetFieldRequest{
 		TenantId:  req.TenantID,
 		FieldPath: req.FieldPath,
@@ -50,7 +53,10 @@ func (t *ConfigTransport) GetField(ctx context.Context, req *configclient.GetFie
 }
 
 func (t *ConfigTransport) GetConfig(ctx context.Context, req *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetConfig(ctx, &pb.GetConfigRequest{
 		TenantId: req.TenantID,
 		Version:  req.Version,
@@ -71,7 +77,10 @@ func (t *ConfigTransport) GetConfig(ctx context.Context, req *configclient.GetCo
 }
 
 func (t *ConfigTransport) GetFields(ctx context.Context, req *configclient.GetFieldsRequest) (*configclient.GetFieldsResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetFields(ctx, &pb.GetFieldsRequest{
 		TenantId:   req.TenantID,
 		FieldPaths: req.FieldPaths,
@@ -90,7 +99,10 @@ func (t *ConfigTransport) GetFields(ctx context.Context, req *configclient.GetFi
 }
 
 func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.SetFieldRequest{
 		TenantId:         req.TenantID,
 		FieldPath:        req.FieldPath,
@@ -100,7 +112,7 @@ func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFie
 	if req.Description != "" {
 		protoReq.Description = &req.Description
 	}
-	_, err := t.rpc.SetField(ctx, protoReq)
+	_, err = t.rpc.SetField(ctx, protoReq)
 	if err != nil {
 		return nil, mapConfigError(err)
 	}
@@ -108,7 +120,10 @@ func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFie
 }
 
 func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	updates := make([]*pb.FieldUpdate, len(req.Updates))
 	for i, u := range req.Updates {
 		updates[i] = &pb.FieldUpdate{
@@ -124,7 +139,7 @@ func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFi
 	if req.Description != "" {
 		protoReq.Description = &req.Description
 	}
-	_, err := t.rpc.SetFields(ctx, protoReq)
+	_, err = t.rpc.SetFields(ctx, protoReq)
 	if err != nil {
 		return nil, mapConfigError(err)
 	}
@@ -132,7 +147,10 @@ func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFi
 }
 
 func (t *ConfigTransport) Subscribe(ctx context.Context, req *configclient.SubscribeRequest) (configclient.Subscription, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	stream, err := t.rpc.Subscribe(ctx, &pb.SubscribeRequest{
 		TenantId:     req.TenantID,
 		FieldPaths:   req.FieldPaths,

--- a/sdk/grpctransport/schema_transport.go
+++ b/sdk/grpctransport/schema_transport.go
@@ -32,7 +32,10 @@ func NewSchemaTransport(conn grpc.ClientConnInterface, opts ...Option) (*SchemaT
 }
 
 func (t *SchemaTransport) CreateSchema(ctx context.Context, req *adminclient.CreateSchemaRequest) (*adminclient.Schema, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.CreateSchemaRequest{
 		Name:   req.Name,
 		Fields: fieldsToProto(req.Fields),
@@ -48,7 +51,10 @@ func (t *SchemaTransport) CreateSchema(ctx context.Context, req *adminclient.Cre
 }
 
 func (t *SchemaTransport) GetSchema(ctx context.Context, id string, version *int32) (*adminclient.Schema, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetSchema(ctx, &pb.GetSchemaRequest{
 		Id:      id,
 		Version: version,
@@ -60,7 +66,10 @@ func (t *SchemaTransport) GetSchema(ctx context.Context, id string, version *int
 }
 
 func (t *SchemaTransport) ListSchemas(ctx context.Context, pageSize int32, pageToken string) (*adminclient.ListSchemasResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ListSchemas(ctx, &pb.ListSchemasRequest{
 		PageSize:  pageSize,
 		PageToken: pageToken,
@@ -79,7 +88,10 @@ func (t *SchemaTransport) ListSchemas(ctx context.Context, pageSize int32, pageT
 }
 
 func (t *SchemaTransport) UpdateSchema(ctx context.Context, req *adminclient.UpdateSchemaRequest) (*adminclient.Schema, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	protoReq := &pb.UpdateSchemaRequest{
 		Id:           req.ID,
 		Fields:       fieldsToProto(req.AddOrModify),
@@ -96,7 +108,10 @@ func (t *SchemaTransport) UpdateSchema(ctx context.Context, req *adminclient.Upd
 }
 
 func (t *SchemaTransport) PublishSchema(ctx context.Context, id string, version int32) (*adminclient.Schema, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.PublishSchema(ctx, &pb.PublishSchemaRequest{
 		Id:      id,
 		Version: version,
@@ -108,13 +123,19 @@ func (t *SchemaTransport) PublishSchema(ctx context.Context, id string, version 
 }
 
 func (t *SchemaTransport) DeleteSchema(ctx context.Context, id string) error {
-	ctx = applyAuth(ctx, t.auth)
-	_, err := t.rpc.DeleteSchema(ctx, &pb.DeleteSchemaRequest{Id: id})
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return err
+	}
+	_, err = t.rpc.DeleteSchema(ctx, &pb.DeleteSchemaRequest{Id: id})
 	return mapAdminError(err)
 }
 
 func (t *SchemaTransport) ExportSchema(ctx context.Context, id string, version *int32) ([]byte, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ExportSchema(ctx, &pb.ExportSchemaRequest{
 		Id:      id,
 		Version: version,
@@ -126,7 +147,10 @@ func (t *SchemaTransport) ExportSchema(ctx context.Context, id string, version *
 }
 
 func (t *SchemaTransport) ImportSchema(ctx context.Context, yamlContent []byte, autoPublish bool) (*adminclient.Schema, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ImportSchema(ctx, &pb.ImportSchemaRequest{
 		YamlContent: yamlContent,
 		AutoPublish: autoPublish,
@@ -140,7 +164,10 @@ func (t *SchemaTransport) ImportSchema(ctx context.Context, yamlContent []byte, 
 // --- Tenant methods ---
 
 func (t *SchemaTransport) CreateTenant(ctx context.Context, req *adminclient.CreateTenantRequest) (*adminclient.Tenant, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.CreateTenant(ctx, &pb.CreateTenantRequest{
 		Name:          req.Name,
 		SchemaId:      req.SchemaID,
@@ -153,7 +180,10 @@ func (t *SchemaTransport) CreateTenant(ctx context.Context, req *adminclient.Cre
 }
 
 func (t *SchemaTransport) GetTenant(ctx context.Context, id string) (*adminclient.Tenant, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.GetTenant(ctx, &pb.GetTenantRequest{Id: id})
 	if err != nil {
 		return nil, mapAdminError(err)
@@ -162,7 +192,10 @@ func (t *SchemaTransport) GetTenant(ctx context.Context, id string) (*adminclien
 }
 
 func (t *SchemaTransport) ListTenants(ctx context.Context, schemaID *string, pageSize int32, pageToken string) (*adminclient.ListTenantsResponse, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ListTenants(ctx, &pb.ListTenantsRequest{
 		SchemaId:  schemaID,
 		PageSize:  pageSize,
@@ -182,7 +215,10 @@ func (t *SchemaTransport) ListTenants(ctx context.Context, schemaID *string, pag
 }
 
 func (t *SchemaTransport) UpdateTenant(ctx context.Context, req *adminclient.UpdateTenantRequest) (*adminclient.Tenant, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.UpdateTenant(ctx, &pb.UpdateTenantRequest{
 		Id:            req.ID,
 		Name:          req.Name,
@@ -195,16 +231,22 @@ func (t *SchemaTransport) UpdateTenant(ctx context.Context, req *adminclient.Upd
 }
 
 func (t *SchemaTransport) DeleteTenant(ctx context.Context, id string) error {
-	ctx = applyAuth(ctx, t.auth)
-	_, err := t.rpc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: id})
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return err
+	}
+	_, err = t.rpc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: id})
 	return mapAdminError(err)
 }
 
 // --- Field lock methods ---
 
 func (t *SchemaTransport) LockField(ctx context.Context, tenantID, fieldPath string, lockedValues []string) error {
-	ctx = applyAuth(ctx, t.auth)
-	_, err := t.rpc.LockField(ctx, &pb.LockFieldRequest{
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return err
+	}
+	_, err = t.rpc.LockField(ctx, &pb.LockFieldRequest{
 		TenantId:     tenantID,
 		FieldPath:    fieldPath,
 		LockedValues: lockedValues,
@@ -213,8 +255,11 @@ func (t *SchemaTransport) LockField(ctx context.Context, tenantID, fieldPath str
 }
 
 func (t *SchemaTransport) UnlockField(ctx context.Context, tenantID, fieldPath string) error {
-	ctx = applyAuth(ctx, t.auth)
-	_, err := t.rpc.UnlockField(ctx, &pb.UnlockFieldRequest{
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return err
+	}
+	_, err = t.rpc.UnlockField(ctx, &pb.UnlockFieldRequest{
 		TenantId:  tenantID,
 		FieldPath: fieldPath,
 	})
@@ -222,7 +267,10 @@ func (t *SchemaTransport) UnlockField(ctx context.Context, tenantID, fieldPath s
 }
 
 func (t *SchemaTransport) ListFieldLocks(ctx context.Context, tenantID string) ([]adminclient.FieldLock, error) {
-	ctx = applyAuth(ctx, t.auth)
+	ctx, err := applyAuth(ctx, t.auth)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := t.rpc.ListFieldLocks(ctx, &pb.ListFieldLocksRequest{
 		TenantId: tenantID,
 	})


### PR DESCRIPTION
## Summary

- Long-lived watchers and streaming subscriptions fail silently when a fixed bearer token expires; this adds a `WithTokenSource` option that calls a user-supplied function on every RPC so credentials are always fresh.
- The token source receives the RPC context, enabling cancellation-aware refresh flows (e.g. OAuth2 token sources from `golang.org/x/oauth2`).
- `applyAuth` now returns an error so token-source failures propagate cleanly rather than being swallowed.

## Test plan

- [x] `TestBuildConfig_WithTokenSource_NoRoleRequired` — `WithTokenSource` alone satisfies the auth requirement (no `WithRole` needed)
- [x] `TestBuildConfig_WithTokenSource_ErrorPropagates` — construction succeeds even when the token source would error; errors surface on the first RPC call
- [x] Existing tests unchanged — `WithBearerToken`, `WithRole`, and missing-auth cases all pass
- [x] `make test` green across all modules

Closes #496