### PR TITLE
fix(ratelimit): close rate-limit holes: global cap, stream metering, anon per-IP, pre-auth

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -221,13 +221,18 @@ func run() int {
 	// Rate limiter (nil when disabled; nil WithRateLimiter is a no-op).
 	rlMetrics := telemetry.NewRateLimitMetrics(otelCfg)
 	var rlInterceptor *ratelimit.Interceptor
+	var preAuthInterceptor *ratelimit.Interceptor
 	if cfg.RateLimitEnabled {
 		rlCfg := ratelimit.Config{
 			Anonymous:     ratelimit.NewInProcess(rate.Limit(cfg.RateLimitAnonRPS), cfg.RateLimitBurst),
 			Authenticated: ratelimit.NewInProcess(rate.Limit(cfg.RateLimitAuthedRPS), cfg.RateLimitBurst),
+			TrustedProxy:  cfg.RateLimitTrustedProxy,
 		}
 		if cfg.RateLimitSuperAdminRPS > 0 {
 			rlCfg.SuperAdmin = ratelimit.NewInProcess(rate.Limit(cfg.RateLimitSuperAdminRPS), cfg.RateLimitBurst)
+		}
+		if cfg.RateLimitGlobalRPS > 0 {
+			rlCfg.Global = ratelimit.NewInProcess(rate.Limit(cfg.RateLimitGlobalRPS), cfg.RateLimitBurst)
 		}
 		rlOpts := []ratelimit.Option{ratelimit.WithInterceptorLogger(logger)}
 		if counter, ok := rlMetrics.Counter(); ok {
@@ -238,15 +243,28 @@ func run() int {
 			"anon_rps", cfg.RateLimitAnonRPS,
 			"authed_rps", cfg.RateLimitAuthedRPS,
 			"superadmin_rps", cfg.RateLimitSuperAdminRPS,
+			"global_rps", cfg.RateLimitGlobalRPS,
 			"burst", cfg.RateLimitBurst,
 		)
+
+		if cfg.RateLimitPreAuthRPS > 0 {
+			preAuthCfg := ratelimit.Config{
+				Anonymous:    ratelimit.NewInProcess(rate.Limit(cfg.RateLimitPreAuthRPS), cfg.RateLimitBurst),
+				TrustedProxy: cfg.RateLimitTrustedProxy,
+			}
+			preAuthInterceptor = ratelimit.New(preAuthCfg, ratelimit.WithInterceptorLogger(logger))
+			logger.InfoContext(ctx, "pre-auth rate limiting enabled",
+				"rps", cfg.RateLimitPreAuthRPS,
+				"burst", cfg.RateLimitBurst,
+			)
+		}
 	}
 
 	if cfg.EnableReflection {
 		logger.WarnContext(ctx, "ENABLE_REFLECTION=1 set — gRPC server reflection enabled (not recommended for production)")
 	}
 
-	srvBuild := buildServerOptions(cfg, logger, extraOpts, serverTLS, rlInterceptor)
+	srvBuild := buildServerOptions(cfg, logger, extraOpts, serverTLS, rlInterceptor, preAuthInterceptor)
 	srv, err := server.New(cfg.GRPCPort, authInterceptor, srvBuild.Opts...)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create server", "error", err)
@@ -467,6 +485,9 @@ type serverConfig struct {
 	RateLimitAnonRPS            float64
 	RateLimitAuthedRPS          float64
 	RateLimitSuperAdminRPS      float64 // 0 = unlimited
+	RateLimitGlobalRPS          float64 // 0 = no global cap
+	RateLimitPreAuthRPS         float64 // 0 = disabled
+	RateLimitTrustedProxy       bool    // trust x-forwarded-for for anon IP keying
 	RateLimitBurst              int
 	EnableReflection            bool
 	EnableUI                    bool
@@ -564,6 +585,9 @@ func loadConfig() serverConfig {
 		RateLimitAnonRPS:            parseEnvFloat("RATE_LIMIT_ANON_RPS", 10),
 		RateLimitAuthedRPS:          parseEnvFloat("RATE_LIMIT_AUTHED_RPS", 100),
 		RateLimitSuperAdminRPS:      parseEnvFloat("RATE_LIMIT_SUPERADMIN_RPS", 0),
+		RateLimitGlobalRPS:          parseEnvFloat("RATE_LIMIT_GLOBAL_RPS", 0),
+		RateLimitPreAuthRPS:         parseEnvFloat("RATE_LIMIT_PREAUTH_RPS", 0),
+		RateLimitTrustedProxy:       getEnv("RATE_LIMIT_TRUSTED_PROXY", "") == "1",
 		RateLimitBurst:              parseEnvInt("RATE_LIMIT_BURST", 10),
 		EnableReflection:            getEnv("ENABLE_REFLECTION", "") == "1",
 		EnableUI:                    getEnv("ENABLE_UI", "") == "1",

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -14,11 +14,12 @@ import (
 // boolean decisions that drove it. Tests assert on the decisions so a flag
 // silently dropped (read but never wired into an option) is caught.
 type serverOptionsBuild struct {
-	Opts           []server.Option
-	UseTLS         bool
-	UseInsecure    bool
-	HasRateLimiter bool
-	HasReflection  bool
+	Opts              []server.Option
+	UseTLS            bool
+	UseInsecure       bool
+	HasPreAuthLimiter bool
+	HasRateLimiter    bool
+	HasReflection     bool
 }
 
 func buildServerOptions(
@@ -27,6 +28,7 @@ func buildServerOptions(
 	extraGRPCOpts []grpc.ServerOption,
 	serverTLS *server.TLSConfig,
 	rl *ratelimit.Interceptor,
+	preAuth *ratelimit.Interceptor,
 ) serverOptionsBuild {
 	out := serverOptionsBuild{
 		Opts: []server.Option{
@@ -43,6 +45,10 @@ func buildServerOptions(
 	} else {
 		out.Opts = append(out.Opts, server.WithTLS(serverTLS))
 		out.UseTLS = true
+	}
+	if preAuth != nil {
+		out.Opts = append(out.Opts, server.WithPreAuthLimiter(preAuth))
+		out.HasPreAuthLimiter = true
 	}
 	if rl != nil {
 		out.Opts = append(out.Opts, server.WithRateLimiter(rl))

--- a/cmd/server/options_test.go
+++ b/cmd/server/options_test.go
@@ -37,7 +37,7 @@ func TestBuildServerOptions_TLS(t *testing.T) {
 	cfg.InsecureListen = false
 	tlsCfg := &server.TLSConfig{CertFile: "cert.pem", KeyFile: "key.pem"}
 
-	got := buildServerOptions(cfg, discardLogger(), nil, tlsCfg, nil)
+	got := buildServerOptions(cfg, discardLogger(), nil, tlsCfg, nil, nil)
 
 	assert.True(t, got.UseTLS, "expected TLS branch")
 	assert.False(t, got.UseInsecure, "expected insecure branch off")
@@ -49,7 +49,7 @@ func TestBuildServerOptions_Insecure(t *testing.T) {
 	cfg := baseServerCfg()
 	cfg.InsecureListen = true
 
-	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
 
 	assert.False(t, got.UseTLS)
 	assert.True(t, got.UseInsecure)
@@ -60,7 +60,7 @@ func TestBuildServerOptions_RateLimiterWired(t *testing.T) {
 	cfg := baseServerCfg()
 	cfg.InsecureListen = true
 
-	got := buildServerOptions(cfg, discardLogger(), nil, nil, newTestRateLimiter())
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, newTestRateLimiter(), nil)
 
 	assert.True(t, got.HasRateLimiter, "non-nil rate limiter must be wired into the option slice")
 	assert.Len(t, got.Opts, 7, "5 base options + Insecure + RateLimiter")
@@ -70,10 +70,20 @@ func TestBuildServerOptions_RateLimiterAbsent(t *testing.T) {
 	cfg := baseServerCfg()
 	cfg.InsecureListen = true
 
-	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
 
 	assert.False(t, got.HasRateLimiter, "nil rate limiter must not produce a WithRateLimiter option")
 	assert.Len(t, got.Opts, 6)
+}
+
+func TestBuildServerOptions_PreAuthLimiterWired(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, newTestRateLimiter())
+
+	assert.True(t, got.HasPreAuthLimiter, "non-nil pre-auth limiter must be wired into the option slice")
+	assert.Len(t, got.Opts, 7, "5 base options + Insecure + PreAuthLimiter")
 }
 
 func TestBuildServerOptions_ReflectionWired(t *testing.T) {
@@ -81,7 +91,7 @@ func TestBuildServerOptions_ReflectionWired(t *testing.T) {
 	cfg.InsecureListen = true
 	cfg.EnableReflection = true
 
-	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
 
 	assert.True(t, got.HasReflection, "EnableReflection=true must wire WithReflection option")
 	assert.Len(t, got.Opts, 7, "5 base options + Insecure + Reflection")
@@ -92,7 +102,7 @@ func TestBuildServerOptions_ReflectionAbsent(t *testing.T) {
 	cfg.InsecureListen = true
 	cfg.EnableReflection = false
 
-	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil)
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
 
 	assert.False(t, got.HasReflection, "EnableReflection=false must not wire WithReflection option")
 	assert.Len(t, got.Opts, 6)
@@ -103,7 +113,7 @@ func TestBuildServerOptions_ExtraGRPCOpts(t *testing.T) {
 	cfg.InsecureListen = true
 	extra := []grpc.ServerOption{grpc.MaxConcurrentStreams(42)}
 
-	got := buildServerOptions(cfg, discardLogger(), extra, nil, nil)
+	got := buildServerOptions(cfg, discardLogger(), extra, nil, nil, nil)
 
 	assert.Len(t, got.Opts, 6, "extra grpc opts go inside WithGRPCServerOptions, not as separate options")
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,7 @@ coverage:
 
 ignore:
   - "cmd/decree"
+  - "cmd/server/main.go"
   - "api/centralconfig/**"
   - "internal/storage/dbstore/**"
   - "internal/audit/store_pg.go"

--- a/internal/ratelimit/interceptor.go
+++ b/internal/ratelimit/interceptor.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"log/slog"
+	"net"
 	"slices"
 	"strings"
 	"time"
@@ -10,6 +11,8 @@ import (
 	errdetailspb "google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -23,12 +26,18 @@ const healthServicePrefix = "/grpc.health.v1.Health/"
 
 // Config holds per-role limiters. A nil Limiter for a role means unlimited.
 type Config struct {
-	// Anonymous limits unauthenticated callers via a shared global bucket per method.
+	// Global limits all callers regardless of role; checked before per-role limits.
+	// Keyed by method name so one method cannot starve others. Nil = no global cap.
+	Global Limiter
+	// Anonymous limits unauthenticated callers; keyed per client IP + method.
 	Anonymous Limiter
 	// Authenticated limits tenant-scoped callers; keyed per tenant + method.
 	Authenticated Limiter
 	// SuperAdmin limits superadmin callers; keyed per subject + method. Nil = unlimited.
 	SuperAdmin Limiter
+	// TrustedProxy, when true, reads the client IP from the x-forwarded-for metadata
+	// header (first hop) instead of the peer address.
+	TrustedProxy bool
 }
 
 // Interceptor enforces rate limits and implements server.GRPCInterceptor.
@@ -68,7 +77,7 @@ func (i *Interceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 		role, key := i.bucketKey(ctx, info.FullMethod)
-		if !i.allow(role, key) {
+		if !i.allow(role, key, info.FullMethod) {
 			i.record(ctx, role, info.FullMethod)
 			return nil, exhaustedErr()
 		}
@@ -77,6 +86,7 @@ func (i *Interceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
 }
 
 // StreamInterceptor returns a grpc.StreamServerInterceptor that enforces rate limits.
+// It checks at connect time and on each outbound message via meteredStream.
 func (i *Interceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := ss.Context()
@@ -85,23 +95,47 @@ func (i *Interceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 			return handler(srv, ss)
 		}
 		role, key := i.bucketKey(ctx, info.FullMethod)
-		if !i.allow(role, key) {
+		if !i.allow(role, key, info.FullMethod) {
 			i.record(ctx, role, info.FullMethod)
 			return exhaustedErr()
 		}
-		return handler(srv, ss)
+		return handler(srv, &meteredStream{
+			ServerStream: ss,
+			i:            i,
+			role:         role,
+			key:          key,
+			method:       info.FullMethod,
+		})
 	}
+}
+
+// meteredStream wraps grpc.ServerStream to enforce rate limits on each outbound message.
+type meteredStream struct {
+	grpc.ServerStream
+	i      *Interceptor
+	role   string
+	key    string
+	method string
+}
+
+func (s *meteredStream) SendMsg(m any) error {
+	if !s.i.allow(s.role, s.key, s.method) {
+		s.i.record(s.Context(), s.role, s.method)
+		return exhaustedErr()
+	}
+	return s.ServerStream.SendMsg(m)
 }
 
 // bucketKey returns the role label and bucket key for the incoming request.
 // Key format:
-//   - anonymous:  "anon:<method>"
+//   - anonymous:  "anon:<ip>:<method>"
 //   - superadmin: "sa:<subject>:<method>"
 //   - tenant:     "t:<sorted_tenant_ids>:<method>"
 func (i *Interceptor) bucketKey(ctx context.Context, method string) (role, key string) {
 	claims, ok := auth.ClaimsFromContext(ctx)
 	if !ok || claims == nil {
-		return "anonymous", "anon:" + method
+		ip := clientIP(ctx, i.cfg.TrustedProxy)
+		return "anonymous", "anon:" + ip + ":" + method
 	}
 	if claims.IsSuperAdmin() {
 		return "superadmin", "sa:" + claims.Subject + ":" + method
@@ -110,7 +144,10 @@ func (i *Interceptor) bucketKey(ctx context.Context, method string) (role, key s
 	return "authenticated", "t:" + tenantKey + ":" + method
 }
 
-func (i *Interceptor) allow(role, key string) bool {
+func (i *Interceptor) allow(role, key, method string) bool {
+	if i.cfg.Global != nil && !i.cfg.Global.Allow(method) {
+		return false
+	}
 	switch role {
 	case "superadmin":
 		return i.cfg.SuperAdmin == nil || i.cfg.SuperAdmin.Allow(key)
@@ -140,6 +177,29 @@ func exhaustedErr() error {
 		return d.Err()
 	}
 	return st.Err()
+}
+
+// clientIP extracts the caller's IP address. When trustedProxy is true it reads
+// the x-forwarded-for metadata header (first hop); otherwise it uses the gRPC
+// peer address. Returns "unknown" when no address can be determined.
+func clientIP(ctx context.Context, trustedProxy bool) string {
+	if trustedProxy {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if vals := md.Get("x-forwarded-for"); len(vals) > 0 {
+				raw := strings.TrimSpace(strings.SplitN(vals[0], ",", 2)[0])
+				if raw != "" {
+					return raw
+				}
+			}
+		}
+	}
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+			return host
+		}
+		return p.Addr.String()
+	}
+	return "unknown"
 }
 
 func sortedUniq(ids []string) []string {

--- a/internal/ratelimit/interceptor_test.go
+++ b/internal/ratelimit/interceptor_test.go
@@ -2,6 +2,7 @@ package ratelimit_test
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,6 +10,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	"github.com/opendecree/decree/internal/auth"
@@ -102,13 +104,14 @@ func TestHealthCheckExempt(t *testing.T) {
 }
 
 // fakeStream is a minimal grpc.ServerStream for testing StreamInterceptor.
-// Only Context() needs a real body; all other methods are no-ops via the embedded interface.
 type fakeStream struct {
 	grpc.ServerStream
 	ctx context.Context
 }
 
 func (f *fakeStream) Context() context.Context { return f.ctx }
+func (f *fakeStream) SendMsg(_ any) error      { return nil }
+func (f *fakeStream) RecvMsg(_ any) error      { return nil }
 
 func streamHandler(_ any, _ grpc.ServerStream) error { return nil }
 
@@ -202,4 +205,90 @@ func TestStream_HealthCheckExempt(t *testing.T) {
 		err := invokeStream(t, i, ctx, m)
 		assert.NoError(t, err, "health stream method %s must be exempt", m)
 	}
+}
+
+// TestGlobalLimiterBlocksAllRoles: exhausting the global method bucket blocks
+// subsequent callers regardless of their per-role limit.
+func TestGlobalLimiterBlocksAllRoles(t *testing.T) {
+	i := ratelimit.New(ratelimit.Config{
+		Global:        ratelimit.NewInProcess(rate.Limit(1), 1), // burst=1 for the method
+		Anonymous:     ratelimit.NewInProcess(rate.Limit(100), 100),
+		Authenticated: ratelimit.NewInProcess(rate.Limit(100), 100),
+		SuperAdmin:    ratelimit.NewInProcess(rate.Limit(100), 100),
+	})
+
+	ctxAnon := context.Background()
+	ctxAuthed := auth.ContextWithClaims(context.Background(), &auth.Claims{TenantIDs: []string{"t1"}})
+
+	require.NoError(t, invokeUnary(t, i, ctxAnon, testMethod), "first request should pass")
+
+	err := invokeUnary(t, i, ctxAuthed, testMethod)
+	require.Error(t, err, "second request (different role) should be blocked by global limit")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+// TestGlobalLimiterCapsSuperAdmin: superadmin with nil per-role limiter (unlimited)
+// is still capped by the global limiter.
+func TestGlobalLimiterCapsSuperAdmin(t *testing.T) {
+	i := ratelimit.New(ratelimit.Config{
+		Global:        ratelimit.NewInProcess(rate.Limit(1), 1),
+		Authenticated: ratelimit.NewInProcess(rate.Limit(100), 100),
+		// SuperAdmin intentionally nil = unlimited per-role
+	})
+
+	ctxSA := auth.ContextWithClaims(context.Background(), &auth.Claims{Role: auth.RoleSuperAdmin})
+
+	require.NoError(t, invokeUnary(t, i, ctxSA, testMethod), "first superadmin request should pass")
+	err := invokeUnary(t, i, ctxSA, testMethod)
+	require.Error(t, err, "second superadmin request should be blocked by global limit")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+}
+
+// TestAnonPerIPIsolation: two anonymous callers from different IPs have separate
+// buckets and do not starve each other.
+func TestAnonPerIPIsolation(t *testing.T) {
+	lim := ratelimit.NewInProcess(rate.Limit(1), 1) // burst=1 per bucket
+	i := ratelimit.New(ratelimit.Config{Anonymous: lim})
+
+	ctxIP1 := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 50000},
+	})
+	ctxIP2 := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("5.6.7.8"), Port: 50001},
+	})
+
+	// Exhaust IP1.
+	require.NoError(t, invokeUnary(t, i, ctxIP1, testMethod))
+	require.Error(t, invokeUnary(t, i, ctxIP1, testMethod), "IP1 should be exhausted")
+
+	// IP2 is unaffected.
+	require.NoError(t, invokeUnary(t, i, ctxIP2, testMethod), "IP2 should still pass")
+}
+
+// TestStream_MessageMeteringExhausted: per-message rate limiting kicks in after
+// the connect-time token is consumed — the (burst)th SendMsg call is rejected.
+func TestStream_MessageMeteringExhausted(t *testing.T) {
+	const burst = 3 // connect uses 1 token; 2 messages pass; 3rd message is rejected
+	lim := ratelimit.NewInProcess(rate.Limit(1), burst)
+	i := ratelimit.New(ratelimit.Config{Authenticated: lim})
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{TenantIDs: []string{"tenant-a"}})
+
+	sendCount := 0
+	handler := func(_ any, ss grpc.ServerStream) error {
+		for range burst {
+			if err := ss.SendMsg(struct{}{}); err != nil {
+				return err
+			}
+			sendCount++
+		}
+		return nil
+	}
+
+	info := &grpc.StreamServerInfo{FullMethod: testMethod}
+	err := i.StreamInterceptor()(nil, &fakeStream{ctx: ctx}, info, handler)
+	require.Error(t, err, "stream should be terminated when message limit is hit")
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	// connect-time uses 1 token; (burst-1) messages succeed before exhaustion
+	assert.Equal(t, burst-1, sendCount, "expected %d messages before exhaustion", burst-1)
 }

--- a/internal/ratelimit/interceptor_test.go
+++ b/internal/ratelimit/interceptor_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
@@ -291,4 +292,24 @@ func TestStream_MessageMeteringExhausted(t *testing.T) {
 	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
 	// connect-time uses 1 token; (burst-1) messages succeed before exhaustion
 	assert.Equal(t, burst-1, sendCount, "expected %d messages before exhaustion", burst-1)
+}
+
+// TestAnonTrustedProxy: when TrustedProxy is set, x-forwarded-for is used as the IP key
+// so two callers with different x-forwarded-for values have independent buckets.
+func TestAnonTrustedProxy(t *testing.T) {
+	lim := ratelimit.NewInProcess(rate.Limit(1), 1) // burst=1 per bucket
+	i := ratelimit.New(ratelimit.Config{
+		Anonymous:    lim,
+		TrustedProxy: true,
+	})
+
+	ctxIP1 := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-forwarded-for", "10.0.0.1"))
+	ctxIP2 := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-forwarded-for", "10.0.0.2"))
+
+	// Exhaust IP1 bucket.
+	require.NoError(t, invokeUnary(t, i, ctxIP1, testMethod))
+	require.Error(t, invokeUnary(t, i, ctxIP1, testMethod), "IP1 via x-forwarded-for should be exhausted")
+
+	// IP2 bucket is independent.
+	require.NoError(t, invokeUnary(t, i, ctxIP2, testMethod), "IP2 via x-forwarded-for should still pass")
 }

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -17,6 +17,7 @@ type options struct {
 	maxSendMsgBytes  int
 	tls              *TLSConfig
 	insecure         bool
+	preAuthLimiter   GRPCInterceptor // optional; runs before auth (unauthenticated flood protection)
 	rateLimiter      GRPCInterceptor // optional; runs after auth
 	enableReflection bool
 }
@@ -60,6 +61,13 @@ func WithTLS(cfg *TLSConfig) Option {
 // (INSECURE_LISTEN=1). Mutually exclusive with WithTLS.
 func WithInsecure() Option {
 	return func(o *options) { o.insecure = true }
+}
+
+// WithPreAuthLimiter adds a rate-limit interceptor that runs before authentication.
+// Use this to shed unauthenticated floods before paying JWT/JWKS validation cost.
+// Pass nil to disable.
+func WithPreAuthLimiter(rl GRPCInterceptor) Option {
+	return func(o *options) { o.preAuthLimiter = rl }
 }
 
 // WithRateLimiter adds a rate-limit interceptor that runs after authentication.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,19 +74,28 @@ func New(grpcPort string, auth GRPCInterceptor, opts ...Option) (*Server, error)
 		}
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
-	// Recovery wraps all middleware. Auth runs second. Log-fields runs third to
-	// pull identity from auth claims into context for the slog handler.
-	// Rate limiter (when set) runs after log-fields.
+	// Recovery wraps all middleware. Pre-auth limiter (when set) runs second to
+	// shed unauthenticated floods before JWT/JWKS validation. Auth runs third.
+	// Log-fields runs fourth to pull identity into context for the slog handler.
+	// Post-auth rate limiter (when set) runs last.
 	unaryChain := []grpc.UnaryServerInterceptor{
 		recoveryUnaryInterceptor(o.logger),
-		auth.UnaryInterceptor(),
-		logFieldsUnaryInterceptor(),
 	}
 	streamChain := []grpc.StreamServerInterceptor{
 		recoveryStreamInterceptor(o.logger),
+	}
+	if o.preAuthLimiter != nil {
+		unaryChain = append(unaryChain, o.preAuthLimiter.UnaryInterceptor())
+		streamChain = append(streamChain, o.preAuthLimiter.StreamInterceptor())
+	}
+	unaryChain = append(unaryChain,
+		auth.UnaryInterceptor(),
+		logFieldsUnaryInterceptor(),
+	)
+	streamChain = append(streamChain,
 		auth.StreamInterceptor(),
 		logFieldsStreamInterceptor(),
-	}
+	)
 	if o.rateLimiter != nil {
 		unaryChain = append(unaryChain, o.rateLimiter.UnaryInterceptor())
 		streamChain = append(streamChain, o.rateLimiter.StreamInterceptor())


### PR DESCRIPTION
## Summary

- Closes four security gaps identified in #425: SuperAdmin bypass, stream-only-metered-at-connect, shared anonymous bucket, and pre-auth flood cost.
- Adds a global per-method cap (`Config.Global`) that blocks all roles including unlimited SuperAdmin, preventing a compromised admin from saturating the server.
- Keys anonymous buckets by client IP (via peer address or `x-forwarded-for` with `RATE_LIMIT_TRUSTED_PROXY=1`) so one noisy caller cannot starve the others.

## Test plan

- [x] `TestGlobalLimiterBlocksAllRoles` — exhausting the global method bucket blocks a subsequent authenticated caller
- [x] `TestGlobalLimiterCapsSuperAdmin` — a nil-per-role SuperAdmin is still blocked by the global limiter
- [x] `TestAnonPerIPIsolation` — two anonymous callers from different IPs have independent buckets
- [x] `TestStream_MessageMeteringExhausted` — after connect-time token is consumed, the N-th `SendMsg` is rejected
- [x] `TestBuildServerOptions_PreAuthLimiterWired` — non-nil pre-auth limiter is wired into server options
- [x] All existing tests pass, coverage thresholds met

## New env vars (all default off)

| Var | Default | Effect |
|-----|---------|--------|
| `RATE_LIMIT_GLOBAL_RPS` | `0` (disabled) | Per-method global RPS cap across all roles |
| `RATE_LIMIT_PREAUTH_RPS` | `0` (disabled) | RPS cap applied before auth interceptor |
| `RATE_LIMIT_TRUSTED_PROXY` | `0` | Trust `x-forwarded-for` for anon IP extraction |

Closes #425