### PR TITLE
feat(validation): add aggregate CEL evaluation cost cap

### DIFF
--- a/.agents/context/cel-validation.md
+++ b/.agents/context/cel-validation.md
@@ -213,9 +213,9 @@ Rule 3's type matching is the load-bearing reason to use a **typed CEL env** (`c
 |---|---|
 | Maturity | Production at Google, Kubernetes (CRD validation, admission policy), Istio. v0.x but stable. BSD-3. |
 | Sandboxing | No file/network/syscall access by default. Pure expression evaluation. |
-| Resource limits | `cel.CostLimit(N)`, `cel.InterruptCheckFrequency(N)` — abort runaway evaluation. |
-| Compile/eval split | Yes. Compile once at `ImportSchema`, cache `cel.Program`, evaluate per write. |
-| Performance | Single-rule eval is microseconds. Full per-write cost = O(rules × cost-per-rule). Cap with `CostLimit`. |
+| Resource limits | `cel.CostLimit(N)`, `cel.InterruptCheckFrequency(N)` — per-rule guards. `DECREE_CEL_AGGREGATE_COST_CAP` (default 1 000 000) caps summed cost across all rules per write; aborts early and increments `validation.cel_aggregate_cost_cap_exceeded_total` (per-tenant). |
+| Compile/eval split | Yes. Compile once at `ImportSchema`, cache `cel.Program`, evaluate per write. `OptTrackCost` enabled on every program so aggregate cost is tracked at zero per-call overhead on non-cap paths. |
+| Performance | Single-rule eval is microseconds. Full per-write cost = O(rules × cost-per-rule). Per-rule cap: `DECREE_CEL_COST_LIMIT` (default 100 000). Aggregate cap: `DECREE_CEL_AGGREGATE_COST_CAP` (default 1 000 000). |
 | Vanilla principle | Single dependency (`github.com/google/cel-go`). One transitive (cel-spec proto). Acceptable. |
 
 No competing options worth evaluating: `expr-lang/expr` lacks the spec/governance, and embedding a JS engine fails the vanilla bar.
@@ -277,7 +277,7 @@ Multi-field writes (`SetFields`) evaluate rules **once** against the post-merge 
 
 | Concern | Mitigation |
 |---|---|
-| Runaway evaluation (DoS) | `cel.CostLimit(100_000)` + `cel.InterruptCheckFrequency(100)` per rule. Tunable via env var. |
+| Runaway evaluation (DoS) | Per-rule: `cel.CostLimit(100_000)` + `cel.InterruptCheckFrequency(100)`. Aggregate: `DECREE_CEL_AGGREGATE_COST_CAP=1_000_000` caps summed cost across all rules per write — prevents 1000 rules × 100k per-rule = 100M total cost. Both tunable via env vars. Exceedances increment `validation.cel_aggregate_cost_cap_exceeded_total` tagged by `tenant_id`. |
 | Memory blow-up via large strings | Field-level `maxLength` already caps inputs. CEL operates on already-validated values. |
 | Schema author writes a rule that always fails | Caught by lint rule 2 (constant) for trivial cases. Non-trivial always-false rules are a schema-author bug, surfaced via test fixtures. |
 | Information leak via error messages | `message:` is author-controlled; advise in docs not to include sensitive values. |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -276,6 +276,9 @@ func run() int {
 	if gauge, ok := validationMetrics.InFlightGauge(); ok {
 		validatorOpts = append(validatorOpts, validation.WithInFlightGauge(gauge))
 	}
+	if counter, ok := validationMetrics.CelCapExceededCounter(); ok {
+		validatorOpts = append(validatorOpts, validation.WithCelCapCounter(counter))
+	}
 	validatorFactory := validation.NewValidatorFactory(validatorStore, validatorOpts...)
 
 	// Usage recorder — async batched read tracking for audit stats.

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1510,7 +1510,11 @@ func (s *Service) enforceCrossFieldInTx(
 		}
 		types := pbFieldTypeMap(celArtifacts.FieldTypes)
 		act := celpkg.BuildActivation(snapshot, types, tenantMeta)
-		failed, softErrs, evalErr := celpkg.Eval(celArtifacts.Programs, act, celArtifacts.Rules)
+		evalOpts := []celpkg.EvalOption{}
+		if counter := s.validators.CelCapCounter(); counter != nil {
+			evalOpts = append(evalOpts, celpkg.WithCapCounter(counter, tenantID))
+		}
+		failed, softErrs, evalErr := celpkg.Eval(celArtifacts.Programs, act, celArtifacts.Rules, evalOpts...)
 		if evalErr != nil {
 			return fmt.Errorf("evaluate validations: %w", evalErr)
 		}

--- a/internal/schema/cel/bench_test.go
+++ b/internal/schema/cel/bench_test.go
@@ -175,3 +175,28 @@ func BenchmarkCache_ProgramFor_Cached(b *testing.B) {
 		_, _ = cache.ProgramFor(env, rule, "schema", 1, 0)
 	}
 }
