### PR TITLE
fix(audit): bound final flush on shutdown with configurable timeout

### DIFF
--- a/internal/audit/recorder.go
+++ b/internal/audit/recorder.go
@@ -13,15 +13,23 @@ import (
 type Option func(*recorderOptions)
 
 type recorderOptions struct {
-	flushInterval time.Duration
-	logger        *slog.Logger
-	dbErrCounter  metric.Int64Counter
+	flushInterval       time.Duration
+	shutdownTimeout     time.Duration
+	logger              *slog.Logger
+	dbErrCounter        metric.Int64Counter
+	flushTimeoutCounter metric.Int64Counter
 }
 
 // WithFlushInterval sets how often pending stats are flushed to the store.
 // Zero or negative falls back to 30s.
 func WithFlushInterval(d time.Duration) Option {
 	return func(o *recorderOptions) { o.flushInterval = d }
+}
+
+// WithShutdownTimeout sets the deadline for the final flush performed when
+// the recorder's context is cancelled. Zero or negative falls back to 5s.
+func WithShutdownTimeout(d time.Duration) Option {
+	return func(o *recorderOptions) { o.shutdownTimeout = d }
 }
 
 // WithLogger sets the recorder logger. Defaults to slog.Default() when unset.
@@ -33,6 +41,12 @@ func WithLogger(l *slog.Logger) Option {
 // during a usage-stats flush. Nil disables the metric.
 func WithDBErrorCounter(c metric.Int64Counter) Option {
 	return func(o *recorderOptions) { o.dbErrCounter = c }
+}
+
+// WithFlushTimeoutCounter sets the OTel counter incremented when the final
+// shutdown flush exceeds its deadline. Nil disables the metric.
+func WithFlushTimeoutCounter(c metric.Int64Counter) Option {
+	return func(o *recorderOptions) { o.flushTimeoutCounter = c }
 }
 
 // usageKey identifies a unique (tenant, field) pair for batching.
@@ -53,10 +67,12 @@ type usageBucket struct {
 // to the audit store periodically as batched usage statistics.
 // A nil *UsageRecorder is safe to call — all methods are no-ops.
 type UsageRecorder struct {
-	store        Store
-	logger       *slog.Logger
-	interval     time.Duration
-	dbErrCounter metric.Int64Counter // nil when metrics are disabled
+	store               Store
+	logger              *slog.Logger
+	interval            time.Duration
+	shutdownTimeout     time.Duration
+	dbErrCounter        metric.Int64Counter // nil when metrics are disabled
+	flushTimeoutCounter metric.Int64Counter // nil when metrics are disabled
 
 	mu      sync.Mutex
 	pending map[usageKey]*usageBucket
@@ -67,8 +83,9 @@ type UsageRecorder struct {
 // NewUsageRecorder creates a new recorder. Call Start to begin the background flush goroutine.
 func NewUsageRecorder(store Store, opts ...Option) *UsageRecorder {
 	o := recorderOptions{
-		flushInterval: 30 * time.Second,
-		logger:        slog.Default(),
+		flushInterval:   30 * time.Second,
+		shutdownTimeout: 5 * time.Second,
+		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -76,16 +93,21 @@ func NewUsageRecorder(store Store, opts ...Option) *UsageRecorder {
 	if o.flushInterval <= 0 {
 		o.flushInterval = 30 * time.Second
 	}
+	if o.shutdownTimeout <= 0 {
+		o.shutdownTimeout = 5 * time.Second
+	}
 	if o.logger == nil {
 		o.logger = slog.Default()
 	}
 	return &UsageRecorder{
-		store:        store,
-		logger:       o.logger,
-		interval:     o.flushInterval,
-		dbErrCounter: o.dbErrCounter,
-		pending:      make(map[usageKey]*usageBucket),
-		done:         make(chan struct{}),
+		store:               store,
+		logger:              o.logger,
+		interval:            o.flushInterval,
+		shutdownTimeout:     o.shutdownTimeout,
+		dbErrCounter:        o.dbErrCounter,
+		flushTimeoutCounter: o.flushTimeoutCounter,
+		pending:             make(map[usageKey]*usageBucket),
+		done:                make(chan struct{}),
 	}
 }
 
@@ -132,8 +154,11 @@ func (r *UsageRecorder) RecordReads(tenantID string, fieldPaths []string, actor 
 	r.mu.Unlock()
 }
 
-// Start runs the background flush loop. Blocks until ctx is cancelled,
-// then performs a final flush before returning.
+// Start runs the background flush loop. Blocks until ctx is cancelled, then
+// performs a final flush bounded by the shutdown timeout (default 5s) before
+// returning. If the flush exceeds the deadline, Start logs a warning, increments
+// the flush-timeout counter (if configured), and returns without blocking further.
+// GracefulStop callers must account for up to shutdownTimeout of additional delay.
 func (r *UsageRecorder) Start(ctx context.Context) {
 	if r == nil {
 		return
@@ -148,9 +173,17 @@ func (r *UsageRecorder) Start(ctx context.Context) {
 				r.logger.WarnContext(ctx, "usage stats flush failed", "error", err)
 			}
 		case <-ctx.Done():
-			// Final flush with a fresh context so it isn't cancelled.
-			if err := r.Flush(context.Background()); err != nil {
-				r.logger.Warn("usage stats final flush failed", "error", err)
+			flushCtx, cancel := context.WithTimeout(context.Background(), r.shutdownTimeout)
+			defer cancel()
+			if err := r.Flush(flushCtx); err != nil {
+				if flushCtx.Err() != nil {
+					r.logger.Warn("usage stats final flush timed out", "timeout", r.shutdownTimeout)
+					if r.flushTimeoutCounter != nil {
+						r.flushTimeoutCounter.Add(context.Background(), 1)
+					}
+				} else {
+					r.logger.Warn("usage stats final flush failed", "error", err)
+				}
 			}
 			close(r.done)
 			return

--- a/internal/audit/recorder_test.go
+++ b/internal/audit/recorder_test.go
@@ -314,3 +314,70 @@ func TestFlush_DBErrorCounter(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, int64(2), counter.n.Load(), "one increment per failing DB write")
 }
+
+// blockingStore blocks UpsertUsageStats until its gate is closed.
+type blockingStore struct {
+	*MemoryStore
+	gate chan struct{} // close to unblock
+}
+
+func newBlockingStore() *blockingStore {
+	return &blockingStore{MemoryStore: NewMemoryStore(), gate: make(chan struct{})}
+}
+
+func (s *blockingStore) UpsertUsageStats(ctx context.Context, p UpsertUsageStatsParams) error {
+	select {
+	case <-s.gate:
+		return s.MemoryStore.UpsertUsageStats(ctx, p)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestStop_FinalFlush_Timeout(t *testing.T) {
+	store := newBlockingStore() // gate never closed → always blocks
+	r := NewUsageRecorder(store,
+		WithFlushInterval(time.Hour),
+		WithShutdownTimeout(50*time.Millisecond),
+		WithLogger(testRecorderLogger),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.Start(ctx)
+
+	r.RecordRead("t1", "app.fee", nil)
+
+	cancel()
+
+	done := make(chan struct{})
+	go func() { r.Stop(); close(done) }()
+
+	select {
+	case <-done:
+		// Stop returned within a reasonable margin of the shutdown timeout.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop blocked indefinitely despite shutdown timeout")
+	}
+}
+
+func TestStop_FinalFlush_TimeoutCounter(t *testing.T) {
+	store := newBlockingStore() // gate never closed → always blocks
+	counter := &countingCounter{}
+
+	r := NewUsageRecorder(store,
+		WithFlushInterval(time.Hour),
+		WithShutdownTimeout(50*time.Millisecond),
+		WithLogger(testRecorderLogger),
+		WithFlushTimeoutCounter(counter),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go r.Start(ctx)
+
+	r.RecordRead("t1", "app.fee", nil)
+
+	cancel()
+	r.Stop()
+
+	assert.Equal(t, int64(1), counter.n.Load(), "timeout counter incremented once on flush deadline exceeded")
+}


### PR DESCRIPTION
## Summary

- The audit recorder's final flush on shutdown used `context.Background()`, allowing a hung DB to block `GracefulStop` indefinitely.
- This adds a configurable shutdown deadline (default 5s) so the server can always complete its graceful stop within a bounded time.
- A new `WithFlushTimeoutCounter` OTel option lets operators observe flush timeouts as a metric.

## Test plan

- `TestStop_FinalFlush_Timeout` — verifies that `Stop` returns within the shutdown timeout when the DB blocks indefinitely.
- `TestStop_FinalFlush_TimeoutCounter` — verifies the timeout counter is incremented exactly once when the deadline is exceeded.
- All existing recorder tests pass unchanged.

Closes #444