### PR TITLE
fix(schema): map FK violation to FailedPrecondition in DeleteSchema

### DIFF
--- a/internal/schema/errtostatus_test.go
+++ b/internal/schema/errtostatus_test.go
@@ -55,6 +55,22 @@ func TestErrToStatus(t *testing.T) {
 			wantMsgPart: "already exists",
 		},
 		{
+			name:        "ErrReferencedByOther maps to FailedPrecondition",
+			err:         domain.ErrReferencedByOther,
+			notFoundMsg: "not found",
+			failedMsg:   "failed",
+			wantCode:    codes.FailedPrecondition,
+			wantMsgPart: "referenced by active config versions",
+		},
+		{
+			name:        "wrapped ErrReferencedByOther maps to FailedPrecondition",
+			err:         fmt.Errorf("db: %w", domain.ErrReferencedByOther),
+			notFoundMsg: "not found",
+			failedMsg:   "failed",
+			wantCode:    codes.FailedPrecondition,
+			wantMsgPart: "referenced by active config versions",
+		},
+		{
 			name:        "other error maps to Internal",
 			err:         errors.New("connection reset"),
 			notFoundMsg: "not found",

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -63,6 +63,9 @@ func errToStatus(err error, notFoundMsg, failedMsg string) error {
 	if errors.Is(err, domain.ErrAlreadyExists) {
 		return status.Error(codes.AlreadyExists, "resource with this name already exists")
 	}
+	if errors.Is(err, domain.ErrReferencedByOther) {
+		return status.Error(codes.FailedPrecondition, "schema is referenced by active config versions")
+	}
 	return status.Error(codes.Internal, failedMsg)
 }
 
@@ -421,7 +424,7 @@ func (s *Service) DeleteSchema(ctx context.Context, req *pb.DeleteSchemaRequest)
 		})
 	}); err != nil {
 		s.logger.ErrorContext(ctx, "delete schema", "error", err)
-		return nil, status.Error(codes.Internal, "failed to delete schema")
+		return nil, errToStatus(err, "schema not found", "failed to delete schema")
 	}
 
 	return &pb.DeleteSchemaResponse{}, nil

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -248,6 +248,17 @@ func TestDeleteSchema_InvalidID(t *testing.T) {
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
+func TestDeleteSchema_FKViolation(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+
+	store.On("GetSchemaByID", mock.Anything, testSchemaID).Return(testSchema(), nil)
+	store.On("DeleteSchema", mock.Anything, testSchemaID).Return(domain.ErrReferencedByOther)
+
+	_, err := svc.DeleteSchema(superadminCtx(), &pb.DeleteSchemaRequest{Id: testSchemaID})
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
 // --- GetTenant ---
 
 func TestGetTenant_Success(t *testing.T) {

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -170,7 +170,7 @@ func (s *PGStore) DeleteSchema(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	return s.write.SoftDeleteSchema(ctx, pgID)
+	return pgconv.WrapFKViolation(s.write.SoftDeleteSchema(ctx, pgID))
 }
 
 // --- Schema versions ---

--- a/internal/storage/domain/types.go
+++ b/internal/storage/domain/types.go
@@ -15,6 +15,10 @@ var ErrNotFound = errors.New("not found")
 // ErrAlreadyExists is returned when an insert violates a unique constraint.
 var ErrAlreadyExists = errors.New("already exists")
 
+// ErrReferencedByOther is returned when a delete is blocked by a foreign-key
+// constraint (another row still references the target row).
+var ErrReferencedByOther = errors.New("referenced by other resource")
+
 // FieldType represents a schema field's value type.
 type FieldType string
 

--- a/internal/storage/pgconv/convert.go
+++ b/internal/storage/pgconv/convert.go
@@ -100,6 +100,19 @@ func WrapUniqueViolation(err error) error {
 	return err
 }
 
+// WrapFKViolation converts a PostgreSQL foreign-key constraint violation (23503)
+// to domain.ErrReferencedByOther. Returns the original error for all other errors.
+func WrapFKViolation(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+		return domain.ErrReferencedByOther
+	}
+	return err
+}
+
 // FieldTypeToDB converts a domain FieldType to the DB string representation.
 func FieldTypeToDB(ft domain.FieldType) string {
 	return string(ft)

--- a/internal/storage/pgconv/convert_test.go
+++ b/internal/storage/pgconv/convert_test.go
@@ -145,6 +145,27 @@ func TestWrapUniqueViolation(t *testing.T) {
 	})
 }
 
+func TestWrapFKViolation(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, WrapFKViolation(nil))
+	})
+
+	t.Run("23503 foreign_key_violation", func(t *testing.T) {
+		err := WrapFKViolation(&pgconn.PgError{Code: "23503"})
+		assert.ErrorIs(t, err, domain.ErrReferencedByOther)
+	})
+
+	t.Run("other pg error", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "23505"}
+		assert.Equal(t, pgErr, WrapFKViolation(pgErr))
+	})
+
+	t.Run("non-pg error", func(t *testing.T) {
+		other := errors.New("something else")
+		assert.Equal(t, other, WrapFKViolation(other))
+	})
+}
+
 func TestFieldTypeConversions(t *testing.T) {
 	types := []domain.FieldType{
 		domain.FieldTypeInteger, domain.FieldTypeNumber, domain.FieldTypeString,


### PR DESCRIPTION
## Summary

- `DeleteSchema` was returning `codes.Internal` for any `RunInTx` error, including PostgreSQL FK violations (23503), misleading clients into thinking the server was broken when the operation was actually rejectable.
- Adds `domain.ErrReferencedByOther` and `pgconv.WrapFKViolation` (parallel to the existing unique-violation helper) to translate the 23503 error code into a typed domain error.
- Extends `errToStatus` to map `ErrReferencedByOther` → `codes.FailedPrecondition` so clients receive a clear, actionable signal when active config versions block the delete.

## Test plan

- [x] `TestWrapFKViolation` — nil, 23503 maps to `ErrReferencedByOther`, other pg error passes through, non-pg error passes through
- [x] `TestErrToStatus` — `ErrReferencedByOther` (direct and wrapped) maps to `FailedPrecondition`
- [x] `TestDeleteSchema_FKViolation` — service returns `FailedPrecondition` when store returns `ErrReferencedByOther`
- [x] All existing `DeleteSchema` tests pass unchanged
- [x] Full test suite passes (`make test`)
- [x] Linter clean (`make lint`)

Closes #442