### PR TITLE
Cap regex pattern length at 1024 bytes

### DIFF
--- a/internal/schema/limits.go
+++ b/internal/schema/limits.go
@@ -16,15 +16,20 @@ type Limits struct {
 
 	// MaxRemoveFields caps the number of entries in UpdateSchema.remove_fields.
 	MaxRemoveFields int
+
+	// RegexPatternMaxLength caps the byte length of a regex pattern
+	// accepted at schema-publish time. 0 means no limit.
+	RegexPatternMaxLength int
 }
 
 // DefaultLimits returns conservative defaults: 10 000 fields, 5 MiB per
-// document, and 1 000 remove_fields entries per UpdateSchema request.
-// Tune via env vars at the call site (cmd/server).
+// document, 1 000 remove_fields entries per UpdateSchema request, and a
+// 1 024-byte regex pattern cap. Tune via env vars at the call site (cmd/server).
 func DefaultLimits() Limits {
 	return Limits{
-		MaxFields:       10_000,
-		MaxDocBytes:     5 * 1024 * 1024,
-		MaxRemoveFields: 1_000,
+		MaxFields:             10_000,
+		MaxDocBytes:           5 * 1024 * 1024,
+		MaxRemoveFields:       1_000,
+		RegexPatternMaxLength: 1024,
 	}
 }

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -182,7 +182,7 @@ func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest)
 			return err
 		}
 
-		fields, err = createFieldsOn(ctx, s.logger, tx, version.ID, req.Fields)
+		fields, err = createFieldsOn(ctx, s.logger, tx, version.ID, req.Fields, s.limits.RegexPatternMaxLength)
 		if err != nil {
 			return err
 		}
@@ -355,7 +355,7 @@ func (s *Service) UpdateSchema(ctx context.Context, req *pb.UpdateSchemaRequest)
 			return err
 		}
 
-		fields, err = createFieldsOn(ctx, s.logger, tx, newVersion.ID, mergedFields)
+		fields, err = createFieldsOn(ctx, s.logger, tx, newVersion.ID, mergedFields, s.limits.RegexPatternMaxLength)
 		if err != nil {
 			return err
 		}
@@ -852,7 +852,7 @@ func (s *Service) ImportSchema(ctx context.Context, req *pb.ImportSchemaRequest)
 	}
 	// Validate field constraints (including regex compilation) before any
 	// storage write so that bad patterns are caught immediately.
