### PR TITLE
Restrict URL fields to an allowed scheme list

### DIFF
--- a/api/centralconfig/v1/types.pb.go
+++ b/api/centralconfig/v1/types.pb.go
@@ -130,9 +130,13 @@ type FieldConstraints struct {
 	// For string: minimum allowed length.
 	MinLength *int32 `protobuf:"varint,8,opt,name=min_length,json=minLength,proto3,oneof" json:"min_length,omitempty"`
 	// For string: maximum allowed length.
-	MaxLength     *int32 `protobuf:"varint,9,opt,name=max_length,json=maxLength,proto3,oneof" json:"max_length,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	MaxLength *int32 `protobuf:"varint,9,opt,name=max_length,json=maxLength,proto3,oneof" json:"max_length,omitempty"`
+	// For url: allowed URI schemes (e.g. "https", "http").
+	// If non-empty, schemes not in this list are rejected with InvalidArgument.
+	// Defaults to ["http", "https"] when empty.
+	AllowedSchemes []string `protobuf:"bytes,10,rep,name=allowed_schemes,json=allowedSchemes,proto3" json:"allowed_schemes,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *FieldConstraints) Reset() {
@@ -226,6 +230,13 @@ func (x *FieldConstraints) GetMaxLength() int32 {
 		return *x.MaxLength
 	}
 	return 0
+}
+
+func (x *FieldConstraints) GetAllowedSchemes() []string {
+	if x != nil {
+		return x.AllowedSchemes
+	}
+	return nil
 }
 
 // SchemaField defines a single field within a configuration schema.
@@ -1929,7 +1940,7 @@ var File_centralconfig_v1_types_proto protoreflect.FileDescriptor
 
 const file_centralconfig_v1_types_proto_rawDesc = "" +
 	"\n" +
-	"\x1ccentralconfig/v1/types.proto\x12\x10centralconfig.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xaa\x03\n" +
+	"\x1ccentralconfig/v1/types.proto\x12\x10centralconfig.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd3\x03\n" +
 	"\x10FieldConstraints\x12\x15\n" +
 	"\x03min\x18\x01 \x01(\x01H\x00R\x03min\x88\x01\x01\x12\x15\n" +
 	"\x03max\x18\x02 \x01(\x01H\x01R\x03max\x88\x01\x01\x12\x19\n" +
@@ -1943,7 +1954,9 @@ const file_centralconfig_v1_types_proto_rawDesc = "" +
 	"\n" +
 	"min_length\x18\b \x01(\x05H\x06R\tminLength\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"max_length\x18\t \x01(\x05H\aR\tmaxLength\x88\x01\x01B\x06\n" +
+	"max_length\x18\t \x01(\x05H\aR\tmaxLength\x88\x01\x01\x12'\n" +
+	"\x0fallowed_schemes\x18\n" +
+	" \x03(\tR\x0eallowedSchemesB\x06\n" +
 	"\x04_minB\x06\n" +
 	"\x04_maxB\b\n" +
 	"\x06_regexB\x0e\n" +

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -1927,6 +1927,13 @@
           "type": "integer",
           "format": "int32",
           "description": "For string: maximum allowed length."
+        },
+        "allowedSchemes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "For url: allowed URI schemes (e.g. \"https\", \"http\").\nIf non-empty, schemes not in this list are rejected with InvalidArgument.\nDefaults to [\"http\", \"https\"] when empty."
         }
       },
       "description": "FieldConstraints defines validation rules for a schema field.\nWhich constraints apply depends on the field's type \u2014 see FieldType docs."

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -289,6 +289,7 @@ Which constraints apply depends on the field&#39;s type — see FieldType docs.
 | exclusive_max | [double](#double) | optional | For integer/number/duration: exclusive maximum (strict, &lt;). |
 | min_length | [int32](#int32) | optional | For string: minimum allowed length. |
 | max_length | [int32](#int32) | optional | For string: maximum allowed length. |
+| allowed_schemes | [string](#string) | repeated | For url: allowed URI schemes (e.g. &#34;https&#34;, &#34;http&#34;). If non-empty, schemes not in this list are rejected with InvalidArgument. Defaults to [&#34;http&#34;, &#34;https&#34;] when empty. |
 
 
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -1927,6 +1927,13 @@
           "type": "integer",
           "format": "int32",
           "description": "For string: maximum allowed length."
+        },
+        "allowedSchemes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "For url: allowed URI schemes (e.g. \"https\", \"http\").\nIf non-empty, schemes not in this list are rejected with InvalidArgument.\nDefaults to [\"http\", \"https\"] when empty."
         }
       },
       "description": "FieldConstraints defines validation rules for a schema field.\nWhich constraints apply depends on the field's type \u2014 see FieldType docs."

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -106,6 +106,26 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 			}
 			return nil
 		})
