### PR TITLE
fix(telemetry): drop tenant_id from default metric labels, add opt-in allowlist

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -182,8 +182,9 @@ All observability flags are opt-in. Set to `true` or `1` to enable.
 | `OTEL_METRICS_GRPC` | gRPC request count, latency histograms, and message sizes (via otelgrpc). |
 | `OTEL_METRICS_DB_POOL` | Database connection pool gauges: total, acquired, idle, and max connections. |
 | `OTEL_METRICS_CACHE` | Cache hit/miss counters for config value reads. |
-| `OTEL_METRICS_CONFIG` | Config write counter and current version gauge per tenant. |
+| `OTEL_METRICS_CONFIG` | Config write counter and current version gauge. By default, no `tenant_id` label is emitted. |
 | `OTEL_METRICS_SCHEMA` | Schema publish counter. |
+| `OTEL_METRICS_TENANT_ALLOWLIST` | Comma-separated list of tenant IDs that receive a `tenant_id` label on config metrics. Empty by default to prevent cardinality explosion. See [Observability](observability.md) for the trade-off. |
 
 ### Standard OTel Variables
 

--- a/docs/server/observability.md
+++ b/docs/server/observability.md
@@ -120,8 +120,26 @@ Monitor your cache hit ratio to tune TTL and capacity.
 
 ### Config Metrics (`OTEL_METRICS_CONFIG`)
 
