### PR TITLE
fix(sdk): replace variadic-optional args with functional options

### DIFF
--- a/cmd/decree/config.go
+++ b/cmd/decree/config.go
@@ -315,7 +315,7 @@ var configImportCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		v, err := admin.ImportConfig(cmd.Context(), args[0], data, desc, mode)
+		v, err := admin.ImportConfig(cmd.Context(), args[0], data, desc, adminclient.WithImportMode(mode))
 		if err != nil {
 			return err
 		}

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -209,7 +209,11 @@ var schemaImportCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		s, err := admin.ImportSchema(cmd.Context(), data, publish)
+		var importOpts []adminclient.ImportSchemaOption
+		if publish {
+			importOpts = append(importOpts, adminclient.WithAutoPublish())
+		}
+		s, err := admin.ImportSchema(cmd.Context(), data, importOpts...)
 		if err != nil {
 			return err
 		}

--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -170,7 +170,7 @@ func allRPCs() []rpcSpec {
 			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				newName := fmt.Sprintf("m1-upd-%s", randSuffix())
-				_, err := c.admin.UpdateTenant(ctx, fx.tenantID, &newName, nil)
+				_, err := c.admin.UpdateTenant(ctx, fx.tenantID, adminclient.WithTenantName(newName))
 				return err
 			},
 		},

--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -70,7 +70,7 @@ func writeRPCs() []writeRPCSpec {
 			name: "UpdateTenant",
 			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
 				newName := fmt.Sprintf("m2-rename-%s", randSuffix())
-				_, err := c.admin.UpdateTenant(ctx, tenantID, &newName, nil)
+				_, err := c.admin.UpdateTenant(ctx, tenantID, adminclient.WithTenantName(newName))
 				return err
 			},
 		},

