### PR TITLE
fix(validation): treat CEL runtime errors as validation failures

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -279,6 +279,9 @@ func run() int {
 	if counter, ok := validationMetrics.CelCapExceededCounter(); ok {
 		validatorOpts = append(validatorOpts, validation.WithCelCapCounter(counter))
 	}
+	if counter, ok := validationMetrics.CelSoftErrCounter(); ok {
+		validatorOpts = append(validatorOpts, validation.WithCelSoftErrCounter(counter))
+	}
 	validatorFactory := validation.NewValidatorFactory(validatorStore, validatorOpts...)
 
 	// Usage recorder — async batched read tracking for audit stats.

--- a/e2e/validations_test.go
+++ b/e2e/validations_test.go
@@ -33,7 +33,7 @@ fields:
     nullable: true
 validations:
   - path: payments
-    rule: "self.payments.min_amount < self.payments.max_amount"
+    rule: "!has(self.payments.min_amount) || !has(self.payments.max_amount) || self.payments.min_amount < self.payments.max_amount"
     message: "payments.min_amount must be less than payments.max_amount"
     reason: MIN_LESS_THAN_MAX
 dependentRequired:

--- a/e2e/validations_test.go
+++ b/e2e/validations_test.go
@@ -33,7 +33,7 @@ fields:
     nullable: true
 validations:
   - path: payments
-    rule: "!has(self.payments.min_amount) || !has(self.payments.max_amount) || self.payments.min_amount < self.payments.max_amount"
+    rule: "self.payments.min_amount == null || self.payments.max_amount == null || self.payments.min_amount < self.payments.max_amount"
     message: "payments.min_amount must be less than payments.max_amount"
     reason: MIN_LESS_THAN_MAX
 dependentRequired:

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1514,6 +1514,9 @@ func (s *Service) enforceCrossFieldInTx(
 		if counter := s.validators.CelCapCounter(); counter != nil {
 			evalOpts = append(evalOpts, celpkg.WithCapCounter(counter, tenantID))
 		}
+		if counter := s.validators.CelSoftErrCounter(); counter != nil {
+			evalOpts = append(evalOpts, celpkg.WithSoftErrCounter(counter, tenantID))
+		}
 		failed, softErrs, evalErr := celpkg.Eval(celArtifacts.Programs, act, celArtifacts.Rules, evalOpts...)
 		if evalErr != nil {
 			return fmt.Errorf("evaluate validations: %w", evalErr)

--- a/internal/schema/cel/activation.go
+++ b/internal/schema/cel/activation.go
@@ -29,9 +29,10 @@ type TenantBinding struct {
 // BuildActivation returns the activation map handed to cel.Program.Eval.
 // The returned map has two top-level keys:
 //
-//   - self   — nested map keyed by dotted-path segments. Null/absent fields
-//     surface as the CEL `null` literal (Go nil) so authors can write
-//     `has(self.x)` or `self.x == null` interchangeably.
+//   - self   — nested map keyed by dotted-path segments. Unset fields
+//     surface as the CEL `null` literal (Go nil). Use `self.x == null` to
+//     guard comparisons — do NOT use `has(self.x)`, which returns true for
+//     pre-seeded nil keys and will not short-circuit correctly.
 //   - tenant — flat `{id, name}` map of strings.
 //
 // types must cover every path declared on the schema. Every key in types is

--- a/internal/schema/cel/eval.go
+++ b/internal/schema/cel/eval.go
@@ -20,8 +20,10 @@ import (
 type EvalOption func(*evalConfig)
 
 type evalConfig struct {
-	capCounter metric.Int64Counter
-	tenantID   string
+	capCounter     metric.Int64Counter
+	softErrCounter metric.Int64Counter
+	tenantID       string
+	lenient        bool // if true, runtime errors are soft-errors (logged, write proceeds)
 }
 
 // WithCapCounter wires an OTEL counter that is incremented (with the
@@ -32,6 +34,25 @@ func WithCapCounter(c metric.Int64Counter, tenantID string) EvalOption {
 		cfg.capCounter = c
 		cfg.tenantID = tenantID
 	}
+}
+
+// WithSoftErrCounter wires an OTEL counter that is incremented (with the
+// given tenantID attribute) whenever a CEL runtime error is treated as a
+// soft error (lenient mode only). Pass nil to disable.
+func WithSoftErrCounter(c metric.Int64Counter, tenantID string) EvalOption {
+	return func(cfg *evalConfig) {
+		cfg.softErrCounter = c
+		cfg.tenantID = tenantID
+	}
+}
+
+// WithLenientRuntimeErrors opts into the legacy soft-error behaviour: CEL
+// runtime errors (type mismatches, nil dereferences, non-bool results) are
+// collected as warnings and the write proceeds. Without this option the
+// default is strict: runtime errors fail the write with a descriptive
+// FailedRule entry so the rule author is notified immediately.
+func WithLenientRuntimeErrors() EvalOption {
+	return func(cfg *evalConfig) { cfg.lenient = true }
 }
 
 // FailedRule names a CEL rule that returned false against the current
@@ -48,17 +69,21 @@ type FailedRule struct {
 // rules that failed. Programs and rules must align by index — the caller
 // builds them together in factory.GetCelArtifacts.
 //
-// Three outcome shapes:
+// Outcome shapes (strict mode — default):
 //
 //   - rule returns false      → appended to the failed slice.
 //   - rule returns true       → dropped.
-//   - rule errors at runtime  → appended to the soft-error slice (returned
-//     separately so the caller can log without failing the write). The
-//     common runtime error is comparison against an unset (null) field;
-//     authors should not need to wrap every reference in `has()` to keep
-//     unrelated writes from being rejected.
+//   - rule errors at runtime  → appended to the failed slice with a
+//     descriptive message so the write is rejected and the rule author
+//     receives immediate feedback.
+//   - rule returns non-bool   → appended to the failed slice.
 //
-// Three terminal errors:
+// In lenient mode (pass [WithLenientRuntimeErrors]):
+//
+//   - runtime errors and non-bool results are collected as soft errors
+//     (returned in the second return value) and the write proceeds.
+//
+// Three terminal errors (both modes):
 //
 //   - per-rule cost-limit exceedance  — abort; caller returns InvalidArgument.
 //   - aggregate cost-limit exceedance — abort after summing cost across all
@@ -89,7 +114,21 @@ func Eval(programs []cel.Program, activation map[string]any, rules []*pb.Validat
 			if isCostLimit(err) {
 				return nil, softErrs, fmt.Errorf("cel: cost limit exceeded for validations[%d]: %w", i, err)
 			}
-			softErrs = append(softErrs, fmt.Errorf("validations[%d]: %w", i, err))
+			runtimeErr := fmt.Errorf("validations[%d]: %w", i, err)
+			if cfg.lenient {
+				if cfg.softErrCounter != nil {
+					cfg.softErrCounter.Add(context.Background(), 1, metric.WithAttributes(
+						attribute.String("tenant_id", cfg.tenantID),
+					))
+				}
+				softErrs = append(softErrs, runtimeErr)
+			} else {
+				failed = append(failed, FailedRule{
+					Index:   i,
+					Message: fmt.Sprintf("rule evaluation failed: %v", err),
+					Reason:  "cel_runtime_error",
+				})
+			}
 			continue
 		}
 		if details != nil {
@@ -106,7 +145,21 @@ func Eval(programs []cel.Program, activation map[string]any, rules []*pb.Validat
 			}
 		}
 		if val == nil || val.Type() != types.BoolType {
-			softErrs = append(softErrs, fmt.Errorf("validations[%d]: rule did not evaluate to bool (got %v)", i, valType(val)))
+			nonBoolErr := fmt.Errorf("validations[%d]: rule did not evaluate to bool (got %v)", i, valType(val))
+			if cfg.lenient {
+				if cfg.softErrCounter != nil {
+					cfg.softErrCounter.Add(context.Background(), 1, metric.WithAttributes(
+						attribute.String("tenant_id", cfg.tenantID),
+					))
+				}
+				softErrs = append(softErrs, nonBoolErr)
+			} else {
+				failed = append(failed, FailedRule{
+					Index:   i,
+					Message: fmt.Sprintf("rule did not evaluate to bool (got %v)", valType(val)),
+					Reason:  "cel_non_bool_result",
+				})
+			}
 			continue
 		}
 		if val.Value() == false {

--- a/internal/schema/cel/eval_test.go
+++ b/internal/schema/cel/eval_test.go
@@ -193,7 +193,9 @@ type stringError string
 
 func (a stringError) Error() string { return string(a) }
 
-func TestEval_NonBoolResultIsSoftError(t *testing.T) {
+func TestEval_NonBoolResult_StrictMode_FailsWrite(t *testing.T) {
+	// In strict mode (default), a rule that evaluates to a non-bool value
+	// must be treated as a validation failure so the write is rejected.
 	programs, rules := compileRunnable(t, []ruleSpec{
 		{rule: "self.payments.min_amount + 1.0", message: "not bool"},
 	})
@@ -204,17 +206,16 @@ func TestEval_NonBoolResultIsSoftError(t *testing.T) {
 	)
 	failed, softErrs, err := Eval(programs, act, rules)
 	require.NoError(t, err)
-	assert.Empty(t, failed, "non-bool rule must not count as a failure")
-	require.Len(t, softErrs, 1)
-	assert.Contains(t, softErrs[0].Error(), "did not evaluate to bool")
+	assert.Empty(t, softErrs, "strict mode must not produce soft errors")
+	require.Len(t, failed, 1, "non-bool rule must fail the write in strict mode")
+	assert.Equal(t, "cel_non_bool_result", failed[0].Reason)
+	assert.Contains(t, failed[0].Message, "did not evaluate to bool")
 }
 
-func TestEval_NullComparisonIsSoftError(t *testing.T) {
-	// Rule references a field that is null in the activation. cel-go raises
-	// a runtime error ("no such overload") that must surface as a soft
-	// error rather than failing the write — otherwise authors would have to
-	// wrap every field reference in has() to keep unrelated writes from
-	// being rejected.
+func TestEval_RuntimeError_StrictMode_FailsWrite(t *testing.T) {
+	// In strict mode (default), a CEL runtime error (e.g. null dereference)
+	// must fail the write so the rule author receives immediate feedback.
+	// Previously this was a silent soft-error that allowed the write to proceed.
 	programs, rules := compileRunnable(t, []ruleSpec{
 		{rule: "self.payments.min_amount < self.payments.max_amount", message: "min < max"},
 	})
@@ -228,8 +229,71 @@ func TestEval_NullComparisonIsSoftError(t *testing.T) {
 	)
 	failed, softErrs, err := Eval(programs, act, rules)
 	require.NoError(t, err)
-	assert.Empty(t, failed, "null comparison must not fail the write")
+	assert.Empty(t, softErrs, "strict mode must not produce soft errors")
+	require.Len(t, failed, 1, "runtime error must fail the write in strict mode")
+	assert.Equal(t, "cel_runtime_error", failed[0].Reason)
+	assert.Contains(t, failed[0].Message, "rule evaluation failed")
+}
+
+func TestEval_NonBoolResult_LenientMode_IsSoftError(t *testing.T) {
+	// Lenient mode restores legacy behaviour: non-bool results are logged as
+	// soft errors and the write proceeds.
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount + 1.0", message: "not bool"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{{FieldPath: "payments.min_amount", Value: strPtr("1")}},
+		map[string]pb.FieldType{"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER},
+		TenantBinding{},
+	)
+	failed, softErrs, err := Eval(programs, act, rules, WithLenientRuntimeErrors())
+	require.NoError(t, err)
+	assert.Empty(t, failed, "lenient mode: non-bool rule must not count as a failure")
 	require.Len(t, softErrs, 1)
+	assert.Contains(t, softErrs[0].Error(), "did not evaluate to bool")
+}
+
+func TestEval_RuntimeError_LenientMode_IsSoftError(t *testing.T) {
+	// Lenient mode restores legacy behaviour: runtime errors (e.g. null
+	// dereference when a field is missing from the activation) are soft errors
+	// and the write proceeds.
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount < self.payments.max_amount", message: "min < max"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{{FieldPath: "payments.max_amount", Value: strPtr("100")}},
+		map[string]pb.FieldType{
+			"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+			"payments.max_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+		},
+		TenantBinding{},
+	)
+	failed, softErrs, err := Eval(programs, act, rules, WithLenientRuntimeErrors())
+	require.NoError(t, err)
+	assert.Empty(t, failed, "lenient mode: null comparison must not fail the write")
+	require.Len(t, softErrs, 1)
+}
+
+func TestEval_LenientMode_SoftErrCounterIncremented(t *testing.T) {
+	// Verify the soft-error counter fires in lenient mode on a runtime error.
+	programs, rules := compileRunnable(t, []ruleSpec{
+		{rule: "self.payments.min_amount < self.payments.max_amount", message: "min < max"},
+	})
+	act := BuildActivation(
+		[]SnapshotRow{{FieldPath: "payments.max_amount", Value: strPtr("100")}},
+		map[string]pb.FieldType{
+			"payments.min_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+			"payments.max_amount": pb.FieldType_FIELD_TYPE_NUMBER,
+		},
+		TenantBinding{},
+	)
+	counter := &fakeCounter{}
+	_, _, err := Eval(programs, act, rules,
+		WithLenientRuntimeErrors(),
+		WithSoftErrCounter(counter, "tenant-xyz"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), counter.n.Load(), "soft-error counter must be incremented once")
 }
 
 func TestEval_AggregateCostCapExceeded(t *testing.T) {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -149,6 +149,7 @@ type ValidationMetrics struct {
 	regexCompileErrors  metric.Int64Counter
 	inFlightCompiles    metric.Int64UpDownCounter
 	celAggregateCostCap metric.Int64Counter
+	celSoftErr          metric.Int64Counter
 }
 
 // NewValidationMetrics creates validation metrics. Returns nil if not enabled.
@@ -165,7 +166,9 @@ func NewValidationMetrics(cfg Config) *ValidationMetrics {
 		metric.WithDescription("Number of JSON-Schema compile goroutines currently in flight, including zombies that outlived their timeout"))
 	celCap, _ := meter.Int64Counter("validation.cel_aggregate_cost_cap_exceeded_total",
 		metric.WithDescription("Number of times the aggregate CEL evaluation cost cap was exceeded per tenant, causing the write to be rejected"))
-	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors, inFlightCompiles: inFlight, celAggregateCostCap: celCap}
+	celSoftErr, _ := meter.Int64Counter("validation.cel_soft_error_total",
+		metric.WithDescription("Number of CEL runtime errors treated as soft errors in lenient mode"))
+	return &ValidationMetrics{compileTimeouts: timeouts, regexCompileErrors: regexErrors, inFlightCompiles: inFlight, celAggregateCostCap: celCap, celSoftErr: celSoftErr}
 }
 
 // TimeoutCounter returns the underlying Int64Counter and true when metrics are
@@ -202,6 +205,15 @@ func (m *ValidationMetrics) CelCapExceededCounter() (metric.Int64Counter, bool) 
 		return nil, false
 	}
 	return m.celAggregateCostCap, true
+}
+
+// CelSoftErrCounter returns the counter incremented when a CEL runtime error
+// is treated as a soft error in lenient mode, and true when metrics are enabled.
+func (m *ValidationMetrics) CelSoftErrCounter() (metric.Int64Counter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.celSoftErr, true
 }
 
 // StartDBPoolMetrics starts a background goroutine that periodically records

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -150,11 +150,21 @@ func TestValidationMetrics_NilSafe(t *testing.T) {
 	counter, ok = m.CelCapExceededCounter()
 	assert.False(t, ok)
 	assert.Nil(t, counter)
+	counter, ok = m.CelSoftErrCounter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
 }
 
 func TestValidationMetrics_CelCapExceededCounter(t *testing.T) {
 	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
 	counter, ok := m.CelCapExceededCounter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
+}
+
+func TestValidationMetrics_CelSoftErrCounter(t *testing.T) {
+	m := NewValidationMetrics(Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.CelSoftErrCounter()
 	assert.True(t, ok)
 	assert.NotNil(t, counter)
 }

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -26,15 +26,16 @@ type Store interface {
 
 // ValidatorFactory builds and caches field validators per tenant.
 type ValidatorFactory struct {
-	store            Store
-	cache            *ValidatorCache
-	rulesCache       sync.Map // tenantID → []byte (raw dependent_required JSON)
-	validationsCache sync.Map // tenantID → []*pb.ValidationRule
-	celEnvCache      sync.Map // tenantID → *cel.Env
-	celProgramsCache sync.Map // tenantID → []cel.Program
-	celCache         *celpkg.Cache
-	limits           Limits
-	celCapCounter    metric.Int64Counter // nil when metrics are disabled
+	store             Store
+	cache             *ValidatorCache
+	rulesCache        sync.Map // tenantID → []byte (raw dependent_required JSON)
+	validationsCache  sync.Map // tenantID → []*pb.ValidationRule
+	celEnvCache       sync.Map // tenantID → *cel.Env
+	celProgramsCache  sync.Map // tenantID → []cel.Program
+	celCache          *celpkg.Cache
+	limits            Limits
+	celCapCounter     metric.Int64Counter // nil when metrics are disabled
+	celSoftErrCounter metric.Int64Counter // nil when metrics are disabled
 }
 
 // NewValidatorFactory creates a new validator factory. Pass [WithLimits]
@@ -42,11 +43,12 @@ type ValidatorFactory struct {
 func NewValidatorFactory(store Store, opts ...Option) *ValidatorFactory {
 	o := resolveOptions(opts)
 	return &ValidatorFactory{
-		store:         store,
-		cache:         NewValidatorCache(0),
-		celCache:      celpkg.NewCache(),
-		limits:        o.limits,
-		celCapCounter: o.celCapCounter,
+		store:             store,
+		cache:             NewValidatorCache(0),
+		celCache:          celpkg.NewCache(),
+		limits:            o.limits,
+		celCapCounter:     o.celCapCounter,
+		celSoftErrCounter: o.celSoftErrCounter,
 	}
 }
 
@@ -55,6 +57,13 @@ func NewValidatorFactory(store Store, opts ...Option) *ValidatorFactory {
 // celpkg.Eval via celpkg.WithCapCounter.
 func (f *ValidatorFactory) CelCapCounter() metric.Int64Counter {
 	return f.celCapCounter
+}
+
+// CelSoftErrCounter returns the OTEL counter for CEL soft errors in lenient
+// mode (nil when metrics are disabled). Callers pass it to celpkg.Eval via
+// celpkg.WithSoftErrCounter.
+func (f *ValidatorFactory) CelSoftErrCounter() metric.Int64Counter {
+	return f.celSoftErrCounter
 }
 
 // Cache returns the underlying cache for invalidation.

--- a/internal/validation/factory_test.go
+++ b/internal/validation/factory_test.go
@@ -84,6 +84,21 @@ func TestValidatorFactory_CelCapCounter_NilWhenUnset(t *testing.T) {
 	assert.Nil(t, f.CelCapCounter())
 }
 
+func TestNewValidatorFactory_WithCelSoftErrCounter(t *testing.T) {
+	store := newMockStore()
+	m := telemetry.NewValidationMetrics(telemetry.Config{Enabled: true, MetricsValidation: true})
+	counter, ok := m.CelSoftErrCounter()
+	require.True(t, ok)
+
+	f := NewValidatorFactory(store, WithCelSoftErrCounter(counter))
+	assert.NotNil(t, f.CelSoftErrCounter())
+}
+
+func TestValidatorFactory_CelSoftErrCounter_NilWhenUnset(t *testing.T) {
+	f := NewValidatorFactory(newMockStore())
+	assert.Nil(t, f.CelSoftErrCounter())
+}
+
 // --- GetValidators: cache miss → builds validators ---
 
 func TestGetValidators_CacheMiss_BuildsValidators(t *testing.T) {

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -62,6 +62,7 @@ type options struct {
 	regexErrorCounter metric.Int64Counter       // nil when metrics are disabled
 	inFlightGauge     metric.Int64UpDownCounter // nil when metrics are disabled
 	celCapCounter     metric.Int64Counter       // nil when metrics are disabled
+	celSoftErrCounter metric.Int64Counter       // nil when metrics are disabled
 	compileSem        chan struct{}             // nil when MaxConcurrentCompiles == 0
 }
 
@@ -107,6 +108,14 @@ func WithInFlightGauge(g metric.Int64UpDownCounter) Option {
 // "validation.cel_aggregate_cost_cap_exceeded_total". Pass nil to disable.
 func WithCelCapCounter(c metric.Int64Counter) Option {
 	return func(o *options) { o.celCapCounter = c }
+}
+
+// WithCelSoftErrCounter sets the OTEL counter incremented (with a tenant_id
+// attribute) when a CEL runtime error is treated as a soft error in lenient
+// mode. The metric name should be
+// "validation.cel_soft_error_total". Pass nil to disable.
+func WithCelSoftErrCounter(c metric.Int64Counter) Option {
+	return func(o *options) { o.celSoftErrCounter = c }
 }
 
 func resolveOptions(opts []Option) options {


### PR DESCRIPTION
## Summary
- Closes #561
- CEL runtime errors (type mismatch, nil dereference, divide-by-zero) now cause validation to fail with InvalidArgument instead of silently passing
- Prevents values that trigger broken validation rules from being accepted
- Adds `WithLenientRuntimeErrors()` EvalOption to restore old soft-error behaviour for opt-in cases
- Adds `WithSoftErrCounter` / `CelSoftErrCounter` metric to track soft errors in lenient mode

## Test plan
- [ ] CEL rule that triggers a null dereference (missing field) rejects the write in strict mode
- [ ] CEL rule that returns a non-bool value rejects the write in strict mode
- [ ] Lenient mode restores soft-error behaviour (write proceeds, counter incremented)
- [ ] Valid values with working CEL rules still pass
- [ ] Existing validation tests pass