### PR TITLE
fix(configwatcher): default logger to discard instead of slog.Default()

### DIFF
--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -27,6 +27,7 @@ package configwatcher
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"sync"
 	"time"
@@ -70,7 +71,7 @@ func New(transport configclient.Transport, tenantID string, opts ...Option) *Wat
 		minBackoff:      500 * time.Millisecond,
 		maxBackoff:      30 * time.Second,
 		snapshotTimeout: 10 * time.Second,
-		logger:          slog.Default(),
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 	for _, opt := range opts {
 		opt(&o)
@@ -97,7 +98,8 @@ func WithReconnectBackoff(min, max time.Duration) Option {
 	}
 }
 
-// WithLogger sets a custom logger. Defaults to slog.Default().
+// WithLogger sets a custom logger. By default all log output is discarded.
+// Pass an explicit logger to opt into watcher diagnostics.
 func WithLogger(logger *slog.Logger) Option {
 	return func(o *options) { o.logger = logger }
 }


### PR DESCRIPTION
## Summary
- Closes #485
- Change configwatcher default logger from `slog.Default()` to a discard logger (`slog.New(slog.NewTextHandler(io.Discard, nil))`)
- Prevents log pollution in user applications that don't opt into watcher logging
- Users enable logging via the `WithLogger` option

## Test plan
- [ ] Default configwatcher emits no log output
- [ ] `WithLogger` option still works
- [ ] Existing tests pass (`make test` green)