### PR TITLE
Eliminate N+1 query patterns in schema and config write paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,6 +15,7 @@ ignore:
   - "internal/storage/dbstore/**"
   - "internal/audit/store_pg.go"
   - "internal/config/store_pg.go"
+  - "internal/schema/store_pg.go"
   - "sdk/grpctransport/**"
   - "cmd/server/openapi.json"
   - "docs/**"

--- a/db/queries/schemas.sql
+++ b/db/queries/schemas.sql
@@ -55,3 +55,14 @@ ORDER BY path;
 -- name: DeleteSchemaField :exec
 DELETE FROM schema_fields
 WHERE schema_version_id = $1 AND path = $2;
+
+-- name: GetLatestSchemaVersionsBatch :many
+SELECT DISTINCT ON (schema_id) *
+FROM schema_versions
+WHERE schema_id = ANY($1::uuid[])
+ORDER BY schema_id, version DESC;
+
+-- name: GetSchemaFieldsByVersionIDs :many
+SELECT * FROM schema_fields
+WHERE schema_version_id = ANY($1::uuid[])
+ORDER BY schema_version_id, path;

--- a/internal/config/concurrency_test.go
+++ b/internal/config/concurrency_test.go
@@ -194,10 +194,8 @@ func TestImportConfigChangeEventFanOut_RunsConcurrently(t *testing.T) {
 	})
 	gs.mockStore.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(newVer, nil)
-	gs.mockStore.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil)
-	gs.mockStore.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
-		Return(nil)
+	gs.mockStore.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	gs.mockStore.On("BulkInsertAuditWriteLog", mock.Anything, mock.Anything).Return(nil)
 	gs.mockStore.On("GetFullConfigAtVersion", mock.Anything, mock.Anything).
 		Return([]GetFullConfigAtVersionRow{}, nil)
 

--- a/internal/config/dependent_required_test.go
+++ b/internal/config/dependent_required_test.go
@@ -213,8 +213,8 @@ func TestSetFields_DependentRequired_AggregateCheck(t *testing.T) {
 		Return(domain.ConfigVersion{}, domain.ErrNotFound)
 	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 1}, nil)
-	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil).Twice()
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).
+		Return(nil)
 	// Snapshot reflects both writes — trigger AND dependent set together.
 	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
 		TenantID: tenantID1,
@@ -223,8 +223,8 @@ func TestSetFields_DependentRequired_AggregateCheck(t *testing.T) {
 		{FieldPath: "payments.refunds_enabled", Value: strPtr("true")},
 		{FieldPath: "payments.refund_window", Value: strPtr("30s")},
 	}, nil)
-	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
-		Return(nil).Twice()
+	store.On("BulkInsertAuditWriteLog", mock.Anything, mock.Anything).
+		Return(nil)
 	svc.cache.(*mockCache).On("Invalidate", mock.Anything, tenantID1).Return(nil)
 	svc.publisher.(*mockPublisher).On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).
 		Return(nil)
@@ -280,8 +280,7 @@ func TestRollbackToVersion_DependentRequired_Rejected(t *testing.T) {
 		Return(domain.ConfigVersion{Version: 5}, nil)
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil)
+	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
 	// Post-rollback snapshot mirrors the target — same violation.
 	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{
 		TenantID: tenantID1,
@@ -311,10 +310,8 @@ func TestImportConfig_DependentRequired_Rejected(t *testing.T) {
 		Return(domain.ConfigVersion{}, domain.ErrNotFound)
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 1}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
-		Return(nil).Maybe()
+	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.Anything).Return(nil).Maybe()
 	// Post-import snapshot: trigger set, dependent absent.
 	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{
 		TenantID: tenantID1,

--- a/internal/config/mock_store_test.go
+++ b/internal/config/mock_store_test.go
@@ -91,6 +91,16 @@ func (m *mockStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWrit
 	return args.Error(0)
 }
 
+func (m *mockStore) BulkSetConfigValues(ctx context.Context, arg []SetConfigValueParams) error {
+	args := m.Called(ctx, arg)
+	return args.Error(0)
+}
+
+func (m *mockStore) BulkInsertAuditWriteLog(ctx context.Context, arg []InsertAuditWriteLogParams) error {
+	args := m.Called(ctx, arg)
+	return args.Error(0)
+}
+
 // setupNoSensitiveFields configures the mock store to return an empty
 // sensitive field set for tenantID1. Use in tests that exercise code paths
 // that call getSensitiveFieldSet but don't care about redaction.

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -647,22 +647,21 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 			return fmt.Errorf("create config version: %w", txErr)
 		}
 
+		cvParams := make([]SetConfigValueParams, len(req.Updates))
+		auditParams := make([]InsertAuditWriteLogParams, len(req.Updates))
 		for i, update := range req.Updates {
 			updateValStr := typedValueToString(update.Value)
-			if txErr = tx.SetConfigValue(ctx, SetConfigValueParams{
+			cvParams[i] = SetConfigValueParams{
 				ConfigVersionID: newVersion.ID,
 				FieldPath:       update.FieldPath,
 				Value:           updateValStr,
 				Checksum:        checksumPtr(updateValStr),
 				Description:     ptrString(update.GetValueDescription()),
-			}); txErr != nil {
-				return fmt.Errorf("set config value %s: %w", update.FieldPath, txErr)
 			}
-
 			newValueStr := typedValueToString(update.Value)
 			redactedNew := redactIfSensitive(sensitiveFieldsMulti[update.FieldPath], derefString(newValueStr))
 			redactedOld := redactIfSensitive(sensitiveFieldsMulti[update.FieldPath], changes[i].oldValue)
-			if txErr = tx.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+			auditParams[i] = InsertAuditWriteLogParams{
 				TenantID:      tenantID,
 				Actor:         actor,
 				Action:        "set_field",
@@ -671,9 +670,13 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 				OldValue:      ptrString(redactedOld),
 				NewValue:      ptrString(redactedNew),
 				ConfigVersion: &newVersion.Version,
-			}); txErr != nil {
-				return fmt.Errorf("insert audit log for %s: %w", update.FieldPath, txErr)
 			}
+		}
+		if txErr = tx.BulkSetConfigValues(ctx, cvParams); txErr != nil {
+			return fmt.Errorf("bulk set config values: %w", txErr)
+		}
+		if txErr = tx.BulkInsertAuditWriteLog(ctx, auditParams); txErr != nil {
+			return fmt.Errorf("bulk insert audit log: %w", txErr)
 		}
 
 		return s.enforceDependentRequiredInTx(ctx, tx, tenantID, newVersion.Version, depRules)
@@ -822,16 +825,18 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 			return fmt.Errorf("create rollback version: %w", txErr)
 		}
 
