### PR TITLE
Fix ListSchemas swallowing DB errors as partial results

### DIFF
--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -279,11 +279,17 @@ func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (
 	for _, schema := range schemas {
 		version, err := s.store.GetLatestSchemaVersion(ctx, schema.ID)
 		if err != nil {
-			continue // Schema with no versions — skip.
+			if errors.Is(err, domain.ErrNotFound) {
+				continue // Schema with no versions — skip.
+			}
+			return nil, status.Errorf(codes.Internal, "failed to get latest version for schema %s", schema.ID)
 		}
 		fields, err := s.store.GetSchemaFields(ctx, version.ID)
 		if err != nil {
-			continue
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return nil, status.Errorf(codes.Internal, "failed to get fields for schema %s", schema.ID)
 		}
 		pbSchemas = append(pbSchemas, schemaToProto(schema, version, fields))
 	}

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -172,6 +173,31 @@ func TestListSchemas_ZeroPageSize(t *testing.T) {
 	resp, err = svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: -1})
 	require.NoError(t, err)
 	assert.Len(t, resp.Schemas, 1)
+}
+
+func TestListSchemas_VersionDBError_ReturnsInternal(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+
+	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(domain.SchemaVersion{}, errors.New("db connection lost"))
+
+	_, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestListSchemas_FieldsDBError_ReturnsInternal(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+
+	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
+	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, errors.New("db connection lost"))
+
+	_, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
 // --- DeleteSchema ---

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -175,6 +175,31 @@ func TestListSchemas_ZeroPageSize(t *testing.T) {
 	assert.Len(t, resp.Schemas, 1)
 }
 
+func TestListSchemas_VersionNotFound_Skips(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+
+	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(domain.SchemaVersion{}, domain.ErrNotFound)
+
+	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Schemas)
+}
+
+func TestListSchemas_FieldsNotFound_Skips(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+
+	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
+	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
+	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, domain.ErrNotFound)
+
+	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Schemas)
+}
+
 func TestListSchemas_VersionDBError_ReturnsInternal(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))


### PR DESCRIPTION
## Summary

- `ListSchemas` was silently skipping schemas on any store error, returning incomplete results without surfacing the underlying failure to callers.
- Only `domain.ErrNotFound` (schema exists but has no versions) is a valid skip condition; all other errors now propagate as `codes.Internal` with the schema ID in the message.

## Test plan

- [x] `TestListSchemas_VersionDBError_ReturnsInternal` — non-NotFound error from `GetLatestSchemaVersion` returns `codes.Internal`
- [x] `TestListSchemas_FieldsDBError_ReturnsInternal` — non-NotFound error from `GetSchemaFields` returns `codes.Internal`
- [x] `make test` passes (all packages)

Closes #441