### PR TITLE
fix(configwatcher): enable gRPC keepalive on dial

### DIFF
--- a/sdk/grpctransport/dial.go
+++ b/sdk/grpctransport/dial.go
@@ -3,18 +3,39 @@ package grpctransport
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
+
+// defaultKeepalive is applied to every Dial call unless overridden via
+// [WithKeepalive]. These values prevent silent connection drops on long-lived
+// watch streams behind NAT/firewalls:
+//   - Time=30s: send a keepalive ping after 30s of inactivity.
+//   - Timeout=10s: treat the connection as dead if no ACK arrives within 10s.
+//   - PermitWithoutStream=true: send pings even when no RPCs are in flight
+//     (critical for configwatcher, which holds an idle subscription stream).
+var defaultKeepalive = keepalive.ClientParameters{
+	Time:                30 * time.Second,
+	Timeout:             10 * time.Second,
+	PermitWithoutStream: true,
+}
+
+// DefaultKeepalive returns the keepalive parameters applied by [Dial] when
+// [WithKeepalive] is not provided. Callers can use this to inspect or modify
+// the defaults before passing them to [WithKeepalive].
+func DefaultKeepalive() keepalive.ClientParameters { return defaultKeepalive }
 
 // DialOption configures [Dial].
 type DialOption func(*dialConfig)
 
 type dialConfig struct {
-	insecure bool
-	customCA *x509.CertPool
+	insecure  bool
+	customCA  *x509.CertPool
+	keepalive keepalive.ClientParameters
 }
 
 // WithCustomCA configures TLS with the provided certificate pool instead of system roots.
@@ -28,7 +49,21 @@ func WithInsecure() DialOption {
 	return func(c *dialConfig) { c.insecure = true }
 }
 
+// WithKeepalive overrides the default keepalive parameters applied by [Dial].
+//
+// The defaults (Time=30s, Timeout=10s, PermitWithoutStream=true) are chosen
+// for long-lived watch streams. Override only when you have specific network
+// requirements — for example, a low-latency private network that tolerates
+// longer ping intervals.
+func WithKeepalive(params keepalive.ClientParameters) DialOption {
+	return func(c *dialConfig) { c.keepalive = params }
+}
+
 // Dial opens a gRPC connection to target with TLS and system roots by default.
+//
+// Keepalive is enabled by default (Time=30s, Timeout=10s,
+// PermitWithoutStream=true) to prevent silent connection drops on long-lived
+// watch streams. Override with [WithKeepalive].
 //
 // For production use, omit options to get TLS with system certificate roots:
 //
@@ -42,7 +77,7 @@ func WithInsecure() DialOption {
 //
 //	conn, err := grpctransport.Dial("internal:9090", grpctransport.WithCustomCA(pool))
 func Dial(target string, opts ...DialOption) (*grpc.ClientConn, error) {
-	var cfg dialConfig
+	cfg := dialConfig{keepalive: defaultKeepalive}
 	for _, o := range opts {
 		o(&cfg)
 	}
@@ -57,5 +92,8 @@ func Dial(target string, opts ...DialOption) (*grpc.ClientConn, error) {
 		creds = credentials.NewTLS(&tls.Config{})
 	}
 
-	return grpc.NewClient(target, grpc.WithTransportCredentials(creds))
+	return grpc.NewClient(target,
+		grpc.WithTransportCredentials(creds),
+		grpc.WithKeepaliveParams(cfg.keepalive),
+	)
 }

--- a/sdk/grpctransport/dial_test.go
+++ b/sdk/grpctransport/dial_test.go
@@ -3,6 +3,9 @@ package grpctransport_test
 import (
 	"crypto/x509"
 	"testing"
+	"time"
+
+	"google.golang.org/grpc/keepalive"
 
 	"github.com/opendecree/decree/sdk/grpctransport"
 )
@@ -30,4 +33,49 @@ func TestDial_WithCustomCA(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	conn.Close()
+}
+
+// TestDial_DefaultKeepalive verifies that Dial succeeds with the default
+// keepalive parameters applied (Time=30s, Timeout=10s, PermitWithoutStream=true).
+// grpc.NewClient does not expose the negotiated params directly, so we verify
+// that the option is accepted without error (i.e. no panic or validation failure).
+func TestDial_DefaultKeepalive(t *testing.T) {
+	conn, err := grpctransport.Dial("passthrough:///localhost:9999", grpctransport.WithInsecure())
+	if err != nil {
+		t.Fatalf("Dial with default keepalive failed: %v", err)
+	}
+	conn.Close()
+}
+
+// TestDial_WithKeepalive verifies that WithKeepalive overrides the defaults
+// without error.
+func TestDial_WithKeepalive(t *testing.T) {
+	custom := keepalive.ClientParameters{
+		Time:                60 * time.Second,
+		Timeout:             5 * time.Second,
+		PermitWithoutStream: false,
+	}
+	conn, err := grpctransport.Dial("passthrough:///localhost:9999",
+		grpctransport.WithInsecure(),
+		grpctransport.WithKeepalive(custom),
+	)
+	if err != nil {
+		t.Fatalf("Dial with custom keepalive failed: %v", err)
+	}
+	conn.Close()
+}
+
+// TestDefaultKeepaliveParams verifies the exported default values match the
+// documented constants so a future refactor cannot silently change them.
+func TestDefaultKeepaliveParams(t *testing.T) {
+	params := grpctransport.DefaultKeepalive()
+	if got := params.Time; got != 30*time.Second {
+		t.Errorf("Time: got %v, want 30s", got)
+	}
+	if got := params.Timeout; got != 10*time.Second {
+		t.Errorf("Timeout: got %v, want 10s", got)
+	}
+	if !params.PermitWithoutStream {
+		t.Error("PermitWithoutStream: got false, want true")
+	}
 }


### PR DESCRIPTION
## Summary
- Closes #487
- Add keepalive.ClientParameters to configwatcher gRPC dial (30s ping interval, 10s timeout, PermitWithoutStream=true)
- Prevents silent connection drops on long-lived watch streams behind NAT/firewalls
- Optional WithKeepalive() override for custom parameters

## Test plan
- [ ] Dial options include keepalive parameters
- [ ] WithKeepalive() override works
- [ ] Existing tests pass