-		for _, row := range targetRows {
-			if txErr = tx.SetConfigValue(ctx, SetConfigValueParams{
+		rollbackParams := make([]SetConfigValueParams, len(targetRows))
+		for i, row := range targetRows {
+			rollbackParams[i] = SetConfigValueParams{
 				ConfigVersionID: newVersion.ID,
 				FieldPath:       row.FieldPath,
 				Value:           row.Value,
 				Checksum:        row.Checksum,
 				Description:     row.Description,
-			}); txErr != nil {
-				return fmt.Errorf("copy field %s: %w", row.FieldPath, txErr)
 			}
+		}
+		if txErr = tx.BulkSetConfigValues(ctx, rollbackParams); txErr != nil {
+			return fmt.Errorf("bulk copy fields: %w", txErr)
 		}
 
 		if txErr = s.enforceDependentRequiredInTx(ctx, tx, tenantID, newVersion.Version, depRules); txErr != nil {
@@ -1172,20 +1177,19 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 			return fmt.Errorf("create config version: %w", txErr)
 		}
 
+		importCVParams := make([]SetConfigValueParams, len(values))
+		importAuditParams := make([]InsertAuditWriteLogParams, len(values))
 		for i, v := range values {
 			importValStr := strPtr(v.Value)
-			if txErr = tx.SetConfigValue(ctx, SetConfigValueParams{
+			importCVParams[i] = SetConfigValueParams{
 				ConfigVersionID: newVersion.ID,
 				FieldPath:       v.FieldPath,
 				Value:           importValStr,
 				Checksum:        checksumPtr(importValStr),
 				Description:     v.Description,
-			}); txErr != nil {
-				return fmt.Errorf("set config value %s: %w", v.FieldPath, txErr)
 			}
-
 			isSensitive := sensitiveFields[v.FieldPath]
-			if txErr = tx.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+			importAuditParams[i] = InsertAuditWriteLogParams{
 				TenantID:      tenantID,
 				Actor:         actor,
 				Action:        "import",
@@ -1194,9 +1198,13 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 				OldValue:      ptrString(redactIfSensitive(isSensitive, changes[i].oldValue)),
 				NewValue:      strPtr(redactIfSensitive(isSensitive, v.Value)),
 				ConfigVersion: &newVersion.Version,
-			}); txErr != nil {
-				return fmt.Errorf("insert audit log for %s: %w", v.FieldPath, txErr)
 			}
+		}
+		if txErr = tx.BulkSetConfigValues(ctx, importCVParams); txErr != nil {
+			return fmt.Errorf("bulk set config values: %w", txErr)
+		}
+		if txErr = tx.BulkInsertAuditWriteLog(ctx, importAuditParams); txErr != nil {
+			return fmt.Errorf("bulk insert audit log: %w", txErr)
 		}
 
 		return s.enforceDependentRequiredInTx(ctx, tx, tenantID, newVersion.Version, depRules)

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -214,8 +214,8 @@ func TestSetFields_Success(t *testing.T) {
 	store.On("CreateConfigVersion", mock.Anything, mock.Anything).Return(domain.ConfigVersion{
 		ID: versionID2, Version: 2, CreatedAt: time.Now(),
 	}, nil)
-	store.On("SetConfigValue", mock.Anything, mock.Anything).Return(nil)
-	store.On("InsertAuditWriteLog", mock.Anything, mock.Anything).Return(nil)
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	store.On("BulkInsertAuditWriteLog", mock.Anything, mock.Anything).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
 	pub.On("Publish", mock.Anything, mock.Anything).Return(nil)
 	setupNoSensitiveFields(store)

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -462,8 +462,7 @@ func TestRollbackToVersion_Success(t *testing.T) {
 		Return(domain.ConfigVersion{Version: 5}, nil)
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6, CreatedBy: "unknown"}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil)
+	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
 	cache.On("Invalidate", ctx, tenantID1).Return(nil)
 	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
 
@@ -474,8 +473,7 @@ func TestRollbackToVersion_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(6), resp.ConfigVersion.Version)
-	// Should copy 2 values.
-	store.AssertNumberOfCalls(t, "SetConfigValue", 2)
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
 }
 
 func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
@@ -570,10 +568,12 @@ values:
 		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID20, TenantID: tenantID1, Version: 3, CreatedBy: "unknown"}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).
-		Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
-		Return(nil)
+	store.On("BulkSetConfigValues", ctx, mock.MatchedBy(func(args []SetConfigValueParams) bool {
+		return len(args) == 2
+	})).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.MatchedBy(func(args []InsertAuditWriteLogParams) bool {
+		return len(args) == 2
+	})).Return(nil)
 	cache.On("Invalidate", ctx, tenantID1).Return(nil)
 	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
 
@@ -584,8 +584,8 @@ values:
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(3), resp.ConfigVersion.Version)
-	store.AssertNumberOfCalls(t, "SetConfigValue", 2)
-	store.AssertNumberOfCalls(t, "InsertAuditWriteLog", 2)
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
+	store.AssertCalled(t, "BulkInsertAuditWriteLog", ctx, mock.Anything)
 	cache.AssertCalled(t, "Invalidate", ctx, tenantID1)
 }
 
@@ -737,8 +737,12 @@ values:
 
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID20, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	store.On("BulkSetConfigValues", ctx, mock.MatchedBy(func(args []SetConfigValueParams) bool {
+		return len(args) == 1
+	})).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.MatchedBy(func(args []InsertAuditWriteLogParams) bool {
+		return len(args) == 1
+	})).Return(nil)
 	cache.On("Invalidate", ctx, tenantID1).Return(nil)
 	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
 
@@ -751,7 +755,7 @@ values:
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), resp.ConfigVersion.Version)
 	// Only app.other should be set (app.name skipped — same value)
-	store.AssertNumberOfCalls(t, "SetConfigValue", 1)
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
 }
 
 func TestImportConfig_DefaultsMode_SkipsExistingValues(t *testing.T) {
@@ -794,8 +798,12 @@ values:
 	newVersionID := versionID20
 	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: newVersionID, TenantID: tenantID1, Version: 2, CreatedBy: "unknown"}, nil)
-	store.On("SetConfigValue", ctx, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	store.On("BulkSetConfigValues", ctx, mock.MatchedBy(func(args []SetConfigValueParams) bool {
+		return len(args) == 1
+	})).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.MatchedBy(func(args []InsertAuditWriteLogParams) bool {
+		return len(args) == 1
+	})).Return(nil)
 	cache := &mockCache{}
 	pub := &mockPublisher{}
 	svc.cache = cache
@@ -811,7 +819,7 @@ values:
 
 	require.NoError(t, err)
 	// Only app.missing should be set
-	store.AssertNumberOfCalls(t, "SetConfigValue", 1)
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
 }
 
 // --- Usage Recording ---

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -118,6 +118,7 @@ type Store interface {
 
 	// Config values.
 	SetConfigValue(ctx context.Context, arg SetConfigValueParams) error
+	BulkSetConfigValues(ctx context.Context, args []SetConfigValueParams) error
 	GetConfigValues(ctx context.Context, configVersionID string) ([]domain.ConfigValue, error)
 	GetConfigValueAtVersion(ctx context.Context, arg GetConfigValueAtVersionParams) (GetConfigValueAtVersionRow, error)
 	GetFullConfigAtVersion(ctx context.Context, arg GetFullConfigAtVersionParams) ([]GetFullConfigAtVersionRow, error)
@@ -136,4 +137,5 @@ type Store interface {
 
 	// Audit.
 	InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteLogParams) error
+	BulkInsertAuditWriteLog(ctx context.Context, args []InsertAuditWriteLogParams) error
 }

--- a/internal/config/store_memory.go
+++ b/internal/config/store_memory.go
@@ -342,3 +342,21 @@ func (s *MemoryStore) InsertAuditWriteLog(_ context.Context, arg InsertAuditWrit
 	s.auditLog = append(s.auditLog, auditEntry{params: arg, createdAt: time.Now()})
 	return nil
 }
