### PR TITLE
fix: map PG unique-violation (23505) to domain.ErrAlreadyExists

### DIFF
--- a/internal/schema/errtostatus_test.go
+++ b/internal/schema/errtostatus_test.go
@@ -39,6 +39,22 @@ func TestErrToStatus(t *testing.T) {
 			wantMsgPart: "record not found",
 		},
 		{
+			name:        "ErrAlreadyExists maps to AlreadyExists",
+			err:         domain.ErrAlreadyExists,
+			notFoundMsg: "not found",
+			failedMsg:   "failed",
+			wantCode:    codes.AlreadyExists,
+			wantMsgPart: "already exists",
+		},
+		{
+			name:        "wrapped ErrAlreadyExists maps to AlreadyExists",
+			err:         fmt.Errorf("db: %w", domain.ErrAlreadyExists),
+			notFoundMsg: "not found",
+			failedMsg:   "failed",
+			wantCode:    codes.AlreadyExists,
+			wantMsgPart: "already exists",
+		},
+		{
 			name:        "other error maps to Internal",
 			err:         errors.New("connection reset"),
 			notFoundMsg: "not found",

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -60,6 +60,9 @@ func errToStatus(err error, notFoundMsg, failedMsg string) error {
 	if errors.Is(err, domain.ErrNotFound) {
 		return status.Error(codes.NotFound, notFoundMsg)
 	}
+	if errors.Is(err, domain.ErrAlreadyExists) {
+		return status.Error(codes.AlreadyExists, "resource with this name already exists")
+	}
 	return status.Error(codes.Internal, failedMsg)
 }
 
@@ -170,6 +173,9 @@ func (s *Service) CreateSchema(ctx context.Context, req *pb.CreateSchemaRequest)
 			Description: ptrString(req.GetDescription()),
 		})
 		if err != nil {
+			if errors.Is(err, domain.ErrAlreadyExists) {
+				return status.Error(codes.AlreadyExists, "schema with this name already exists")
+			}
 			return err
 		}
 
@@ -510,6 +516,9 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 			SchemaVersion: req.SchemaVersion,
 		})
 		if err != nil {
+			if errors.Is(err, domain.ErrAlreadyExists) {
+				return status.Error(codes.AlreadyExists, "tenant with this name already exists")
+			}
 			return err
 		}
 		meta, _ := json.Marshal(map[string]any{"name": req.Name, "schema_id": req.SchemaId, "schema_version": req.SchemaVersion})
@@ -522,6 +531,9 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 			Metadata:   meta,
 		})
 	}); err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() != codes.OK {
+			return nil, err
+		}
 		s.logger.ErrorContext(ctx, "create tenant", "error", err)
 		return nil, status.Error(codes.Internal, "failed to create tenant")
 	}

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -67,6 +67,21 @@ func TestCreateSchema_EmptyName(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func TestCreateSchema_AlreadyExists(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	store.On("CreateSchema", ctx, mock.AnythingOfType("schema.CreateSchemaParams")).
+		Return(domain.Schema{}, domain.ErrAlreadyExists)
+
+	_, err := svc.CreateSchema(ctx, &pb.CreateSchemaRequest{Name: "dup-schema"})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+	store.AssertExpectations(t)
+}
+
 // --- GetSchema ---
 
 func TestGetSchema_LatestVersion(t *testing.T) {
@@ -219,6 +234,27 @@ func TestCreateTenant_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "test-tenant", resp.Tenant.Name)
+	store.AssertExpectations(t)
+}
+
+func TestCreateTenant_AlreadyExists(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
+		Return(domain.SchemaVersion{Published: true}, nil)
+	store.On("CreateTenant", ctx, mock.AnythingOfType("schema.CreateTenantParams")).
+		Return(domain.Tenant{}, domain.ErrAlreadyExists)
+
+	_, err := svc.CreateTenant(ctx, &pb.CreateTenantRequest{
+		Name:          "dup-tenant",
+		SchemaId:      testSchemaID,
+		SchemaVersion: 1,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
 	store.AssertExpectations(t)
 }
 

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -125,7 +125,7 @@ func (s *PGStore) CreateSchema(ctx context.Context, arg CreateSchemaParams) (dom
 		Description: arg.Description,
 	})
 	if err != nil {
-		return domain.Schema{}, err
+		return domain.Schema{}, pgconv.WrapUniqueViolation(err)
 	}
 	return schemaFromDB(row), nil
 }
