### PR TITLE
fix(gateway): close upstream gRPC connection on Shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529

--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -22,6 +22,7 @@ import (
 // It is optional — only started when httpPort is non-empty.
 type Gateway struct {
 	httpServer *http.Server
+	conn       *grpc.ClientConn
 	logger     *slog.Logger
 }
 
@@ -145,6 +146,7 @@ func NewGateway(ctx context.Context, httpPort, grpcAddr string, opts ...GatewayO
 
 	return &Gateway{
 		httpServer: httpServer,
+		conn:       conn,
 		logger:     o.logger,
 	}, nil
 }
@@ -163,6 +165,7 @@ func (g *Gateway) Serve(ctx context.Context) error {
 func (g *Gateway) Shutdown(ctx context.Context) {
 	g.logger.InfoContext(ctx, "shutting down HTTP gateway")
 	_ = g.httpServer.Shutdown(ctx)
+	_ = g.conn.Close()
 }
 
 // forwardAuthHeaders extracts auth-related HTTP headers and forwards them as

--- a/internal/server/gateway_test.go
+++ b/internal/server/gateway_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -55,6 +56,20 @@ func TestGateway_ServeAndShutdown(t *testing.T) {
 	// Shutdown should return cleanly.
 	gw.Shutdown(context.Background())
 	assert.NoError(t, <-errCh)
+}
+
+func TestGateway_ShutdownClosesGRPCConn(t *testing.T) {
+	// Snapshot goroutines before creating the gateway so that any leaked by
+	// other tests in the suite do not cause a false failure here.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	gw, err := NewGateway(context.Background(), "0", "localhost:9090",
+		WithGatewayLogger(slog.Default()),
+		WithGatewayInsecure(),
+	)
+	require.NoError(t, err)
+
+	gw.Shutdown(context.Background())
 }
 
 func TestForwardAuthHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- The gRPC client connection created in `NewGateway` was never closed, leaking its goroutines across server restarts and in tests that recreate gateways.
- Storing `conn` on the `Gateway` struct and closing it in `Shutdown` fixes the leak.

## Test plan

- [x] Added `TestGateway_ShutdownClosesGRPCConn` using `goleak` to assert no goroutine leak after `Shutdown`
- [x] Full test suite passes with `-race` flag
- [x] `goleak.IgnoreCurrent()` used to isolate the test from pre-existing goroutines in the suite

Closes #445