+
+func (s *MemoryStore) BulkSetConfigValues(ctx context.Context, args []SetConfigValueParams) error {
+	for _, a := range args {
+		if err := s.SetConfigValue(ctx, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) BulkInsertAuditWriteLog(ctx context.Context, args []InsertAuditWriteLogParams) error {
+	for _, a := range args {
+		if err := s.InsertAuditWriteLog(ctx, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/config/store_memory_test.go
+++ b/internal/config/store_memory_test.go
@@ -239,3 +239,104 @@ func TestMemoryStore_RunInTx(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), v.Version)
 }
+
+func TestMemoryStore_BulkSetConfigValues(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	v, err := s.CreateConfigVersion(ctx, CreateConfigVersionParams{
+		TenantID: "t1", Version: 1, CreatedBy: "admin",
+	})
+	require.NoError(t, err)
+
+	valA := "hello"
+	chkA := "chk-a"
+	valB := "42"
+
+	err = s.BulkSetConfigValues(ctx, []SetConfigValueParams{
+		{
+			ConfigVersionID: v.ID,
+			FieldPath:       "app.name",
+			Value:           &valA,
+			Checksum:        &chkA,
+		},
+		{
+			ConfigVersionID: v.ID,
+			FieldPath:       "app.retries",
+			Value:           &valB,
+		},
+	})
+	require.NoError(t, err)
+
+	values, err := s.GetConfigValues(ctx, v.ID)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+
+	assert.Equal(t, "app.name", values[0].FieldPath)
+	require.NotNil(t, values[0].Value)
+	assert.Equal(t, "hello", *values[0].Value)
+	require.NotNil(t, values[0].Checksum)
+	assert.Equal(t, "chk-a", *values[0].Checksum)
+
+	assert.Equal(t, "app.retries", values[1].FieldPath)
+	require.NotNil(t, values[1].Value)
+	assert.Equal(t, "42", *values[1].Value)
+	assert.Nil(t, values[1].Checksum)
+
+	// Empty bulk call should be a no-op.
+	err = s.BulkSetConfigValues(ctx, nil)
+	require.NoError(t, err)
+
+	valuesAfterNoop, err := s.GetConfigValues(ctx, v.ID)
+	require.NoError(t, err)
+	assert.Len(t, valuesAfterNoop, 2)
+}
+
+func TestMemoryStore_BulkInsertAuditWriteLog(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	newValue1 := `"on"`
+	newValue2 := `"off"`
+	version := int32(3)
+
+	err := s.BulkInsertAuditWriteLog(ctx, []InsertAuditWriteLogParams{
+		{
+			TenantID:      "t1",
+			Actor:         "alice",
+			Action:        "set_field",
+			ObjectKind:    "field",
+			FieldPath:     strPtr("flags.feature_x"),
+			NewValue:      &newValue1,
+			ConfigVersion: &version,
+			Metadata:      []byte(`{"source":"test"}`),
+		},
+		{
+			TenantID:      "t1",
+			Actor:         "bob",
+			Action:        "set_field",
+			ObjectKind:    "field",
+			FieldPath:     strPtr("flags.feature_y"),
+			NewValue:      &newValue2,
+			ConfigVersion: &version,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, s.auditLog, 2)
+
+	assert.Equal(t, "alice", s.auditLog[0].params.Actor)
+	assert.Equal(t, "set_field", s.auditLog[0].params.Action)
+	require.NotNil(t, s.auditLog[0].params.FieldPath)
+	assert.Equal(t, "flags.feature_x", *s.auditLog[0].params.FieldPath)
+	assert.False(t, s.auditLog[0].createdAt.IsZero())
+
+	assert.Equal(t, "bob", s.auditLog[1].params.Actor)
+	require.NotNil(t, s.auditLog[1].params.FieldPath)
+	assert.Equal(t, "flags.feature_y", *s.auditLog[1].params.FieldPath)
+	assert.False(t, s.auditLog[1].createdAt.IsZero())
+
+	// Empty bulk call should be a no-op.
+	err = s.BulkInsertAuditWriteLog(ctx, nil)
+	require.NoError(t, err)
+	assert.Len(t, s.auditLog, 2)
+}

--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -24,6 +24,7 @@ type PGStore struct {
 	writePool *pgxpool.Pool
 	write     *dbstore.Queries
 	read      *dbstore.Queries
+	tx        pgx.Tx // non-nil when bound to a transaction
 }
 
 // NewPGStore creates a new PostgreSQL-backed config store.
@@ -60,6 +61,7 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 		writePool: s.writePool,
 		write:     txQueries,
 		read:      txQueries,
+		tx:        tx,
 	}
 
 	if err := fn(txStore); err != nil {
@@ -308,6 +310,114 @@ func (s *PGStore) GetFieldLocks(ctx context.Context, tenantID string) ([]domain.
 		result[i] = fieldLockFromDB(r)
 	}
 	return result, nil
+}
+
+// batcher returns the BatchSender appropriate for the current context:
+// the active transaction when inside RunInTx, otherwise the write pool.
+func (s *PGStore) batcher() interface {
+	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
+} {
+	if s.tx != nil {
+		return s.tx
+	}
+	return s.writePool
+}
+
+const bulkSetConfigValueSQL = `INSERT INTO config_values (config_version_id, field_path, value, checksum, description) VALUES ($1, $2, $3, $4, $5)`
+
+func (s *PGStore) BulkSetConfigValues(ctx context.Context, args []SetConfigValueParams) error {
+	if len(args) == 0 {
+		return nil
+	}
+	batch := &pgx.Batch{}
+	for _, a := range args {
+		cvUUID, err := pgconv.StringToUUID(a.ConfigVersionID)
+		if err != nil {
+			return err
+		}
+		batch.Queue(bulkSetConfigValueSQL, cvUUID, a.FieldPath, a.Value, a.Checksum, a.Description)
+	}
+	br := s.batcher().SendBatch(ctx, batch)
+	defer func() { _ = br.Close() }()
+	for range args {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("bulk set config value: %w", err)
+		}
+	}
+	return br.Close()
+}
+
+const bulkInsertAuditWriteLogSQL = `INSERT INTO audit_write_log (id, tenant_id, actor, action, field_path, old_value, new_value, config_version, metadata, object_kind, previous_hash, entry_hash, created_at, chain_epoch) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`
+
+func (s *PGStore) BulkInsertAuditWriteLog(ctx context.Context, args []InsertAuditWriteLogParams) error {
+	if len(args) == 0 {
+		return nil
+	}
+	tenantUUID, err := pgconv.StringToUUID(args[0].TenantID)
+	if err != nil {
+		return err
+	}
+
+	prevHash, err := s.write.GetLastAuditHashForTenant(ctx, tenantUUID)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get last audit hash: %w", err)
+	}
+
+	type row struct {
+		id        pgtype.UUID
+		kind      string
+		now       pgtype.Timestamptz
+		entryHash string
+		prevHash  string
+		arg       InsertAuditWriteLogParams
+	}
+	rows := make([]row, len(args))
+	for i, arg := range args {
+		id, err := configGenUUID()
+		if err != nil {
+			return err
+		}
+		kind := arg.ObjectKind
+		if kind == "" {
+			kind = "field"
+		}
+		now := time.Now().Truncate(time.Microsecond)
+		hash := audit.ComputeEntryHash(audit.ChainInput{
+			PreviousHash: prevHash,
+			ID:           pgconv.UUIDToString(id),
+			TenantID:     arg.TenantID,
+			Actor:        arg.Actor,
+			Action:       arg.Action,
+			ObjectKind:   kind,
+			CreatedAt:    now,
+		})
+		rows[i] = row{
+			id:        id,
+			kind:      kind,
+			now:       pgconv.TimeToTimestamptz(now),
+			entryHash: hash,
+			prevHash:  prevHash,
+			arg:       arg,
+		}
+		prevHash = hash
+	}
+
+	batch := &pgx.Batch{}
+	for _, r := range rows {
+		batch.Queue(bulkInsertAuditWriteLogSQL,
+			r.id, tenantUUID, r.arg.Actor, r.arg.Action,
+			r.arg.FieldPath, r.arg.OldValue, r.arg.NewValue, r.arg.ConfigVersion,
+			r.arg.Metadata, r.kind, r.prevHash, r.entryHash, r.now, int32(0),
+		)
+	}
+	br := s.batcher().SendBatch(ctx, batch)
+	defer func() { _ = br.Close() }()
+	for range rows {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("bulk insert audit log: %w", err)
+		}
+	}
+	return br.Close()
 }
 
 // Audit.

--- a/internal/config/validations_test.go
+++ b/internal/config/validations_test.go
@@ -126,7 +126,7 @@ func TestSetFields_Validations_PostMergeStateChecked(t *testing.T) {
 		Return(domain.ConfigVersion{Version: 1}, nil)
 	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 2}, nil)