-	if err := validateFieldConstraintsBatch(fields); err != nil {
+	if err := validateFieldConstraintsBatch(fields, s.limits.RegexPatternMaxLength); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	depReqs := parsed.DependentRequired
@@ -993,16 +993,16 @@ func (s *Service) getActor(ctx context.Context) string {
 }
 
 func (s *Service) createFields(ctx context.Context, versionID string, fields []*pb.SchemaField) ([]domain.SchemaField, error) {
-	return createFieldsOn(ctx, s.logger, s.store, versionID, fields)
+	return createFieldsOn(ctx, s.logger, s.store, versionID, fields, s.limits.RegexPatternMaxLength)
 }
 
-func createFieldsOn(ctx context.Context, logger *slog.Logger, store Store, versionID string, fields []*pb.SchemaField) ([]domain.SchemaField, error) {
+func createFieldsOn(ctx context.Context, logger *slog.Logger, store Store, versionID string, fields []*pb.SchemaField, regexPatternMaxLength int) ([]domain.SchemaField, error) {
 	if err := validateNoPrefixOverlap(fields); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	result := make([]domain.SchemaField, 0, len(fields))
 	for _, f := range fields {
-		if err := validateFieldConstraints(f); err != nil {
+		if err := validateFieldConstraints(f, regexPatternMaxLength); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 

--- a/internal/schema/validate_constraints.go
+++ b/internal/schema/validate_constraints.go
@@ -13,9 +13,10 @@ import (
 // the slice and returns the first error encountered. It is used by ImportSchema
 // to validate all constraints before any storage writes, ensuring that bad
 // patterns (e.g. invalid regex) are rejected immediately with a clear error.
-func validateFieldConstraintsBatch(fields []*pb.SchemaField) error {
+// regexMaxLen is the maximum allowed byte length for a regex pattern (0 = no limit).
+func validateFieldConstraintsBatch(fields []*pb.SchemaField, regexMaxLen int) error {
 	for _, f := range fields {
-		if err := validateFieldConstraints(f); err != nil {
+		if err := validateFieldConstraints(f, regexMaxLen); err != nil {
 			return err
 		}
 	}
@@ -51,8 +52,9 @@ func validateNoPrefixOverlap(fields []*pb.SchemaField) error {
 }
 
 // validateFieldConstraints checks that constraints are applicable to the field type.
+// regexMaxLen caps the byte length of regex patterns (0 = no limit).
 // Returns an error if a constraint is applied to an incompatible type.
-func validateFieldConstraints(field *pb.SchemaField) error {
+func validateFieldConstraints(field *pb.SchemaField, regexMaxLen int) error {
 	c := field.Constraints
 	if c == nil {
 		return nil
@@ -92,6 +94,9 @@ func validateFieldConstraints(field *pb.SchemaField) error {
 		return fmt.Errorf("field %s: 'pattern' constraint is not valid for type %s (only string)", path, ft)
 	}
 	if c.Regex != nil && ft == pb.FieldType_FIELD_TYPE_STRING {
+		if regexMaxLen > 0 && len(*c.Regex) > regexMaxLen {
+			return fmt.Errorf("field %s: regex pattern exceeds maximum length of %d characters", path, regexMaxLen)
+		}
 		if _, err := regexp.Compile(*c.Regex); err != nil {
 			return fmt.Errorf("field %s: invalid regex constraint: %w", path, err)
 		}

--- a/internal/schema/validate_constraints_test.go
+++ b/internal/schema/validate_constraints_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,7 @@ func TestValidateConstraints_IntegerMinMax(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_INT,
 		Constraints: &pb.FieldConstraints{Min: pf(0), Max: pf(10)},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -27,7 +28,7 @@ func TestValidateConstraints_NumberExclusive(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_NUMBER,
 		Constraints: &pb.FieldConstraints{ExclusiveMin: pf(0), ExclusiveMax: pf(1)},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -35,7 +36,7 @@ func TestValidateConstraints_StringLength(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 		Constraints: &pb.FieldConstraints{MinLength: pi(2), MaxLength: pi(50)},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -43,7 +44,7 @@ func TestValidateConstraints_StringPattern(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 		Constraints: &pb.FieldConstraints{Regex: ps("^[A-Z]+$")},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -59,7 +60,7 @@ func TestValidateConstraints_InvalidRegex_Rejected(t *testing.T) {
 			err := validateFieldConstraints(&pb.SchemaField{
 				Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 				Constraints: &pb.FieldConstraints{Regex: ps(pat)},
-			})
+			}, 0)
 			assert.Error(t, err, "expected error for invalid regex %q", pat)
 			assert.Contains(t, err.Error(), "invalid regex constraint")
 		})
@@ -70,7 +71,7 @@ func TestValidateConstraints_DurationMinMax(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_DURATION,
 		Constraints: &pb.FieldConstraints{Min: pf(1), Max: pf(3600)},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -79,7 +80,7 @@ func TestValidateConstraints_JSONSchema(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_JSON,
 		Constraints: &pb.FieldConstraints{JsonSchema: &schema},
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -93,7 +94,7 @@ func TestValidateConstraints_EnumOnAnyType(t *testing.T) {
 		err := validateFieldConstraints(&pb.SchemaField{
 			Path: "x", Type: ft,
 			Constraints: &pb.FieldConstraints{EnumValues: []string{"a", "b"}},
-		})
+		}, 0)
 		require.NoError(t, err, "enum should be valid on %s", ft)
 	}
 }
@@ -101,7 +102,7 @@ func TestValidateConstraints_EnumOnAnyType(t *testing.T) {
 func TestValidateConstraints_NoConstraints(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_BOOL,
-	})
+	}, 0)
 	require.NoError(t, err)
 }
 
@@ -111,7 +112,7 @@ func TestValidateConstraints_MinOnString_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 		Constraints: &pb.FieldConstraints{Min: pf(0)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "minimum")
 	assert.Contains(t, err.Error(), "not valid")
@@ -121,7 +122,7 @@ func TestValidateConstraints_MinLengthOnInteger_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_INT,
 		Constraints: &pb.FieldConstraints{MinLength: pi(2)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "minLength")
 }
@@ -130,7 +131,7 @@ func TestValidateConstraints_PatternOnBool_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_BOOL,
 		Constraints: &pb.FieldConstraints{Regex: ps("^true$")},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "pattern")
 }
@@ -140,7 +141,7 @@ func TestValidateConstraints_JsonSchemaOnString_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 		Constraints: &pb.FieldConstraints{JsonSchema: &schema},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "json_schema")
 }
@@ -149,7 +150,7 @@ func TestValidateConstraints_ExclusiveMinOnBool_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_BOOL,
 		Constraints: &pb.FieldConstraints{ExclusiveMin: pf(0)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "exclusiveMinimum")
 }
@@ -158,7 +159,7 @@ func TestValidateConstraints_MaxOnURL_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_URL,
 		Constraints: &pb.FieldConstraints{Max: pf(100)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "maximum")
 }
@@ -169,7 +170,7 @@ func TestValidateConstraints_MinGreaterThanMax_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_INT,
 		Constraints: &pb.FieldConstraints{Min: pf(10), Max: pf(5)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "greater than maximum")
 }
@@ -178,7 +179,7 @@ func TestValidateConstraints_ExclusiveMinEqualToMax_Rejected(t *testing.T) {
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_NUMBER,
 		Constraints: &pb.FieldConstraints{ExclusiveMin: pf(5), ExclusiveMax: pf(5)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "must be less than")
 }
@@ -187,9 +188,40 @@ func TestValidateConstraints_MinLengthGreaterThanMaxLength_Rejected(t *testing.T
 	err := validateFieldConstraints(&pb.SchemaField{
 		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
 		Constraints: &pb.FieldConstraints{MinLength: pi(10), MaxLength: pi(5)},
-	})
+	}, 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "minLength")
+}
+
+// --- Regex pattern length cap ---
+
+func TestValidateConstraints_RegexAtLimit_Accepted(t *testing.T) {
+	pat := strings.Repeat("a", 1024)
+	err := validateFieldConstraints(&pb.SchemaField{
+		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
+		Constraints: &pb.FieldConstraints{Regex: ps(pat)},
+	}, 1024)
+	require.NoError(t, err)
+}
+
+func TestValidateConstraints_RegexOverLimit_Rejected(t *testing.T) {
+	pat := strings.Repeat("a", 1025)
+	err := validateFieldConstraints(&pb.SchemaField{
+		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
+		Constraints: &pb.FieldConstraints{Regex: ps(pat)},
+	}, 1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum length")
+}
+
+func TestValidateConstraints_RegexLimitDisabled_LongPatternAccepted(t *testing.T) {
+	// 0 means no limit.
+	pat := strings.Repeat("a", 5000)
+	err := validateFieldConstraints(&pb.SchemaField{
+		Path: "x", Type: pb.FieldType_FIELD_TYPE_STRING,
+		Constraints: &pb.FieldConstraints{Regex: ps(pat)},
+	}, 0)
+	require.NoError(t, err)
 }
 
 // --- Prefix-overlap (cross-field) ---

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -136,6 +136,9 @@ func (f *ValidatorFactory) GetValidators(ctx context.Context, tenantID string) (
 			constraints = &pb.FieldConstraints{}
 			_ = json.Unmarshal(field.Constraints, constraints)
 		}
+		if f.limits.RegexMaxLength > 0 && constraints.GetRegex() != "" && len(constraints.GetRegex()) > f.limits.RegexMaxLength {
+			return nil, fmt.Errorf("field %s: regex pattern exceeds maximum length of %d characters", field.Path, f.limits.RegexMaxLength)
+		}
 		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, field.Sensitive, constraints, WithLimits(f.limits))
 	}
 