+		schemes := constraints.GetAllowedSchemes()
+		if len(schemes) == 0 {
+			schemes = []string{"http", "https"}
+		}
+		allowedSchemes := make(map[string]struct{}, len(schemes))
+		for _, s := range schemes {
+			allowedSchemes[s] = struct{}{}
+		}
+		schemeList := schemes
+		v.checks = append(v.checks, func(tv *pb.TypedValue) error {
+			val := tv.Kind.(*pb.TypedValue_UrlValue).UrlValue
+			u, _ := url.Parse(val)
+			if _, ok := allowedSchemes[u.Scheme]; !ok {
+				if v.sensitive {
+					return fmt.Errorf("URL scheme is not in the allowed list %v", schemeList)
+				}
+				return fmt.Errorf("URL scheme %q is not in the allowed list %v", u.Scheme, schemeList)
+			}
+			return nil
+		})
 	}
 
 	if constraints == nil {

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -208,6 +208,46 @@ func TestValidate_URL(t *testing.T) {
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "/relative/path"}}))
 }
 
+// --- URL scheme allowlist ---
+
+func TestValidate_URL_DefaultSchemeAllowlist(t *testing.T) {
+	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com"}}))
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "http://example.com"}}))
+
+	for _, blocked := range []string{
+		"gopher://example.com",
+		"file:///etc/passwd",
+		"ftp://files.example.com",
+		"javascript:alert(1)",
+		"data:text/html,<h1>x</h1>",
+	} {
+		err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: blocked}})
+		assert.Errorf(t, err, "expected error for scheme in %q", blocked)
+		assert.Contains(t, err.Error(), "not in the allowed list")
+	}
+}
+
+func TestValidate_URL_CustomSchemeAllowlist(t *testing.T) {
+	v := NewFieldValidator("s3path", pb.FieldType_FIELD_TYPE_URL, false, false, &pb.FieldConstraints{
+		AllowedSchemes: []string{"s3", "gs"},
+	})
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "s3://my-bucket/key"}}))
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "gs://my-bucket/key"}}))
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com"}}))
+}
+
+func TestValidate_URL_SensitiveSchemeError(t *testing.T) {
+	v := NewFieldValidator("secret.url", pb.FieldType_FIELD_TYPE_URL, false, true, nil)
+
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "gopher://example.com"}})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "gopher://example.com")
+	assert.Contains(t, err.Error(), "not in the allowed list")
+}
+
 // --- JSON Schema validation ---
 
 func TestValidate_JSONSchema(t *testing.T) {

--- a/proto/centralconfig/v1/types.proto
+++ b/proto/centralconfig/v1/types.proto
@@ -65,6 +65,11 @@ message FieldConstraints {
 
   // For string: maximum allowed length.
   optional int32 max_length = 9;
+
+  // For url: allowed URI schemes (e.g. "https", "http").
+  // If non-empty, schemes not in this list are rejected with InvalidArgument.
+  // Defaults to ["http", "https"] when empty.
+  repeated string allowed_schemes = 10;
 }
 
 // SchemaField defines a single field within a configuration schema.


### PR DESCRIPTION
## Summary

- URL-typed fields accepted any scheme (gopher://, file://, ftp://, javascript:, data:), creating SSRF and XSS exposure in tenant configuration endpoints.
- The validator now enforces a configurable scheme allowlist, defaulting to `["http", "https"]` when the field constraint is absent or empty.
- Schema authors can override the default via `FieldConstraints.allowed_schemes` to permit other schemes (e.g. `s3://`, `gs://`).

## Test plan

- [x] `TestValidate_URL_DefaultSchemeAllowlist` — http and https pass; gopher, file, ftp, javascript, data are blocked
- [x] `TestValidate_URL_CustomSchemeAllowlist` — custom allowlist (s3, gs) accepted; https rejected when not listed
- [x] `TestValidate_URL_SensitiveSchemeError` — error message omits the raw value for sensitive fields
- [x] Full test suite passes (`make test`)
- [x] Lint clean (`make lint`)

Closes #436