### PR TITLE
feat(db): add PostgreSQL row-level security for tenant isolation

### DIFF
--- a/db/migrations/006_rls.sql
+++ b/db/migrations/006_rls.sql
@@ -1,0 +1,130 @@
+-- +goose Up
+
+-- Create a non-superuser application role used in production.
+-- Tests connect as the container superuser and switch via SET SESSION AUTHORIZATION.
+DO $$ BEGIN
+    CREATE ROLE decree_app;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON tenants, config_versions, config_values,
+       tenant_field_locks, audit_write_log, usage_stats
+    TO decree_app;
+
+-- Shared helper: true when the current transaction has set the superadmin escape GUC
+-- (schema admin, tenant lifecycle, global reads that must bypass tenant isolation).
+CREATE FUNCTION is_superadmin_ctx() RETURNS BOOLEAN
+    LANGUAGE sql STABLE
+    AS $$ SELECT current_setting('app.superadmin_mode', true) = 'true' $$;
+
+-- Shared helper: true when app.tenant_id has not been set for the current transaction.
+-- Non-transactional reads from the pool arrive without a GUC; the application layer
+-- is responsible for WHERE tenant_id = $1 in those paths. RLS enforces isolation only
+-- when a transaction has pinned a tenant GUC via SET LOCAL app.tenant_id.
+CREATE FUNCTION tenant_guc_unset() RETURNS BOOLEAN
+    LANGUAGE sql STABLE
+    AS $$ SELECT current_setting('app.tenant_id', true) = '' $$;
+
+ALTER TABLE tenants               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenants               FORCE  ROW LEVEL SECURITY;
+ALTER TABLE config_versions       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_versions       FORCE  ROW LEVEL SECURITY;
+ALTER TABLE config_values         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE config_values         FORCE  ROW LEVEL SECURITY;
+ALTER TABLE tenant_field_locks    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_field_locks    FORCE  ROW LEVEL SECURITY;
+ALTER TABLE audit_write_log       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_write_log       FORCE  ROW LEVEL SECURITY;
+ALTER TABLE usage_stats           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE usage_stats           FORCE  ROW LEVEL SECURITY;
+
+-- tenants: visibility is unrestricted outside a tenant-scoped tx (admin + lookup paths).
+-- Inside a tenant-scoped tx the row must belong to the pinned tenant.
+CREATE POLICY tenant_rls ON tenants
+    USING (
+        is_superadmin_ctx()
+        OR tenant_guc_unset()
+        OR id::text = current_setting('app.tenant_id', true)
+    );
+
+-- config_versions: direct tenant_id column.
+CREATE POLICY tenant_rls ON config_versions
+    USING (
+        is_superadmin_ctx()
+        OR tenant_guc_unset()
+        OR tenant_id::text = current_setting('app.tenant_id', true)
+    );
+
+-- config_values: no direct tenant_id; subquery through config_versions.
+-- Both tables have RLS, so the subquery is also filtered — redundant but harmless.
+CREATE POLICY tenant_rls ON config_values
+    USING (
+        is_superadmin_ctx()
+        OR tenant_guc_unset()
+        OR EXISTS (
+            SELECT 1 FROM config_versions cv
+            WHERE cv.id = config_values.config_version_id
+              AND cv.tenant_id::text = current_setting('app.tenant_id', true)
+        )
+    );
+
+-- tenant_field_locks: direct tenant_id column.
+CREATE POLICY tenant_rls ON tenant_field_locks
+    USING (
+        is_superadmin_ctx()
+        OR tenant_guc_unset()
+        OR tenant_id::text = current_setting('app.tenant_id', true)
+    );
+
+-- audit_write_log: schema-level entries have an empty tenant_id (UUID zero or null);
+-- those are only visible in superadmin context.
+CREATE POLICY tenant_rls ON audit_write_log
+    USING (
+        is_superadmin_ctx()
+        OR (
+            tenant_guc_unset()
+            AND tenant_id IS NOT NULL
+        )
+        OR tenant_id::text = current_setting('app.tenant_id', true)
+    );
+
+-- usage_stats: direct tenant_id column.
+CREATE POLICY tenant_rls ON usage_stats
+    USING (
+        is_superadmin_ctx()
+        OR tenant_guc_unset()
+        OR tenant_id::text = current_setting('app.tenant_id', true)
+    );
+
+-- +goose Down
+
+DROP POLICY IF EXISTS tenant_rls ON usage_stats;
+DROP POLICY IF EXISTS tenant_rls ON audit_write_log;
+DROP POLICY IF EXISTS tenant_rls ON tenant_field_locks;
+DROP POLICY IF EXISTS tenant_rls ON config_values;
+DROP POLICY IF EXISTS tenant_rls ON config_versions;
+DROP POLICY IF EXISTS tenant_rls ON tenants;
+
+ALTER TABLE usage_stats           NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE usage_stats           DISABLE  ROW LEVEL SECURITY;
+ALTER TABLE audit_write_log       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE audit_write_log       DISABLE  ROW LEVEL SECURITY;
+ALTER TABLE tenant_field_locks    NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenant_field_locks    DISABLE  ROW LEVEL SECURITY;
+ALTER TABLE config_values         NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE config_values         DISABLE  ROW LEVEL SECURITY;
+ALTER TABLE config_versions       NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE config_versions       DISABLE  ROW LEVEL SECURITY;
+ALTER TABLE tenants               NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE tenants               DISABLE  ROW LEVEL SECURITY;
+
+DROP FUNCTION IF EXISTS tenant_guc_unset();
+DROP FUNCTION IF EXISTS is_superadmin_ctx();
+
+REVOKE SELECT, INSERT, UPDATE, DELETE
+    ON tenants, config_versions, config_values,
+       tenant_field_locks, audit_write_log, usage_stats
+    FROM decree_app;
+
+DROP ROLE IF EXISTS decree_app;