-- `ccs.config.writes` -- counter of config write operations (by tenant)
-- `ccs.config.version` -- gauge of the current config version (by tenant)
+- `config.writes` -- counter of config write operations (labeled by `action`)
+- `config.versions` -- gauge of the current config version
+
+By default, neither metric carries a `tenant_id` label. In deployments with many short-lived
+tenants, adding `tenant_id` would create unbounded label cardinality and exhaust the
+Prometheus/OTel collector cardinality budget.
+
+To attach `tenant_id` for a known subset of tenants (useful when debugging noisy activity from
+specific tenants), set `OTEL_METRICS_TENANT_ALLOWLIST`:
+
+```bash
+OTEL_METRICS_TENANT_ALLOWLIST=tenant-a,tenant-b
+```
+
+Only the listed tenant IDs receive the `tenant_id` attribute; all other tenants record into the
+unlabeled series. The allowlist is additive — removing a tenant from the list does not delete
+historical labeled series from your backend.
+
+**Trade-off:** without `tenant_id`, you lose per-tenant resolution on write activity. Use the
+allowlist sparingly (e.g. during an incident investigation) and remove entries once you are done.
 
 ### Schema Metrics (`OTEL_METRICS_SCHEMA`)
 

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -1,6 +1,9 @@
 package telemetry
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // Config holds the telemetry feature flags parsed from environment variables.
 type Config struct {
@@ -26,6 +29,10 @@ type Config struct {
 	MetricsRateLimit bool
 	// MetricsValidation enables validation counters (e.g. JSON-Schema compile timeouts).
 	MetricsValidation bool
+	// MetricsTenantAllowlist is the opt-in set of tenant IDs that receive a tenant_id label
+	// on config metrics. Empty (the default) suppresses the label on all tenants to prevent
+	// Prometheus/OTel cardinality explosion in deployments with many tenants.
+	MetricsTenantAllowlist []string
 }
 
 // AnyMetrics returns true if any metric flag is enabled.
@@ -36,21 +43,37 @@ func (c Config) AnyMetrics() bool {
 // ConfigFromEnv parses telemetry configuration from environment variables.
 func ConfigFromEnv() Config {
 	return Config{
-		Enabled:           envBool("OTEL_ENABLED"),
-		TracesGRPC:        envBool("OTEL_TRACES_GRPC"),
-		TracesDB:          envBool("OTEL_TRACES_DB"),
-		TracesRedis:       envBool("OTEL_TRACES_REDIS"),
-		MetricsGRPC:       envBool("OTEL_METRICS_GRPC"),
-		MetricsDBPool:     envBool("OTEL_METRICS_DB_POOL"),
-		MetricsCache:      envBool("OTEL_METRICS_CACHE"),
-		MetricsConfig:     envBool("OTEL_METRICS_CONFIG"),
-		MetricsSchema:     envBool("OTEL_METRICS_SCHEMA"),
-		MetricsRateLimit:  envBool("OTEL_METRICS_RATE_LIMIT"),
-		MetricsValidation: envBool("OTEL_METRICS_VALIDATION"),
+		Enabled:                envBool("OTEL_ENABLED"),
+		TracesGRPC:             envBool("OTEL_TRACES_GRPC"),
+		TracesDB:               envBool("OTEL_TRACES_DB"),
+		TracesRedis:            envBool("OTEL_TRACES_REDIS"),
+		MetricsGRPC:            envBool("OTEL_METRICS_GRPC"),
+		MetricsDBPool:          envBool("OTEL_METRICS_DB_POOL"),
+		MetricsCache:           envBool("OTEL_METRICS_CACHE"),
+		MetricsConfig:          envBool("OTEL_METRICS_CONFIG"),
+		MetricsSchema:          envBool("OTEL_METRICS_SCHEMA"),
+		MetricsRateLimit:       envBool("OTEL_METRICS_RATE_LIMIT"),
+		MetricsValidation:      envBool("OTEL_METRICS_VALIDATION"),
+		MetricsTenantAllowlist: envStringSlice("OTEL_METRICS_TENANT_ALLOWLIST"),
 	}
 }
 
 func envBool(key string) bool {
 	v := os.Getenv(key)
 	return v == "true" || v == "1"
+}
+
+func envStringSlice(key string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -64,3 +64,34 @@ func TestAnyMetrics_OneEnabled(t *testing.T) {
 	assert.True(t, Config{MetricsConfig: true}.AnyMetrics())
 	assert.True(t, Config{MetricsSchema: true}.AnyMetrics())
 }
+
+func TestConfigFromEnv_TenantAllowlist(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		cfg := ConfigFromEnv()
+		assert.Nil(t, cfg.MetricsTenantAllowlist)
+	})
+
+	t.Run("single", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_TENANT_ALLOWLIST", "tenant-a")
+		cfg := ConfigFromEnv()
+		assert.Equal(t, []string{"tenant-a"}, cfg.MetricsTenantAllowlist)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_TENANT_ALLOWLIST", "tenant-a,tenant-b,tenant-c")
+		cfg := ConfigFromEnv()
+		assert.Equal(t, []string{"tenant-a", "tenant-b", "tenant-c"}, cfg.MetricsTenantAllowlist)
+	})
+
+	t.Run("trims_spaces", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_TENANT_ALLOWLIST", " tenant-a , tenant-b ")
+		cfg := ConfigFromEnv()
+		assert.Equal(t, []string{"tenant-a", "tenant-b"}, cfg.MetricsTenantAllowlist)
+	})
+
+	t.Run("skips_empty_entries", func(t *testing.T) {
+		t.Setenv("OTEL_METRICS_TENANT_ALLOWLIST", "tenant-a,,tenant-b")
+		cfg := ConfigFromEnv()
+		assert.Equal(t, []string{"tenant-a", "tenant-b"}, cfg.MetricsTenantAllowlist)
+	})
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -47,8 +47,9 @@ func (m *CacheMetrics) Miss(ctx context.Context) {
 
 // ConfigMetrics records config write counters and version gauge.
 type ConfigMetrics struct {
-	writes   metric.Int64Counter
-	versions metric.Int64Gauge
+	writes          metric.Int64Counter
+	versions        metric.Int64Gauge
+	tenantAllowlist map[string]struct{}
 }
 
 // NewConfigMetrics creates config metrics. Returns nil if not enabled.
@@ -61,26 +62,37 @@ func NewConfigMetrics(cfg Config) *ConfigMetrics {
 		metric.WithDescription("Number of config write operations"))
 	versions, _ := meter.Int64Gauge("config.versions",
 		metric.WithDescription("Current config version number per tenant"))
-	return &ConfigMetrics{writes: writes, versions: versions}
+	allowlist := make(map[string]struct{}, len(cfg.MetricsTenantAllowlist))
+	for _, id := range cfg.MetricsTenantAllowlist {
+		allowlist[id] = struct{}{}
+	}
+	return &ConfigMetrics{writes: writes, versions: versions, tenantAllowlist: allowlist}
 }
 
