### PR TITLE
fix(validation): bound JSON-Schema compile goroutine concurrency

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -262,8 +262,9 @@ func run() int {
 	// Validator factory (shared between schema + config services).
 	validatorOpts := []validation.Option{
 		validation.WithLimits(validation.Limits{
-			CompileTimeout: cfg.SchemaCompileTimeout,
-			MaxDepth:       cfg.SchemaMaxRefDepth,
+			CompileTimeout:        cfg.SchemaCompileTimeout,
+			MaxDepth:              cfg.SchemaMaxRefDepth,
+			MaxConcurrentCompiles: cfg.SchemaMaxConcurrentCompiles,
 		}),
 	}
 	if counter, ok := validationMetrics.TimeoutCounter(); ok {
@@ -271,6 +272,9 @@ func run() int {
 	}
 	if counter, ok := validationMetrics.RegexErrorCounter(); ok {
 		validatorOpts = append(validatorOpts, validation.WithRegexErrorCounter(counter))
+	}
+	if gauge, ok := validationMetrics.InFlightGauge(); ok {
+		validatorOpts = append(validatorOpts, validation.WithInFlightGauge(gauge))
 	}
 	validatorFactory := validation.NewValidatorFactory(validatorStore, validatorOpts...)
 
@@ -417,49 +421,50 @@ func run() int {
 }
 
 type serverConfig struct {
-	GRPCPort                 string
-	HTTPPort                 string
-	StorageBackend           string
-	DBWriteURL               string
-	DBReadURL                string
-	DBMaxConns               int
-	DBMinConns               int
-	DBMaxConnLifetime        time.Duration
-	DBMaxConnIdleTime        time.Duration
-	DBHealthCheckPeriod      time.Duration
-	RedisURL                 string
-	EnableServices           []string
-	JWTIssuer                string
-	JWTJWKSURL               string
-	LogLevel                 string
-	UsageTrackingEnabled     bool
-	UsageFlushInterval       time.Duration
-	GRPCMaxRecvMsgBytes      int
-	GRPCMaxSendMsgBytes      int
-	SchemaMaxFields          int
-	SchemaMaxDocBytes        int
-	SchemaMaxRemoveFields    int
-	SchemaCompileTimeout     time.Duration
-	SchemaMaxRefDepth        int
-	ConfigMaxListLen         int
-	ConfigMaxDocBytes        int
-	ConfigMaxFieldValueBytes int
-	InsecureListen           bool
-	TLSCertFile              string
-	TLSKeyFile               string
-	TLSClientCAFile          string
-	TLSGatewayCAFile         string
-	TLSGatewayServerName     string
-	TLSGatewayClientCertFile string
-	TLSGatewayClientKeyFile  string
-	RateLimitEnabled         bool
-	RateLimitAnonRPS         float64
-	RateLimitAuthedRPS       float64
-	RateLimitSuperAdminRPS   float64 // 0 = unlimited
-	RateLimitBurst           int
-	EnableReflection         bool
-	EnableUI                 bool
-	GatewayTrustedProxy      bool
+	GRPCPort                    string
+	HTTPPort                    string
+	StorageBackend              string
+	DBWriteURL                  string
+	DBReadURL                   string
+	DBMaxConns                  int
+	DBMinConns                  int
+	DBMaxConnLifetime           time.Duration
+	DBMaxConnIdleTime           time.Duration
+	DBHealthCheckPeriod         time.Duration
+	RedisURL                    string
+	EnableServices              []string
+	JWTIssuer                   string
+	JWTJWKSURL                  string
+	LogLevel                    string
+	UsageTrackingEnabled        bool
+	UsageFlushInterval          time.Duration
+	GRPCMaxRecvMsgBytes         int
+	GRPCMaxSendMsgBytes         int
+	SchemaMaxFields             int
+	SchemaMaxDocBytes           int
+	SchemaMaxRemoveFields       int
+	SchemaCompileTimeout        time.Duration
+	SchemaMaxRefDepth           int
+	SchemaMaxConcurrentCompiles int
+	ConfigMaxListLen            int
+	ConfigMaxDocBytes           int
+	ConfigMaxFieldValueBytes    int
+	InsecureListen              bool
+	TLSCertFile                 string
+	TLSKeyFile                  string
+	TLSClientCAFile             string
+	TLSGatewayCAFile            string
+	TLSGatewayServerName        string
+	TLSGatewayClientCertFile    string
+	TLSGatewayClientKeyFile     string
+	RateLimitEnabled            bool
+	RateLimitAnonRPS            float64
+	RateLimitAuthedRPS          float64
+	RateLimitSuperAdminRPS      float64 // 0 = unlimited
+	RateLimitBurst              int
+	EnableReflection            bool
+	EnableUI                    bool
+	GatewayTrustedProxy         bool
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -513,49 +518,50 @@ func loadConfig() serverConfig {
 	}
 
 	return serverConfig{
-		GRPCPort:                 getEnv("GRPC_PORT", "9090"),
-		HTTPPort:                 getEnv("HTTP_PORT", ""),
-		StorageBackend:           getEnv("STORAGE_BACKEND", "postgres"),
-		DBWriteURL:               dbWriteURL,
-		DBReadURL:                dbReadURL,
-		DBMaxConns:               parseEnvInt("DB_MAX_CONNS", 0),
-		DBMinConns:               parseEnvInt("DB_MIN_CONNS", 0),
-		DBMaxConnLifetime:        dbMaxConnLifetime,
-		DBMaxConnIdleTime:        dbMaxConnIdleTime,
-		DBHealthCheckPeriod:      dbHealthCheckPeriod,
-		RedisURL:                 getEnv("REDIS_URL", ""),
-		EnableServices:           parseServices(enableServices),
-		JWTIssuer:                getEnv("JWT_ISSUER", ""),
-		JWTJWKSURL:               getEnv("JWT_JWKS_URL", ""),
-		LogLevel:                 getEnv("LOG_LEVEL", "info"),
-		UsageTrackingEnabled:     getEnv("USAGE_TRACKING_ENABLED", "true") != "false",
-		UsageFlushInterval:       flushInterval,
-		GRPCMaxRecvMsgBytes:      parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
-		GRPCMaxSendMsgBytes:      parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
-		SchemaMaxFields:          parseEnvInt("SCHEMA_MAX_FIELDS", 10_000),
-		SchemaMaxDocBytes:        parseEnvInt("SCHEMA_MAX_DOC_BYTES", 5*1024*1024),
-		SchemaMaxRemoveFields:    parseEnvInt("SCHEMA_MAX_REMOVE_FIELDS", 1_000),
-		SchemaCompileTimeout:     compileTimeout,
-		SchemaMaxRefDepth:        parseEnvInt("SCHEMA_MAX_REF_DEPTH", 64),
-		ConfigMaxListLen:         parseEnvInt("CONFIG_MAX_LIST_LEN", 1_000),
-		ConfigMaxDocBytes:        parseEnvInt("CONFIG_MAX_DOC_BYTES", 5*1024*1024),
-		ConfigMaxFieldValueBytes: parseEnvInt("CONFIG_MAX_FIELD_VALUE_BYTES", 1*1024*1024),
-		InsecureListen:           getEnv("INSECURE_LISTEN", "") == "1",
-		TLSCertFile:              getEnv("TLS_CERT_FILE", ""),
-		TLSKeyFile:               getEnv("TLS_KEY_FILE", ""),
-		TLSClientCAFile:          getEnv("TLS_CLIENT_CA_FILE", ""),
-		TLSGatewayCAFile:         getEnv("TLS_GATEWAY_CA_FILE", ""),
-		TLSGatewayServerName:     getEnv("TLS_GATEWAY_SERVER_NAME", ""),
-		TLSGatewayClientCertFile: getEnv("TLS_GATEWAY_CLIENT_CERT_FILE", ""),
-		TLSGatewayClientKeyFile:  getEnv("TLS_GATEWAY_CLIENT_KEY_FILE", ""),
-		RateLimitEnabled:         getEnv("RATE_LIMIT_ENABLED", "true") != "false",
-		RateLimitAnonRPS:         parseEnvFloat("RATE_LIMIT_ANON_RPS", 10),
-		RateLimitAuthedRPS:       parseEnvFloat("RATE_LIMIT_AUTHED_RPS", 100),
-		RateLimitSuperAdminRPS:   parseEnvFloat("RATE_LIMIT_SUPERADMIN_RPS", 0),
-		RateLimitBurst:           parseEnvInt("RATE_LIMIT_BURST", 10),
-		EnableReflection:         getEnv("ENABLE_REFLECTION", "") == "1",
-		EnableUI:                 getEnv("ENABLE_UI", "") == "1",
-		GatewayTrustedProxy:      getEnv("DECREE_GATEWAY_TRUSTED_PROXY", "") == "1",
+		GRPCPort:                    getEnv("GRPC_PORT", "9090"),
+		HTTPPort:                    getEnv("HTTP_PORT", ""),
+		StorageBackend:              getEnv("STORAGE_BACKEND", "postgres"),
+		DBWriteURL:                  dbWriteURL,
+		DBReadURL:                   dbReadURL,
+		DBMaxConns:                  parseEnvInt("DB_MAX_CONNS", 0),
+		DBMinConns:                  parseEnvInt("DB_MIN_CONNS", 0),
+		DBMaxConnLifetime:           dbMaxConnLifetime,
+		DBMaxConnIdleTime:           dbMaxConnIdleTime,
+		DBHealthCheckPeriod:         dbHealthCheckPeriod,
+		RedisURL:                    getEnv("REDIS_URL", ""),
+		EnableServices:              parseServices(enableServices),
+		JWTIssuer:                   getEnv("JWT_ISSUER", ""),
+		JWTJWKSURL:                  getEnv("JWT_JWKS_URL", ""),
+		LogLevel:                    getEnv("LOG_LEVEL", "info"),
+		UsageTrackingEnabled:        getEnv("USAGE_TRACKING_ENABLED", "true") != "false",
+		UsageFlushInterval:          flushInterval,
+		GRPCMaxRecvMsgBytes:         parseEnvInt("GRPC_MAX_RECV_MSG_BYTES", 0),
+		GRPCMaxSendMsgBytes:         parseEnvInt("GRPC_MAX_SEND_MSG_BYTES", 0),
+		SchemaMaxFields:             parseEnvInt("SCHEMA_MAX_FIELDS", 10_000),
+		SchemaMaxDocBytes:           parseEnvInt("SCHEMA_MAX_DOC_BYTES", 5*1024*1024),
+		SchemaMaxRemoveFields:       parseEnvInt("SCHEMA_MAX_REMOVE_FIELDS", 1_000),
+		SchemaCompileTimeout:        compileTimeout,
+		SchemaMaxRefDepth:           parseEnvInt("SCHEMA_MAX_REF_DEPTH", 64),
+		SchemaMaxConcurrentCompiles: parseEnvInt("SCHEMA_MAX_CONCURRENT_COMPILES", 32),
+		ConfigMaxListLen:            parseEnvInt("CONFIG_MAX_LIST_LEN", 1_000),
+		ConfigMaxDocBytes:           parseEnvInt("CONFIG_MAX_DOC_BYTES", 5*1024*1024),
+		ConfigMaxFieldValueBytes:    parseEnvInt("CONFIG_MAX_FIELD_VALUE_BYTES", 1*1024*1024),
+		InsecureListen:              getEnv("INSECURE_LISTEN", "") == "1",
+		TLSCertFile:                 getEnv("TLS_CERT_FILE", ""),
+		TLSKeyFile:                  getEnv("TLS_KEY_FILE", ""),
+		TLSClientCAFile:             getEnv("TLS_CLIENT_CA_FILE", ""),
+		TLSGatewayCAFile:            getEnv("TLS_GATEWAY_CA_FILE", ""),
+		TLSGatewayServerName:        getEnv("TLS_GATEWAY_SERVER_NAME", ""),
+		TLSGatewayClientCertFile:    getEnv("TLS_GATEWAY_CLIENT_CERT_FILE", ""),
+		TLSGatewayClientKeyFile:     getEnv("TLS_GATEWAY_CLIENT_KEY_FILE", ""),
+		RateLimitEnabled:            getEnv("RATE_LIMIT_ENABLED", "true") != "false",
+		RateLimitAnonRPS:            parseEnvFloat("RATE_LIMIT_ANON_RPS", 10),
+		RateLimitAuthedRPS:          parseEnvFloat("RATE_LIMIT_AUTHED_RPS", 100),
+		RateLimitSuperAdminRPS:      parseEnvFloat("RATE_LIMIT_SUPERADMIN_RPS", 0),
+		RateLimitBurst:              parseEnvInt("RATE_LIMIT_BURST", 10),
+		EnableReflection:            getEnv("ENABLE_REFLECTION", "") == "1",
+		EnableUI:                    getEnv("ENABLE_UI", "") == "1",
+		GatewayTrustedProxy:         getEnv("DECREE_GATEWAY_TRUSTED_PROXY", "") == "1",
 	}
 }
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -131,10 +131,11 @@ func (m *RateLimitMetrics) Counter() (metric.Int64Counter, bool) {
 	return m.rejected, true
 }
 
-// ValidationMetrics records validation-related counters.
+// ValidationMetrics records validation-related counters and gauges.
 type ValidationMetrics struct {
 	compileTimeouts    metric.Int64Counter
 	regexCompileErrors metric.Int64Counter
+	inFlightCompiles   metric.Int64UpDownCounter
 }
 
 // NewValidationMetrics creates validation metrics. Returns nil if not enabled.
@@ -147,7 +148,9 @@ func NewValidationMetrics(cfg Config) *ValidationMetrics {
 		metric.WithDescription("Number of JSON-Schema compile goroutines that exceeded their deadline"))
 	regexErrors, _ := meter.Int64Counter("validator_regex_compile_errors_total",
 		metric.WithDescription("Number of regex constraint patterns that failed to compile"))
-	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors}
+	inFlight, _ := meter.Int64UpDownCounter("validation.json_schema_compiles_in_flight",
+		metric.WithDescription("Number of JSON-Schema compile goroutines currently in flight, including zombies that outlived their timeout"))
+	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors, inFlightCompiles: inFlight}
 }
 
 // TimeoutCounter returns the underlying Int64Counter and true when metrics are
