### PR TITLE
fix(configwatcher): eliminate Close/channel-send race to prevent panic

### DIFF
--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -142,3 +142,123 @@ func TestWatcher_ConcurrentStartAndClose(t *testing.T) {
 	cancel()
 	_ = w.Close()
 }
+
+// TestValue_CloseRacesWithUpdate exercises the race between Value.close() and
+// Value.update() that previously caused a "send on closed channel" panic.
+// Run with: go test -race ./sdk/configwatcher/
+func TestValue_CloseRacesWithUpdate(t *testing.T) {
+	const iterations = 1000
+
+	for range iterations {
+		v := newValue(int64(0), parseInt)
+
+		// ready gates both goroutines to start at the same instant.
+		ready := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine 1: hammer update.
+		go func() {
+			defer wg.Done()
+			<-ready
+			for i := range 50 {
+				v.update(fmt.Sprintf("%d", i), true)
+			}
+		}()
+
+		// Goroutine 2: close immediately after the gate opens.
+		go func() {
+			defer wg.Done()
+			<-ready
+			v.close()
+		}()
+
+		close(ready)
+		wg.Wait()
+	}
+}
+
+// TestWatcher_CloseWhileStreamSends verifies that Close does not panic when
+// the subscription stream delivers updates concurrently with shutdown.
+func TestWatcher_CloseWhileStreamSends(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// subCh is written to by the test to simulate incoming stream events.
+	subCh := make(chan *configclient.ConfigChange, 64)
+	sub := &mockSubscription{ch: subCh, ctx: ctx}
+
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+		},
+		subscribeFn: func(sCtx context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	w := &Watcher{
+		transport: tr,
+		tenantID:  "t1",
+		opts: options{
+			minBackoff: 5 * time.Millisecond,
+			maxBackoff: 10 * time.Millisecond,
+			logger:     slog.Default(),
+		},
+		fields: make(map[string]*fieldEntry),
+		done:   make(chan struct{}),
+	}
+
+	val := w.String("key", "default")
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Drain Changes so the buffer doesn't fill.
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		for range val.Changes() {
+		}
+	}()
+
+	// Flood the stream with changes while concurrently closing.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range 200 {
+			select {
+			case subCh <- &configclient.ConfigChange{
+				TenantID:  "t1",
+				FieldPath: "key",
+				NewValue:  configclient.StringVal(fmt.Sprintf("v%d", i)),
+			}:
+			default:
+			}
+		}
+	}()
+
+	// Close shortly after starting the flood.
+	time.Sleep(2 * time.Millisecond)
+	cancel()
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	wg.Wait()
+
+	// Changes channel must be closed after Close returns.
+	select {
+	case _, ok := <-val.Changes():
+		if ok {
+			t.Error("expected Changes channel to be closed")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Changes channel was not closed after Close()")
+	}
+
+	<-drainDone
+}

--- a/sdk/configwatcher/value.go
+++ b/sdk/configwatcher/value.go
@@ -23,6 +23,7 @@ type Value[T any] struct {
 	mu         sync.RWMutex
 	current    T
 	isSet      bool
+	closed     bool // true after close(); guarded by mu
 	defaultVal T
 	parse      func(string) (T, error)
 	changesCh  chan Change[T]
@@ -87,14 +88,21 @@ func (v *Value[T]) update(rawValue string, isSet bool) {
 		}
 	}
 
-	// Send change notification (non-blocking).
-	select {
-	case v.changesCh <- Change[T]{
+	// Do not send on a closed channel.
+	if v.closed {
+		return
+	}
+
+	ch := Change[T]{
 		Old:     oldVal,
 		New:     v.current,
 		WasNull: wasNull,
 		IsNull:  !v.isSet,
-	}:
+	}
+
+	// Send change notification (non-blocking).
+	select {
+	case v.changesCh <- ch:
 	default:
 		// Channel full — drop oldest, send new.
 		select {
@@ -102,18 +110,20 @@ func (v *Value[T]) update(rawValue string, isSet bool) {
 		default:
 		}
 		select {
-		case v.changesCh <- Change[T]{
-			Old:     oldVal,
-			New:     v.current,
-			WasNull: wasNull,
-			IsNull:  !v.isSet,
-		}:
+		case v.changesCh <- ch:
 		default:
 		}
 	}
 }
 
-// close closes the changes channel.
+// close marks the value as closed and closes the changes channel.
+// It is safe to call concurrently with update.
 func (v *Value[T]) close() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.closed {
+		return
+	}
+	v.closed = true
 	close(v.changesCh)
 }


### PR DESCRIPTION
## Summary

- Closes #486
- Fix race condition between `configwatcher.Close()` and goroutines sending on internal `Value.changesCh` channels
- Prevents panic: send on closed channel under concurrent use

### Root cause

`Value.close()` called `close(changesCh)` without holding `v.mu`, while `Value.update()` held `v.mu.Lock()` during its channel send. A concurrent `close()` could therefore close the channel while `update()` was mid-select, triggering a "send on closed channel" panic.

### Fix

- Added `closed bool` field to `Value[T]`, guarded by `v.mu`
- `Value.close()` now acquires `v.mu.Lock()` before setting `closed = true` and closing the channel — makes close atomic with respect to update
- `Value.update()` checks `v.closed` before sending (still under `v.mu.Lock()`), returning early if the value is already closed

## Test plan

- [x] `TestValue_CloseRacesWithUpdate` — tight loop racing `close()` vs `update()` 1000 times; passes `-race`
- [x] `TestWatcher_CloseWhileStreamSends` — full watcher with a stream flooding changes while `Close()` is called; passes `-race`
- [x] All existing tests pass (`make test` with `-race`)