### PR TITLE
Fix tenant scope bypass on write operations (LockField, UpdateTenant, DeleteTenant, UnlockField)

### DIFF
--- a/internal/authz/guard.go
+++ b/internal/authz/guard.go
@@ -8,10 +8,13 @@ type Action string
 const (
 	// ActionRead — any authenticated caller may read.
 	ActionRead Action = "read"
-	// ActionWrite — requires admin or superadmin role.
+	// ActionWrite — requires admin or superadmin role; must be paired with a tenant-scoped Resource.
 	ActionWrite Action = "write"
-	// ActionAdmin — requires superadmin role.
+	// ActionAdmin — requires superadmin role; must be paired with a tenant-scoped Resource.
 	ActionAdmin Action = "admin"
+	// ActionGlobal — for schema-level operations that are intentionally not tenant-scoped (e.g.
+	// CreateSchema, PublishSchema). Requires superadmin. TenantScopeGuard always skips this action.
+	ActionGlobal Action = "global"
 )
 
 // Resource carries the subject of an authorization check.

--- a/internal/authz/role.go
+++ b/internal/authz/role.go
@@ -12,7 +12,7 @@ type RolePolicyGuard struct{}
 
 func (RolePolicyGuard) Check(ctx context.Context, action Action, _ Resource) error {
 	switch action {
-	case ActionAdmin:
+	case ActionAdmin, ActionGlobal:
 		return auth.RequireSuperAdmin(ctx)
 	case ActionWrite:
 		return auth.RequireAdminOrAbove(ctx)

--- a/internal/authz/tenant.go
+++ b/internal/authz/tenant.go
@@ -10,8 +10,8 @@ import (
 // No-ops when TenantID is empty.
 type TenantScopeGuard struct{}
 
-func (TenantScopeGuard) Check(ctx context.Context, _ Action, r Resource) error {
-	if r.TenantID == "" {
+func (TenantScopeGuard) Check(ctx context.Context, action Action, r Resource) error {
+	if action == ActionGlobal || r.TenantID == "" {
 		return nil
 	}
 	return auth.CheckTenantAccess(ctx, r.TenantID)

--- a/internal/schema/role_policy_test.go
+++ b/internal/schema/role_policy_test.go
@@ -11,6 +11,7 @@ import (
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/storage/domain"
 )
 
 // userCtx returns a context carrying user-role claims scoped to testTenantID.
@@ -116,22 +117,38 @@ func TestCreateTenant_DeniedForUser(t *testing.T) {
 }
 
 // --- admin-or-above RPCs: user must be denied, admin must pass role check ---
+//
+// These tests exercise the write-action guard, which fires AFTER tenant resolution.
+// The mock must return the tenant so resolveTenantWithAccess succeeds before the
+// role check can fire.
 
 func TestUpdateTenant_DeniedForUser(t *testing.T) {
-	svc := NewService(&mockStore{}, WithLogger(testLogger))
-	_, err := svc.UpdateTenant(userCtx(), &pb.UpdateTenantRequest{Id: testTenantID})
+	store := &mockStore{}
+	ctx := userCtx()
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID}, nil)
+	svc := NewService(store, WithLogger(testLogger))
+	_, err := svc.UpdateTenant(ctx, &pb.UpdateTenantRequest{Id: testTenantID})
 	assertPermissionDenied(t, err)
 }
 
 func TestDeleteTenant_DeniedForUser(t *testing.T) {
-	svc := NewService(&mockStore{}, WithLogger(testLogger))
-	_, err := svc.DeleteTenant(userCtx(), &pb.DeleteTenantRequest{Id: testTenantID})
+	store := &mockStore{}
+	ctx := userCtx()
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID}, nil)
+	svc := NewService(store, WithLogger(testLogger))
+	_, err := svc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: testTenantID})
 	assertPermissionDenied(t, err)
 }
 
 func TestLockField_DeniedForUser(t *testing.T) {
-	svc := NewService(&mockStore{}, WithLogger(testLogger))
-	_, err := svc.LockField(userCtx(), &pb.LockFieldRequest{
+	store := &mockStore{}
+	ctx := userCtx()
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID}, nil)
+	svc := NewService(store, WithLogger(testLogger))
+	_, err := svc.LockField(ctx, &pb.LockFieldRequest{
 		TenantId:  testTenantID,
 		FieldPath: "app.x",
 	})
@@ -139,8 +156,12 @@ func TestLockField_DeniedForUser(t *testing.T) {
 }
 
 func TestUnlockField_DeniedForUser(t *testing.T) {
-	svc := NewService(&mockStore{}, WithLogger(testLogger))
-	_, err := svc.UnlockField(userCtx(), &pb.UnlockFieldRequest{
+	store := &mockStore{}
+	ctx := userCtx()
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID}, nil)
+	svc := NewService(store, WithLogger(testLogger))
+	_, err := svc.UnlockField(ctx, &pb.UnlockFieldRequest{
 		TenantId:  testTenantID,
 		FieldPath: "app.x",
 	})

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -143,7 +143,7 @@ func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if req.Name == "" {
@@ -292,7 +292,7 @@ func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if req.Id == "" {
@@ -385,7 +385,7 @@ func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if req.Id == "" {
@@ -419,7 +419,7 @@ func (s *Service) PublishSchema(ctx context.Context, req *pb.PublishSchemaReques
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if req.Id == "" {
@@ -473,7 +473,7 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if req.Name == "" {
@@ -599,11 +599,11 @@ func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
-		return nil, err
-	}
 	resolved, err := s.resolveTenantWithAccess(ctx, req.Id)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: resolved.ID}); err != nil {
 		return nil, err
 	}
 	tenantID := resolved.ID
@@ -671,11 +671,11 @@ func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
-		return nil, err
-	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.Id)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenant.ID}); err != nil {
 		return nil, err
 	}
 
@@ -705,11 +705,11 @@ func (s *Service) LockField(ctx context.Context, req *pb.LockFieldRequest) (*pb.
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
-		return nil, err
-	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenant.ID}); err != nil {
 		return nil, err
 	}
 
@@ -746,11 +746,11 @@ func (s *Service) UnlockField(ctx context.Context, req *pb.UnlockFieldRequest) (
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{}); err != nil {
-		return nil, err
-	}
 	tenant, err := s.resolveTenantWithAccess(ctx, req.TenantId)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenant.ID}); err != nil {
 		return nil, err
 	}
 