-// RecordWrite records a config write event.
+// RecordWrite records a config write event. The tenant_id label is only added when the
+// tenant is in the allowlist (OTEL_METRICS_TENANT_ALLOWLIST) to prevent cardinality explosion.
 func (m *ConfigMetrics) RecordWrite(ctx context.Context, tenantID, action string) {
-	if m != nil {
-		m.writes.Add(ctx, 1,
-			metric.WithAttributes(
-				attribute.String("tenant_id", tenantID),
-				attribute.String("action", action),
-			))
+	if m == nil {
+		return
 	}
+	attrs := []attribute.KeyValue{attribute.String("action", action)}
+	if _, ok := m.tenantAllowlist[tenantID]; ok {
+		attrs = append(attrs, attribute.String("tenant_id", tenantID))
+	}
+	m.writes.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
-// RecordVersion records the current config version for a tenant.
+// RecordVersion records the current config version for a tenant. The tenant_id label is
+// only added when the tenant is in the allowlist (OTEL_METRICS_TENANT_ALLOWLIST).
 func (m *ConfigMetrics) RecordVersion(ctx context.Context, tenantID string, version int64) {
-	if m != nil {
-		m.versions.Record(ctx, version,
-			metric.WithAttributes(attribute.String("tenant_id", tenantID)))
+	if m == nil {
+		return
 	}
+	var opts []metric.RecordOption
+	if _, ok := m.tenantAllowlist[tenantID]; ok {
+		opts = append(opts, metric.WithAttributes(attribute.String("tenant_id", tenantID)))
+	}
+	m.versions.Record(ctx, version, opts...)
 }
 
 // SchemaMetrics records schema lifecycle counters.

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -51,6 +51,26 @@ func TestConfigMetrics_RecordWrite_RecordVersion(t *testing.T) {
 	m.RecordVersion(context.Background(), "t1", 5)
 }
 
+func TestConfigMetrics_AllowlistEmptyByDefault(t *testing.T) {
+	// No allowlist — tenant_id label is suppressed; recording must not panic.
+	m := NewConfigMetrics(Config{Enabled: true, MetricsConfig: true})
+	m.RecordWrite(context.Background(), "t1", "set_field")
+	m.RecordVersion(context.Background(), "t1", 5)
+}
+
+func TestConfigMetrics_AllowlistLabelsMatchingTenants(t *testing.T) {
+	// Only tenants in the allowlist receive the label; others must still record without panic.
+	m := NewConfigMetrics(Config{
+		Enabled:                true,
+		MetricsConfig:          true,
+		MetricsTenantAllowlist: []string{"tenant-a"},
+	})
+	m.RecordWrite(context.Background(), "tenant-a", "set_field") // in allowlist
+	m.RecordWrite(context.Background(), "tenant-b", "set_field") // not in allowlist
+	m.RecordVersion(context.Background(), "tenant-a", 3)
+	m.RecordVersion(context.Background(), "tenant-b", 7)
+}
+
 func TestNewSchemaMetrics_Disabled(t *testing.T) {
 	assert.Nil(t, NewSchemaMetrics(Config{}))
 	assert.Nil(t, NewSchemaMetrics(Config{Enabled: true, MetricsSchema: false}))


### PR DESCRIPTION
## Summary

- Removes `tenant_id` from `config.writes` and `config.versions` metric labels by default, preventing Prometheus/OTel cardinality explosion in deployments with many tenants.
- Adds an opt-in `OTEL_METRICS_TENANT_ALLOWLIST` env var (comma-separated tenant IDs) so operators can re-enable per-tenant labeling for specific tenants when debugging.
- Documents the cardinality trade-off in the observability and configuration reference docs.

## Test plan

- [ ] New `TestConfigFromEnv_TenantAllowlist` subtests verify env var parsing (empty, single, multi, spaces, empty entries).
- [ ] `TestConfigMetrics_AllowlistEmptyByDefault` confirms metrics record without panic when no allowlist is set.
- [ ] `TestConfigMetrics_AllowlistLabelsMatchingTenants` confirms allowlisted tenant gets label, non-allowlisted tenant does not panic.
- [ ] Full test suite passes with `-race`.
- [ ] Lint clean (0 issues).

Closes #443