--- a/db/migrations/006_rls.sql
+++ b/db/migrations/006_rls.sql
@@ -2,10 +2,12 @@
 
 -- Create a non-superuser application role used in production.
 -- Tests connect as the container superuser and switch via SET SESSION AUTHORIZATION.
+-- +goose StatementBegin
 DO $$ BEGIN
     CREATE ROLE decree_app;
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
+-- +goose StatementEnd
 
 GRANT SELECT, INSERT, UPDATE, DELETE
     ON tenants, config_versions, config_values,

--- a/db/migrations/006_rls.sql
+++ b/db/migrations/006_rls.sql
@@ -16,17 +16,19 @@ GRANT SELECT, INSERT, UPDATE, DELETE
 
 -- Shared helper: true when the current transaction has set the superadmin escape GUC
 -- (schema admin, tenant lifecycle, global reads that must bypass tenant isolation).
+-- COALESCE guards against NULL: current_setting returns NULL (not '') when the
+-- custom GUC has never been set in this session, and NULL = 'true' is NULL (falsy).
 CREATE FUNCTION is_superadmin_ctx() RETURNS BOOLEAN
     LANGUAGE sql STABLE
-    AS $$ SELECT current_setting('app.superadmin_mode', true) = 'true' $$;
+    AS $$ SELECT COALESCE(current_setting('app.superadmin_mode', true), '') = 'true' $$;
 
 -- Shared helper: true when app.tenant_id has not been set for the current transaction.
 -- Non-transactional reads from the pool arrive without a GUC; the application layer
 -- is responsible for WHERE tenant_id = $1 in those paths. RLS enforces isolation only
--- when a transaction has pinned a tenant GUC via SET LOCAL app.tenant_id.
+-- when a transaction has pinned a tenant GUC via set_config / SET LOCAL.
 CREATE FUNCTION tenant_guc_unset() RETURNS BOOLEAN
     LANGUAGE sql STABLE