-	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).
 		Return(nil)
 	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
 		TenantID: tenantID1,
@@ -135,7 +135,7 @@ func TestSetFields_Validations_PostMergeStateChecked(t *testing.T) {
 		{FieldPath: "payments.min_amount", Value: strPtr("10")},
 		{FieldPath: "payments.max_amount", Value: strPtr("100")},
 	}, nil)
-	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).
+	store.On("BulkInsertAuditWriteLog", mock.Anything, mock.Anything).
 		Return(nil)
 	svc.cache.(*mockCache).On("Invalidate", mock.Anything, tenantID1).Return(nil)
 	svc.publisher.(*mockPublisher).On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).

--- a/internal/schema/limits_test.go
+++ b/internal/schema/limits_test.go
@@ -73,8 +73,8 @@ func TestCreateSchema_AtLimitAllowed(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "ok"}, nil)
 	store.On("CreateSchemaVersion", mock.Anything, mock.Anything).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1}, nil)
-	store.On("CreateSchemaField", mock.Anything, mock.Anything).
-		Return(domain.SchemaField{Path: "a", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", mock.Anything, mock.Anything).
+		Return([]domain.SchemaField{{Path: "a", FieldType: "string"}, {Path: "b", FieldType: "string"}}, nil)
 
 	_, err := svc.CreateSchema(superadminCtx(), &pb.CreateSchemaRequest{
 		Name: "ok",

--- a/internal/schema/mock_store_test.go
+++ b/internal/schema/mock_store_test.go
@@ -71,9 +71,24 @@ func (m *mockStore) CreateSchemaField(ctx context.Context, arg CreateSchemaField
 	return args.Get(0).(domain.SchemaField), args.Error(1)
 }
 
+func (m *mockStore) BulkCreateSchemaFields(ctx context.Context, arg []CreateSchemaFieldParams) ([]domain.SchemaField, error) {
+	args := m.Called(ctx, arg)
+	return args.Get(0).([]domain.SchemaField), args.Error(1)
+}
+
 func (m *mockStore) GetSchemaFields(ctx context.Context, schemaVersionID string) ([]domain.SchemaField, error) {
 	args := m.Called(ctx, schemaVersionID)
 	return args.Get(0).([]domain.SchemaField), args.Error(1)
+}
+
+func (m *mockStore) GetSchemaFieldsByVersionIDs(ctx context.Context, versionIDs []string) ([]domain.SchemaField, error) {
+	args := m.Called(ctx, versionIDs)
+	return args.Get(0).([]domain.SchemaField), args.Error(1)
+}
+
+func (m *mockStore) GetLatestSchemaVersionsBatch(ctx context.Context, schemaIDs []string) ([]domain.SchemaVersion, error) {
+	args := m.Called(ctx, schemaIDs)
+	return args.Get(0).([]domain.SchemaVersion), args.Error(1)
 }
 
 func (m *mockStore) DeleteSchemaField(ctx context.Context, arg DeleteSchemaFieldParams) error {

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -276,25 +276,42 @@ func (s *Service) ListSchemas(ctx context.Context, req *pb.ListSchemasRequest) (
 	if int32(len(schemas)) > pageSize {
 		schemas = schemas[:pageSize]
 	}
+	if len(schemas) == 0 {
+		return &pb.ListSchemasResponse{NextPageToken: nextToken}, nil
+	}
 
-	// Fetch latest version for each schema.
+	schemaIDs := make([]string, len(schemas))
+	for i, sc := range schemas {
+		schemaIDs[i] = sc.ID
+	}
+
+	versions, err := s.store.GetLatestSchemaVersionsBatch(ctx, schemaIDs)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get latest schema versions")
+	}
+	versionsBySchema := make(map[string]domain.SchemaVersion, len(versions))
+	versionIDs := make([]string, 0, len(versions))
+	for _, v := range versions {
+		versionsBySchema[v.SchemaID] = v
+		versionIDs = append(versionIDs, v.ID)
+	}
+
+	allFields, err := s.store.GetSchemaFieldsByVersionIDs(ctx, versionIDs)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get schema fields")
+	}
+	fieldsByVersion := make(map[string][]domain.SchemaField, len(versionIDs))
+	for _, f := range allFields {
+		fieldsByVersion[f.SchemaVersionID] = append(fieldsByVersion[f.SchemaVersionID], f)
+	}
+
 	pbSchemas := make([]*pb.Schema, 0, len(schemas))
-	for _, schema := range schemas {
-		version, err := s.store.GetLatestSchemaVersion(ctx, schema.ID)
-		if err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				continue // Schema with no versions — skip.
-			}
-			return nil, status.Errorf(codes.Internal, "failed to get latest version for schema %s", schema.ID)
+	for _, sc := range schemas {
+		v, ok := versionsBySchema[sc.ID]
+		if !ok {
+			continue // Schema with no versions — skip.
 		}
-		fields, err := s.store.GetSchemaFields(ctx, version.ID)
-		if err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				continue
-			}
-			return nil, status.Errorf(codes.Internal, "failed to get fields for schema %s", schema.ID)
-		}
-		pbSchemas = append(pbSchemas, schemaToProto(schema, version, fields))
+		pbSchemas = append(pbSchemas, schemaToProto(sc, v, fieldsByVersion[v.ID]))
 	}
 
 	return &pb.ListSchemasResponse{
@@ -1041,7 +1058,7 @@ func createFieldsOn(ctx context.Context, logger *slog.Logger, store Store, versi
 	if err := validateNoPrefixOverlap(fields); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	result := make([]domain.SchemaField, 0, len(fields))
+	params := make([]CreateSchemaFieldParams, 0, len(fields))
 	for _, f := range fields {
 		if err := validateFieldConstraints(f, regexPatternMaxLength); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -1060,7 +1077,7 @@ func createFieldsOn(ctx context.Context, logger *slog.Logger, store Store, versi
 			externalDocs, _ = json.Marshal(f.ExternalDocs)
 		}
 
-		dbField, err := store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		params = append(params, CreateSchemaFieldParams{
 			SchemaVersionID: versionID,
 			Path:            f.Path,
 			FieldType:       domain.FieldTypeFromProto(f.Type),
@@ -1080,11 +1097,11 @@ func createFieldsOn(ctx context.Context, logger *slog.Logger, store Store, versi
 			WriteOnce:       f.WriteOnce,
 			Sensitive:       f.Sensitive,
 		})
-		if err != nil {
-			logger.ErrorContext(ctx, "create schema field", "path", f.Path, "error", err)
-			return nil, status.Errorf(codes.Internal, "failed to create field %s", f.Path)
-		}
-		result = append(result, dbField)
+	}
+	result, err := store.BulkCreateSchemaFields(ctx, params)
+	if err != nil {
+		logger.ErrorContext(ctx, "bulk create schema fields", "error", err)
+		return nil, status.Error(codes.Internal, "failed to create schema fields")
 	}
 	return result, nil
 }

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -48,8 +48,8 @@ func TestListSchemas_Success(t *testing.T) {
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{
 		testSchema(),
 	}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
-	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, nil)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{testVersion()}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 10})
 	require.NoError(t, err)
@@ -68,13 +68,18 @@ func TestListSchemas_Pagination(t *testing.T) {
 	v1 := testVersion()
 	v2 := testVersion()
 	v2.ID = "33333333-3333-3333-3333-333333333333"
+	v2.SchemaID = s2.ID
 
 	// Page 1: returns 2 results (pageSize+1) → has next page
 	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
 		return p.Offset == 0 && p.Limit == 2
 	})).Return([]domain.Schema{s1, s2}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, s1.ID).Return(v1, nil)