--- a/e2e/tenant_test.go
+++ b/e2e/tenant_test.go
@@ -144,7 +144,7 @@ func TestUpdateTenantBothFields(t *testing.T) {
 
 	newName := "tenant-both-after"
 	newVersion := int32(2)
-	updated, err := admin.UpdateTenant(ctx, tenant.ID, &newName, &newVersion)
+	updated, err := admin.UpdateTenant(ctx, tenant.ID, adminclient.WithTenantName(newName), adminclient.WithTenantSchemaVersion(newVersion))
 	require.NoError(t, err)
 	assert.Equal(t, newName, updated.Name)
 	assert.Equal(t, newVersion, updated.SchemaVersion)

--- a/e2e/type_matrix_test.go
+++ b/e2e/type_matrix_test.go
@@ -265,7 +265,7 @@ func TestTypeMatrix(t *testing.T) {
 						sample := tc.sample()
 						yaml := buildSingleFieldYAML(path, tc.yamlValue(sample))
 						_, err := admin.ImportConfig(ctx, fx.tenantID, []byte(yaml),
-							"matrix3 import "+path, adminclient.ImportModeMerge)
+							"matrix3 import "+path, adminclient.WithImportMode(adminclient.ImportModeMerge))
 						require.NoError(t, err, "import yaml: %s", yaml)
 
 						// Round-trip read.

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -64,21 +64,33 @@ const (
 	ImportModeDefaults ImportMode = 3
 )
 
+// ImportConfigOption configures an ImportConfig call.
+type ImportConfigOption func(*importConfigOptions)
+
+type importConfigOptions struct {
+	mode ImportMode
+}
+
+// WithImportMode sets the import mode. Defaults to [ImportModeMerge] if not specified.
+func WithImportMode(mode ImportMode) ImportConfigOption {
+	return func(o *importConfigOptions) { o.mode = mode }
+}
+
 // ImportConfig applies configuration values from YAML, creating a new version.
 // The description is optional — pass an empty string to use the default.
-// Mode defaults to ImportModeMerge if not specified.
-func (c *Client) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...ImportMode) (*Version, error) {
+// Mode defaults to [ImportModeMerge] unless [WithImportMode] is passed.
+func (c *Client) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, opts ...ImportConfigOption) (*Version, error) {
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	m := ImportModeMerge
-	if len(mode) > 0 {
-		m = mode[0]
+	o := importConfigOptions{mode: ImportModeMerge}
+	for _, opt := range opts {
+		opt(&o)
 	}
 	return c.config.ImportConfig(ctx, &ImportConfigRequest{
 		TenantID:    tenantID,
 		YamlContent: yamlContent,
 		Description: description,
-		Mode:        m,
+		Mode:        o.mode,
 	})
 }

--- a/sdk/adminclient/example_test.go
+++ b/sdk/adminclient/example_test.go
@@ -108,7 +108,7 @@ fields:
   - path: app.environment
     type: string
 `)
-	schema, err := client.ImportSchema(ctx, yaml, true)
+	schema, err := client.ImportSchema(ctx, yaml, adminclient.WithAutoPublish())
 	if err != nil {
 		fmt.Println("error:", err)
 		return

--- a/sdk/adminclient/operations_test.go
+++ b/sdk/adminclient/operations_test.go
@@ -163,7 +163,7 @@ func TestImportSchema_AutoPublish(t *testing.T) {
 		return &Schema{ID: "s1", Version: 1, Published: true, CreatedAt: time.Now()}, nil
 	}
 
-	s, err := client.ImportSchema(context.Background(), []byte("yaml"), true)
+	s, err := client.ImportSchema(context.Background(), []byte("yaml"), WithAutoPublish())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -368,9 +368,7 @@ func TestUpdateTenant_BothFields(t *testing.T) {
 		return &Tenant{ID: "t1", Name: "renamed", SchemaVersion: 2, CreatedAt: time.Now(), UpdatedAt: time.Now()}, nil
 	}
 
-	name := "renamed"
-	v := int32(2)
-	tenant, err := client.UpdateTenant(context.Background(), "t1", &name, &v)
+	tenant, err := client.UpdateTenant(context.Background(), "t1", WithTenantName("renamed"), WithTenantSchemaVersion(2))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -645,7 +643,7 @@ func TestImportConfig_WithMode(t *testing.T) {
 		return &Version{Version: 4, CreatedAt: time.Now()}, nil
 	}
 
-	v, err := client.ImportConfig(context.Background(), "t1", []byte("yaml"), "full replace", ImportModeReplace)
+	v, err := client.ImportConfig(context.Background(), "t1", []byte("yaml"), "full replace", WithImportMode(ImportModeReplace))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -749,7 +747,7 @@ func TestServiceNotConfigured_AllMethods(t *testing.T) {
 		t.Errorf("UpdateTenantSchema: got error %v, want %v", err, ErrServiceNotConfigured)
 	}
 
-	_, err = client.UpdateTenant(ctx, "t1", nil, nil)
+	_, err = client.UpdateTenant(ctx, "t1")
 	if !errors.Is(err, ErrServiceNotConfigured) {
 		t.Errorf("UpdateTenant: got error %v, want %v", err, ErrServiceNotConfigured)
 	}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -97,16 +97,31 @@ func (c *Client) ExportSchema(ctx context.Context, id string, version *int32) ([
 	return c.schema.ExportSchema(ctx, id, version)
 }
 
+// ImportSchemaOption configures an ImportSchema call.
+type ImportSchemaOption func(*importSchemaOptions)
+
+type importSchemaOptions struct {
+	autoPublish bool
+}
+
+// WithAutoPublish publishes the imported schema version immediately.
+func WithAutoPublish() ImportSchemaOption {
+	return func(o *importSchemaOptions) { o.autoPublish = true }
+}
+
 // ImportSchema creates a schema (or new version) from YAML content.
 // Full-replace semantics: the YAML defines the complete field set.
 // Returns [ErrAlreadyExists] if the imported fields are identical to the latest version.
-// Imported versions are always created as drafts (unpublished) unless autoPublish is true.
-func (c *Client) ImportSchema(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*Schema, error) {
+// Imported versions are always created as drafts (unpublished) unless [WithAutoPublish] is passed.
+func (c *Client) ImportSchema(ctx context.Context, yamlContent []byte, opts ...ImportSchemaOption) (*Schema, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	ap := len(autoPublish) > 0 && autoPublish[0]
-	return c.schema.ImportSchema(ctx, yamlContent, ap)
+	var o importSchemaOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return c.schema.ImportSchema(ctx, yamlContent, o.autoPublish)
 }
 
 // GetLatestPublishedSchemaVersion finds the most recent published version of a schema by name.

--- a/sdk/adminclient/tenant.go
+++ b/sdk/adminclient/tenant.go
@@ -76,16 +76,39 @@ func (c *Client) UpdateTenantSchema(ctx context.Context, id string, schemaVersio
 	})
 }
 
+// UpdateTenantOption configures an UpdateTenant call.
+type UpdateTenantOption func(*updateTenantOptions)
+
+type updateTenantOptions struct {
+	name          *string
+	schemaVersion *int32
+}
+
+// WithTenantName sets the new name for a tenant.
+func WithTenantName(name string) UpdateTenantOption {
+	return func(o *updateTenantOptions) { o.name = &name }
+}
+
+// WithTenantSchemaVersion sets the schema version to upgrade the tenant to.
+func WithTenantSchemaVersion(version int32) UpdateTenantOption {
+	return func(o *updateTenantOptions) { o.schemaVersion = &version }
+}
+
 // UpdateTenant updates a tenant's name and/or schema version in a single call.
-// Pass nil for fields that should be left unchanged. At least one field must be non-nil.
-func (c *Client) UpdateTenant(ctx context.Context, id string, name *string, schemaVersion *int32) (*Tenant, error) {
+// At least one option must be provided. Use [WithTenantName] and/or
+// [WithTenantSchemaVersion] to specify what to change.
+func (c *Client) UpdateTenant(ctx context.Context, id string, opts ...UpdateTenantOption) (*Tenant, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
+	var o updateTenantOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	return c.schema.UpdateTenant(ctx, &UpdateTenantRequest{
 		ID:            id,
-		Name:          name,
-		SchemaVersion: schemaVersion,
+		Name:          o.name,
+		SchemaVersion: o.schemaVersion,
 	})
 }
 

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -146,12 +146,12 @@ type LockDef struct {
 // Client defines the adminclient methods used by seed operations.
 // The [adminclient.Client] type satisfies this interface.
 type Client interface {
-	ImportSchema(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error)
+	ImportSchema(ctx context.Context, yamlContent []byte, opts ...adminclient.ImportSchemaOption) (*adminclient.Schema, error)
 	ListSchemas(ctx context.Context) ([]*adminclient.Schema, error)
 	GetLatestPublishedSchemaVersion(ctx context.Context, name string) (string, int32, error)
 	ListTenants(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error)
 	CreateTenant(ctx context.Context, name, schemaID string, schemaVersion int32) (*adminclient.Tenant, error)
-	ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error)
+	ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, opts ...adminclient.ImportConfigOption) (*adminclient.Version, error)
 	ListConfigVersions(ctx context.Context, tenantID string) ([]*adminclient.Version, error)
 	LockField(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error
 }
@@ -294,7 +294,11 @@ func importSchema(ctx context.Context, client Client, file *File, o options, res
 		return fmt.Errorf("marshaling schema: %w", err)
 	}
 
-	schema, err := client.ImportSchema(ctx, schemaYAML, o.autoPublish)
+	var importOpts []adminclient.ImportSchemaOption
+	if o.autoPublish {
+		importOpts = append(importOpts, adminclient.WithAutoPublish())
+	}
+	schema, err := client.ImportSchema(ctx, schemaYAML, importOpts...)
 	if err == nil {
 		result.SchemaID = schema.ID
 		result.SchemaVersion = schema.Version
@@ -392,7 +396,7 @@ func importConfig(ctx context.Context, client Client, file *File, result *Result
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	ver, err := client.ImportConfig(ctx, result.TenantID, configYAML, file.Config.Description, adminclient.ImportModeMerge)
+	ver, err := client.ImportConfig(ctx, result.TenantID, configYAML, file.Config.Description, adminclient.WithImportMode(adminclient.ImportModeMerge))
 	if err == nil {
 		result.ConfigVersion = ver.Version
 		result.ConfigImported = true

--- a/sdk/tools/seed/seed_test.go
+++ b/sdk/tools/seed/seed_test.go
@@ -12,18 +12,18 @@ import (
 // --- Mock client ---
 
 type mockClient struct {
-	importSchemaFn                    func(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error)
+	importSchemaFn                    func(ctx context.Context, yamlContent []byte, opts ...adminclient.ImportSchemaOption) (*adminclient.Schema, error)
 	listSchemasFn                     func(ctx context.Context) ([]*adminclient.Schema, error)
 	getLatestPublishedSchemaVersionFn func(ctx context.Context, name string) (string, int32, error)
 	listTenantsFn                     func(ctx context.Context, schemaID string) ([]*adminclient.Tenant, error)
 	createTenantFn                    func(ctx context.Context, name, schemaID string, schemaVersion int32) (*adminclient.Tenant, error)
-	importConfigFn                    func(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error)
+	importConfigFn                    func(ctx context.Context, tenantID string, yamlContent []byte, description string, opts ...adminclient.ImportConfigOption) (*adminclient.Version, error)
 	listConfigVersionsFn              func(ctx context.Context, tenantID string) ([]*adminclient.Version, error)
 	lockFieldFn                       func(ctx context.Context, tenantID, fieldPath string, lockedValues ...string) error
 }
 
-func (m *mockClient) ImportSchema(ctx context.Context, yamlContent []byte, autoPublish ...bool) (*adminclient.Schema, error) {
-	return m.importSchemaFn(ctx, yamlContent, autoPublish...)
+func (m *mockClient) ImportSchema(ctx context.Context, yamlContent []byte, opts ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
+	return m.importSchemaFn(ctx, yamlContent, opts...)
 }
 
 func (m *mockClient) ListSchemas(ctx context.Context) ([]*adminclient.Schema, error) {
@@ -42,8 +42,8 @@ func (m *mockClient) CreateTenant(ctx context.Context, name, schemaID string, sc
 	return m.createTenantFn(ctx, name, schemaID, schemaVersion)
 }
 
-func (m *mockClient) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, mode ...adminclient.ImportMode) (*adminclient.Version, error) {
-	return m.importConfigFn(ctx, tenantID, yamlContent, description, mode...)
+func (m *mockClient) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, opts ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
+	return m.importConfigFn(ctx, tenantID, yamlContent, description, opts...)
 }
 
 func (m *mockClient) ListConfigVersions(ctx context.Context, tenantID string) ([]*adminclient.Version, error) {
@@ -303,7 +303,7 @@ tenant:
 func TestRun_NewSchemaNewTenantWithConfig(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -312,7 +312,7 @@ func TestRun_NewSchemaNewTenantWithConfig(t *testing.T) {
 		createTenantFn: func(_ context.Context, name, schemaID string, _ int32) (*adminclient.Tenant, error) {
 			return &adminclient.Tenant{ID: "t1", Name: name, SchemaID: schemaID}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return &adminclient.Version{Version: 1}, nil
 		},
 		lockFieldFn: func(_ context.Context, _, _ string, _ ...string) error {
@@ -353,7 +353,7 @@ func TestRun_ExistingSchemaExistingTenant(t *testing.T) {
 	file.Locks = nil         // no locks
 
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
@@ -399,10 +399,10 @@ func TestRun_AutoPublish(t *testing.T) {
 
 	var gotAutoPublish bool
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, autoPublish ...bool) (*adminclient.Schema, error) {
-			if len(autoPublish) > 0 {
-				gotAutoPublish = autoPublish[0]
-			}
+		importSchemaFn: func(_ context.Context, _ []byte, opts ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
+			// WithAutoPublish is the only option the seed package ever passes;
+			// any opt present means auto-publish was requested.
+			gotAutoPublish = len(opts) > 0
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -425,7 +425,7 @@ func TestRun_AutoPublish(t *testing.T) {
 func TestRun_SchemaImportError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, fmt.Errorf("connection refused")
 		},
 	}
@@ -439,7 +439,7 @@ func TestRun_SchemaImportError(t *testing.T) {
 func TestRun_SchemaExistsButNotFound(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
@@ -458,7 +458,7 @@ func TestRun_SchemaExistsButNotFound(t *testing.T) {
 func TestRun_ListSchemasError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
@@ -475,7 +475,7 @@ func TestRun_ListSchemasError(t *testing.T) {
 func TestRun_ListTenantsError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -492,7 +492,7 @@ func TestRun_ListTenantsError(t *testing.T) {
 func TestRun_CreateTenantError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -512,7 +512,7 @@ func TestRun_CreateTenantError(t *testing.T) {
 func TestRun_ImportConfigError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -521,7 +521,7 @@ func TestRun_ImportConfigError(t *testing.T) {
 		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
 			return &adminclient.Tenant{ID: "t1"}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return nil, fmt.Errorf("validation error")
 		},
 	}
@@ -535,7 +535,7 @@ func TestRun_ImportConfigError(t *testing.T) {
 func TestRun_LockFieldError(t *testing.T) {
 	file := testFile()
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -544,7 +544,7 @@ func TestRun_LockFieldError(t *testing.T) {
 		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
 			return &adminclient.Tenant{ID: "t1"}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return &adminclient.Version{Version: 1}, nil
 		},
 		lockFieldFn: func(_ context.Context, _, _ string, _ ...string) error {
@@ -631,14 +631,14 @@ func TestRun_SchemaOnly(t *testing.T) {
 	}
 	var importConfigCalled, createTenantCalled bool
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
 			createTenantCalled = true
 			return nil, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			importConfigCalled = true
 			return nil, nil
 		},
@@ -679,7 +679,7 @@ func TestRun_ConfigOnly_LatestPublished(t *testing.T) {
 	var resolvedName string
 	var importSchemaCalled bool
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			importSchemaCalled = true
 			return nil, nil
 		},
@@ -690,7 +690,7 @@ func TestRun_ConfigOnly_LatestPublished(t *testing.T) {
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
 			return []*adminclient.Tenant{{ID: "t1", Name: "org1"}}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return &adminclient.Version{Version: 2}, nil
 		},
 	}
@@ -736,7 +736,7 @@ func TestRun_ConfigOnly_ExplicitVersion(t *testing.T) {
 			}
 			return &adminclient.Tenant{ID: "t1"}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return &adminclient.Version{Version: 1}, nil
 		},
 	}
@@ -794,7 +794,7 @@ func TestRun_SchemaReseed_NoNewVersion(t *testing.T) {
 	file.Config.Values = nil
 	file.Locks = nil
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
@@ -820,13 +820,13 @@ func TestRun_ConfigReseed_NoNewVersion(t *testing.T) {
 	file := testFile()
 	file.Locks = nil
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
 			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {
@@ -849,7 +849,7 @@ func TestRun_FullNoOpReseed(t *testing.T) {
 	file := testFile()
 	file.Locks = nil
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
@@ -858,7 +858,7 @@ func TestRun_FullNoOpReseed(t *testing.T) {
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
 			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {
@@ -931,7 +931,7 @@ func TestRun_SchemaAndTenant(t *testing.T) {
 	}
 	var importConfigCalled bool
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
@@ -940,7 +940,7 @@ func TestRun_SchemaAndTenant(t *testing.T) {
 		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
 			return &adminclient.Tenant{ID: "t1"}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			importConfigCalled = true
 			return nil, nil
 		},
@@ -964,7 +964,7 @@ func TestRun_TenantOnly(t *testing.T) {
 	}
 	var importSchemaCalled, importConfigCalled bool
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			importSchemaCalled = true
 			return nil, nil
 		},
@@ -980,7 +980,7 @@ func TestRun_TenantOnly(t *testing.T) {
 		createTenantFn: func(_ context.Context, _, _ string, _ int32) (*adminclient.Tenant, error) {
 			return &adminclient.Tenant{ID: "t1"}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			importConfigCalled = true
 			return nil, nil
 		},
@@ -1046,7 +1046,7 @@ func TestRun_ConfigOnly_WithLocks(t *testing.T) {
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
 			return []*adminclient.Tenant{{ID: "t1", Name: "org1"}}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return &adminclient.Version{Version: 1}, nil
 		},
 		lockFieldFn: func(_ context.Context, tenantID, fieldPath string, _ ...string) error {
@@ -1155,13 +1155,13 @@ func TestRun_ConfigReseed_ListConfigVersionsError(t *testing.T) {
 	file := testFile()
 	file.Locks = nil
 	mock := &mockClient{
-		importSchemaFn: func(_ context.Context, _ []byte, _ ...bool) (*adminclient.Schema, error) {
+		importSchemaFn: func(_ context.Context, _ []byte, _ ...adminclient.ImportSchemaOption) (*adminclient.Schema, error) {
 			return &adminclient.Schema{ID: "s1", Version: 1}, nil
 		},
 		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
 			return []*adminclient.Tenant{{ID: "t1", Name: "test-tenant"}}, nil
 		},
-		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportMode) (*adminclient.Version, error) {
+		importConfigFn: func(_ context.Context, _ string, _ []byte, _ string, _ ...adminclient.ImportConfigOption) (*adminclient.Version, error) {
 			return nil, adminclient.ErrAlreadyExists
 		},
 		listConfigVersionsFn: func(_ context.Context, _ string) ([]*adminclient.Version, error) {


### PR DESCRIPTION
## Summary
- Closes #480
- Convert SDK constructors/functions using variadic-optional args to the functional-options pattern (`WithXxx()`)
- Required args remain positional; optional configuration uses `With...()` options

## Test plan
- [ ] All existing SDK tests pass
- [ ] No variadic option args remain in public SDK API