### PR TITLE
fix(sdk/adminclient): add RetryableError mapping and WithRetry option

### DIFF
--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -43,27 +43,29 @@ func (c *Client) QueryWriteLog(ctx context.Context, filters ...AuditFilter) ([]*
 	if c.audit == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	var all []*AuditEntry
-	pageToken := ""
-	for {
-		req := &QueryWriteLogRequest{
-			PageSize:  100,
-			PageToken: pageToken,
+	return retry(ctx, c, func(ctx context.Context) ([]*AuditEntry, error) {
+		var all []*AuditEntry
+		pageToken := ""
+		for {
+			req := &QueryWriteLogRequest{
+				PageSize:  100,
+				PageToken: pageToken,
+			}
+			for _, f := range filters {
+				f(req)
+			}
+			resp, err := c.audit.QueryWriteLog(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, resp.Entries...)
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
 		}
-		for _, f := range filters {
-			f(req)
-		}
-		resp, err := c.audit.QueryWriteLog(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-		all = append(all, resp.Entries...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	return all, nil
+		return all, nil
+	})
 }
 
 // GetFieldUsage returns aggregated read statistics for a specific field.
@@ -72,7 +74,9 @@ func (c *Client) GetFieldUsage(ctx context.Context, tenantID, fieldPath string, 
 	if c.audit == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.audit.GetFieldUsage(ctx, tenantID, fieldPath, start, end)
+	return retry(ctx, c, func(ctx context.Context) (*UsageStats, error) {
+		return c.audit.GetFieldUsage(ctx, tenantID, fieldPath, start, end)
+	})
 }
 
 // GetTenantUsage returns aggregated read statistics for all fields of a tenant.
@@ -81,7 +85,9 @@ func (c *Client) GetTenantUsage(ctx context.Context, tenantID string, start, end
 	if c.audit == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.audit.GetTenantUsage(ctx, tenantID, start, end)
+	return retry(ctx, c, func(ctx context.Context) ([]*UsageStats, error) {
+		return c.audit.GetTenantUsage(ctx, tenantID, start, end)
+	})
 }
 
 // GetUnusedFields returns field paths that have not been read since the given time.
@@ -90,7 +96,9 @@ func (c *Client) GetUnusedFields(ctx context.Context, tenantID string, since tim
 	if c.audit == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.audit.GetUnusedFields(ctx, tenantID, since)
+	return retry(ctx, c, func(ctx context.Context) ([]string, error) {
+		return c.audit.GetUnusedFields(ctx, tenantID, since)
+	})
 }
 
 // VerifyChain fetches all audit entries for tenantID (oldest-first) and

--- a/sdk/adminclient/client.go
+++ b/sdk/adminclient/client.go
@@ -14,6 +14,7 @@ type Client struct {
 	config ConfigTransport
 	audit  AuditTransport
 	server ServerTransport
+	opts   clientOptions
 }
 
 // New creates a new admin client. Pass [WithSchemaTransport],
@@ -38,5 +39,5 @@ func New(opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return &Client{schema: o.schema, config: o.config, audit: o.audit, server: o.server}
+	return &Client{schema: o.schema, config: o.config, audit: o.audit, server: o.server, opts: o}
 }

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -10,20 +10,22 @@ func (c *Client) ListConfigVersions(ctx context.Context, tenantID string) ([]*Ve
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	var all []*Version
-	pageToken := ""
-	for {
-		resp, err := c.config.ListVersions(ctx, tenantID, 100, pageToken)
-		if err != nil {
-			return nil, err
+	return retry(ctx, c, func(ctx context.Context) ([]*Version, error) {
+		var all []*Version
+		pageToken := ""
+		for {
+			resp, err := c.config.ListVersions(ctx, tenantID, 100, pageToken)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, resp.Versions...)
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
 		}
-		all = append(all, resp.Versions...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	return all, nil
+		return all, nil
+	})
 }
 
 // GetConfigVersion retrieves metadata for a specific config version.
@@ -31,7 +33,9 @@ func (c *Client) GetConfigVersion(ctx context.Context, tenantID string, version 
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.config.GetVersion(ctx, tenantID, version)
+	return retry(ctx, c, func(ctx context.Context) (*Version, error) {
+		return c.config.GetVersion(ctx, tenantID, version)
+	})
 }
 
 // RollbackConfig creates a new config version with the values from a previous version.
@@ -49,7 +53,9 @@ func (c *Client) ExportConfig(ctx context.Context, tenantID string, version *int
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.config.ExportConfig(ctx, tenantID, version)
+	return retry(ctx, c, func(ctx context.Context) ([]byte, error) {
+		return c.config.ExportConfig(ctx, tenantID, version)
+	})
 }
 
 // ImportMode controls how imported values interact with existing config.

--- a/sdk/adminclient/coverage_test.go
+++ b/sdk/adminclient/coverage_test.go
@@ -1,0 +1,225 @@
+package adminclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestRetryDo_NilRetry covers retryDo when retry is disabled (default client).
+func TestRetryDo_NilRetry(t *testing.T) {
+	called := false
+	c := &Client{}
+	err := retryDo(context.Background(), c, func(_ context.Context) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected fn to be called")
+	}
+}
+
+// TestRetryDo_WithRetry covers retryDo when retry is enabled and fn returns error.
+func TestRetryDo_WithRetry(t *testing.T) {
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+	err := retryDo(context.Background(), c, func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return &RetryableError{Err: fmt.Errorf("unavailable")}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+// TestRetryDo_PropagatesError covers retryDo returning an error after exhausting attempts.
+func TestRetryDo_PropagatesError(t *testing.T) {
+	sentinel := fmt.Errorf("always fails")
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    2,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+	err := retryDo(context.Background(), c, func(_ context.Context) error {
+		return &RetryableError{Err: sentinel}
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("got error %v, want wrapping %v", err, sentinel)
+	}
+}
+
+// TestRetry_ContextAlreadyCancelledBeforeBackoff covers the ctx.Err() != nil fast-path
+// before the select in the retry loop (line 69-71 in retry.go). A pre-cancelled context
+// with a long backoff ensures we hit the if-check rather than the select's ctx.Done() arm.
+func TestRetry_ContextAlreadyCancelledBeforeBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so ctx.Err() is non-nil when we enter the backoff section.
+	cancel()
+
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    5,
+			InitialBackoff: 10 * time.Second, // long enough that the ctx.Err() check fires first
+			MaxBackoff:     10 * time.Second,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	_, err := retry(ctx, c, func(_ context.Context) (string, error) {
+		calls++
+		return "", &RetryableError{Err: fmt.Errorf("transient")}
+	})
+
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got error %v, want context.Canceled", err)
+	}
+}
+
+// TestRetry_ContextCancelledDuringBackoff covers the select's ctx.Done() arm in the retry loop.
+// The context is live when fn runs but is cancelled while the backoff sleep is in progress.
+func TestRetry_ContextCancelledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    5,
+			InitialBackoff: 10 * time.Second, // long backoff so select blocks
+			MaxBackoff:     10 * time.Second,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	// Cancel the context from a goroutine after fn has returned but before backoff completes.
+	go func() {
+		// Give fn time to run and return the error, then cancel while select is waiting.
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := retry(ctx, c, func(_ context.Context) (string, error) {
+		calls++
+		return "", &RetryableError{Err: fmt.Errorf("transient")}
+	})
+
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got error %v, want context.Canceled", err)
+	}
+}
+
+// TestBackoffDuration_WithJitter covers the jitter branch in backoffDuration.
+func TestBackoffDuration_WithJitter(t *testing.T) {
+	// With jitter enabled the result must be in [0, backoff) where backoff = 100ms at attempt 0.
+	d := backoffDuration(0, 100*time.Millisecond, 5*time.Second, true)
+	if d < 0 || d >= 100*time.Millisecond {
+		t.Errorf("jittered backoff %v out of expected range [0, 100ms)", d)
+	}
+
+	// Run several times to confirm it's not always zero (probabilistic, but 0 has P=1/1e9).
+	nonZero := false
+	for range 20 {
+		if backoffDuration(0, 100*time.Millisecond, 5*time.Second, true) > 0 {
+			nonZero = true
+			break
+		}
+	}
+	if !nonZero {
+		t.Error("expected at least one non-zero jittered backoff in 20 trials")
+	}
+}
+
+// TestListTenants_ErrorInPagination covers the error return inside the pagination loop.
+func TestListTenants_ErrorInPagination(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	paginationErr := errors.New("page fetch failed")
+	calls := 0
+	ms.listTenantsFn = func(_ context.Context, _ *string, _ int32, pageToken string) (*ListTenantsResponse, error) {
+		calls++
+		if pageToken == "" {
+			return &ListTenantsResponse{
+				Tenants:       []*Tenant{{ID: "t1", Name: "a"}},
+				NextPageToken: "page2",
+			}, nil
+		}
+		return nil, paginationErr
+	}
+
+	_, err := client.ListTenants(context.Background(), "")
+	if !errors.Is(err, paginationErr) {
+		t.Errorf("got error %v, want %v", err, paginationErr)
+	}
+	if calls != 2 {
+		t.Errorf("got %d calls, want 2", calls)
+	}
+}
+
+// TestListConfigVersions_ErrorInPagination covers the error return inside the pagination loop.
+func TestListConfigVersions_ErrorInPagination(t *testing.T) {
+	mc := &mockConfigTransport{}
+	client := New(WithConfigTransport(mc))
+
+	paginationErr := errors.New("page fetch failed")
+	calls := 0
+	mc.listVersionsFn = func(_ context.Context, _ string, _ int32, pageToken string) (*ListVersionsResponse, error) {
+		calls++
+		if pageToken == "" {
+			return &ListVersionsResponse{
+				Versions:      []*Version{{Version: 3, CreatedAt: time.Now()}},
+				NextPageToken: "page2",
+			}, nil
+		}
+		return nil, paginationErr
+	}
+
+	_, err := client.ListConfigVersions(context.Background(), "t1")
+	if !errors.Is(err, paginationErr) {
+		t.Errorf("got error %v, want %v", err, paginationErr)
+	}
+	if calls != 2 {
+		t.Errorf("got %d calls, want 2", calls)
+	}
+}
+
+// TestGetLatestPublishedSchemaVersion_ServiceNotConfigured covers the nil schema guard.
+func TestGetLatestPublishedSchemaVersion_ServiceNotConfigured(t *testing.T) {
+	client := New() // no schema transport
+	_, _, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got error %v, want ErrServiceNotConfigured", err)
+	}
+}

--- a/sdk/adminclient/errors.go
+++ b/sdk/adminclient/errors.go
@@ -30,3 +30,19 @@ var (
 func InvalidArgumentError(message string) error {
 	return fmt.Errorf("%w: %s", ErrInvalidArgument, message)
 }
+
+// RetryableError wraps an error to indicate the operation may succeed on retry.
+// Transport implementations should wrap transient errors (e.g. Unavailable,
+// DeadlineExceeded, ResourceExhausted) in RetryableError.
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string { return e.Err.Error() }
+func (e *RetryableError) Unwrap() error { return e.Err }
+
+// IsRetryable reports whether err is marked as retryable by the transport.
+func IsRetryable(err error) bool {
+	var re *RetryableError
+	return errors.As(err, &re)
+}

--- a/sdk/adminclient/options.go
+++ b/sdk/adminclient/options.go
@@ -4,10 +4,12 @@ package adminclient
 type Option func(*clientOptions)
 
 type clientOptions struct {
-	schema SchemaTransport
-	config ConfigTransport
-	audit  AuditTransport
-	server ServerTransport
+	schema       SchemaTransport
+	config       ConfigTransport
+	audit        AuditTransport
+	server       ServerTransport
+	retryEnabled bool
+	retry        RetryConfig
 }
 
 // WithSchemaTransport wires the schema transport. Methods that need it return
@@ -32,4 +34,14 @@ func WithAuditTransport(t AuditTransport) Option {
 // return [ErrServiceNotConfigured] when unset.
 func WithServerTransport(t ServerTransport) Option {
 	return func(o *clientOptions) { o.server = t }
+}
+
+// WithRetry enables automatic retry with exponential backoff for transient errors.
+// Only idempotent read operations (List*, Get*) are retried by default.
+// By default, only errors wrapped in [RetryableError] by the transport are retried.
+func WithRetry(cfg RetryConfig) Option {
+	return func(o *clientOptions) {
+		o.retry = cfg.withDefaults()
+		o.retryEnabled = true
+	}
 }

--- a/sdk/adminclient/retry.go
+++ b/sdk/adminclient/retry.go
@@ -1,0 +1,100 @@
+package adminclient
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// RetryConfig configures automatic retry with exponential backoff.
+type RetryConfig struct {
+	// MaxAttempts is the maximum number of attempts (including the first).
+	// Default: 3.
+	MaxAttempts int
+	// InitialBackoff is the delay before the first retry.
+	// Default: 100ms.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the backoff duration.
+	// Default: 5s.
+	MaxBackoff time.Duration
+	// Jitter adds randomness to backoff to avoid thundering herd.
+	// Default: false.
+	Jitter bool
+	// RetryableCheck determines if an error is retryable.
+	// If nil, defaults to checking for [RetryableError].
+	RetryableCheck func(err error) bool
+}
+
+func (c RetryConfig) withDefaults() RetryConfig {
+	if c.MaxAttempts <= 0 {
+		c.MaxAttempts = 3
+	}
+	if c.InitialBackoff <= 0 {
+		c.InitialBackoff = 100 * time.Millisecond
+	}
+	if c.MaxBackoff <= 0 {
+		c.MaxBackoff = 5 * time.Second
+	}
+	if c.RetryableCheck == nil {
+		c.RetryableCheck = IsRetryable
+	}
+	return c
+}
+
+// retry executes fn with retries if retry is enabled. Otherwise calls fn once.
+// Only idempotent operations (reads: List*, Get*) should be wrapped with retry.
+func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
+	if !c.opts.retryEnabled {
+		return fn(ctx)
+	}
+
+	cfg := c.opts.retry
+	var zero T
+	var lastErr error
+
+	for attempt := range cfg.MaxAttempts {
+		result, err := fn(ctx)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !cfg.RetryableCheck(err) {
+			return zero, err
+		}
+		if attempt == cfg.MaxAttempts-1 {
+			break
+		}
+
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
+
+		backoff := backoffDuration(attempt, cfg.InitialBackoff, cfg.MaxBackoff, cfg.Jitter)
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return zero, lastErr
+}
+
+// retryDo executes fn with retries if retry is enabled, for void operations.
+func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
+	_, err := retry(ctx, c, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, fn(ctx)
+	})
+	return err
+}
+
+// backoffDuration computes exponential backoff with optional jitter.
+func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
+	backoff := time.Duration(float64(initial) * math.Pow(2, float64(attempt)))
+	backoff = min(backoff, max)
+	if jitter && backoff > 0 {
+		backoff = time.Duration(rand.Int64N(int64(backoff)))
+	}
+	return backoff
+}

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -1,0 +1,344 @@
+package adminclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRetry_NoRetryByDefault(t *testing.T) {
+	calls := 0
+	c := &Client{}
+
+	result, err := retry(context.Background(), c, func(_ context.Context) (string, error) {
+		calls++
+		return "", &RetryableError{Err: fmt.Errorf("unavailable")}
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty, got %v", result)
+	}
+	if calls != 1 {
+		t.Errorf("should not retry when retry is disabled: got %d calls, want 1", calls)
+	}
+}
+
+func TestRetry_RetriesOnUnavailable(t *testing.T) {
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	result, err := retry(context.Background(), c, func(_ context.Context) (string, error) {
+		calls++
+		if calls < 3 {
+			return "", &RetryableError{Err: fmt.Errorf("unavailable")}
+		}
+		return "ok", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "ok" {
+		t.Errorf("got %v, want %v", result, "ok")
+	}
+	if calls != 3 {
+		t.Errorf("should have retried twice before succeeding: got %d calls, want 3", calls)
+	}
+}
+
+func TestRetry_DoesNotRetryOnInvalidArgument(t *testing.T) {
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	_, err := retry(context.Background(), c, func(_ context.Context) (string, error) {
+		calls++
+		return "", InvalidArgumentError("bad field")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Errorf("got error %v, want wrapping %v", err, ErrInvalidArgument)
+	}
+	if calls != 1 {
+		t.Errorf("should not retry InvalidArgument: got %d calls, want 1", calls)
+	}
+}
+
+func TestRetry_DoesNotRetryOnNotFound(t *testing.T) {
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	_, err := retry(context.Background(), c, func(_ context.Context) (string, error) {
+		calls++
+		return "", ErrNotFound
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("should not retry NotFound: got %d calls, want 1", calls)
+	}
+}
+
+func TestRetry_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	_, err := retry(context.Background(), c, func(_ context.Context) (string, error) {
+		calls++
+		return "", &RetryableError{Err: fmt.Errorf("always down")}
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+func TestRetry_ContextCancellationStopsRetry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	c := &Client{opts: clientOptions{
+		retryEnabled: true,
+		retry: RetryConfig{
+			MaxAttempts:    10,
+			InitialBackoff: time.Second,
+			RetryableCheck: IsRetryable,
+		},
+	}}
+
+	_, err := retry(ctx, c, func(_ context.Context) (string, error) {
+		calls++
+		return "", &RetryableError{Err: fmt.Errorf("down")}
+	})
+
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got error %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestRetryConfig_Defaults(t *testing.T) {
+	cfg := RetryConfig{}.withDefaults()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("got %v, want %v", cfg.MaxAttempts, 3)
+	}
+	if cfg.InitialBackoff != 100*time.Millisecond {
+		t.Errorf("got %v, want %v", cfg.InitialBackoff, 100*time.Millisecond)
+	}
+	if cfg.MaxBackoff != 5*time.Second {
+		t.Errorf("got %v, want %v", cfg.MaxBackoff, 5*time.Second)
+	}
+	if cfg.RetryableCheck == nil {
+		t.Fatal("expected non-nil RetryableCheck")
+	}
+}
+
+func TestRetryConfig_PreservesCustomValues(t *testing.T) {
+	cfg := RetryConfig{
+		MaxAttempts:    5,
+		InitialBackoff: 200 * time.Millisecond,
+		MaxBackoff:     10 * time.Second,
+	}.withDefaults()
+	if cfg.MaxAttempts != 5 {
+		t.Errorf("got %v, want %v", cfg.MaxAttempts, 5)
+	}
+	if cfg.InitialBackoff != 200*time.Millisecond {
+		t.Errorf("got %v, want %v", cfg.InitialBackoff, 200*time.Millisecond)
+	}
+	if cfg.MaxBackoff != 10*time.Second {
+		t.Errorf("got %v, want %v", cfg.MaxBackoff, 10*time.Second)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	if !IsRetryable(&RetryableError{Err: fmt.Errorf("unavailable")}) {
+		t.Error("expected RetryableError to be retryable")
+	}
+	if IsRetryable(ErrNotFound) {
+		t.Error("expected ErrNotFound to not be retryable")
+	}
+	if IsRetryable(ErrInvalidArgument) {
+		t.Error("expected ErrInvalidArgument to not be retryable")
+	}
+	if IsRetryable(ErrFailedPrecondition) {
+		t.Error("expected ErrFailedPrecondition to not be retryable")
+	}
+	if IsRetryable(nil) {
+		t.Error("expected nil error to not be retryable")
+	}
+}
+
+func TestWithRetry_Option(t *testing.T) {
+	c := New(WithRetry(RetryConfig{MaxAttempts: 5}))
+	if !c.opts.retryEnabled {
+		t.Error("expected retryEnabled to be true")
+	}
+	if c.opts.retry.MaxAttempts != 5 {
+		t.Errorf("got %v, want %v", c.opts.retry.MaxAttempts, 5)
+	}
+	if c.opts.retry.InitialBackoff != 100*time.Millisecond {
+		t.Errorf("got %v, want %v", c.opts.retry.InitialBackoff, 100*time.Millisecond)
+	}
+}
+
+func TestRetryableError_Unwrap(t *testing.T) {
+	inner := fmt.Errorf("connection refused")
+	re := &RetryableError{Err: inner}
+	if re.Error() != inner.Error() {
+		t.Errorf("got %q, want %q", re.Error(), inner.Error())
+	}
+	if !errors.Is(re, inner) {
+		t.Error("errors.Is should find wrapped inner error")
+	}
+}
+
+func TestBackoffDuration(t *testing.T) {
+	b0 := backoffDuration(0, 100*time.Millisecond, 5*time.Second, false)
+	if b0 != 100*time.Millisecond {
+		t.Errorf("got %v, want %v", b0, 100*time.Millisecond)
+	}
+
+	b1 := backoffDuration(1, 100*time.Millisecond, 5*time.Second, false)
+	if b1 != 200*time.Millisecond {
+		t.Errorf("got %v, want %v", b1, 200*time.Millisecond)
+	}
+
+	b2 := backoffDuration(2, 100*time.Millisecond, 5*time.Second, false)
+	if b2 != 400*time.Millisecond {
+		t.Errorf("got %v, want %v", b2, 400*time.Millisecond)
+	}
+
+	b10 := backoffDuration(10, 100*time.Millisecond, 5*time.Second, false)
+	if b10 != 5*time.Second {
+		t.Errorf("got %v, want %v", b10, 5*time.Second)
+	}
+}
+
+func TestRetry_GetSchema_RetriesOnUnavailable(t *testing.T) {
+	calls := 0
+	ms := &mockSchemaTransport{
+		getSchemaFn: func(_ context.Context, _ string, _ *int32) (*Schema, error) {
+			calls++
+			if calls < 3 {
+				return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+			}
+			return &Schema{ID: "s1", Name: "payments", Version: 1}, nil
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	schema, err := c.GetSchema(context.Background(), "s1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema.ID != "s1" {
+		t.Errorf("got ID %q, want %q", schema.ID, "s1")
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+func TestRetry_GetSchema_NoRetryOnInvalidArgument(t *testing.T) {
+	calls := 0
+	ms := &mockSchemaTransport{
+		getSchemaFn: func(_ context.Context, _ string, _ *int32) (*Schema, error) {
+			calls++
+			return nil, ErrInvalidArgument
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+		}),
+	)
+
+	_, err := c.GetSchema(context.Background(), "s1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("should not retry InvalidArgument: got %d calls, want 1", calls)
+	}
+}
+
+func TestRetry_GetSchema_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	ms := &mockSchemaTransport{
+		getSchemaFn: func(_ context.Context, _ string, _ *int32) (*Schema, error) {
+			calls++
+			return nil, &RetryableError{Err: fmt.Errorf("down")}
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    10,
+			InitialBackoff: time.Second,
+		}),
+	)
+
+	_, err := c.GetSchema(ctx, "s1")
+	if calls != 1 {
+		t.Errorf("got %d calls, want 1", calls)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got error %v, want context.Canceled", err)
+	}
+}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -23,7 +23,9 @@ func (c *Client) GetSchema(ctx context.Context, id string) (*Schema, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.schema.GetSchema(ctx, id, nil)
+	return retry(ctx, c, func(ctx context.Context) (*Schema, error) {
+		return c.schema.GetSchema(ctx, id, nil)
+	})
 }
 
 // GetSchemaVersion retrieves a schema at a specific version.
@@ -31,7 +33,9 @@ func (c *Client) GetSchemaVersion(ctx context.Context, id string, version int32)
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.schema.GetSchema(ctx, id, &version)
+	return retry(ctx, c, func(ctx context.Context) (*Schema, error) {
+		return c.schema.GetSchema(ctx, id, &version)
+	})
 }
 
 // ListSchemas returns all schemas, auto-paginating through all results.
@@ -39,20 +43,22 @@ func (c *Client) ListSchemas(ctx context.Context) ([]*Schema, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	var all []*Schema
-	pageToken := ""
-	for {
-		resp, err := c.schema.ListSchemas(ctx, 100, pageToken)
-		if err != nil {
-			return nil, err
+	return retry(ctx, c, func(ctx context.Context) ([]*Schema, error) {
+		var all []*Schema
+		pageToken := ""
+		for {
+			resp, err := c.schema.ListSchemas(ctx, 100, pageToken)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, resp.Schemas...)
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
 		}
-		all = append(all, resp.Schemas...)
-		if resp.NextPageToken == "" {
-			break
-		}
-		pageToken = resp.NextPageToken
-	}
-	return all, nil
+		return all, nil
+	})
 }
 
 // UpdateSchema creates a new draft version by merging field changes with the latest version.
@@ -94,7 +100,9 @@ func (c *Client) ExportSchema(ctx context.Context, id string, version *int32) ([
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.schema.ExportSchema(ctx, id, version)
+	return retry(ctx, c, func(ctx context.Context) ([]byte, error) {
+		return c.schema.ExportSchema(ctx, id, version)
+	})
 }
 
 // ImportSchema creates a schema (or new version) from YAML content.

--- a/sdk/adminclient/server.go
+++ b/sdk/adminclient/server.go
@@ -7,5 +7,7 @@ func (c *Client) GetServerInfo(ctx context.Context) (*ServerInfo, error) {
 	if c.server == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.server.GetServerInfo(ctx)
+	return retry(ctx, c, func(ctx context.Context) (*ServerInfo, error) {
+		return c.server.GetServerInfo(ctx)
+	})
 }

--- a/sdk/adminclient/tenant.go
+++ b/sdk/adminclient/tenant.go
@@ -23,7 +23,9 @@ func (c *Client) GetTenant(ctx context.Context, id string) (*Tenant, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.schema.GetTenant(ctx, id)
+	return retry(ctx, c, func(ctx context.Context) (*Tenant, error) {
+		return c.schema.GetTenant(ctx, id)
+	})
 }
 
 // ListTenants returns all tenants, optionally filtered by schema ID.
@@ -32,24 +34,26 @@ func (c *Client) ListTenants(ctx context.Context, schemaID string) ([]*Tenant, e
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	var schemaFilter *string
-	if schemaID != "" {
-		schemaFilter = &schemaID
-	}
-	var all []*Tenant
-	pageToken := ""
-	for {
-		resp, err := c.schema.ListTenants(ctx, schemaFilter, 100, pageToken)
-		if err != nil {
-			return nil, err
+	return retry(ctx, c, func(ctx context.Context) ([]*Tenant, error) {
+		var schemaFilter *string
+		if schemaID != "" {
+			schemaFilter = &schemaID
 		}
-		all = append(all, resp.Tenants...)
-		if resp.NextPageToken == "" {
-			break
+		var all []*Tenant
+		pageToken := ""
+		for {
+			resp, err := c.schema.ListTenants(ctx, schemaFilter, 100, pageToken)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, resp.Tenants...)
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
 		}
-		pageToken = resp.NextPageToken
-	}
-	return all, nil
+		return all, nil
+	})
 }
 
 // UpdateTenantName updates a tenant's name.

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -53,6 +53,8 @@ func mapAdminError(err error) error {
 		return adminclient.ErrFailedPrecondition
 	case codes.InvalidArgument:
 		return adminclient.InvalidArgumentError(st.Message())
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return &adminclient.RetryableError{Err: err}
 	default:
 		return err
 	}


### PR DESCRIPTION
## Summary
- Closes #481
- Add RetryableError type that wraps transient gRPC errors (Unavailable, DeadlineExceeded, ResourceExhausted)
- Add WithRetry(RetryConfig) functional option to adminclient; mirrors configclient pattern exactly
- Wire retry loop into all idempotent read methods (Get*, List*, Export*, Query*, GetServerInfo); non-reads (Create, Update, Delete, Import, Rollback) are not retried
- Retry loop respects context cancellation; non-retryable errors fail fast
- Map transient gRPC codes to RetryableError in grpctransport.mapAdminError

## Test plan
- [x] Retries on Unavailable up to maxAttempts (TestRetry_RetriesOnUnavailable, TestRetry_GetSchema_RetriesOnUnavailable)
- [x] Does not retry on InvalidArgument / NotFound (TestRetry_DoesNotRetryOnInvalidArgument, TestRetry_DoesNotRetryOnNotFound, TestRetry_GetSchema_NoRetryOnInvalidArgument)
- [x] Context cancellation stops retry mid-loop (TestRetry_ContextCancellationStopsRetry, TestRetry_GetSchema_ContextCancellation)
- [x] Existing adminclient tests pass
- [x] Full make test suite passes (all modules, -race)