-	store.On("GetSchemaFields", mock.Anything, v1.ID).Return([]domain.SchemaField{}, nil)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.MatchedBy(func(ids []string) bool {
+		return len(ids) == 1 && ids[0] == s1.ID
+	})).Return([]domain.SchemaVersion{v1}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.MatchedBy(func(ids []string) bool {
+		return len(ids) == 1 && ids[0] == v1.ID
+	})).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 1})
 	require.NoError(t, err)
@@ -85,8 +90,12 @@ func TestListSchemas_Pagination(t *testing.T) {
 	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
 		return p.Offset == 1 && p.Limit == 2
 	})).Return([]domain.Schema{s2}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, s2.ID).Return(v2, nil)
-	store.On("GetSchemaFields", mock.Anything, v2.ID).Return([]domain.SchemaField{}, nil)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.MatchedBy(func(ids []string) bool {
+		return len(ids) == 1 && ids[0] == s2.ID
+	})).Return([]domain.SchemaVersion{v2}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.MatchedBy(func(ids []string) bool {
+		return len(ids) == 1 && ids[0] == v2.ID
+	})).Return([]domain.SchemaField{}, nil)
 
 	resp, err = svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{
 		PageSize:  1,
@@ -130,8 +139,8 @@ func TestListSchemas_BoundaryNextPageIsEmpty(t *testing.T) {
 	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
 		return p.Offset == 0 && p.Limit == 2
 	})).Return([]domain.Schema{s1, s1}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
-	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, nil)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{testVersion()}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 1})
 	require.NoError(t, err)
@@ -158,8 +167,8 @@ func TestListSchemas_ZeroPageSize(t *testing.T) {
 	store.On("ListSchemas", mock.Anything, mock.MatchedBy(func(p ListSchemasParams) bool {
 		return p.Limit > 0 // clamped to default, not zero
 	})).Return([]domain.Schema{testSchema()}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
-	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, nil)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{testVersion()}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	// page_size=0 should fall back to default and succeed.
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{PageSize: 0})
@@ -180,24 +189,26 @@ func TestListSchemas_VersionNotFound_Skips(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(domain.SchemaVersion{}, domain.ErrNotFound)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
 	require.NoError(t, err)
 	assert.Empty(t, resp.Schemas)
 }
 
-func TestListSchemas_FieldsNotFound_Skips(t *testing.T) {
+func TestListSchemas_FieldsNotFound_IncludesSchemaWithEmptyFields(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
-	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, domain.ErrNotFound)
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{testVersion()}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, nil)
 
 	resp, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
 	require.NoError(t, err)