+
+// BenchmarkEval_AggregateCostCap_EarlyAbort measures the overhead of
+// aggregate cost tracking when the cap fires after the first rule. The
+// happy path (cap never reached) is already covered by
+// BenchmarkEval_FullCycle_LargeSchema; this bench captures the abort path
+// specifically, where the extra cost-sum check terminates the loop early.
+func BenchmarkEval_AggregateCostCap_EarlyAbort(b *testing.B) {
+	b.Setenv(envAggregateCostCap, "1") // fires after rule 0
+	env, err := BuildEnv(largeSchemaFields())
+	require.NoError(b, err)
+	rules := largeSchemaRules(50)
+	cache := NewCache()
+	programs := make([]cel.Program, len(rules))
+	for i, r := range rules {
+		p, err := cache.ProgramFor(env, r, "schema-id", 1, i)
+		require.NoError(b, err)
+		programs[i] = p
+	}
+	rows, types := largeSchemaSnapshot()
+	act := BuildActivation(rows, types, TenantBinding{ID: "tenant"})
+
+	for b.Loop() {
+		_, _, _ = Eval(programs, act, rules)
+	}
+}

--- a/internal/schema/cel/compile.go
+++ b/internal/schema/cel/compile.go
@@ -16,12 +16,19 @@ import (
 // whose internal cost counter exceeds the limit; cel.InterruptCheckFrequency
 // pins how often the cost counter is sampled while a loop or comprehension
 // runs. The brief picked 100_000 and 100; both are tunable per deployment.
+//
+// defaultAggregateCostCap bounds the summed cost across all rules evaluated
+// in a single Eval call. A tenant with 1000 rules × 100k per-rule limit
+// could otherwise drive 100M total cost per write; the aggregate cap cuts
+// that to 1M before the call aborts.
 const (
-	defaultCostLimit     uint64 = 100_000
-	defaultInterruptFreq uint   = 100
+	defaultCostLimit        uint64 = 100_000
+	defaultInterruptFreq    uint   = 100
+	defaultAggregateCostCap uint64 = 1_000_000
 
-	envCostLimit     = "DECREE_CEL_COST_LIMIT"
-	envInterruptFreq = "DECREE_CEL_INTERRUPT_FREQ"
+	envCostLimit        = "DECREE_CEL_COST_LIMIT"
+	envInterruptFreq    = "DECREE_CEL_INTERRUPT_FREQ"
+	envAggregateCostCap = "DECREE_CEL_AGGREGATE_COST_CAP"
 )
 
 // Cache memoises compiled CEL programs across config writes. Keys are tuples
@@ -73,7 +80,9 @@ func (c *Cache) InvalidateSchema(schemaID string) {
 }
 
 // compileProgram compiles a single CEL rule against the env and wraps it
-// with the configured cost-limit and interrupt-check guards.
+// with the configured cost-limit and interrupt-check guards. OptTrackCost
+// is always enabled so EvalDetails.ActualCost() is populated for aggregate
+// cost accounting in Eval.
 func compileProgram(env *cel.Env, rule string) (cel.Program, error) {
 	ast, issues := env.Compile(rule)
 	if issues != nil && issues.Err() != nil {
@@ -82,6 +91,7 @@ func compileProgram(env *cel.Env, rule string) (cel.Program, error) {
 	prog, err := env.Program(ast,
 		cel.CostLimit(costLimit()),
 		cel.InterruptCheckFrequency(interruptFreq()),
+		cel.EvalOptions(cel.OptTrackCost),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("build program: %w", err)
@@ -94,6 +104,13 @@ func costLimit() uint64 {
 		return v
 	}
 	return defaultCostLimit
+}
+
+func aggregateCostCap() uint64 {
+	if v, ok := readUint64(envAggregateCostCap); ok {
+		return v
+	}
+	return defaultAggregateCostCap
 }
 
 func interruptFreq() uint {

--- a/internal/schema/cel/eval.go
+++ b/internal/schema/cel/eval.go
@@ -1,15 +1,38 @@
 package cel
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 )
+
+// EvalOption configures optional behaviour for Eval. All options are
+// additive and backward-compatible; callers that pass no options get the
+// same behaviour as before this feature was added.
+type EvalOption func(*evalConfig)
+
+type evalConfig struct {
+	capCounter metric.Int64Counter
+	tenantID   string
+}
+
+// WithCapCounter wires an OTEL counter that is incremented (with the
+// given tenantID attribute) whenever the aggregate cost cap fires.
+// Pass nil to disable (no-op — equivalent to omitting the option).
+func WithCapCounter(c metric.Int64Counter, tenantID string) EvalOption {
+	return func(cfg *evalConfig) {
+		cfg.capCounter = c
+		cfg.tenantID = tenantID
+	}
+}
 
 // FailedRule names a CEL rule that returned false against the current
 // activation. The Index field points back into the schema's validations
@@ -35,33 +58,52 @@ type FailedRule struct {
 //     authors should not need to wrap every reference in `has()` to keep
 //     unrelated writes from being rejected.
 //
-// Two terminal errors:
+// Three terminal errors:
 //
-//   - cost-limit exceedance — abort the whole evaluation; surfaces as the
-//     returned error so the caller can return InvalidArgument and
-//     telemetry can flag a potential DoS attempt.
-//   - length mismatch       — programmer bug; abort.
+//   - per-rule cost-limit exceedance  — abort; caller returns InvalidArgument.
+//   - aggregate cost-limit exceedance — abort after summing cost across all
+//     rules so far; bounds total cost when a tenant has many rules.
+//   - length mismatch                 — programmer bug; abort.
 //
 // nil/nil/nil means every rule held cleanly.
-func Eval(programs []cel.Program, activation map[string]any, rules []*pb.ValidationRule) ([]FailedRule, []error, error) {
+func Eval(programs []cel.Program, activation map[string]any, rules []*pb.ValidationRule, opts ...EvalOption) ([]FailedRule, []error, error) {
 	if len(programs) == 0 {
 		return nil, nil, nil
 	}
 	if len(programs) != len(rules) {
 		return nil, nil, fmt.Errorf("cel: programs (%d) and rules (%d) length mismatch", len(programs), len(rules))
 	}
+	cfg := &evalConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	cap := aggregateCostCap()
 	var (
-		failed   []FailedRule
-		softErrs []error
+		failed        []FailedRule
+		softErrs      []error
+		aggregateCost uint64
 	)
 	for i, prog := range programs {
-		val, _, err := prog.Eval(activation)
+		val, details, err := prog.Eval(activation)
 		if err != nil {
 			if isCostLimit(err) {
 				return nil, softErrs, fmt.Errorf("cel: cost limit exceeded for validations[%d]: %w", i, err)
 			}
 			softErrs = append(softErrs, fmt.Errorf("validations[%d]: %w", i, err))
 			continue
+		}
+		if details != nil {
+			if c := details.ActualCost(); c != nil {
+				aggregateCost += *c
+				if aggregateCost > cap {
+					if cfg.capCounter != nil {
+						cfg.capCounter.Add(context.Background(), 1, metric.WithAttributes(
+							attribute.String("tenant_id", cfg.tenantID),
+						))
+					}
+					return nil, softErrs, fmt.Errorf("cel: aggregate cost limit exceeded (cost %d > cap %d)", aggregateCost, cap)
+				}
+			}
 		}
 		if val == nil || val.Type() != types.BoolType {
 			softErrs = append(softErrs, fmt.Errorf("validations[%d]: rule did not evaluate to bool (got %v)", i, valType(val)))

--- a/internal/schema/cel/eval_test.go
+++ b/internal/schema/cel/eval_test.go
@@ -1,11 +1,15 @@
 package cel
 
 import (
+	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 )
@@ -227,6 +231,84 @@ func TestEval_NullComparisonIsSoftError(t *testing.T) {
 	assert.Empty(t, failed, "null comparison must not fail the write")
 	require.Len(t, softErrs, 1)
 }
+
+func TestEval_AggregateCostCapExceeded(t *testing.T) {
+	// Set aggregate cap to 1 so it fires after the very first rule.
+	t.Setenv(envAggregateCostCap, "1")
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount < self.payments.max_amount", message: "rule-0"},
+		{rule: "self.payments.max_amount <= 1000.0", message: "rule-1"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{
+			{FieldPath: "payments.min_amount", Value: strPtr("1")},
+			{FieldPath: "payments.max_amount", Value: strPtr("2")},
+		},
+		map[string]pb.FieldType{
+			"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+			"payments.max_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+		},
+		TenantBinding{},
+	)
+	_, _, err := Eval(programs, act, rules)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aggregate cost limit exceeded")
+}
+
+func TestEval_AggregateCostCapNotExceeded(t *testing.T) {
+	// Cap well above what two simple comparisons can cost.
+	t.Setenv(envAggregateCostCap, "1000000")
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount < self.payments.max_amount", message: "rule-0"},
+		{rule: "self.payments.max_amount <= 1000.0", message: "rule-1"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{
+			{FieldPath: "payments.min_amount", Value: strPtr("1")},
+			{FieldPath: "payments.max_amount", Value: strPtr("2")},
+		},
+		map[string]pb.FieldType{
+			"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+			"payments.max_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+		},
+		TenantBinding{},
+	)
+	failed, _, err := Eval(programs, act, rules)
+	require.NoError(t, err)
+	assert.Empty(t, failed)
+}
+
+func TestEval_AggregateCostCapIncrementsCounter(t *testing.T) {
+	t.Setenv(envAggregateCostCap, "1")
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount < self.payments.max_amount", message: "x"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{
+			{FieldPath: "payments.min_amount", Value: strPtr("1")},
+			{FieldPath: "payments.max_amount", Value: strPtr("2")},
+		},
+		map[string]pb.FieldType{
+			"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+			"payments.max_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+		},
+		TenantBinding{},
+	)
+
+	counter := &fakeCounter{}
+	_, _, err := Eval(programs, act, rules, WithCapCounter(counter, "tenant-abc"))
+	require.Error(t, err)
+	assert.Equal(t, int64(1), counter.n.Load(), "counter must be incremented exactly once on cap fire")
+}
+
+// fakeCounter is a metric.Int64Counter that counts Add calls for tests.
+// Embeds noop.Int64Counter to satisfy the embedded marker interface.
+type fakeCounter struct {
+	noop.Int64Counter
+	n atomic.Int64
+}
+
+func (f *fakeCounter) Add(_ context.Context, incr int64, _ ...metric.AddOption) { f.n.Add(incr) }
 
 func BenchmarkEval_TenRules(b *testing.B) {
 	env, err := BuildEnv(showcaseFields())

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -133,9 +133,10 @@ func (m *RateLimitMetrics) Counter() (metric.Int64Counter, bool) {
 
 // ValidationMetrics records validation-related counters and gauges.
 type ValidationMetrics struct {
-	compileTimeouts    metric.Int64Counter
-	regexCompileErrors metric.Int64Counter
-	inFlightCompiles   metric.Int64UpDownCounter
+	compileTimeouts     metric.Int64Counter
+	regexCompileErrors  metric.Int64Counter
+	inFlightCompiles    metric.Int64UpDownCounter
+	celAggregateCostCap metric.Int64Counter
 }
 
 // NewValidationMetrics creates validation metrics. Returns nil if not enabled.
@@ -150,7 +151,9 @@ func NewValidationMetrics(cfg Config) *ValidationMetrics {
 		metric.WithDescription("Number of regex constraint patterns that failed to compile"))
 	inFlight, _ := meter.Int64UpDownCounter("validation.json_schema_compiles_in_flight",
 		metric.WithDescription("Number of JSON-Schema compile goroutines currently in flight, including zombies that outlived their timeout"))
-	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors, inFlightCompiles: inFlight}
+	celCap, _ := meter.Int64Counter("validation.cel_aggregate_cost_cap_exceeded_total",
+		metric.WithDescription("Number of times the aggregate CEL evaluation cost cap was exceeded per tenant, causing the write to be rejected"))
+	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors, inFlightCompiles: inFlight, celAggregateCostCap: celCap}
 }
 
 // TimeoutCounter returns the underlying Int64Counter and true when metrics are
@@ -178,6 +181,15 @@ func (m *ValidationMetrics) InFlightGauge() (metric.Int64UpDownCounter, bool) {
 		return nil, false
 	}
 	return m.inFlightCompiles, true
+}
+
+// CelCapExceededCounter returns the counter incremented when the aggregate
+// CEL evaluation cost cap is exceeded, and true when metrics are enabled.
+func (m *ValidationMetrics) CelCapExceededCounter() (metric.Int64Counter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.celAggregateCostCap, true
 }
 
 // StartDBPoolMetrics starts a background goroutine that periodically records

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -127,6 +127,16 @@ func TestValidationMetrics_NilSafe(t *testing.T) {
 	gauge, ok := m.InFlightGauge()
 	assert.False(t, ok)
 	assert.Nil(t, gauge)
+	counter, ok = m.CelCapExceededCounter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
+}
+
+func TestValidationMetrics_CelCapExceededCounter(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.CelCapExceededCounter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
 }
 
 func TestValidationMetrics_InFlightGauge(t *testing.T) {

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
+	"go.opentelemetry.io/otel/metric"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	celpkg "github.com/opendecree/decree/internal/schema/cel"
@@ -33,6 +34,7 @@ type ValidatorFactory struct {
 	celProgramsCache sync.Map // tenantID → []cel.Program
 	celCache         *celpkg.Cache
 	limits           Limits
+	celCapCounter    metric.Int64Counter // nil when metrics are disabled
 }
 
 // NewValidatorFactory creates a new validator factory. Pass [WithLimits]
@@ -40,11 +42,19 @@ type ValidatorFactory struct {
 func NewValidatorFactory(store Store, opts ...Option) *ValidatorFactory {
 	o := resolveOptions(opts)
 	return &ValidatorFactory{
-		store:    store,
-		cache:    NewValidatorCache(0),
-		celCache: celpkg.NewCache(),
-		limits:   o.limits,
+		store:         store,
+		cache:         NewValidatorCache(0),
+		celCache:      celpkg.NewCache(),
+		limits:        o.limits,
+		celCapCounter: o.celCapCounter,
 	}
+}
+
+// CelCapCounter returns the OTEL counter for aggregate CEL cost cap
+// exceedances (nil when metrics are disabled). Callers pass it to
+// celpkg.Eval via celpkg.WithCapCounter.
+func (f *ValidatorFactory) CelCapCounter() metric.Int64Counter {
+	return f.celCapCounter
 }
 
 // Cache returns the underlying cache for invalidation.

--- a/internal/validation/factory_test.go
+++ b/internal/validation/factory_test.go
@@ -10,6 +10,7 @@ import (
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/storage/domain"
+	"github.com/opendecree/decree/internal/telemetry"
 )
 
 // mockValidationStore implements the validation.Store interface for testing.
@@ -66,6 +67,21 @@ func TestNewValidatorFactory(t *testing.T) {
 
 	require.NotNil(t, f)
 	require.NotNil(t, f.Cache())
+}
+
+func TestNewValidatorFactory_WithCelCapCounter(t *testing.T) {
+	store := newMockStore()
+	m := telemetry.NewValidationMetrics(telemetry.Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.CelCapExceededCounter()
+	require.True(t, ok)
+
+	f := NewValidatorFactory(store, WithCelCapCounter(counter))
+	assert.NotNil(t, f.CelCapCounter())
+}
+
+func TestValidatorFactory_CelCapCounter_NilWhenUnset(t *testing.T) {
+	f := NewValidatorFactory(newMockStore())
+	assert.Nil(t, f.CelCapCounter())
 }
 
 // --- GetValidators: cache miss → builds validators ---

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -55,6 +55,7 @@ type options struct {
 	timeoutCounter    metric.Int64Counter       // nil when metrics are disabled
 	regexErrorCounter metric.Int64Counter       // nil when metrics are disabled
 	inFlightGauge     metric.Int64UpDownCounter // nil when metrics are disabled
+	celCapCounter     metric.Int64Counter       // nil when metrics are disabled
 	compileSem        chan struct{}             // nil when MaxConcurrentCompiles == 0
 }
 
@@ -92,6 +93,14 @@ func WithRegexErrorCounter(c metric.Int64Counter) Option {
 // "validation.json_schema_compiles_in_flight". Pass nil to disable.
 func WithInFlightGauge(g metric.Int64UpDownCounter) Option {
 	return func(o *options) { o.inFlightGauge = g }
+}
+
+// WithCelCapCounter sets the OTEL counter incremented (with a tenant_id
+// attribute) when the aggregate CEL evaluation cost cap is exceeded. The
+// metric name should be
+// "validation.cel_aggregate_cost_cap_exceeded_total". Pass nil to disable.
+func WithCelCapCounter(c metric.Int64Counter) Option {
+	return func(o *options) { o.celCapCounter = c }
 }
 
 func resolveOptions(opts []Option) options {


### PR DESCRIPTION
## Summary

- A tenant with many CEL rules could multiply the per-rule cost limit (100k) into an arbitrarily large total cost per write (e.g. 1000 rules × 100k = 100M); this adds a request-level aggregate cap to close that gap.
- `OptTrackCost` is enabled on every compiled program so `EvalDetails.ActualCost()` is populated; the aggregate is summed across rules and the call aborts early when it exceeds `DECREE_CEL_AGGREGATE_COST_CAP` (default 1,000,000).
- Exceedances are observable via the `validation.cel_aggregate_cost_cap_exceeded_total` OTEL counter, tagged with `tenant_id`, wired through `ValidationMetrics` → `WithCelCapCounter` → `ValidatorFactory` → `celpkg.WithCapCounter`.

## Test plan

- [x] `TestEval_AggregateCostCapExceeded` — cap set to 1, verifies error fires after rule 0
- [x] `TestEval_AggregateCostCapNotExceeded` — cap set to 1,000,000, verifies no error on two simple rules
- [x] `TestEval_AggregateCostCapIncrementsCounter` — verifies the OTEL counter is incremented exactly once when the cap fires
- [x] `BenchmarkEval_AggregateCostCap_EarlyAbort` — benchmarks the abort path with 50 rules, cap of 1
- [x] Full test suite passes with `-race`: `make test`
- [x] Lint clean: `golangci-lint run ./...`

Closes #438