### PR TITLE
fix(sdk): capture client in LockedValue.Set

### DIFF
--- a/e2e/bench_test.go
+++ b/e2e/bench_test.go
@@ -271,7 +271,7 @@ func BenchmarkGetForUpdate_ThenSet(b *testing.B) {
 		if err != nil {
 			continue
 		}
-		_ = lv.Set(ctx, cfg, "updated")
+		_ = lv.Set(ctx, "updated")
 	}
 }
 

--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -94,10 +94,10 @@ func TestFullFlow(t *testing.T) {
 	assert.Equal(t, "0.5%", lv.Value)
 
 	// Set with correct checksum → succeeds.
-	require.NoError(t, lv.Set(ctx, cfg, "0.3%"))
+	require.NoError(t, lv.Set(ctx, "0.3%"))
 
 	// Set with stale checksum → fails.
-	err = lv.Set(ctx, cfg, "0.1%")
+	err = lv.Set(ctx, "0.1%")
 	assert.ErrorIs(t, err, configclient.ErrChecksumMismatch)
 
 	// 8. Update convenience CAS.

--- a/examples/optimistic-concurrency/main.go
+++ b/examples/optimistic-concurrency/main.go
@@ -56,13 +56,13 @@ func run() error {
 	fmt.Printf("Current app.name: %q (checksum: %s)\n", locked.Value, locked.Checksum)
 
 	// Update with the checksum — succeeds only if no one else changed it.
-	if err := locked.Set(ctx, client, "Acme Corp App v2"); err != nil {
+	if err := locked.Set(ctx, "Acme Corp App v2"); err != nil {
 		return fmt.Errorf("cas set: %w", err)
 	}
 	fmt.Println("Updated to \"Acme Corp App v2\" via CAS")
 
 	// Try again with the stale checksum — fails with ErrChecksumMismatch.
-	err = locked.Set(ctx, client, "Acme Corp App v3")
+	err = locked.Set(ctx, "Acme Corp App v3")
 	if err != nil {
 		fmt.Printf("Stale CAS correctly rejected: %v\n", err)
 	}

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -328,7 +328,7 @@ func TestGetForUpdate_ThenSet(t *testing.T) {
 		return r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk123" && r.Value != nil && r.Value.String() == "new"
 	}, &SetFieldResponse{}, nil)
 
-	err = lv.Set(ctx, client, "new")
+	err = lv.Set(ctx, "new")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -350,9 +350,47 @@ func TestGetForUpdate_ChecksumMismatch(t *testing.T) {
 
 	tr.on("SetField", nil, (*SetFieldResponse)(nil), ErrChecksumMismatch)
 
-	err = lv.Set(ctx, client, "new")
+	err = lv.Set(ctx, "new")
 	if !errors.Is(err, ErrChecksumMismatch) {
 		t.Errorf("got error %v, want %v", err, ErrChecksumMismatch)
+	}
+}
+
+// TestLockedValue_CapturesClient verifies that the client is captured at
+// GetForUpdate time so that Set() can invoke the remote call without the
+// caller having to pass the client explicitly.
+func TestLockedValue_CapturesClient(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", func(args ...any) bool {
+		r := args[0].(*GetFieldRequest)
+		return r.TenantID == "tenant-a" && r.FieldPath == "feature.flag"
+	}, &GetFieldResponse{
+		FieldPath: "feature.flag", Value: StringVal("off"), Checksum: "sum42",
+	}, nil)
+
+	lv, err := client.GetForUpdate(ctx, "tenant-a", "feature.flag")
+	if err != nil {
+		t.Fatalf("GetForUpdate: unexpected error: %v", err)
+	}
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		return r.TenantID == "tenant-a" &&
+			r.FieldPath == "feature.flag" &&
+			r.Value != nil && r.Value.String() == "on" &&
+			r.ExpectedChecksum != nil && *r.ExpectedChecksum == "sum42"
+	}, &SetFieldResponse{}, nil)
+
+	// Set takes only ctx + new value — no client argument required.
+	if err := lv.Set(ctx, "on"); err != nil {
+		t.Fatalf("Set: unexpected error: %v", err)
+	}
+
+	if n := tr.called("SetField"); n != 1 {
+		t.Errorf("expected SetField to be called once, got %d", n)
 	}
 }
 

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -101,6 +101,7 @@ type LockedValue struct {
 	Checksum string
 
 	tenantID string
+	client   *Client
 }
 
 // GetForUpdate reads a field's current value along with its checksum.
@@ -121,6 +122,7 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 			Value:     resp.Value.String(),
 			Checksum:  resp.Checksum,
 			tenantID:  tenantID,
+			client:    c,
 		}, nil
 	})
 }
@@ -128,9 +130,9 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 // Set writes a new value for this field, but only if the value has not been
 // modified since the [LockedValue] was obtained via [Client.GetForUpdate].
 // Returns [ErrChecksumMismatch] if the value was changed by another writer.
-func (lv *LockedValue) Set(ctx context.Context, client *Client, newValue string) error {
-	return retryDo(ctx, client, func(ctx context.Context) error {
-		_, err := client.transport.SetField(ctx, &SetFieldRequest{
+func (lv *LockedValue) Set(ctx context.Context, newValue string) error {
+	return retryDo(ctx, lv.client, func(ctx context.Context) error {
+		_, err := lv.client.transport.SetField(ctx, &SetFieldRequest{
 			TenantID:         lv.tenantID,
 			FieldPath:        lv.FieldPath,
 			Value:            StringVal(newValue),
@@ -155,7 +157,7 @@ func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateF
 	if err != nil {
 		return err
 	}
-	return lv.Set(ctx, c, newValue)
+	return lv.Set(ctx, newValue)
 }
 
 // --- Type-specific setters ---


### PR DESCRIPTION
## Summary
- Closes #497
- LockedValue now captures the configclient reference at construction time
- LockedValue.Set() uses the captured client to make the remote set call
- Prevents nil-pointer panic or silent no-op when calling Set()

## Test plan
- [ ] LockedValue.Set() invokes client.Set with correct field path and value
- [ ] Existing SDK tests pass