@@ -166,6 +169,15 @@ func (m *ValidationMetrics) RegexErrorCounter() (metric.Int64Counter, bool) {
 		return nil, false
 	}
 	return m.regexCompileErrors, true
+}
+
+// InFlightGauge returns the in-flight compile gauge and true when metrics are
+// enabled, or a nil interface and false when disabled.
+func (m *ValidationMetrics) InFlightGauge() (metric.Int64UpDownCounter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.inFlightCompiles, true
 }
 
 // StartDBPoolMetrics starts a background goroutine that periodically records

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -124,6 +124,16 @@ func TestValidationMetrics_NilSafe(t *testing.T) {
 	counter, ok = m.RegexErrorCounter()
 	assert.False(t, ok)
 	assert.Nil(t, counter)
+	gauge, ok := m.InFlightGauge()
+	assert.False(t, ok)
+	assert.Nil(t, gauge)
+}
+
+func TestValidationMetrics_InFlightGauge(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	gauge, ok := m.InFlightGauge()
+	assert.True(t, ok)
+	assert.NotNil(t, gauge)
 }
 
 func TestValidationMetrics_TimeoutCounter(t *testing.T) {

--- a/internal/validation/json_schema.go
+++ b/internal/validation/json_schema.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/metric"
-
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -18,27 +16,52 @@ type jsonSchemaValidator struct {
 }
 
 // newJSONSchemaValidator compiles a JSON Schema document for validation.
-// limits.MaxDepth bounds structural nesting before compile;
-// limits.CompileTimeout caps the wall-clock duration of the compile call.
-// timeoutCounter, if non-nil, is incremented when the deadline fires.
+// opts.limits.MaxDepth bounds structural nesting before compile;
+// opts.limits.CompileTimeout caps the wall-clock duration of the compile call.
+// opts.limits.MaxConcurrentCompiles caps simultaneous goroutines — new requests
+// block until a slot is free or the timeout fires, bounding goroutine growth
+// when malicious input repeatedly triggers the timeout path.
 //
 // Goroutine leak: jsonschema/v6 has no CompileContext, so a compile that
 // exceeds the deadline will continue running until it finishes or the
-// process exits. This is acceptable because:
-//   - The pre-compile depth check (MaxDepth) rejects deeply-nested bombs
-//     before the goroutine is started.
-//   - The upstream document-size cap (schema.Limits.MaxDocBytes) bounds
-//     the total input the compiler can process.
+// process exits. MaxConcurrentCompiles bounds the number of such zombies at
+// any instant; the depth and upstream document-size checks (schema.Limits.MaxDocBytes)
+// bound the work each zombie can perform.
 //
-// Together these make the worst-case work finite. The timeout is a
-// defence-in-depth backstop against unanticipated compiler pathologies.
-// When it fires, the counter "validation.json_schema_compile_timeouts_total"
-// is incremented so operators can alert on sustained activity.
-func newJSONSchemaValidator(schemaDoc string, limits Limits, timeoutCounter metric.Int64Counter) (*jsonSchemaValidator, error) {
-	if limits.MaxDepth > 0 {
-		if err := scanJSONDepth(schemaDoc, limits.MaxDepth); err != nil {
+// When the deadline fires, opts.timeoutCounter is incremented.
+// opts.inFlightGauge tracks goroutines currently executing the compile
+// (including zombies), incremented before spawn and decremented on finish.
+func newJSONSchemaValidator(schemaDoc string, opts options) (*jsonSchemaValidator, error) {
+	if opts.limits.MaxDepth > 0 {
+		if err := scanJSONDepth(schemaDoc, opts.limits.MaxDepth); err != nil {
 			return nil, err
 		}
+	}
+
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	if opts.limits.CompileTimeout > 0 {
+		timer = time.NewTimer(opts.limits.CompileTimeout)
+		defer timer.Stop()
+		timerC = timer.C
+	}
+
+	// Acquire semaphore slot before spawning the goroutine.
+	// If the semaphore is full (MaxConcurrentCompiles zombies already running),
+	// block here until a slot is released or the deadline fires.
+	if opts.compileSem != nil {
+		select {
+		case opts.compileSem <- struct{}{}:
+		case <-timerC:
+			if opts.timeoutCounter != nil {
+				opts.timeoutCounter.Add(context.Background(), 1)
+			}
+			return nil, fmt.Errorf("compile json schema: timeout after %s", opts.limits.CompileTimeout)
+		}
+	}
+
+	if opts.inFlightGauge != nil {
+		opts.inFlightGauge.Add(context.Background(), 1)
 	}
 
 	type result struct {
@@ -50,14 +73,32 @@ func newJSONSchemaValidator(schemaDoc string, limits Limits, timeoutCounter metr
 		c := jsonschema.NewCompiler()
 		doc, err := jsonschema.UnmarshalJSON(strings.NewReader(schemaDoc))
 		if err != nil {
+			if opts.inFlightGauge != nil {
+				opts.inFlightGauge.Add(context.Background(), -1)
+			}
+			if opts.compileSem != nil {
+				<-opts.compileSem
+			}
 			ch <- result{nil, fmt.Errorf("invalid json schema: %w", err)}
 			return
 		}
 		if err := c.AddResource("schema.json", doc); err != nil {
+			if opts.inFlightGauge != nil {
+				opts.inFlightGauge.Add(context.Background(), -1)
+			}
+			if opts.compileSem != nil {
+				<-opts.compileSem
+			}
 			ch <- result{nil, fmt.Errorf("add json schema resource: %w", err)}
 			return
 		}
 		schema, err := c.Compile("schema.json")
+		if opts.inFlightGauge != nil {
+			opts.inFlightGauge.Add(context.Background(), -1)
+		}
+		if opts.compileSem != nil {
+			<-opts.compileSem
+		}
 		if err != nil {
 			ch <- result{nil, fmt.Errorf("compile json schema: %w", err)}
 			return
@@ -65,20 +106,18 @@ func newJSONSchemaValidator(schemaDoc string, limits Limits, timeoutCounter metr
 		ch <- result{&jsonSchemaValidator{schema: schema}, nil}
 	}()
 
-	if limits.CompileTimeout <= 0 {
+	if timerC == nil {
 		r := <-ch
 		return r.v, r.err
 	}
-	timer := time.NewTimer(limits.CompileTimeout)
-	defer timer.Stop()
 	select {
 	case r := <-ch:
 		return r.v, r.err
-	case <-timer.C:
-		if timeoutCounter != nil {
-			timeoutCounter.Add(context.Background(), 1)
+	case <-timerC:
+		if opts.timeoutCounter != nil {
+			opts.timeoutCounter.Add(context.Background(), 1)
 		}
-		return nil, fmt.Errorf("compile json schema: timeout after %s", limits.CompileTimeout)
+		return nil, fmt.Errorf("compile json schema: timeout after %s", opts.limits.CompileTimeout)
 	}
 }
 

--- a/internal/validation/json_schema_test.go
+++ b/internal/validation/json_schema_test.go
@@ -24,15 +24,30 @@ func (c *countingCounter) Add(_ context.Context, incr int64, _ ...metric.AddOpti
 	c.n.Add(incr)
 }
 
+// countingGauge wraps noop.Int64UpDownCounter to track the running sum of Add calls.
+type countingGauge struct {
+	noop.Int64UpDownCounter
+	n atomic.Int64
+}
+
+func (g *countingGauge) Add(_ context.Context, incr int64, _ ...metric.AddOption) {
+	g.n.Add(incr)
+}
+
+func optsWithLimits(l Limits) options {
+	return resolveOptions([]Option{WithLimits(l)})
+}
+
 func TestDefaultLimits(t *testing.T) {
 	l := DefaultLimits()
 	assert.Equal(t, 5*time.Second, l.CompileTimeout)
 	assert.Equal(t, 64, l.MaxDepth)
+	assert.Equal(t, 32, l.MaxConcurrentCompiles)
 }
 
 func TestNewJSONSchemaValidator_Compiles(t *testing.T) {
 	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
-	v, err := newJSONSchemaValidator(doc, DefaultLimits(), nil)
+	v, err := newJSONSchemaValidator(doc, optsWithLimits(DefaultLimits()))
 	require.NoError(t, err)
 	require.NotNil(t, v)
 	require.NoError(t, v.validate(`{"name":"x"}`))
@@ -42,28 +57,28 @@ func TestNewJSONSchemaValidator_Compiles(t *testing.T) {
 func TestNewJSONSchemaValidator_DepthExceeded(t *testing.T) {
 	// Build a schema with nesting depth 10, then cap MaxDepth to 5.
 	doc := strings.Repeat(`{"properties":{"x":`, 10) + `{"type":"string"}` + strings.Repeat(`}}`, 10)
-	_, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 5}, nil)
+	_, err := newJSONSchemaValidator(doc, optsWithLimits(Limits{MaxDepth: 5}))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nesting depth exceeds limit of 5")
 }
 
 func TestNewJSONSchemaValidator_DepthDisabled(t *testing.T) {
 	doc := strings.Repeat(`{"properties":{"x":`, 5) + `{"type":"string"}` + strings.Repeat(`}}`, 5)
-	v, err := newJSONSchemaValidator(doc, Limits{MaxDepth: 0}, nil)
+	v, err := newJSONSchemaValidator(doc, optsWithLimits(Limits{MaxDepth: 0}))
 	require.NoError(t, err)
 	require.NotNil(t, v)
 }
 
 func TestNewJSONSchemaValidator_MalformedJSONFallsThrough(t *testing.T) {
 	// Pre-scan ignores non-JSON; compiler reports the syntax error.
-	_, err := newJSONSchemaValidator(`not-json`, DefaultLimits(), nil)
+	_, err := newJSONSchemaValidator(`not-json`, optsWithLimits(DefaultLimits()))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid json schema")
 }
 
 func TestNewJSONSchemaValidator_TimeoutZeroIsUnbounded(t *testing.T) {
 	doc := `{"type":"string"}`
-	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 0, MaxDepth: 0}, nil)
+	v, err := newJSONSchemaValidator(doc, optsWithLimits(Limits{CompileTimeout: 0, MaxDepth: 0}))
 	require.NoError(t, err)
 	require.NotNil(t, v)
 }
@@ -73,7 +88,7 @@ func TestNewJSONSchemaValidator_CompileTimeoutFires(t *testing.T) {
 	// scheduled, unmarshal the document, and push to the (buffered) result
 	// channel — the select therefore reaches the timeout branch.
 	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
-	v, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}, nil)
+	v, err := newJSONSchemaValidator(doc, optsWithLimits(Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}))
 	require.Error(t, err)
 	require.Nil(t, v)
 	assert.Contains(t, err.Error(), "compile json schema: timeout after")
@@ -83,7 +98,11 @@ func TestNewJSONSchemaValidator_TimeoutIncrementsCounter(t *testing.T) {
 	// Verify that the timeout branch increments the provided OTEL counter.
 	counter := &countingCounter{}
 	doc := `{"type":"object","properties":{"name":{"type":"string"}}}`
-	_, err := newJSONSchemaValidator(doc, Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}, counter)
+	opts := resolveOptions([]Option{
+		WithLimits(Limits{CompileTimeout: 1 * time.Nanosecond, MaxDepth: 0}),
+		WithTimeoutCounter(counter),
+	})
+	_, err := newJSONSchemaValidator(doc, opts)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "compile json schema: timeout after")
 	assert.Equal(t, int64(1), counter.n.Load(), "timeout counter should be incremented exactly once")
@@ -93,10 +112,61 @@ func TestNewJSONSchemaValidator_SuccessDoesNotIncrementCounter(t *testing.T) {
 	// Successful compile must not increment the counter.
 	counter := &countingCounter{}
 	doc := `{"type":"string"}`
-	v, err := newJSONSchemaValidator(doc, DefaultLimits(), counter)
+	opts := resolveOptions([]Option{
+		WithLimits(DefaultLimits()),
+		WithTimeoutCounter(counter),
+	})
+	v, err := newJSONSchemaValidator(doc, opts)
 	require.NoError(t, err)
 	require.NotNil(t, v)
 	assert.Equal(t, int64(0), counter.n.Load(), "counter must not be incremented on success")
+}
+
+func TestNewJSONSchemaValidator_SemaphoreFullTimeoutsOnWait(t *testing.T) {
+	// With a full semaphore (MaxConcurrentCompiles=1, slot pre-consumed) and a
+	// short timeout, newJSONSchemaValidator should return a timeout error while
+	// waiting for a slot — not a compile error.
+	opts := resolveOptions([]Option{
+		WithLimits(Limits{
+			MaxConcurrentCompiles: 1,
+			CompileTimeout:        10 * time.Millisecond,
+		}),
+	})
+	// Pre-fill the semaphore to simulate a running compile occupying the slot.
+	opts.compileSem <- struct{}{}
+
+	doc := `{"type":"string"}`
+	_, err := newJSONSchemaValidator(doc, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout after")
+}
+
+func TestNewJSONSchemaValidator_InFlightGaugeSuccessPath(t *testing.T) {
+	// Gauge must return to 0 after a successful compile.
+	// The gauge is decremented before the goroutine sends its result, so the
+	// value is guaranteed 0 by the time newJSONSchemaValidator returns.
+	gauge := &countingGauge{}
+	doc := `{"type":"string"}`
+	opts := resolveOptions([]Option{
+		WithLimits(DefaultLimits()),
+		WithInFlightGauge(gauge),
+	})
+	v, err := newJSONSchemaValidator(doc, opts)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, int64(0), gauge.n.Load(), "gauge must return to 0 after successful compile")
+}
+
+func TestNewJSONSchemaValidator_InFlightGaugeMalformedJSON(t *testing.T) {
+	// Gauge must return to 0 when the compile goroutine exits early with an error.
+	gauge := &countingGauge{}
+	opts := resolveOptions([]Option{
+		WithLimits(DefaultLimits()),
+		WithInFlightGauge(gauge),
+	})
+	_, err := newJSONSchemaValidator(`not-json`, opts)
+	require.Error(t, err)
+	assert.Equal(t, int64(0), gauge.n.Load(), "gauge must return to 0 after compile error")
 }
 
 func TestScanJSONDepth(t *testing.T) {

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -25,32 +25,50 @@ type Limits struct {
 	// before compilation. A schema deeper than this is rejected
 	// without invoking the compiler.
 	MaxDepth int
+
+	// MaxConcurrentCompiles caps the number of jsonschema.Compile calls
+	// that may run simultaneously across the process. When the limit is
+	// reached, new compile requests block until a slot is released or
+	// CompileTimeout fires. This bounds goroutine growth when malicious
+	// input repeatedly triggers the timeout path. 0 means no limit.
+	MaxConcurrentCompiles int
 }
 
 // DefaultLimits returns conservative defaults: a 5-second compile
-// timeout and a max nesting depth of 64. Tune via env vars at the call
-// site (cmd/server).
+// timeout, a max nesting depth of 64, and a concurrency cap of 32.
+// Tune via env vars at the call site (cmd/server).
 func DefaultLimits() Limits {
 	return Limits{
-		CompileTimeout: 5 * time.Second,
-		MaxDepth:       64,
+		CompileTimeout:        5 * time.Second,
+		MaxDepth:              64,
+		MaxConcurrentCompiles: 32,
 	}
 }
 
 // Option configures a [ValidatorFactory] or [FieldValidator]. See
-// [WithLimits], [WithTimeoutCounter], and [WithRegexErrorCounter].
+// [WithLimits], [WithTimeoutCounter], [WithRegexErrorCounter], and
+// [WithInFlightGauge].
 type Option func(*options)
 
 type options struct {
 	limits            Limits
-	timeoutCounter    metric.Int64Counter // nil when metrics are disabled
-	regexErrorCounter metric.Int64Counter // nil when metrics are disabled
+	timeoutCounter    metric.Int64Counter       // nil when metrics are disabled
+	regexErrorCounter metric.Int64Counter       // nil when metrics are disabled
+	inFlightGauge     metric.Int64UpDownCounter // nil when metrics are disabled
+	compileSem        chan struct{}             // nil when MaxConcurrentCompiles == 0
 }
 
 // WithLimits sets the JSON-Schema compile limits. Defaults to
 // [DefaultLimits] when unset.
 func WithLimits(l Limits) Option {
-	return func(o *options) { o.limits = l }
+	return func(o *options) {
+		o.limits = l
+		if l.MaxConcurrentCompiles > 0 {
+			o.compileSem = make(chan struct{}, l.MaxConcurrentCompiles)
+		} else {
+			o.compileSem = nil
+		}
+	}
 }
 
 // WithTimeoutCounter sets the OTEL counter incremented when a JSON-Schema
@@ -68,8 +86,20 @@ func WithRegexErrorCounter(c metric.Int64Counter) Option {
 	return func(o *options) { o.regexErrorCounter = c }
 }
 
+// WithInFlightGauge sets the OTEL up-down counter tracking the number of
+// JSON-Schema compile goroutines currently in flight (including zombies
+// that outlived their timeout). The metric name should be
+// "validation.json_schema_compiles_in_flight". Pass nil to disable.
+func WithInFlightGauge(g metric.Int64UpDownCounter) Option {
+	return func(o *options) { o.inFlightGauge = g }
+}
+
 func resolveOptions(opts []Option) options {
-	o := options{limits: DefaultLimits()}
+	defaults := DefaultLimits()
+	o := options{
+		limits:     defaults,
+		compileSem: make(chan struct{}, defaults.MaxConcurrentCompiles),
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -199,7 +199,7 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 
 	case pb.FieldType_FIELD_TYPE_JSON:
 		if constraints.JsonSchema != nil {
-			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o.limits, o.timeoutCounter)
+			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o)
 			if err == nil {
 				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 					val := tv.Kind.(*pb.TypedValue_JsonValue).JsonValue


### PR DESCRIPTION
## Summary

- Unbounded goroutine growth was possible when malicious schemas repeatedly triggered the compile timeout — each timeout left a zombie goroutine holding no slot, so N concurrent requests could spawn N goroutines.
- A channel semaphore (default cap 32, tunable via `SCHEMA_MAX_CONCURRENT_COMPILES`) now gates goroutine spawning: new compile requests block until a slot is released or `CompileTimeout` fires, bounding worst-case zombie count.
- A new `validation.json_schema_compiles_in_flight` gauge tracks running compile goroutines (including zombies) so operators can alert on elevated in-flight counts.

## Test plan

- [x] `TestNewJSONSchemaValidator_SemaphoreFullTimeoutsOnWait` — pre-fills the semaphore to cap and verifies that a new compile returns a timeout error while waiting for a slot.
- [x] `TestNewJSONSchemaValidator_InFlightGaugeSuccessPath` — gauge returns to 0 after a successful compile.
- [x] `TestNewJSONSchemaValidator_InFlightGaugeMalformedJSON` — gauge returns to 0 when the goroutine exits early with an error.
- [x] `TestValidationMetrics_InFlightGauge` — `ValidationMetrics.InFlightGauge()` returns the gauge and `true` when metrics are enabled.
- [x] `TestValidationMetrics_NilSafe` — `InFlightGauge()` returns `nil, false` on a nil receiver.
- [x] All pre-existing JSON-Schema validator tests continue to pass.
- [x] Full `make test` green.

Closes #437