-	assert.Empty(t, resp.Schemas)
+	assert.Len(t, resp.Schemas, 1)
+	assert.Empty(t, resp.Schemas[0].Fields)
 }
 
 func TestListSchemas_VersionDBError_ReturnsInternal(t *testing.T) {
@@ -205,7 +216,7 @@ func TestListSchemas_VersionDBError_ReturnsInternal(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(domain.SchemaVersion{}, errors.New("db connection lost"))
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{}, errors.New("db connection lost"))
 
 	_, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
 	require.Error(t, err)
@@ -217,8 +228,8 @@ func TestListSchemas_FieldsDBError_ReturnsInternal(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("ListSchemas", mock.Anything, mock.Anything).Return([]domain.Schema{testSchema()}, nil)
-	store.On("GetLatestSchemaVersion", mock.Anything, testSchemaID).Return(testVersion(), nil)
-	store.On("GetSchemaFields", mock.Anything, testVersionID).Return([]domain.SchemaField{}, errors.New("db connection lost"))
+	store.On("GetLatestSchemaVersionsBatch", mock.Anything, mock.Anything).Return([]domain.SchemaVersion{testVersion()}, nil)
+	store.On("GetSchemaFieldsByVersionIDs", mock.Anything, mock.Anything).Return([]domain.SchemaField{}, errors.New("db connection lost"))
 
 	_, err := svc.ListSchemas(auth.WithoutAuth(context.Background()), &pb.ListSchemasRequest{})
 	require.Error(t, err)
@@ -868,8 +879,9 @@ func TestImportSchema_NewSchema(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "my-schema"}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "app.name", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "app.name"
+	})).Return([]domain.SchemaField{{Path: "app.name", FieldType: "string"}}, nil)
 
 	resp, err := svc.ImportSchema(ctx, &pb.ImportSchemaRequest{
 		YamlContent: validYAML("my-schema"),
@@ -890,8 +902,9 @@ func TestImportSchema_NewSchemaWithAutoPublish(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "pub-schema"}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "app.name", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "app.name"
+	})).Return([]domain.SchemaField{{Path: "app.name", FieldType: "string"}}, nil)
 	// autoPublish calls PublishSchema which calls GetSchemaByID + PublishSchemaVersion + GetSchemaFields.
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(domain.Schema{ID: testSchemaID, Name: "pub-schema"}, nil)
@@ -925,8 +938,9 @@ func TestImportSchema_ExistingSchemaNewVersion(t *testing.T) {
 	store.On("GetLatestSchemaVersion", ctx, testSchemaID).Return(latestVersion, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: newVersionID, SchemaID: testSchemaID, Version: 2, Checksum: "new-checksum"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "app.name", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "app.name"
+	})).Return([]domain.SchemaField{{Path: "app.name", FieldType: "string"}}, nil)
 
 	resp, err := svc.ImportSchema(ctx, &pb.ImportSchemaRequest{
 		YamlContent: validYAML("my-schema"),
@@ -1022,8 +1036,8 @@ func TestImportSchema_AcceptsValidCELRule(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "cel-good"}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "payments.min", FieldType: "integer"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.Anything).
+		Return([]domain.SchemaField{{Path: "payments.min", FieldType: "integer"}, {Path: "payments.max", FieldType: "integer"}}, nil)
 
 	yaml := []byte(`spec_version: v1
 name: cel-good
@@ -1072,8 +1086,9 @@ func TestImportSchema_ExistingWithAutoPublish(t *testing.T) {
 	store.On("GetLatestSchemaVersion", ctx, testSchemaID).Return(latestVersion, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: newVersionID, SchemaID: testSchemaID, Version: 2, Checksum: "new"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "app.name", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "app.name"
+	})).Return([]domain.SchemaField{{Path: "app.name", FieldType: "string"}}, nil)
 	// autoPublish flow
 	store.On("GetSchemaByID", ctx, testSchemaID).
 		Return(existingSchema, nil)

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -40,8 +40,9 @@ func TestCreateSchema_Success(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "test-schema"}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{Path: "test.field", FieldType: "string"}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "test.field"
+	})).Return([]domain.SchemaField{{Path: "test.field", FieldType: "string"}}, nil)
 
 	resp, err := svc.CreateSchema(ctx, &pb.CreateSchemaRequest{
 		Name: "test-schema",
@@ -158,8 +159,9 @@ func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 		}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: newVersionID, Version: 2, ParentVersion: ptrInt32(1)}, nil)
-	store.On("CreateSchemaField", ctx, mock.AnythingOfType("schema.CreateSchemaFieldParams")).
-		Return(domain.SchemaField{}, nil)
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 2 // existing + new
+	})).Return([]domain.SchemaField{{}, {}}, nil)
 
 	resp, err := svc.UpdateSchema(ctx, &pb.UpdateSchemaRequest{
 		Id: testSchemaID,
@@ -170,8 +172,6 @@ func TestUpdateSchema_CreatesNewVersion(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), resp.Schema.Version)
-	// Should have 2 fields: existing + new
-	store.AssertNumberOfCalls(t, "CreateSchemaField", 2)
 	store.AssertExpectations(t)
 }
 
@@ -293,9 +293,9 @@ func TestCreateSchema_FieldTagsNotPersisted(t *testing.T) {
 		Return(domain.Schema{ID: testSchemaID, Name: "test-schema"}, nil)
 	store.On("CreateSchemaVersion", ctx, mock.AnythingOfType("schema.CreateSchemaVersionParams")).
 		Return(domain.SchemaVersion{ID: testVersionID, SchemaID: testSchemaID, Version: 1, Checksum: "abc"}, nil)
-	store.On("CreateSchemaField", ctx, mock.MatchedBy(func(p CreateSchemaFieldParams) bool {
-		return p.Path == "payments.fee_rate"
-	})).Return(domain.SchemaField{
+	store.On("BulkCreateSchemaFields", ctx, mock.MatchedBy(func(args []CreateSchemaFieldParams) bool {
+		return len(args) == 1 && args[0].Path == "payments.fee_rate"
+	})).Return([]domain.SchemaField{{
 		Path:        "payments.fee_rate",
 		FieldType:   "number",
 		Description: &desc,
@@ -304,7 +304,7 @@ func TestCreateSchema_FieldTagsNotPersisted(t *testing.T) {
 		Tags:        []string{"billing", "critical"},
 		ReadOnly:    true,
 		Sensitive:   true,
-	}, nil)
+	}}, nil)
 
 	resp, err := svc.CreateSchema(ctx, &pb.CreateSchemaRequest{
 		Name:   "test-schema",

--- a/internal/schema/store.go
+++ b/internal/schema/store.go
@@ -157,9 +157,14 @@ type Store interface {
 	GetLatestSchemaVersion(ctx context.Context, schemaID string) (domain.SchemaVersion, error)
 	PublishSchemaVersion(ctx context.Context, arg PublishSchemaVersionParams) (domain.SchemaVersion, error)
 
+	// Schema versions (batch).
+	GetLatestSchemaVersionsBatch(ctx context.Context, schemaIDs []string) ([]domain.SchemaVersion, error)
+
 	// Schema fields.
 	CreateSchemaField(ctx context.Context, arg CreateSchemaFieldParams) (domain.SchemaField, error)
+	BulkCreateSchemaFields(ctx context.Context, args []CreateSchemaFieldParams) ([]domain.SchemaField, error)
 	GetSchemaFields(ctx context.Context, schemaVersionID string) ([]domain.SchemaField, error)
+	GetSchemaFieldsByVersionIDs(ctx context.Context, versionIDs []string) ([]domain.SchemaField, error)
 	DeleteSchemaField(ctx context.Context, arg DeleteSchemaFieldParams) error
 
 	// Tenants.

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -268,6 +268,61 @@ func (m *MemoryStore) GetSchemaFields(_ context.Context, schemaVersionID string)
 	return result, nil
 }
 
+func (m *MemoryStore) BulkCreateSchemaFields(ctx context.Context, args []CreateSchemaFieldParams) ([]domain.SchemaField, error) {
+	result := make([]domain.SchemaField, 0, len(args))
+	for _, a := range args {
+		f, err := m.CreateSchemaField(ctx, a)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, f)
+	}
+	return result, nil
+}
+
+func (m *MemoryStore) GetSchemaFieldsByVersionIDs(_ context.Context, versionIDs []string) ([]domain.SchemaField, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	idSet := make(map[string]struct{}, len(versionIDs))
+	for _, id := range versionIDs {
+		idSet[id] = struct{}{}
+	}
+	var result []domain.SchemaField
+	for vID, fields := range m.schemaFields {
+		if _, ok := idSet[vID]; ok {
+			result = append(result, fields...)
+		}
+	}
+	return result, nil
+}
+
+func (m *MemoryStore) GetLatestSchemaVersionsBatch(_ context.Context, schemaIDs []string) ([]domain.SchemaVersion, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	idSet := make(map[string]struct{}, len(schemaIDs))
+	for _, id := range schemaIDs {
+		idSet[id] = struct{}{}
+	}
+	latest := make(map[string]*domain.SchemaVersion)
+	for _, sv := range m.schemaVersions {
+		if _, ok := idSet[sv.SchemaID]; !ok {
+			continue
+		}
+		cur := latest[sv.SchemaID]
+		if cur == nil || sv.Version > cur.Version {
+			cp := sv
+			latest[sv.SchemaID] = &cp
+		}
+	}
+	result := make([]domain.SchemaVersion, 0, len(latest))
+	for _, sv := range latest {
+		result = append(result, *sv)
+	}
+	return result, nil
+}
+
 func (m *MemoryStore) DeleteSchemaField(_ context.Context, arg DeleteSchemaFieldParams) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -679,5 +679,53 @@ func TestMemoryStore_GetSchemaFieldsByVersionIDs(t *testing.T) {
 	assert.Empty(t, none)
 }
 
+func TestMemoryStore_GetLatestSchemaVersionsBatch(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	s1, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "batch-a"})
+	require.NoError(t, err)
+	s2, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "batch-b"})
+	require.NoError(t, err)
+	s3, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "batch-c"})
+	require.NoError(t, err)
+
+	// s1 latest should be version 3.
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s1.ID, Version: 1, Checksum: "a1"})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s1.ID, Version: 3, Checksum: "a3"})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s1.ID, Version: 2, Checksum: "a2"})
+	require.NoError(t, err)
+
+	// s2 latest should be version 2.
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s2.ID, Version: 1, Checksum: "b1"})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s2.ID, Version: 2, Checksum: "b2"})
+	require.NoError(t, err)
+
+	// s3 has versions but is not requested.
+	_, err = store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{SchemaID: s3.ID, Version: 9, Checksum: "c9"})
+	require.NoError(t, err)
+
+	got, err := store.GetLatestSchemaVersionsBatch(ctx, []string{s1.ID, s2.ID, "missing"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	bySchema := make(map[string]domain.SchemaVersion, len(got))
+	for _, sv := range got {
+		bySchema[sv.SchemaID] = sv
+	}
+
+	require.Contains(t, bySchema, s1.ID)
+	require.Contains(t, bySchema, s2.ID)
+	assert.Equal(t, int32(3), bySchema[s1.ID].Version)
+	assert.Equal(t, int32(2), bySchema[s2.ID].Version)
+
+	none, err := store.GetLatestSchemaVersionsBatch(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
 // Verify MemoryStore implements Store at compile time.
 var _ Store = (*MemoryStore)(nil)

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -663,7 +663,7 @@ func TestMemoryStore_GetSchemaFieldsByVersionIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 3)
 
-	var gotKeys []string
+	gotKeys := make([]string, 0, len(got))
 	for _, f := range got {
 		gotKeys = append(gotKeys, f.SchemaVersionID+":"+f.Path)
 	}

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -565,5 +565,119 @@ func TestMemoryStore_ListTenantsBySchema_FilteredByAllowedIDs(t *testing.T) {
 	assert.Len(t, all, 2)
 }
 
+func TestMemoryStore_BulkCreateSchemaFields(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "bulk-fields"})
+	require.NoError(t, err)
+
+	sv, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: s.ID, Version: 1, Checksum: "bulk",
+	})
+	require.NoError(t, err)
+
+	created, err := store.BulkCreateSchemaFields(ctx, []CreateSchemaFieldParams{
+		{
+			SchemaVersionID: sv.ID,
+			Path:            "app.name",
+			FieldType:       domain.FieldTypeString,
+		},
+		{
+			SchemaVersionID: sv.ID,
+			Path:            "app.port",
+			FieldType:       domain.FieldTypeInteger,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, created, 2)
+	assert.NotEmpty(t, created[0].ID)
+	assert.NotEmpty(t, created[1].ID)
+
+	fields, err := store.GetSchemaFields(ctx, sv.ID)
+	require.NoError(t, err)
+	require.Len(t, fields, 2)
+
+	gotPaths := []string{fields[0].Path, fields[1].Path}
+	assert.ElementsMatch(t, []string{"app.name", "app.port"}, gotPaths)
+
+	// Empty batch returns empty result and no error.
+	empty, err := store.BulkCreateSchemaFields(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	// Error when any item references a missing schema version.
+	_, err = store.BulkCreateSchemaFields(ctx, []CreateSchemaFieldParams{
+		{
+			SchemaVersionID: "bad-version-id",
+			Path:            "x",
+			FieldType:       domain.FieldTypeString,
+		},
+	})
+	assert.True(t, errors.Is(err, domain.ErrNotFound))
+}
+
+func TestMemoryStore_GetSchemaFieldsByVersionIDs(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "version-ids"})
+	require.NoError(t, err)
+
+	sv1, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: s.ID, Version: 1, Checksum: "v1",
+	})
+	require.NoError(t, err)
+
+	sv2, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: s.ID, Version: 2, Checksum: "v2",
+	})
+	require.NoError(t, err)
+
+	// Control version not requested later.
+	s2, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "other-schema"})
+	require.NoError(t, err)
+	svOther, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: s2.ID, Version: 1, Checksum: "other",
+	})
+	require.NoError(t, err)
+
+	_, err = store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		SchemaVersionID: sv1.ID, Path: "a", FieldType: domain.FieldTypeString,
+	})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		SchemaVersionID: sv1.ID, Path: "b", FieldType: domain.FieldTypeInteger,
+	})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		SchemaVersionID: sv2.ID, Path: "c", FieldType: domain.FieldTypeBool,
+	})
+	require.NoError(t, err)
+	_, err = store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		SchemaVersionID: svOther.ID, Path: "z", FieldType: domain.FieldTypeString,
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetSchemaFieldsByVersionIDs(ctx, []string{sv1.ID, sv2.ID, "missing"})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	var gotKeys []string
+	for _, f := range got {
+		gotKeys = append(gotKeys, f.SchemaVersionID+":"+f.Path)
+	}
+	assert.ElementsMatch(t, []string{
+		sv1.ID + ":a",
+		sv1.ID + ":b",
+		sv2.ID + ":c",
+	}, gotKeys)
+
+	// Empty input -> empty output.
+	none, err := store.GetSchemaFieldsByVersionIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
 // Verify MemoryStore implements Store at compile time.
 var _ Store = (*MemoryStore)(nil)

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -22,6 +22,7 @@ type PGStore struct {
 	writePool *pgxpool.Pool
 	write     *dbstore.Queries
 	read      *dbstore.Queries
+	tx        pgx.Tx // non-nil when bound to a transaction
 }
 
 // NewPGStore creates a new PostgreSQL-backed schema store.
@@ -51,6 +52,7 @@ func (s *PGStore) RunInTx(ctx context.Context, fn func(Store) error) error {
 		writePool: s.writePool,
 		write:     txQueries,
 		read:      txQueries,
+		tx:        tx,
 	}
 
 	if err := fn(txStore); err != nil {
@@ -295,6 +297,97 @@ func (s *PGStore) GetSchemaFields(ctx context.Context, schemaVersionID string) (
 	result := make([]domain.SchemaField, len(rows))
 	for i, r := range rows {
 		result[i] = schemaFieldFromDB(r)
+	}
+	return result, nil
+}
+
+// batcher returns the BatchSender appropriate for the current context:
+// the active transaction when inside RunInTx, otherwise the write pool.
+func (s *PGStore) batcher() interface {
+	SendBatch(context.Context, *pgx.Batch) pgx.BatchResults
+} {
+	if s.tx != nil {
+		return s.tx
+	}
+	return s.writePool
+}
+
+const bulkCreateSchemaFieldSQL = `INSERT INTO schema_fields (
+	schema_version_id, path, field_type, constraints, nullable, deprecated,
+	redirect_to, default_value, description, title, example, examples,
+	external_docs, tags, format, read_only, write_once, sensitive
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+RETURNING id, schema_version_id, path, field_type, constraints, nullable, deprecated,
+	redirect_to, default_value, description, title, example, examples,
+	external_docs, tags, format, read_only, write_once, sensitive`
+
+func (s *PGStore) BulkCreateSchemaFields(ctx context.Context, args []CreateSchemaFieldParams) ([]domain.SchemaField, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+	batch := &pgx.Batch{}
+	for _, a := range args {
+		svID, err := pgconv.StringToUUID(a.SchemaVersionID)
+		if err != nil {
+			return nil, err
+		}
+		batch.Queue(bulkCreateSchemaFieldSQL,
+			svID, a.Path, dbstore.FieldType(a.FieldType),
+			a.Constraints, a.Nullable, a.Deprecated,
+			a.RedirectTo, a.DefaultValue, a.Description,
+			a.Title, a.Example, a.Examples, a.ExternalDocs,
+			a.Tags, a.Format, a.ReadOnly, a.WriteOnce, a.Sensitive,
+		)
+	}
+	br := s.batcher().SendBatch(ctx, batch)
+	defer func() { _ = br.Close() }()
+	result := make([]domain.SchemaField, 0, len(args))
+	for range args {
+		row := br.QueryRow()
+		var f dbstore.SchemaField
+		if err := row.Scan(
+			&f.ID, &f.SchemaVersionID, &f.Path, &f.FieldType,
+			&f.Constraints, &f.Nullable, &f.Deprecated,
+			&f.RedirectTo, &f.DefaultValue, &f.Description,
+			&f.Title, &f.Example, &f.Examples, &f.ExternalDocs,
+			&f.Tags, &f.Format, &f.ReadOnly, &f.WriteOnce, &f.Sensitive,
+		); err != nil {
+			return nil, fmt.Errorf("bulk create schema field: %w", err)
+		}
+		result = append(result, schemaFieldFromDB(f))
+	}
+	return result, br.Close()
+}
+
+func (s *PGStore) GetSchemaFieldsByVersionIDs(ctx context.Context, versionIDs []string) ([]domain.SchemaField, error) {
+	pgIDs, err := stringsToUUIDs(versionIDs)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.read.GetSchemaFieldsByVersionIDs(ctx, pgIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]domain.SchemaField, len(rows))
+	for i, r := range rows {
+		result[i] = schemaFieldFromDB(r)
+	}
+	return result, nil
+}
+
+func (s *PGStore) GetLatestSchemaVersionsBatch(ctx context.Context, schemaIDs []string) ([]domain.SchemaVersion, error) {
+	pgIDs, err := stringsToUUIDs(schemaIDs)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.read.GetLatestSchemaVersionsBatch(ctx, pgIDs)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]domain.SchemaVersion, len(rows))
+	for i, r := range rows {
+		result[i] = schemaVersionFromDB(r)
 	}
 	return result, nil
 }

--- a/internal/server/memory_integration_test.go
+++ b/internal/server/memory_integration_test.go
@@ -126,11 +126,13 @@ func TestMemoryBackend_Integration(t *testing.T) {
 		memConfig.SetSchemaFields(sv2.ID, fields2)
 	}
 
-	// 4. Set config value.
-	_, err = configClient.SetField(authCtx, &pb.SetFieldRequest{
-		TenantId:  tenantID,
-		FieldPath: "fee",
-		Value:     &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 0.025}},
+	// 4. Set config values (exercises BulkSetConfigValues + BulkInsertAuditWriteLog).
+	_, err = configClient.SetFields(authCtx, &pb.SetFieldsRequest{
+		TenantId: tenantID,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "fee", Value: &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 0.025}}},
+			{FieldPath: "enabled", Value: &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: true}}},
+		},
 	})
 	require.NoError(t, err)
 
@@ -141,12 +143,17 @@ func TestMemoryBackend_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0.025, getResp.Value.GetValue().GetNumberValue())
 
-	// 6. List versions.
+	// 6. List schemas (exercises GetLatestSchemaVersionsBatch + GetSchemaFieldsByVersionIDs).
+	listResp, err := schemaClient.ListSchemas(authCtx, &pb.ListSchemasRequest{PageSize: 10})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(listResp.Schemas), 1)
+
+	// 7. List versions.
 	versionsResp, err := configClient.ListVersions(authCtx, &pb.ListVersionsRequest{TenantId: tenantID})
 	require.NoError(t, err)
 	assert.Len(t, versionsResp.Versions, 1)
 
-	// 7. Cleanup.
+	// 8. Cleanup.
 	_, err = schemaClient.DeleteTenant(authCtx, &pb.DeleteTenantRequest{Id: tenantID})
 	require.NoError(t, err)
 	_, err = schemaClient.DeleteSchema(authCtx, &pb.DeleteSchemaRequest{Id: schemaID})

--- a/internal/storage/dbstore/schemas.sql.gen.go
+++ b/internal/storage/dbstore/schemas.sql.gen.go
@@ -195,6 +195,44 @@ func (q *Queries) GetLatestSchemaVersion(ctx context.Context, schemaID pgtype.UU
 	return i, err
 }
 
+const getLatestSchemaVersionsBatch = `-- name: GetLatestSchemaVersionsBatch :many
+SELECT DISTINCT ON (schema_id) id, schema_id, version, parent_version, description, checksum, published, dependent_required, validations, created_at
+FROM schema_versions
+WHERE schema_id = ANY($1::uuid[])
+ORDER BY schema_id, version DESC
+`
+
+func (q *Queries) GetLatestSchemaVersionsBatch(ctx context.Context, dollar_1 []pgtype.UUID) ([]SchemaVersion, error) {
+	rows, err := q.db.Query(ctx, getLatestSchemaVersionsBatch, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SchemaVersion{}
+	for rows.Next() {
+		var i SchemaVersion
+		if err := rows.Scan(
+			&i.ID,
+			&i.SchemaID,
+			&i.Version,
+			&i.ParentVersion,
+			&i.Description,
+			&i.Checksum,
+			&i.Published,
+			&i.DependentRequired,
+			&i.Validations,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getSchemaByID = `-- name: GetSchemaByID :one
 SELECT id, name, description, created_at, updated_at, deleted_at FROM schemas WHERE id = $1 AND deleted_at IS NULL
 `
@@ -239,6 +277,52 @@ ORDER BY path
 
 func (q *Queries) GetSchemaFields(ctx context.Context, schemaVersionID pgtype.UUID) ([]SchemaField, error) {
 	rows, err := q.db.Query(ctx, getSchemaFields, schemaVersionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SchemaField{}
+	for rows.Next() {
+		var i SchemaField
+		if err := rows.Scan(
+			&i.ID,
+			&i.SchemaVersionID,
+			&i.Path,
+			&i.FieldType,
+			&i.Constraints,
+			&i.Nullable,
+			&i.Deprecated,
+			&i.RedirectTo,
+			&i.DefaultValue,
+			&i.Description,
+			&i.Title,
+			&i.Example,
+			&i.Examples,
+			&i.ExternalDocs,
+			&i.Tags,
+			&i.Format,
+			&i.ReadOnly,
+			&i.WriteOnce,
+			&i.Sensitive,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getSchemaFieldsByVersionIDs = `-- name: GetSchemaFieldsByVersionIDs :many
+SELECT id, schema_version_id, path, field_type, constraints, nullable, deprecated, redirect_to, default_value, description, title, example, examples, external_docs, tags, format, read_only, write_once, sensitive FROM schema_fields
+WHERE schema_version_id = ANY($1::uuid[])
+ORDER BY schema_version_id, path
+`
+
+func (q *Queries) GetSchemaFieldsByVersionIDs(ctx context.Context, dollar_1 []pgtype.UUID) ([]SchemaField, error) {
+	rows, err := q.db.Query(ctx, getSchemaFieldsByVersionIDs, dollar_1)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- ListSchemas was making 2N+1 round trips per page; replaced with two batch queries (DISTINCT ON for latest versions, `= ANY` for bulk field fetch) so cost is constant regardless of schema count.
- `createFieldsOn` (schema creation) sent N individual INSERT statements for N fields; replaced with a single `pgx.Batch` round trip via `BulkCreateSchemaFields`.
- `SetFields`, `ImportConfig`, and `RollbackVersion` each looped with per-field `SetConfigValue` + `InsertAuditWriteLog` calls; replaced with `BulkSetConfigValues` and `BulkInsertAuditWriteLog` (one batch each). The audit hash chain is computed sequentially in-memory before the batch is sent, preserving tamper-evident ordering at no extra cost.

## Test plan

- [x] All existing schema and config unit tests updated to use batch mock methods
- [x] `make test` passes across all modules
- [x] `make lint` clean (zero issues)
- [x] `v2.SchemaID` bug in `TestListSchemas_Pagination` caught and fixed during update
- [x] Behavior verified: schemas with no fields are now included with empty field list (previously silently skipped) — test renamed accordingly

Closes #432