@@ -318,7 +318,7 @@ func (s *PGStore) CreateTenant(ctx context.Context, arg CreateTenantParams) (dom
 		SchemaVersion: arg.SchemaVersion,
 	})
 	if err != nil {
-		return domain.Tenant{}, err
+		return domain.Tenant{}, pgconv.WrapUniqueViolation(err)
 	}
 	return tenantFromDB(row), nil
 }

--- a/internal/storage/domain/types.go
+++ b/internal/storage/domain/types.go
@@ -12,6 +12,9 @@ import (
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("not found")
 
+// ErrAlreadyExists is returned when an insert violates a unique constraint.
+var ErrAlreadyExists = errors.New("already exists")
+
 // FieldType represents a schema field's value type.
 type FieldType string
 

--- a/internal/storage/pgconv/convert.go
+++ b/internal/storage/pgconv/convert.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/opendecree/decree/internal/storage/domain"
@@ -82,6 +83,19 @@ func WrapNotFound(err error) error {
 	}
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.ErrNotFound
+	}
+	return err
+}
+
+// WrapUniqueViolation converts a PostgreSQL unique-constraint violation (23505)
+// to domain.ErrAlreadyExists. Returns the original error for all other errors.
+func WrapUniqueViolation(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return domain.ErrAlreadyExists
 	}
 	return err
 }

--- a/internal/storage/pgconv/convert_test.go
+++ b/internal/storage/pgconv/convert_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,27 @@ func TestWrapNotFound(t *testing.T) {
 	t.Run("other error", func(t *testing.T) {
 		other := errors.New("something else")
 		assert.Equal(t, other, WrapNotFound(other))
+	})
+}
+
+func TestWrapUniqueViolation(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, WrapUniqueViolation(nil))
+	})
+
+	t.Run("23505 unique_violation", func(t *testing.T) {
+		err := WrapUniqueViolation(&pgconn.PgError{Code: "23505"})
+		assert.ErrorIs(t, err, domain.ErrAlreadyExists)
+	})
+
+	t.Run("other pg error", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "23503"}
+		assert.Equal(t, pgErr, WrapUniqueViolation(pgErr))
+	})
+
+	t.Run("non-pg error", func(t *testing.T) {
+		other := errors.New("something else")
+		assert.Equal(t, other, WrapUniqueViolation(other))
 	})
 }
 


### PR DESCRIPTION
## Summary

- Duplicate name inserts for schemas and tenants were surfacing as raw PostgreSQL error strings inside a generic `Internal` gRPC status, leaking implementation details and breaking the typed-error contract for clients.
- Centralises the 23505 → domain error mapping in `pgconv.WrapUniqueViolation`, consistent with the existing `WrapNotFound` pattern.
- Fixes `CreateTenant` to propagate gRPC status errors from inside the transaction (they were previously swallowed into a generic Internal response).

## Test plan

- [ ] `make test` passes (all modules, including `internal/storage/pgconv` and `internal/schema`)
- [ ] `make lint` clean
- [ ] `TestWrapUniqueViolation` covers nil, 23505, other PG code, and non-PG error cases
- [ ] Duplicate schema name → `codes.AlreadyExists` with message "schema with this name already exists"
- [ ] Duplicate tenant name → `codes.AlreadyExists` with message "tenant with this name already exists"

Closes #440