### PR TITLE
Harden JWT validation: exp required, leeway, audience, JWKS refresh signaling

### DIFF
--- a/.agents/context/security-review.md
+++ b/.agents/context/security-review.md
@@ -331,9 +331,16 @@ to be correctly protected at the audit date:
   `internal/config/service.go:705` calls `CheckTenantAccess` *before*
   delegating to `pubsub.Subscribe`. Redis channel naming
   (`internal/pubsub/redis.go:12,29,52`) is per-tenant.
-- **JWT algorithm allowlist** — `internal/auth/jwt.go:129` uses
+- **JWT algorithm allowlist** — `internal/auth/jwt.go` uses
   `jwt.WithValidMethods([]string{"RS256", "ES256"})`; `alg=none` and
   `alg=HS256` are rejected. Test coverage in `jwt_test.go`.
+- **JWT hardening (decree#424)** — implemented in `internal/auth/jwt.go`:
+  `jwt.WithExpirationRequired()` (tokens without `exp` are rejected);
+  default 60s leeway overridable via `WithLeeway` / `JWT_LEEWAY` env;
+  optional audience enforcement via `WithAudience` / `JWT_AUDIENCE` env;
+  JWKS refresh error handler logs at ERROR and increments
+  `auth.jwks_refresh_failures_total` metric (`OTEL_METRICS_AUTH=1`);
+  JWT parse errors logged by category only (no raw token bytes in logs).
 - **JWT e2e test suite** — `e2e/jwt_auth_test.go` (decree#470) adds a
   parallel e2e suite for JWT-mode: role matrix, tenant-access matrix, JWKS
   rotation (graceful handoff), and expired-token rejection. Runs via

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -189,12 +189,23 @@ func run() int {
 	}
 
 	// Auth interceptor.
+	authMetrics := telemetry.NewAuthMetrics(otelCfg)
 	var authInterceptor server.GRPCInterceptor
 	if cfg.JWTJWKSURL != "" {
-		jwtInterceptor, jwtErr := auth.NewInterceptor(ctx, cfg.JWTJWKSURL,
+		jwtOpts := []auth.InterceptorOption{
 			auth.WithIssuer(cfg.JWTIssuer),
 			auth.WithLogger(logger),
-		)
+		}
+		if cfg.JWTAudience != "" {
+			jwtOpts = append(jwtOpts, auth.WithAudience(cfg.JWTAudience))
+		}
+		if cfg.JWTLeeway > 0 {
+			jwtOpts = append(jwtOpts, auth.WithLeeway(cfg.JWTLeeway))
+		}
+		if counter, ok := authMetrics.JWKSRefreshFailureCounter(); ok {
+			jwtOpts = append(jwtOpts, auth.WithJWKSRefreshFailureCounter(counter))
+		}
+		jwtInterceptor, jwtErr := auth.NewInterceptor(ctx, cfg.JWTJWKSURL, jwtOpts...)
 		if jwtErr != nil {
 			logger.ErrorContext(ctx, "failed to create auth interceptor", "error", jwtErr)
 			return 1
@@ -464,6 +475,8 @@ type serverConfig struct {
 	RedisURL                    string
 	EnableServices              []string
 	JWTIssuer                   string
+	JWTAudience                 string
+	JWTLeeway                   time.Duration
 	JWTJWKSURL                  string
 	LogLevel                    string
 	UsageTrackingEnabled        bool
@@ -564,6 +577,8 @@ func loadConfig() serverConfig {
 		RedisURL:                    getEnv("REDIS_URL", ""),
 		EnableServices:              parseServices(enableServices),
 		JWTIssuer:                   getEnv("JWT_ISSUER", ""),
+		JWTAudience:                 getEnv("JWT_AUDIENCE", ""),
+		JWTLeeway:                   parseEnvDuration("JWT_LEEWAY", 0),
 		JWTJWKSURL:                  getEnv("JWT_JWKS_URL", ""),
 		LogLevel:                    getEnv("LOG_LEVEL", "info"),
 		UsageTrackingEnabled:        getEnv("USAGE_TRACKING_ENABLED", "true") != "false",

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/MicahParks/keyfunc/v3"
 	"github.com/golang-jwt/jwt/v5"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -65,22 +67,30 @@ func ContextWithClaims(ctx context.Context, claims *Claims) context.Context {
 	return context.WithValue(ctx, claimsContextKey{}, claims)
 }
 
+const defaultLeeway = 60 * time.Second
+
 // Interceptor provides gRPC interceptors for JWT authentication.
 type Interceptor struct {
-	jwks       keyfunc.Keyfunc
-	jwksCancel context.CancelFunc
-	issuer     string
-	leeway     time.Duration
-	logger     *slog.Logger
+	jwks               keyfunc.Keyfunc
+	jwksCancel         context.CancelFunc
+	issuer             string
+	audience           string
+	leeway             time.Duration
+	logger             *slog.Logger
+	jwksRefreshCounter metric.Int64Counter
+	hasCounter         bool
 }
 
 // InterceptorOption configures a JWT Interceptor.
 type InterceptorOption func(*interceptorOptions)
 
 type interceptorOptions struct {
-	issuer string
-	leeway time.Duration
-	logger *slog.Logger
+	issuer             string
+	audience           string
+	leeway             time.Duration
+	logger             *slog.Logger
+	jwksRefreshCounter metric.Int64Counter
+	hasCounter         bool
 }
 
 // WithIssuer enforces an expected `iss` claim during JWT validation.
@@ -89,7 +99,14 @@ func WithIssuer(issuer string) InterceptorOption {
 	return func(o *interceptorOptions) { o.issuer = issuer }
 }
 
+// WithAudience enforces an expected `aud` claim during JWT validation.
+// When unset, the audience claim is not checked.
+func WithAudience(audience string) InterceptorOption {
+	return func(o *interceptorOptions) { o.audience = audience }
+}
+
 // WithLeeway sets the clock-skew tolerance applied to exp, nbf, and iat claims.
+// Defaults to 60s when unset.
 func WithLeeway(d time.Duration) InterceptorOption {
 	return func(o *interceptorOptions) { o.leeway = d }
 }
@@ -99,27 +116,60 @@ func WithLogger(l *slog.Logger) InterceptorOption {
 	return func(o *interceptorOptions) { o.logger = l }
 }
 
+// WithJWKSRefreshFailureCounter sets an OTel counter incremented on each JWKS
+// background refresh failure. Pass the counter from telemetry.AuthMetrics.
+func WithJWKSRefreshFailureCounter(c metric.Int64Counter) InterceptorOption {
+	return func(o *interceptorOptions) {
+		o.jwksRefreshCounter = c
+		o.hasCounter = true
+	}
+}
+
 // NewInterceptor creates a new auth interceptor. jwksURL is the JWKS endpoint
-// for key discovery; pass WithIssuer / WithLogger for optional configuration.
+// for key discovery; pass WithIssuer / WithAudience / WithLeeway / WithLogger for
+// optional configuration. Leeway defaults to 60s when not explicitly set.
 func NewInterceptor(ctx context.Context, jwksURL string, opts ...InterceptorOption) (*Interceptor, error) {
-	o := interceptorOptions{logger: slog.Default()}
+	o := interceptorOptions{
+		logger: slog.Default(),
+		leeway: defaultLeeway,
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
 
+	logger := o.logger
+	var counter metric.Int64Counter
+	hasCounter := o.hasCounter
+	if hasCounter {
+		counter = o.jwksRefreshCounter
+	}
+
 	jwksCtx, jwksCancel := context.WithCancel(ctx)
-	jwks, err := keyfunc.NewDefaultCtx(jwksCtx, []string{jwksURL})
+	override := keyfunc.Override{
+		RefreshErrorHandlerFunc: func(u string) func(ctx context.Context, err error) {
+			return func(ctx context.Context, err error) {
+				logger.ErrorContext(ctx, "jwks refresh failed", "url", u, "error", err)
+				if hasCounter {
+					counter.Add(ctx, 1)
+				}
+			}
+		},
+	}
+	jwks, err := keyfunc.NewDefaultOverrideCtx(jwksCtx, []string{jwksURL}, override)
 	if err != nil {
 		jwksCancel()
 		return nil, fmt.Errorf("create jwks keyfunc: %w", err)
 	}
 
 	return &Interceptor{
-		jwks:       jwks,
-		jwksCancel: jwksCancel,
-		issuer:     o.issuer,
-		leeway:     o.leeway,
-		logger:     o.logger,
+		jwks:               jwks,
+		jwksCancel:         jwksCancel,
+		issuer:             o.issuer,
+		audience:           o.audience,
+		leeway:             o.leeway,
+		logger:             o.logger,
+		jwksRefreshCounter: counter,
+		hasCounter:         hasCounter,
 	}, nil
 }
 
@@ -161,9 +211,15 @@ func (i *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 	}
 
 	claims := &Claims{}
-	opts := []jwt.ParserOption{jwt.WithValidMethods([]string{"RS256", "ES256"})}
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{"RS256", "ES256"}),
+		jwt.WithExpirationRequired(),
+	}
 	if i.issuer != "" {
 		opts = append(opts, jwt.WithIssuer(i.issuer))
+	}
+	if i.audience != "" {
+		opts = append(opts, jwt.WithAudience(i.audience))
 	}
 	if i.leeway > 0 {
 		opts = append(opts, jwt.WithLeeway(i.leeway))
@@ -171,7 +227,7 @@ func (i *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 
 	parsed, err := jwt.ParseWithClaims(token, claims, i.jwks.KeyfuncCtx(ctx), opts...)
 	if err != nil {
-		i.logger.DebugContext(ctx, "jwt validation failed", "error", err)
+		i.logger.DebugContext(ctx, "jwt validation failed", "reason", jwtErrCategory(err))
 		return nil, status.Error(codes.Unauthenticated, "invalid token")
 	}
 	if !parsed.Valid {
@@ -192,6 +248,24 @@ func (i *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 	}
 
 	return context.WithValue(ctx, claimsContextKey{}, claims), nil
+}
+
+// jwtErrCategory returns a safe, non-token-bearing description of a JWT parse error.
+func jwtErrCategory(err error) string {
+	switch {
+	case errors.Is(err, jwt.ErrTokenMalformed):
+		return "malformed"
+	case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+		return "invalid_signature"
+	case errors.Is(err, jwt.ErrTokenExpired):
+		return "expired"
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		return "not_yet_valid"
+	case errors.Is(err, jwt.ErrTokenRequiredClaimMissing):
+		return "missing_required_claim"
+	default:
+		return "invalid"
+	}
 }
 
 func extractBearerToken(ctx context.Context) (string, error) {

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -822,6 +823,20 @@ func TestUnaryInterceptor_JWKSRefreshFailureHandler_LogsOnRefreshError(t *testin
 	// With a broken JWKS server, the token must not be accepted.
 	require.Error(t, authErr)
 	assert.Equal(t, codes.Unauthenticated, status.Code(authErr))
+}
+
+func TestNewInterceptor_WithJWKSRefreshFailureCounter(t *testing.T) {
+	meter := noop.NewMeterProvider().Meter("test")
+	counter, err := meter.Int64Counter("test.failures")
+	require.NoError(t, err)
+
+	interceptor := newTestInterceptor(t, "", WithJWKSRefreshFailureCounter(counter))
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithBearer(signToken(t, validClaims(RoleAdmin, "t1")))
+	resp, authErr := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, authErr)
+	assert.Equal(t, "ok", resp)
 }
 
 // --- EmptyRoleInJWT ---

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -440,7 +440,7 @@ func TestUnaryInterceptor_WrongSigningKey(t *testing.T) {
 // --- Expiry boundary / leeway ---
 
 func TestUnaryInterceptor_ExpiryBoundaryRejected(t *testing.T) {
-	interceptor := newTestInterceptor(t, "")
+	interceptor := newTestInterceptor(t, "", WithLeeway(0))
 	unary := interceptor.UnaryInterceptor()
 
 	claims := Claims{
@@ -550,7 +550,7 @@ func TestUnaryInterceptor_JWKSRotation(t *testing.T) {
 // --- Clock skew (nbf) ---
 
 func TestUnaryInterceptor_ClockSkew_NBF_Rejected(t *testing.T) {
-	interceptor := newTestInterceptor(t, "")
+	interceptor := newTestInterceptor(t, "", WithLeeway(0))
 	unary := interceptor.UnaryInterceptor()
 
 	// nbf 10s in the future — no leeway configured.
@@ -689,6 +689,142 @@ func TestUnaryInterceptor_TenantIDHeader_DoesNotOverrideJWT(t *testing.T) {
 	assert.Equal(t, []string{"t1"}, capturedClaims.TenantIDs, "tenant list must come from JWT, not x-tenant-id header")
 	assert.False(t, capturedClaims.HasTenantAccess("t2"), "header-injected tenant must not grant access")
 }
+
+// --- ExpirationRequired ---
+
+func TestUnaryInterceptor_NoExpiry_Rejected(t *testing.T) {
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt: jwt.NewNumericDate(time.Now()),
+			// No ExpiresAt — should be rejected by WithExpirationRequired.
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// --- Audience ---
+
+func TestUnaryInterceptor_AudienceMismatch_Rejected(t *testing.T) {
+	interceptor := newTestInterceptor(t, "", WithAudience("api.example.com"))
+	unary := interceptor.UnaryInterceptor()
+
+	claims := validClaims(RoleAdmin, "t1")
+	claims.Audience = jwt.ClaimStrings{"wrong.audience"}
+	ctx := ctxWithBearer(signToken(t, claims))
+
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+func TestUnaryInterceptor_AudienceMatch_Accepted(t *testing.T) {
+	interceptor := newTestInterceptor(t, "", WithAudience("api.example.com"))
+	unary := interceptor.UnaryInterceptor()
+
+	claims := validClaims(RoleAdmin, "t1")
+	claims.Audience = jwt.ClaimStrings{"api.example.com"}
+	ctx := ctxWithBearer(signToken(t, claims))
+
+	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestUnaryInterceptor_AudienceNotConfigured_TokenWithAudIgnored(t *testing.T) {
+	// When WithAudience is not set, audience in the token is not checked.
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := validClaims(RoleAdmin, "t1")
+	claims.Audience = jwt.ClaimStrings{"some.audience"}
+	ctx := ctxWithBearer(signToken(t, claims))
+
+	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// --- Default leeway ---
+
+func TestUnaryInterceptor_DefaultLeeway_AcceptsRecentlyExpired(t *testing.T) {
+	// Default leeway is 60s; token expired 30s ago should be accepted.
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-30 * time.Second)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	resp, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestUnaryInterceptor_DefaultLeeway_RejectsFarExpired(t *testing.T) {
+	// Default leeway is 60s; token expired 2 minutes ago must be rejected.
+	interceptor := newTestInterceptor(t, "")
+	unary := interceptor.UnaryInterceptor()
+
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-120 * time.Second)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		},
+		Role:      RoleAdmin,
+		TenantIDs: []string{"t1"},
+	}
+	ctx := ctxWithBearer(signToken(t, claims))
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+}
+
+// --- JWKS refresh failure counter ---
+
+func TestUnaryInterceptor_JWKSRefreshFailureHandler_LogsOnRefreshError(t *testing.T) {
+	// Verify that a JWKS server returning errors causes the refresh error handler to fire.
+	// We verify this indirectly: an unknown KID triggers an on-demand fetch; when the server
+	// is broken, authentication fails with Unauthenticated (not a crash or panic).
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	// NewInterceptor with a broken server — first fetch will fail.
+	interceptor, err := NewInterceptor(context.Background(), srv.URL, WithLogger(logger))
+	// keyfunc.NewDefaultOverrideCtx with NoErrorReturnFirstHTTPReq=true (keyfunc default)
+	// may return nil err even if the first fetch fails. Either way, if we got an interceptor
+	// we should verify it rejects tokens gracefully.
+	if err != nil {
+		t.Skip("interceptor creation failed (expected for broken JWKS)")
+	}
+	t.Cleanup(interceptor.Close)
+
+	unary := interceptor.UnaryInterceptor()
+	ctx := ctxWithBearer(signToken(t, validClaims(RoleAdmin, "t1")))
+	_, authErr := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	// With a broken JWKS server, the token must not be accepted.
+	require.Error(t, authErr)
+	assert.Equal(t, codes.Unauthenticated, status.Code(authErr))
+}
+
+// --- EmptyRoleInJWT ---
 
 // TestUnaryInterceptor_EmptyRoleInJWT verifies that a JWT with an empty role claim
 // is rejected with PermissionDenied — an empty string is not a valid role.

--- a/internal/telemetry/config.go
+++ b/internal/telemetry/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	MetricsValidation bool
 	// MetricsPubSub enables the pubsub dropped-event counter.
 	MetricsPubSub bool
+	// MetricsAuth enables the JWKS refresh-failure counter.
+	MetricsAuth bool
 	// MetricsTenantAllowlist is the opt-in set of tenant IDs that receive a tenant_id label
 	// on config metrics. Empty (the default) suppresses the label on all tenants to prevent
 	// Prometheus/OTel cardinality explosion in deployments with many tenants.
@@ -39,7 +41,7 @@ type Config struct {
 
 // AnyMetrics returns true if any metric flag is enabled.
 func (c Config) AnyMetrics() bool {
-	return c.MetricsGRPC || c.MetricsDBPool || c.MetricsCache || c.MetricsConfig || c.MetricsSchema || c.MetricsRateLimit || c.MetricsValidation || c.MetricsPubSub
+	return c.MetricsGRPC || c.MetricsDBPool || c.MetricsCache || c.MetricsConfig || c.MetricsSchema || c.MetricsRateLimit || c.MetricsValidation || c.MetricsPubSub || c.MetricsAuth
 }
 
 // ConfigFromEnv parses telemetry configuration from environment variables.
@@ -57,6 +59,7 @@ func ConfigFromEnv() Config {
 		MetricsRateLimit:       envBool("OTEL_METRICS_RATE_LIMIT"),
 		MetricsValidation:      envBool("OTEL_METRICS_VALIDATION"),
 		MetricsPubSub:          envBool("OTEL_METRICS_PUBSUB"),
+		MetricsAuth:            envBool("OTEL_METRICS_AUTH"),
 		MetricsTenantAllowlist: envStringSlice("OTEL_METRICS_TENANT_ALLOWLIST"),
 	}
 }

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -65,6 +65,7 @@ func TestAnyMetrics_OneEnabled(t *testing.T) {
 	assert.True(t, Config{MetricsConfig: true}.AnyMetrics())
 	assert.True(t, Config{MetricsSchema: true}.AnyMetrics())
 	assert.True(t, Config{MetricsPubSub: true}.AnyMetrics())
+	assert.True(t, Config{MetricsAuth: true}.AnyMetrics())
 }
 
 func TestConfigFromEnv_TenantAllowlist(t *testing.T) {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -241,6 +241,30 @@ func (m *PubSubMetrics) DroppedCounter() (metric.Int64Counter, bool) {
 	return m.dropped, true
 }
 
+// AuthMetrics records auth-related counters.
+type AuthMetrics struct {
+	jwksRefreshFailures metric.Int64Counter
+}
+
+// NewAuthMetrics creates auth metrics. Returns nil if not enabled.
+func NewAuthMetrics(cfg Config) *AuthMetrics {
+	if !cfg.Enabled || !cfg.MetricsAuth {
+		return nil
+	}
+	meter := otel.Meter(meterName)
+	failures, _ := meter.Int64Counter("auth.jwks_refresh_failures_total",
+		metric.WithDescription("Number of JWKS background refresh failures"))
+	return &AuthMetrics{jwksRefreshFailures: failures}
+}
+
+// JWKSRefreshFailureCounter returns the counter and true when metrics are enabled.
+func (m *AuthMetrics) JWKSRefreshFailureCounter() (metric.Int64Counter, bool) {
+	if m == nil {
+		return nil, false
+	}
+	return m.jwksRefreshFailures, true
+}
+
 // StartDBPoolMetrics starts a background goroutine that periodically records
 // DB connection pool statistics. Returns immediately if not enabled.
 func StartDBPoolMetrics(ctx context.Context, cfg Config, writePool, readPool *pgxpool.Pool) {

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -212,3 +212,27 @@ func TestPubSubMetrics_NilSafe(t *testing.T) {
 	_, ok := m.DroppedCounter()
 	assert.False(t, ok)
 }
+
+func TestNewAuthMetrics_Disabled(t *testing.T) {
+	assert.Nil(t, NewAuthMetrics(Config{}))
+	assert.Nil(t, NewAuthMetrics(Config{Enabled: true, MetricsAuth: false}))
+}
+
+func TestNewAuthMetrics_Enabled(t *testing.T) {
+	m := NewAuthMetrics(Config{Enabled: true, MetricsAuth: true})
+	assert.NotNil(t, m)
+}
+
+func TestAuthMetrics_NilSafe(t *testing.T) {
+	var m *AuthMetrics
+	counter, ok := m.JWKSRefreshFailureCounter()
+	assert.False(t, ok)
+	assert.Nil(t, counter)
+}
+
+func TestAuthMetrics_JWKSRefreshFailureCounter(t *testing.T) {
+	m := NewAuthMetrics(Config{Enabled: true, MetricsAuth: true})
+	counter, ok := m.JWKSRefreshFailureCounter()
+	assert.True(t, ok)
+	assert.NotNil(t, counter)
+}


### PR DESCRIPTION
## Summary

- Tokens without an \`exp\` claim were silently accepted forever; \`jwt.WithExpirationRequired()\` now rejects them unconditionally.
- JWKS background refresh failures were invisible; a \`RefreshErrorHandlerFunc\` now logs at ERROR and increments the \`auth.jwks_refresh_failures_total\` OTel counter (opt-in via \`OTEL_METRICS_AUTH=1\`).
- JWT parse errors were logged with the raw \`err\` string, which could contain token segments; logging now records only the error category (malformed, expired, invalid_signature, etc.).

## Test plan

- [ ] `make test` passes clean
- [ ] `TestUnaryInterceptor_NoExpiry_Rejected` — token without `exp` → Unauthenticated
- [ ] `TestUnaryInterceptor_AudienceMismatch_Rejected` / `_AudienceMatch_Accepted` — audience enforcement
- [ ] `TestUnaryInterceptor_DefaultLeeway_AcceptsRecentlyExpired` / `_RejectsFarExpired` — 60s default leeway
- [ ] `TestUnaryInterceptor_JWKSRefreshFailureHandler_LogsOnRefreshError` — broken server → rejected gracefully
- [ ] Existing leeway / clock-skew tests updated to use `WithLeeway(0)` to opt out of the new default

Closes #424