### PR TITLE
refactor: replace isValidUUID with domain.IsUUID

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -56,7 +56,7 @@ func (s *Service) resolveTenantID(ctx context.Context, idOrName string) (string,
 	if idOrName == "" {
 		return "", status.Error(codes.InvalidArgument, "tenant id or name required")
 	}
-	if isValidUUID(idOrName) {
+	if domain.IsUUID(idOrName) {
 		return idOrName, nil
 	}
 	if s.resolveTenant != nil {
@@ -304,14 +304,6 @@ func (s *Service) GetUnusedFields(ctx context.Context, req *pb.GetUnusedFieldsRe
 }
 
 // --- Helpers ---
-
-func isValidUUID(s string) bool {
-	// Simple length + format check. Full validation happens in the store layer.
-	if len(s) != 36 {
-		return false
-	}
-	return s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
-}
 
 func auditEntryToProto(e domain.AuditWriteLog) *pb.AuditEntry {
 	entry := &pb.AuditEntry{

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -439,9 +439,9 @@ func TestVerifyChain_TenantTamperedEntry(t *testing.T) {
 // --- Helpers ---
 
 func TestIsValidUUID(t *testing.T) {
-	assert.True(t, isValidUUID("11111111-1111-1111-1111-111111111111"))
-	assert.False(t, isValidUUID("not-a-uuid"))
-	assert.False(t, isValidUUID(""))
+	assert.True(t, domain.IsUUID("11111111-1111-1111-1111-111111111111"))
+	assert.False(t, domain.IsUUID("not-a-uuid"))
+	assert.False(t, domain.IsUUID(""))
 }
 
 func TestAuditEntryToProto(t *testing.T) {


### PR DESCRIPTION
## Summary
- Closes #459
- Replace scattered isValidUUID custom checks with the canonical domain.IsUUID function
- Single implementation, consistent validation behavior across the codebase

## Test plan
- [ ] All existing UUID validation tests pass
- [ ] No remaining isValidUUID usages outside domain package