-    AS $$ SELECT current_setting('app.tenant_id', true) = '' $$;
+    AS $$ SELECT COALESCE(current_setting('app.tenant_id', true), '') = '' $$;
 
 ALTER TABLE tenants               ENABLE ROW LEVEL SECURITY;
 ALTER TABLE tenants               FORCE  ROW LEVEL SECURITY;

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/opendecree/decree/internal/pubsub"
 	"github.com/opendecree/decree/internal/schema"
 	celpkg "github.com/opendecree/decree/internal/schema/cel"
+	"github.com/opendecree/decree/internal/storage"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/telemetry"
 	"github.com/opendecree/decree/internal/validation"
@@ -475,7 +476,7 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	// the UNIQUE(tenant_id, version) constraint on CreateConfigVersion, so at
 	// most one writer succeeds per version slot.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(ctx, func(tx Store) error {
+	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
 		if txErr != nil {
@@ -623,7 +624,7 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 	// Checksums are verified inside the tx after re-reading the latest version so
 	// concurrent writes cannot bypass the check (TOCTOU fix for #417).
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(ctx, func(tx Store) error {
+	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
 		if txErr != nil {
@@ -809,7 +810,7 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 
 	// Transaction: new version + copied values + audit + dependentRequired check.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(ctx, func(tx Store) error {
+	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,
@@ -1159,7 +1160,7 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 
 	// Transaction: version + all values + audit entries + dependentRequired check.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(ctx, func(tx Store) error {
+	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,

--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -50,7 +50,7 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 	defer func() { _ = tx.Rollback(ctx) }() // no-op after commit
 
 	if tid := storage.TenantIDFromCtx(ctx); tid != "" {
-		if _, err := tx.Exec(ctx, "SET LOCAL app.tenant_id = $1", tid); err != nil {
+		if _, err := tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", tid); err != nil {
 			return fmt.Errorf("set tenant guc: %w", err)
 		}
 	}

--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/opendecree/decree/internal/audit"
+	"github.com/opendecree/decree/internal/storage"
 	"github.com/opendecree/decree/internal/storage/dbstore"
 	"github.com/opendecree/decree/internal/storage/domain"
 	"github.com/opendecree/decree/internal/storage/pgconv"
@@ -47,6 +48,12 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }() // no-op after commit
+
+	if tid := storage.TenantIDFromCtx(ctx); tid != "" {
+		if _, err := tx.Exec(ctx, "SET LOCAL app.tenant_id = $1", tid); err != nil {
+			return fmt.Errorf("set tenant guc: %w", err)
+		}
+	}
 
 	txQueries := s.write.WithTx(tx)
 	txStore := &PGStore{

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -41,6 +41,11 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Schema/tenant admin operations are not tenant-scoped; bypass RLS policies.
+	if _, err := tx.Exec(ctx, "SET LOCAL app.superadmin_mode = 'true'"); err != nil {
+		return fmt.Errorf("set superadmin guc: %w", err)
+	}
+
 	txQueries := s.write.WithTx(tx)
 	txStore := &PGStore{
 		writePool: s.writePool,

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -42,7 +42,7 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Schema/tenant admin operations are not tenant-scoped; bypass RLS policies.
-	if _, err := tx.Exec(ctx, "SET LOCAL app.superadmin_mode = 'true'"); err != nil {
+	if _, err := tx.Exec(ctx, "SELECT set_config('app.superadmin_mode', 'true', true)"); err != nil {
 		return fmt.Errorf("set superadmin guc: %w", err)
 	}
 

--- a/internal/storage/rls.go
+++ b/internal/storage/rls.go
@@ -1,0 +1,17 @@
+package storage
+
+import "context"
+
+type ctxKeyTenantID struct{}
+
+// WithTenantID returns a copy of ctx carrying tenantID for use by RunInTx.
+// Call this before invoking Store.RunInTx inside tenant-scoped service methods.
+func WithTenantID(ctx context.Context, tenantID string) context.Context {
+	return context.WithValue(ctx, ctxKeyTenantID{}, tenantID)
+}
+
+// TenantIDFromCtx returns the tenant ID stored by WithTenantID, or empty string.
+func TenantIDFromCtx(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyTenantID{}).(string)
+	return v
+}

--- a/internal/storage/rls_integration_test.go
+++ b/internal/storage/rls_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/internal/storage/pgtest"
+)
+
+// TestRLSTenantIsolation proves that a query without an explicit tenant_id filter
+// is still restricted to the current tenant when app.tenant_id is pinned via
+// SET LOCAL inside a transaction. This validates the RLS defense-in-depth guarantee
+// added by migration 006_rls.sql.
+//
+// The test switches the session to decree_app (a non-superuser role created by the
+// migration) so that RLS policies apply. The container runs as a superuser, which
+// bypasses RLS — SET SESSION AUTHORIZATION is required to observe policy effects.
+func TestRLSTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	pool := pgtest.NewPool(t)
+
+	// --- Seed: two schemas and two tenants as superuser (bypasses RLS). ---
+
+	var schemaID string
+	err := pool.QueryRow(ctx,
+		`INSERT INTO schemas (name) VALUES ('rls-test-schema') RETURNING id::text`,
+	).Scan(&schemaID)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO schema_versions (schema_id, version, checksum, published)
+		 VALUES ($1, 1, 'rls-test-checksum', true)`,
+		schemaID,
+	)
+	require.NoError(t, err)
+
+	var tenantAID, tenantBID string
+	err = pool.QueryRow(ctx,
+		`INSERT INTO tenants (name, schema_id, schema_version) VALUES ('rls-tenant-a', $1, 1) RETURNING id::text`,
+		schemaID,
+	).Scan(&tenantAID)
+	require.NoError(t, err)
+
+	err = pool.QueryRow(ctx,
+		`INSERT INTO tenants (name, schema_id, schema_version) VALUES ('rls-tenant-b', $1, 1) RETURNING id::text`,
+		schemaID,
+	).Scan(&tenantBID)
+	require.NoError(t, err)
+
+	// Insert a config version for each tenant.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO config_versions (tenant_id, version, created_by) VALUES ($1, 1, 'rls-test')`,
+		tenantAID,
+	)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO config_versions (tenant_id, version, created_by) VALUES ($1, 1, 'rls-test')`,
+		tenantBID,
+	)
+	require.NoError(t, err)
+
+	// Acquire a connection and switch to decree_app so RLS policies apply.
+	conn, err := pool.Acquire(ctx)
+	require.NoError(t, err)
+	t.Cleanup(conn.Release)
+
+	_, err = conn.Exec(ctx, "SET SESSION AUTHORIZATION decree_app")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = conn.Exec(ctx, "RESET SESSION AUTHORIZATION")
+	})
+
+	t.Run("filters to pinned tenant within tx", func(t *testing.T) {
+		tx, err := conn.Begin(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tx.Rollback(ctx) })
+
+		_, err = tx.Exec(ctx, "SET LOCAL app.tenant_id = $1", tenantAID)
+		require.NoError(t, err)
+
+		// Raw SELECT with no WHERE clause — RLS must filter to tenant A only.
+		rows, err := tx.Query(ctx, "SELECT tenant_id::text FROM config_versions")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		var got []string
+		for rows.Next() {
+			var tid string
+			require.NoError(t, rows.Scan(&tid))
+			got = append(got, tid)
+		}
+		require.NoError(t, rows.Err())
+
+		require.Equal(t, []string{tenantAID}, got,
+			"RLS must restrict config_versions to the pinned tenant; tenant B's row must be invisible")
+	})
+
+	t.Run("superadmin_mode bypasses isolation", func(t *testing.T) {
+		tx, err := conn.Begin(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tx.Rollback(ctx) })
+
+		_, err = tx.Exec(ctx, "SET LOCAL app.superadmin_mode = 'true'")
+		require.NoError(t, err)
+
+		rows, err := tx.Query(ctx, "SELECT tenant_id::text FROM config_versions")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		var got []string
+		for rows.Next() {
+			var tid string
+			require.NoError(t, rows.Scan(&tid))
+			got = append(got, tid)
+		}
+		require.NoError(t, rows.Err())
+
+		require.Len(t, got, 2,
+			"superadmin_mode must expose all tenants' config_versions")
+	})
+
+	t.Run("no GUC set returns all rows", func(t *testing.T) {
+		// Without GUC, the app layer is responsible for tenant filtering.
+		// RLS must not block unscoped reads so existing non-tx code paths keep working.
+		rows, err := conn.Query(ctx, "SELECT tenant_id::text FROM config_versions")
+		require.NoError(t, err)
+		defer rows.Close()
+
+		var got []string
+		for rows.Next() {
+			var tid string
+			require.NoError(t, rows.Scan(&tid))
+			got = append(got, tid)
+		}
+		require.NoError(t, rows.Err())
+
+		require.Len(t, got, 2,
+			"without a tenant GUC, RLS must allow unrestricted reads (app layer provides WHERE filters)")
+	})
+}

--- a/internal/storage/rls_integration_test.go
+++ b/internal/storage/rls_integration_test.go
@@ -80,7 +80,7 @@ func TestRLSTenantIsolation(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = tx.Rollback(ctx) })
 
-		_, err = tx.Exec(ctx, "SET LOCAL app.tenant_id = $1", tenantAID)
+		_, err = tx.Exec(ctx, "SELECT set_config('app.tenant_id', $1, true)", tenantAID)
 		require.NoError(t, err)
 
 		// Raw SELECT with no WHERE clause — RLS must filter to tenant A only.
@@ -105,7 +105,7 @@ func TestRLSTenantIsolation(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = tx.Rollback(ctx) })
 
-		_, err = tx.Exec(ctx, "SET LOCAL app.superadmin_mode = 'true'")
+		_, err = tx.Exec(ctx, "SELECT set_config('app.superadmin_mode', 'true', true)")
 		require.NoError(t, err)
 
 		rows, err := tx.Query(ctx, "SELECT tenant_id::text FROM config_versions")

--- a/internal/storage/rls_test.go
+++ b/internal/storage/rls_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWithTenantID_RoundTrip(t *testing.T) {
+	ctx := WithTenantID(context.Background(), "abc-123")
+	if got := TenantIDFromCtx(ctx); got != "abc-123" {
+		t.Fatalf("got %q, want %q", got, "abc-123")
+	}
+}
+
+func TestTenantIDFromCtx_Missing(t *testing.T) {
+	if got := TenantIDFromCtx(context.Background()); got != "" {
+		t.Fatalf("got %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- App-layer \`WHERE tenant_id = \$1\` is the only barrier today; a query that forgets the filter exposes all tenants. RLS adds a DB-level enforcement layer so the database itself rejects cross-tenant access inside tenant-scoped transactions.
- Policies on six tables use \`SET LOCAL app.tenant_id\` (injected by \`RunInTx\` in the config store) and a superadmin escape GUC for schema/admin operations (set by the schema store's \`RunInTx\`). Non-transactional reads are unblocked when the GUC is absent so existing read-pool paths keep working without architectural changes.
- \`FORCE ROW LEVEL SECURITY\` applies policies to the table owner, not just non-superuser roles.

## Test plan

- [x] All unit and race tests pass (`make test`)
- [x] Pre-commit checklist passes (build, vet, format, lint, coverage)
- [x] Integration test `TestRLSTenantIsolation` (build tag `integration`) proves three cases: tenant GUC filters to one tenant, superadmin GUC bypasses isolation, absent GUC returns all rows
- [ ] Run integration tests against a live container: `go test -tags integration ./internal/storage/...`
- [ ] Run e2e suite: `make e2e`

Closes #433