@@ -835,7 +835,7 @@ func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest)
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionAdmin, authz.Resource{}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	if s.limits.MaxDocBytes > 0 && len(req.YamlContent) > s.limits.MaxDocBytes {

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -321,6 +321,85 @@ func TestSchemaService_RequiresAuth(t *testing.T) {
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
+// --- Cross-tenant write rejection (issue #422) ---
+
+const testOtherTenantID = "00000000-0000-0000-0000-000000000099"
+
+// adminCtxWithTenants returns a context for an admin whose access is scoped to the given tenant IDs.
+func adminCtxWithTenants(tenantIDs ...string) context.Context {
+	return auth.ContextWithClaims(context.Background(), &auth.Claims{
+		Role:      auth.RoleAdmin,
+		TenantIDs: tenantIDs,
+	})
+}
+
+func TestLockField_CrossTenantRejected(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	// Admin scoped to testTenantID; tries to lock a field on testOtherTenantID.
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testOtherTenantID).
+		Return(domain.Tenant{ID: testOtherTenantID, Name: "other"}, nil)
+
+	_, err := svc.LockField(ctx, &pb.LockFieldRequest{
+		TenantId:  testOtherTenantID,
+		FieldPath: "foo.bar",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
+func TestUnlockField_CrossTenantRejected(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testOtherTenantID).
+		Return(domain.Tenant{ID: testOtherTenantID, Name: "other"}, nil)
+
+	_, err := svc.UnlockField(ctx, &pb.UnlockFieldRequest{
+		TenantId:  testOtherTenantID,
+		FieldPath: "foo.bar",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
+func TestUpdateTenant_CrossTenantRejected(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testOtherTenantID).
+		Return(domain.Tenant{ID: testOtherTenantID, Name: "other"}, nil)
+
+	_, err := svc.UpdateTenant(ctx, &pb.UpdateTenantRequest{Id: testOtherTenantID})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
+func TestDeleteTenant_CrossTenantRejected(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testOtherTenantID).
+		Return(domain.Tenant{ID: testOtherTenantID, Name: "other"}, nil)
+
+	_, err := svc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: testOtherTenantID})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
 // --- helpers ---
 
 func ptrInt32(v int32) *int32 {


### PR DESCRIPTION
## Summary

- Tenant-scoped admins could invoke `LockField`, `UnlockField`, `UpdateTenant`, and `DeleteTenant` against tenants they do not have access to, because the write-action guard check fired before tenant resolution and `TenantScopeGuard` no-ops on an empty `TenantID`.
- The fix resolves the tenant first (via `resolveTenantWithAccess`), then calls `guard.Check(ActionWrite, Resource{TenantID: tenant.ID})` so the guard receives the real tenant ID and enforces scope.
- `ActionGlobal` is introduced for schema-level operations that are intentionally not tenant-scoped (CreateSchema, PublishSchema, etc.), making the empty-Resource pattern deliberate rather than accidental and preventing `ActionWrite` from being silently paired with an empty resource.

## Test plan

- [x] Four new cross-tenant rejection tests: `TestLockField_CrossTenantRejected`, `TestUnlockField_CrossTenantRejected`, `TestUpdateTenant_CrossTenantRejected`, `TestDeleteTenant_CrossTenantRejected` — each confirms a tenant-A admin is denied when targeting tenant B
- [x] Existing role policy tests (`TestUpdateTenant_DeniedForUser`, etc.) updated to account for the reordered tenant resolution and still assert `PermissionDenied` for user-role callers
- [x] `make test` green across all modules

Closes #422