--- a/internal/validation/factory_test.go
+++ b/internal/validation/factory_test.go
@@ -179,6 +179,45 @@ func TestGetValidators_GetSchemaFieldsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "fields error")
 }
 
+// --- GetValidators: regex pattern length cap ---
+
+func TestGetValidators_RegexOverLimit_Rejected(t *testing.T) {
+	raw := []byte(`{"regex":"` + repeat("a", 1025) + `"}`)
+	store := newMockStore()
+	store.getSchemaFieldsFn = func(_ context.Context, _ string) ([]domain.SchemaField, error) {
+		return []domain.SchemaField{
+			{Path: "x", FieldType: domain.FieldTypeString, Constraints: raw},
+		}, nil
+	}
+
+	f := NewValidatorFactory(store, WithLimits(Limits{RegexMaxLength: 1024}))
+	_, err := f.GetValidators(context.Background(), testTenantID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum length")
+}
+
+func TestGetValidators_RegexAtLimit_Accepted(t *testing.T) {
+	raw := []byte(`{"regex":"` + repeat("a", 1024) + `"}`)
+	store := newMockStore()
+	store.getSchemaFieldsFn = func(_ context.Context, _ string) ([]domain.SchemaField, error) {
+		return []domain.SchemaField{
+			{Path: "x", FieldType: domain.FieldTypeString, Constraints: raw},
+		}, nil
+	}
+
+	f := NewValidatorFactory(store, WithLimits(Limits{RegexMaxLength: 1024}))
+	_, err := f.GetValidators(context.Background(), testTenantID)
+	require.NoError(t, err)
+}
+
+func repeat(s string, n int) string {
+	result := make([]byte, n)
+	for i := range result {
+		result[i] = s[0]
+	}
+	return string(result)
+}
+
 // --- GetValidators: no constraints ---
 
 func TestGetValidators_FieldWithoutConstraints(t *testing.T) {

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -32,16 +32,22 @@ type Limits struct {
 	// CompileTimeout fires. This bounds goroutine growth when malicious
 	// input repeatedly triggers the timeout path. 0 means no limit.
 	MaxConcurrentCompiles int
+
+	// RegexMaxLength caps the byte length of a regex pattern at SetField
+	// validation time. Patterns longer than this are rejected without
+	// compilation. 0 means no limit.
+	RegexMaxLength int
 }
 
 // DefaultLimits returns conservative defaults: a 5-second compile
-// timeout, a max nesting depth of 64, and a concurrency cap of 32.
-// Tune via env vars at the call site (cmd/server).
+// timeout, a max nesting depth of 64, a concurrency cap of 32, and a
+// 1 024-byte regex pattern cap. Tune via env vars at the call site (cmd/server).
 func DefaultLimits() Limits {
 	return Limits{
 		CompileTimeout:        5 * time.Second,
 		MaxDepth:              64,
 		MaxConcurrentCompiles: 32,
+		RegexMaxLength:        1024,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Uncapped regex patterns waste CPU/RAM at compile time even under Go's RE2 (no catastrophic backtracking, but a 10 MB pattern still costs).
- Adds a 1 024-byte limit at schema-publish time so malformed schemas are rejected immediately with a clear error.
- Adds a matching check in the validator factory as defense in depth, so any pattern that somehow reached the DB is also blocked before compilation.

## Test plan

- `TestValidateConstraints_RegexAtLimit_Accepted` — 1 024-byte pattern passes.
- `TestValidateConstraints_RegexOverLimit_Rejected` — 1 025-byte pattern is rejected with "exceeds maximum length".
- `TestValidateConstraints_RegexLimitDisabled_LongPatternAccepted` — limit=0 disables the cap.
- `TestGetValidators_RegexOverLimit_Rejected` / `_Accepted` — factory-level defense in depth.
- Full suite: `make test` — all packages green.

Closes #439