### PR TITLE
fix(sdk): separate ErrPermissionDenied from ErrLocked sentinel

### DIFF
--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -92,27 +92,17 @@ func scopedClients(t *testing.T, conn *grpc.ClientConn, role roleName, tenantIDs
 // only about whether the auth gate fired, not whether the request was
 // otherwise valid.
 //
-// It also treats configclient.ErrLocked as an auth denial. The
-// configclient SDK collapses every codes.PermissionDenied response into
-// ErrLocked (see sdk/grpctransport/errors.go:mapConfigError), losing the
-// distinction between a field-lock denial and a tenant-access denial at
-// the SDK layer. Callers must therefore guarantee that no field locks
-// exist on the target field at the time of the call. Both matrices that
-// invoke this helper meet that precondition structurally:
-//
-//   - matrix 1 (TestRoleActionMatrix) operates on a fresh fixture from
-//     bootstrapMatrixFixture, which never installs locks.
-//   - matrix 2 (TestTenantAccessMatrix) builds a brand-new fixture per
-//     subtest, so cells cannot leak lock state to one another.
-//
-// If a future cell installs a lock before invoking a write RPC through
-// the configclient SDK, ErrLocked stops being a reliable auth signal and
-// the cell must be reworked to call the proto client directly.
+// It also treats configclient.ErrPermissionDenied as an auth denial.
+// The configclient SDK maps codes.PermissionDenied to ErrPermissionDenied
+// (role / tenant-access denial) and codes.FailedPrecondition to ErrLocked
+// (field-lock denial). Both matrices that invoke this helper guarantee no
+// active field locks on the target fields, so ErrPermissionDenied here
+// always means a genuine auth gate fired.
 func isAuthDenied(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, configclient.ErrLocked) {
+	if errors.Is(err, configclient.ErrPermissionDenied) {
 		return true
 	}
 	st, ok := status.FromError(err)

--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -37,10 +37,9 @@ type writeRPCSpec struct {
 func writeRPCs() []writeRPCSpec {
 	return []writeRPCSpec{
 		// Note: SetField / SetFields go through the configclient SDK
-		// which maps codes.PermissionDenied to ErrLocked. isAuthDenied
-		// recognizes that mapping (matrix 2 setup guarantees no real
-		// field locks, so ErrLocked here is always a tenant-access
-		// denial in disguise).
+		// which maps codes.PermissionDenied to ErrPermissionDenied.
+		// isAuthDenied recognizes that sentinel; matrix 2 setup
+		// guarantees no active field locks on the target fields.
 		{
 			name: "SetField",
 			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {

--- a/internal/authz/fieldlock.go
+++ b/internal/authz/fieldlock.go
@@ -55,7 +55,7 @@ func (g FieldLockGuard) Check(ctx context.Context, action Action, r Resource) er
 	}
 	for _, lock := range locks {
 		if lock.FieldPath == r.FieldPath {
-			return status.Errorf(codes.PermissionDenied, "field %s is locked", r.FieldPath)
+			return status.Errorf(codes.FailedPrecondition, "field %s is locked", r.FieldPath)
 		}
 	}
 	return nil

--- a/internal/authz/guard_test.go
+++ b/internal/authz/guard_test.go
@@ -162,7 +162,9 @@ func TestFieldLockGuard_LockedField(t *testing.T) {
 	})
 	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b"})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	// Field locks use FailedPrecondition (a precondition on the resource state),
+	// distinct from PermissionDenied (role/tenant access denial).
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
 func TestFieldLockGuard_StoreError(t *testing.T) {
@@ -188,7 +190,9 @@ func TestFieldLockGuard_ContextCacheHit_LockedField(t *testing.T) {
 	})
 	err := g.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b"})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	// Field locks use FailedPrecondition (a precondition on the resource state),
+	// distinct from PermissionDenied (role/tenant access denial).
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
 // --- ChainGuard ---

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -187,6 +187,25 @@ func TestSet_Locked(t *testing.T) {
 	if !errors.Is(err, ErrLocked) {
 		t.Errorf("got error %v, want %v", err, ErrLocked)
 	}
+	if errors.Is(err, ErrPermissionDenied) {
+		t.Error("ErrLocked must not match ErrPermissionDenied")
+	}
+}
+
+func TestSet_PermissionDenied(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetField", nil, (*SetFieldResponse)(nil), ErrPermissionDenied)
+
+	err := client.Set(ctx, "t1", "a", "new")
+	if !errors.Is(err, ErrPermissionDenied) {
+		t.Errorf("got error %v, want ErrPermissionDenied", err)
+	}
+	if errors.Is(err, ErrLocked) {
+		t.Error("ErrPermissionDenied must not match ErrLocked")
+	}
 }
 
 // --- SetMany ---

--- a/sdk/configclient/errors.go
+++ b/sdk/configclient/errors.go
@@ -14,8 +14,15 @@ var (
 	// ErrNotFound is returned when a requested field or version does not exist.
 	ErrNotFound = errors.New("not found")
 
-	// ErrLocked is returned when attempting to write a field that is locked.
+	// ErrLocked is returned when attempting to write a field that is
+	// administratively locked (FieldLock). Use errors.Is to distinguish
+	// this from ErrPermissionDenied.
 	ErrLocked = errors.New("field is locked")
+
+	// ErrPermissionDenied is returned when the caller lacks the required
+	// role or tenant access to perform the operation. This is distinct from
+	// ErrLocked, which indicates an administratively locked field.
+	ErrPermissionDenied = errors.New("permission denied")
 
 	// ErrChecksumMismatch is returned when an optimistic concurrency check fails
 	// because the value was modified between read and write.

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -7,7 +7,7 @@ import (
 
 // Set writes a single configuration value as a string.
 // Creates a new config version atomically.
-// Returns [ErrLocked] if the field is locked.
+// Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string) error {
 	return retryDo(ctx, c, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
@@ -21,7 +21,7 @@ func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string) err
 
 // SetTyped writes a single typed configuration value.
 // Creates a new config version atomically.
-// Returns [ErrLocked] if the field is locked.
+// Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue) error {
 	return retryDo(ctx, c, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
@@ -35,7 +35,7 @@ func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value
 
 // SetNull sets a configuration field to null.
 // Creates a new config version atomically.
-// Returns [ErrLocked] if the field is locked.
+// Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string) error {
 	return retryDo(ctx, c, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
@@ -48,7 +48,7 @@ func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string) error 
 
 // SetMany writes multiple configuration values atomically in a single version.
 // The description is optional — pass an empty string to omit it.
-// Returns [ErrLocked] if any of the fields are locked.
+// Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string) error {
 	return retryDo(ctx, c, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))
@@ -70,7 +70,7 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 
 // SetManyTyped writes multiple typed configuration values atomically in a single
 // version. The description is optional — pass an empty string to omit it.
-// Returns [ErrLocked] if any of the fields are locked.
+// Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string) error {
 	return retryDo(ctx, c, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -21,6 +21,8 @@ func mapConfigError(err error) error {
 	case codes.NotFound:
 		return configclient.ErrNotFound
 	case codes.PermissionDenied:
+		return configclient.ErrPermissionDenied
+	case codes.FailedPrecondition:
 		return configclient.ErrLocked
 	case codes.Aborted:
 		return configclient.ErrChecksumMismatch

--- a/sdk/grpctransport/errors_test.go
+++ b/sdk/grpctransport/errors_test.go
@@ -1,0 +1,76 @@
+package grpctransport
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+// --- mapConfigError ---
+
+func TestMapConfigError_PermissionDenied_ReturnsErrPermissionDenied(t *testing.T) {
+	err := mapConfigError(status.Error(codes.PermissionDenied, "no access to tenant acme"))
+	if !errors.Is(err, configclient.ErrPermissionDenied) {
+		t.Errorf("got %v, want ErrPermissionDenied", err)
+	}
+	if errors.Is(err, configclient.ErrLocked) {
+		t.Error("PermissionDenied must NOT map to ErrLocked")
+	}
+}
+
+func TestMapConfigError_FailedPrecondition_ReturnsErrLocked(t *testing.T) {
+	err := mapConfigError(status.Error(codes.FailedPrecondition, "field app.name is locked"))
+	if !errors.Is(err, configclient.ErrLocked) {
+		t.Errorf("got %v, want ErrLocked", err)
+	}
+	if errors.Is(err, configclient.ErrPermissionDenied) {
+		t.Error("FailedPrecondition must NOT map to ErrPermissionDenied")
+	}
+}
+
+func TestMapConfigError_NotFound(t *testing.T) {
+	err := mapConfigError(status.Error(codes.NotFound, "field not found"))
+	if !errors.Is(err, configclient.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestMapConfigError_Aborted_ReturnsErrChecksumMismatch(t *testing.T) {
+	err := mapConfigError(status.Error(codes.Aborted, "checksum mismatch"))
+	if !errors.Is(err, configclient.ErrChecksumMismatch) {
+		t.Errorf("got %v, want ErrChecksumMismatch", err)
+	}
+}
+
+func TestMapConfigError_Nil(t *testing.T) {
+	if err := mapConfigError(nil); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+// --- mapAdminError ---
+
+func TestMapAdminError_FailedPrecondition(t *testing.T) {
+	err := mapAdminError(status.Error(codes.FailedPrecondition, "schema not published"))
+	if !errors.Is(err, adminclient.ErrFailedPrecondition) {
+		t.Errorf("got %v, want ErrFailedPrecondition", err)
+	}
+}
+
+func TestMapAdminError_NotFound(t *testing.T) {
+	err := mapAdminError(status.Error(codes.NotFound, "tenant not found"))
+	if !errors.Is(err, adminclient.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestMapAdminError_Nil(t *testing.T) {
+	if err := mapAdminError(nil); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Closes #489
- Introduce ErrPermissionDenied sentinel distinct from ErrLocked
- PermissionDenied gRPC status maps to ErrPermissionDenied; field-lock responses map to ErrLocked
- Callers can now distinguish between insufficient permissions and locked fields

## Test plan
- [ ] errors.Is(err, ErrLocked) true only for field-lock responses
- [ ] errors.Is(err, ErrPermissionDenied) true for permission denied responses
- [ ] Existing SDK tests updated and passing