### PR TITLE
fix(configclient): stop retrying non-idempotent Set* operations

### DIFF
--- a/api/centralconfig/v1/config_service.pb.go
+++ b/api/centralconfig/v1/config_service.pb.go
@@ -446,8 +446,12 @@ type SetFieldRequest struct {
 	// Value-level description explaining what this specific value means.
 	// Retrievable via include_description in read requests.
 	ValueDescription *string `protobuf:"bytes,6,opt,name=value_description,json=valueDescription,proto3,oneof" json:"value_description,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Idempotency key for safe retries. When set, the server deduplicates
+	// writes with the same key within a 24-hour window. Use the SDK's
+	// WithIdempotencyKey option to set this field and enable retry.
+	IdempotencyKey *string `protobuf:"bytes,7,opt,name=idempotency_key,json=idempotencyKey,proto3,oneof" json:"idempotency_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SetFieldRequest) Reset() {
@@ -522,6 +526,13 @@ func (x *SetFieldRequest) GetValueDescription() string {
 	return ""
 }
 
+func (x *SetFieldRequest) GetIdempotencyKey() string {
+	if x != nil && x.IdempotencyKey != nil {
+		return *x.IdempotencyKey
+	}
+	return ""
+}
+
 type SetFieldResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The newly created config version.
@@ -577,9 +588,13 @@ type SetFieldsRequest struct {
 	// CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument.
 	Updates []*FieldUpdate `protobuf:"bytes,2,rep,name=updates,proto3" json:"updates,omitempty"`
 	// Version-level description explaining why these changes were made.
-	Description   *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Description *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	// Idempotency key for safe retries. When set, the server deduplicates
+	// writes with the same key within a 24-hour window. Use the SDK's
+	// WithIdempotencyKey option to set this field and enable retry.
+	IdempotencyKey *string `protobuf:"bytes,4,opt,name=idempotency_key,json=idempotencyKey,proto3,oneof" json:"idempotency_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SetFieldsRequest) Reset() {
@@ -629,6 +644,13 @@ func (x *SetFieldsRequest) GetUpdates() []*FieldUpdate {
 func (x *SetFieldsRequest) GetDescription() string {
 	if x != nil && x.Description != nil {
 		return *x.Description
+	}
+	return ""
+}
+
+func (x *SetFieldsRequest) GetIdempotencyKey() string {
+	if x != nil && x.IdempotencyKey != nil {
+		return *x.IdempotencyKey
 	}
 	return ""
 }
@@ -1451,7 +1473,7 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\n" +
 	"\b_version\"J\n" +
 	"\x11GetFieldsResponse\x125\n" +
-	"\x06values\x18\x01 \x03(\v2\x1d.centralconfig.v1.ConfigValueR\x06values\"\xc8\x02\n" +
+	"\x06values\x18\x01 \x03(\v2\x1d.centralconfig.v1.ConfigValueR\x06values\"\x8a\x03\n" +
 	"\x0fSetFieldRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1d\n" +
 	"\n" +
@@ -1459,17 +1481,21 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\x05value\x18\x03 \x01(\v2\x1c.centralconfig.v1.TypedValueR\x05value\x120\n" +
 	"\x11expected_checksum\x18\x04 \x01(\tH\x00R\x10expectedChecksum\x88\x01\x01\x12%\n" +
 	"\vdescription\x18\x05 \x01(\tH\x01R\vdescription\x88\x01\x01\x120\n" +
-	"\x11value_description\x18\x06 \x01(\tH\x02R\x10valueDescription\x88\x01\x01B\x14\n" +
+	"\x11value_description\x18\x06 \x01(\tH\x02R\x10valueDescription\x88\x01\x01\x12,\n" +
+	"\x0fidempotency_key\x18\a \x01(\tH\x03R\x0eidempotencyKey\x88\x01\x01B\x14\n" +
 	"\x12_expected_checksumB\x0e\n" +
 	"\f_descriptionB\x14\n" +
-	"\x12_value_description\"Z\n" +
+	"\x12_value_descriptionB\x12\n" +
+	"\x10_idempotency_key\"Z\n" +
 	"\x10SetFieldResponse\x12F\n" +
-	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion\"\x9f\x01\n" +
+	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion\"\xe1\x01\n" +
 	"\x10SetFieldsRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x127\n" +
 	"\aupdates\x18\x02 \x03(\v2\x1d.centralconfig.v1.FieldUpdateR\aupdates\x12%\n" +
-	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01B\x0e\n" +
-	"\f_description\"[\n" +
+	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01\x12,\n" +
+	"\x0fidempotency_key\x18\x04 \x01(\tH\x01R\x0eidempotencyKey\x88\x01\x01B\x0e\n" +
+	"\f_descriptionB\x12\n" +
+	"\x10_idempotency_key\"[\n" +
 	"\x11SetFieldsResponse\x12F\n" +
 	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion\"\xf0\x01\n" +
 	"\vFieldUpdate\x12\x1d\n" +

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -82,13 +82,14 @@ func run() int {
 	pubSubMetrics := telemetry.NewPubSubMetrics(otelCfg)
 
 	var (
-		configStore    config.Store
-		schemaStoreVal schema.Store
-		auditStoreVal  audit.Store
-		configCache    cache.ConfigCache
-		publisher      pubsub.Publisher
-		subscriber     pubsub.Subscriber
-		validatorStore validation.Store
+		configStore      config.Store
+		schemaStoreVal   schema.Store
+		auditStoreVal    audit.Store
+		configCache      cache.ConfigCache
+		idempotencyCache cache.IdempotencyCache
+		publisher        pubsub.Publisher
+		subscriber       pubsub.Subscriber
+		validatorStore   validation.Store
 	)
 
 	if cfg.StorageBackend == "memory" {
@@ -99,6 +100,7 @@ func run() int {
 		schemaStoreVal = memSchema
 		auditStoreVal = audit.NewMemoryStore()
 		configCache = cache.NewMemoryCache(0)
+		idempotencyCache = cache.NewMemoryIdempotencyCache()
 		memOpts := []pubsub.MemoryOption{pubsub.WithLogger(logger)}
 		if counter, ok := pubSubMetrics.DroppedCounter(); ok {
 			memOpts = append(memOpts, pubsub.WithDroppedCounter(counter))
@@ -179,6 +181,7 @@ func run() int {
 		schemaStoreVal = schema.NewPGStore(db.WritePool, db.ReadPool)
 		auditStoreVal = audit.NewPGStore(db.WritePool, db.ReadPool)
 		configCache = cache.NewRedisCache(redisClient)
+		idempotencyCache = cache.NewRedisIdempotencyCache(redisClient)
 		publisher = pubsub.NewRedisPublisher(redisClient)
 		subscriber = pubsub.NewRedisSubscriber(redisClient, logger)
 		defer func() { _ = publisher.Close() }()
@@ -355,6 +358,7 @@ func run() int {
 			config.WithMetrics(configMetrics),
 			config.WithValidators(validatorFactory),
 			config.WithRecorder(recorder),
+			config.WithIdempotencyCache(idempotencyCache),
 			config.WithLimits(config.Limits{
 				MaxListLen:         cfg.ConfigMaxListLen,
 				MaxDocBytes:        cfg.ConfigMaxDocBytes,

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -1464,6 +1464,10 @@
         "valueDescription": {
           "type": "string",
           "description": "Value-level description explaining what this specific value means.\nRetrievable via include_description in read requests."
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Idempotency key for safe retries. When set, the server deduplicates\nwrites with the same key within a 24-hour window. Use the SDK's\nWithIdempotencyKey option to set this field and enable retry."
         }
       }
     },
@@ -1481,6 +1485,10 @@
         "description": {
           "type": "string",
           "description": "Version-level description explaining why these changes were made."
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Idempotency key for safe retries. When set, the server deduplicates\nwrites with the same key within a 24-hour window. Use the SDK's\nWithIdempotencyKey option to set this field and enable retry."
         }
       }
     },

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1098,6 +1098,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | expected_checksum | [string](#string) | optional | Optimistic concurrency control: the checksum from a previous GetField/GetConfig response. If provided and the field&#39;s current checksum doesn&#39;t match, the request fails with ABORTED. This prevents lost updates when multiple actors modify the same field concurrently. |
 | description | [string](#string) | optional | Version-level description explaining why this change was made. |
 | value_description | [string](#string) | optional | Value-level description explaining what this specific value means. Retrievable via include_description in read requests. |
+| idempotency_key | [string](#string) | optional | Idempotency key for safe retries. When set, the server deduplicates writes with the same key within a 24-hour window. Use the SDK&#39;s WithIdempotencyKey option to set this field and enable retry. |
 
 
 
@@ -1130,6 +1131,7 @@ FieldUpdate represents a single field change within a SetFields batch.
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
 | updates | [FieldUpdate](#centralconfig-v1-FieldUpdate) | repeated | Field updates to apply. All updates are applied atomically in a single config version. If any update fails validation (checksum, field lock), no changes are committed. Maximum 1 000 entries (configurable via CONFIG_MAX_LIST_LEN). Exceeds returns InvalidArgument. |
 | description | [string](#string) | optional | Version-level description explaining why these changes were made. |
+| idempotency_key | [string](#string) | optional | Idempotency key for safe retries. When set, the server deduplicates writes with the same key within a 24-hour window. Use the SDK&#39;s WithIdempotencyKey option to set this field and enable retry. |
 
 
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -1464,6 +1464,10 @@
         "valueDescription": {
           "type": "string",
           "description": "Value-level description explaining what this specific value means.\nRetrievable via include_description in read requests."
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Idempotency key for safe retries. When set, the server deduplicates\nwrites with the same key within a 24-hour window. Use the SDK's\nWithIdempotencyKey option to set this field and enable retry."
         }
       }
     },
@@ -1481,6 +1485,10 @@
         "description": {
           "type": "string",
           "description": "Version-level description explaining why these changes were made."
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Idempotency key for safe retries. When set, the server deduplicates\nwrites with the same key within a 24-hour window. Use the SDK's\nWithIdempotencyKey option to set this field and enable retry."
         }
       }
     },

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,3 +17,12 @@ type ConfigCache interface {
 	// Invalidate removes all cached config for a tenant.
 	Invalidate(ctx context.Context, tenantID string) error
 }
+
+// IdempotencyCache deduplicates write operations by key.
+type IdempotencyCache interface {
+	// Claim marks an idempotency key as seen. Returns true on the first call
+	// with this key (caller should proceed with the write), false on subsequent
+	// calls (caller should return a cached success without re-applying the write).
+	// On cache error, callers should degrade gracefully and proceed with the write.
+	Claim(ctx context.Context, key string, ttl time.Duration) (bool, error)
+}

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -153,6 +153,29 @@ func (c *MemoryCache) rebuildOrder() {
 	c.order = cleaned
 }
 
+// MemoryIdempotencyCache implements IdempotencyCache with an in-memory map.
+// Suitable for single-instance dev/test deployments; does not share state across
+// server replicas. Use RedisIdempotencyCache in production.
+type MemoryIdempotencyCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+// NewMemoryIdempotencyCache creates an in-memory idempotency cache.
+func NewMemoryIdempotencyCache() *MemoryIdempotencyCache {
+	return &MemoryIdempotencyCache{entries: make(map[string]time.Time)}
+}
+
+func (c *MemoryIdempotencyCache) Claim(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if exp, ok := c.entries[key]; ok && time.Now().Before(exp) {
+		return false, nil
+	}
+	c.entries[key] = time.Now().Add(ttl)
+	return true, nil
+}
+
 // sweepLoop periodically removes expired entries.
 func (c *MemoryCache) sweepLoop() {
 	ticker := time.NewTicker(time.Minute)

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -175,3 +175,41 @@ func TestMemoryCache_UpdateExistingDoesNotGrow(t *testing.T) {
 	got, _ = c.Get(ctx, "t2", 1)
 	assert.Equal(t, "2", got["a"])
 }
+
+// --- MemoryIdempotencyCache ---
+
+func TestMemoryIdempotencyCache_FirstClaimReturnsTrue(t *testing.T) {
+	c := NewMemoryIdempotencyCache()
+	first, err := c.Claim(context.Background(), "k1", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, first)
+}
+
+func TestMemoryIdempotencyCache_SecondClaimReturnsFalse(t *testing.T) {
+	c := NewMemoryIdempotencyCache()
+	ctx := context.Background()
+	first, _ := c.Claim(ctx, "k1", time.Minute)
+	require.True(t, first)
+	second, err := c.Claim(ctx, "k1", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, second)
+}
+
+func TestMemoryIdempotencyCache_ExpiredKeyAllowsReclaim(t *testing.T) {
+	c := NewMemoryIdempotencyCache()
+	ctx := context.Background()
+	_, _ = c.Claim(ctx, "k1", time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+	again, err := c.Claim(ctx, "k1", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, again)
+}
+
+func TestMemoryIdempotencyCache_DifferentKeysAreIndependent(t *testing.T) {
+	c := NewMemoryIdempotencyCache()
+	ctx := context.Background()
+	a, _ := c.Claim(ctx, "a", time.Minute)
+	b, _ := c.Claim(ctx, "b", time.Minute)
+	assert.True(t, a)
+	assert.True(t, b)
+}

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -74,3 +74,23 @@ func (c *RedisCache) Invalidate(ctx context.Context, tenantID string) error {
 	}
 	return nil
 }
+
+// RedisIdempotencyCache implements IdempotencyCache using Redis SET NX.
+// Safe across multiple server replicas.
+type RedisIdempotencyCache struct {
+	client *redis.Client
+	prefix string
+}
+
+// NewRedisIdempotencyCache creates a Redis-backed idempotency cache.
+func NewRedisIdempotencyCache(client *redis.Client) *RedisIdempotencyCache {
+	return &RedisIdempotencyCache{client: client, prefix: "idem:"}
+}
+
+func (c *RedisIdempotencyCache) Claim(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+	ok, err := c.client.SetNX(ctx, c.prefix+key, 1, ttl).Result()
+	if err != nil {
+		return false, fmt.Errorf("idempotency claim: %w", err)
+	}
+	return ok, nil
+}

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -183,3 +183,49 @@ func TestRedisCache_KeyCollisionAcrossTenants(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "b", gotB["x"])
 }
+
+// --- RedisIdempotencyCache ---
+
+func newTestRedisIdempotencyCache(t *testing.T) (*RedisIdempotencyCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return NewRedisIdempotencyCache(client), mr
+}
+
+func TestRedisIdempotencyCache_FirstClaimReturnsTrue(t *testing.T) {
+	c, _ := newTestRedisIdempotencyCache(t)
+	first, err := c.Claim(context.Background(), "k1", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, first)
+}
+
+func TestRedisIdempotencyCache_SecondClaimReturnsFalse(t *testing.T) {
+	c, _ := newTestRedisIdempotencyCache(t)
+	ctx := context.Background()
+	first, _ := c.Claim(ctx, "k1", time.Minute)
+	require.True(t, first)
+	second, err := c.Claim(ctx, "k1", time.Minute)
+	require.NoError(t, err)
+	assert.False(t, second)
+}
+
+func TestRedisIdempotencyCache_ExpiredKeyAllowsReclaim(t *testing.T) {
+	c, mr := newTestRedisIdempotencyCache(t)
+	ctx := context.Background()
+	_, _ = c.Claim(ctx, "k1", time.Second)
+	mr.FastForward(2 * time.Second)
+	again, err := c.Claim(ctx, "k1", time.Minute)
+	require.NoError(t, err)
+	assert.True(t, again)
+}
+
+func TestRedisIdempotencyCache_DifferentKeysAreIndependent(t *testing.T) {
+	c, _ := newTestRedisIdempotencyCache(t)
+	ctx := context.Background()
+	a, _ := c.Claim(ctx, "a", time.Minute)
+	b, _ := c.Claim(ctx, "b", time.Minute)
+	assert.True(t, a)
+	assert.True(t, b)
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -52,19 +52,23 @@ const (
 	// getFieldsConcurrency caps in-flight per-field reads in GetFields.
 	// Bounded so a large FieldPaths request cannot exhaust the DB pool.
 	getFieldsConcurrency = 16
+
+	// idempotencyKeyTTL is the deduplication window for write idempotency keys.
+	idempotencyKeyTTL = 24 * time.Hour
 )
 
 // Option configures a Service.
 type Option func(*serviceOptions)
 
 type serviceOptions struct {
-	logger       *slog.Logger
-	cacheMetrics *telemetry.CacheMetrics
-	metrics      *telemetry.ConfigMetrics
-	validators   *validation.ValidatorFactory
-	recorder     *audit.UsageRecorder
-	guard        authz.Guard
-	limits       Limits
+	logger           *slog.Logger
+	cacheMetrics     *telemetry.CacheMetrics
+	metrics          *telemetry.ConfigMetrics
+	validators       *validation.ValidatorFactory
+	recorder         *audit.UsageRecorder
+	guard            authz.Guard
+	limits           Limits
+	idempotencyCache cache.IdempotencyCache
 }
 
 // WithLogger sets the service logger. Defaults to slog.Default() when unset.
@@ -104,20 +108,27 @@ func WithLimits(l Limits) Option {
 	return func(o *serviceOptions) { o.limits = l }
 }
 
+// WithIdempotencyCache wires a cache for write deduplication. Nil disables
+// idempotency key handling (writes are not deduplicated).
+func WithIdempotencyCache(c cache.IdempotencyCache) Option {
+	return func(o *serviceOptions) { o.idempotencyCache = c }
+}
+
 // Service implements the ConfigService gRPC server.
 type Service struct {
 	pb.UnimplementedConfigServiceServer
-	store        Store
-	cache        cache.ConfigCache
-	publisher    pubsub.Publisher
-	subscriber   pubsub.Subscriber
-	logger       *slog.Logger
-	cacheMetrics *telemetry.CacheMetrics
-	metrics      *telemetry.ConfigMetrics
-	validators   *validation.ValidatorFactory
-	recorder     *audit.UsageRecorder
-	guard        authz.Guard
-	limits       Limits
+	store            Store
+	cache            cache.ConfigCache
+	idempotencyCache cache.IdempotencyCache
+	publisher        pubsub.Publisher
+	subscriber       pubsub.Subscriber
+	logger           *slog.Logger
+	cacheMetrics     *telemetry.CacheMetrics
+	metrics          *telemetry.ConfigMetrics
+	validators       *validation.ValidatorFactory
+	recorder         *audit.UsageRecorder
+	guard            authz.Guard
+	limits           Limits
 }
 
 // NewService creates a new ConfigService. The four required dependencies
@@ -136,17 +147,18 @@ func NewService(store Store, cache cache.ConfigCache, publisher pubsub.Publisher
 		)
 	}
 	return &Service{
-		store:        store,
-		cache:        cache,
-		publisher:    publisher,
-		subscriber:   subscriber,
-		logger:       o.logger,
-		cacheMetrics: o.cacheMetrics,
-		metrics:      o.metrics,
-		validators:   o.validators,
-		recorder:     o.recorder,
-		guard:        o.guard,
-		limits:       o.limits,
+		store:            store,
+		cache:            cache,
+		idempotencyCache: o.idempotencyCache,
+		publisher:        publisher,
+		subscriber:       subscriber,
+		logger:           o.logger,
+		cacheMetrics:     o.cacheMetrics,
+		metrics:          o.metrics,
+		validators:       o.validators,
+		recorder:         o.recorder,
+		guard:            o.guard,
+		limits:           o.limits,
 	}
 }
 
@@ -447,6 +459,15 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 		return nil, err
 	}
 
+	if key := req.GetIdempotencyKey(); key != "" && s.idempotencyCache != nil {
+		first, idemErr := s.idempotencyCache.Claim(ctx, tenantID+":"+key, idempotencyKeyTTL)
+		if idemErr != nil {
+			s.logger.WarnContext(ctx, "idempotency cache unavailable, proceeding without dedup", "error", idemErr)
+		} else if !first {
+			return &pb.SetFieldResponse{}, nil
+		}
+	}
+
 	actor := s.getActor(ctx)
 
 	// Pre-transaction validation (schema/lock checks only).
@@ -564,6 +585,15 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionWrite)
 	if err != nil {
 		return nil, err
+	}
+
+	if key := req.GetIdempotencyKey(); key != "" && s.idempotencyCache != nil {
+		first, idemErr := s.idempotencyCache.Claim(ctx, tenantID+":"+key, idempotencyKeyTTL)
+		if idemErr != nil {
+			s.logger.WarnContext(ctx, "idempotency cache unavailable, proceeding without dedup", "error", idemErr)
+		} else if !first {
+			return &pb.SetFieldsResponse{}, nil
+		}
 	}
 
 	actor := s.getActor(ctx)

--- a/proto/centralconfig/v1/config_service.proto
+++ b/proto/centralconfig/v1/config_service.proto
@@ -193,6 +193,11 @@ message SetFieldRequest {
   // Value-level description explaining what this specific value means.
   // Retrievable via include_description in read requests.
   optional string value_description = 6;
+
+  // Idempotency key for safe retries. When set, the server deduplicates
+  // writes with the same key within a 24-hour window. Use the SDK's
+  // WithIdempotencyKey option to set this field and enable retry.
+  optional string idempotency_key = 7;
 }
 
 message SetFieldResponse {
@@ -212,6 +217,11 @@ message SetFieldsRequest {
 
   // Version-level description explaining why these changes were made.
   optional string description = 3;
+
+  // Idempotency key for safe retries. When set, the server deduplicates
+  // writes with the same key within a 24-hour window. Use the SDK's
+  // WithIdempotencyKey option to set this field and enable retry.
+  optional string idempotency_key = 4;
 }
 
 message SetFieldsResponse {

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -3,9 +3,11 @@ package configclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 // --- Mock transport ---
@@ -706,4 +708,129 @@ func TestSetNull_Success(t *testing.T) {
 	if err := client.SetNull(ctx, "t1", "retries"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+// --- Write retry semantics ---
+
+func TestSet_NoRetryEvenWithRetryEnabled(t *testing.T) {
+	calls := 0
+	tr := &mockTransport{}
+	client := New(tr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+
+	tr.on("SetField", func(args ...any) bool {
+		calls++
+		return true
+	}, (*SetFieldResponse)(nil), &RetryableError{Err: fmt.Errorf("unavailable")})
+
+	err := client.Set(ctx, "t1", "a", "v")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("Set must not retry without idempotency key: got %d calls, want 1", calls)
+	}
+}
+
+func TestSetMany_NoRetryEvenWithRetryEnabled(t *testing.T) {
+	calls := 0
+	tr := &mockTransport{}
+	client := New(tr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+
+	tr.on("SetFields", func(args ...any) bool {
+		calls++
+		return true
+	}, (*SetFieldsResponse)(nil), &RetryableError{Err: fmt.Errorf("unavailable")})
+
+	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("SetMany must not retry without idempotency key: got %d calls, want 1", calls)
+	}
+}
+
+func TestSet_RetriesWithIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	tr := &countingWriteTransport{failUntil: 2}
+	client := New(tr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+
+	err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("key-123"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.calls != 3 {
+		t.Errorf("Set with idempotency key should retry: got %d calls, want 3", tr.calls)
+	}
+}
+
+func TestSet_IdempotencyKeyPassedToTransport(t *testing.T) {
+	var gotKey string
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		gotKey = r.IdempotencyKey
+		return true
+	}, &SetFieldResponse{}, nil)
+
+	if err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("my-key")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotKey != "my-key" {
+		t.Errorf("got idempotency key %q, want %q", gotKey, "my-key")
+	}
+}
+
+func TestSetMany_IdempotencyKeyPassedToTransport(t *testing.T) {
+	var gotKey string
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		gotKey = r.IdempotencyKey
+		return true
+	}, &SetFieldsResponse{}, nil)
+
+	if err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithIdempotencyKey("batch-key")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotKey != "batch-key" {
+		t.Errorf("got idempotency key %q, want %q", gotKey, "batch-key")
+	}
+}
+
+// countingWriteTransport is a minimal Transport that fails the first N SetField
+// calls with a RetryableError and succeeds thereafter.
+type countingWriteTransport struct {
+	mockTransport
+	failUntil int
+	calls     int
+}
+
+func (t *countingWriteTransport) SetField(_ context.Context, _ *SetFieldRequest) (*SetFieldResponse, error) {
+	t.calls++
+	if t.calls <= t.failUntil {
+		return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+	}
+	return &SetFieldResponse{}, nil
 }

--- a/sdk/configclient/transport.go
+++ b/sdk/configclient/transport.go
@@ -73,6 +73,7 @@ type SetFieldRequest struct {
 	Value            *TypedValue // nil sets the field to null
 	ExpectedChecksum *string
 	Description      string
+	IdempotencyKey   string
 }
 
 // SetFieldResponse is the output of [Transport.SetField].
@@ -87,9 +88,10 @@ type FieldUpdate struct {
 
 // SetFieldsRequest is the input for [Transport.SetFields].
 type SetFieldsRequest struct {
-	TenantID    string
-	Updates     []FieldUpdate
-	Description string
+	TenantID       string
+	Updates        []FieldUpdate
+	Description    string
+	IdempotencyKey string
 }
 
 // SetFieldsResponse is the output of [Transport.SetFields].

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -5,15 +5,61 @@ import (
 	"time"
 )
 
+// WriteOption configures a single write operation.
+//
+// Write operations (Set, SetMany, etc.) do not retry by default because
+// they are not idempotent without an idempotency key — a retry after a
+// transient error could apply the write twice. Use [WithIdempotencyKey]
+// to opt in to safe retry.
+type WriteOption func(*writeOptions)
+
+type writeOptions struct {
+	idempotencyKey string
+}
+
+func applyWriteOptions(opts []WriteOption) writeOptions {
+	var wo writeOptions
+	for _, o := range opts {
+		o(&wo)
+	}
+	return wo
+}
+
+// WithIdempotencyKey attaches an idempotency key to a write operation.
+// When set, the server deduplicates writes with the same key within a
+// 24-hour window, making the write safe to retry on transient errors.
+// If the client was created with [WithRetry], retry is enabled for this call.
+//
+// The key must be unique per logical write; use a UUID or similarly
+// collision-resistant value. Keys are scoped to the tenant.
+func WithIdempotencyKey(key string) WriteOption {
+	return func(o *writeOptions) { o.idempotencyKey = key }
+}
+
+// doWrite executes a write operation. Without an idempotency key, the call
+// is made exactly once regardless of retry configuration. With an idempotency
+// key and retry enabled on the client, transient errors trigger retry.
+func doWrite(ctx context.Context, c *Client, wo writeOptions, fn func(ctx context.Context) error) error {
+	if wo.idempotencyKey != "" && c.opts.retryEnabled {
+		return retryDo(ctx, c, fn)
+	}
+	return fn(ctx)
+}
+
 // Set writes a single configuration value as a string.
 // Creates a new config version atomically.
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
-func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
+//
+// By default, Set does not retry on transient errors. Use [WithIdempotencyKey]
+// to opt in to safe retry with server-side deduplication.
+func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
+	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:  tenantID,
-			FieldPath: fieldPath,
-			Value:     StringVal(value),
+			TenantID:       tenantID,
+			FieldPath:      fieldPath,
+			Value:          StringVal(value),
+			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
 	})
@@ -22,12 +68,17 @@ func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string) err
 // SetTyped writes a single typed configuration value.
 // Creates a new config version atomically.
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
-func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
+//
+// By default, SetTyped does not retry on transient errors. Use [WithIdempotencyKey]
+// to opt in to safe retry with server-side deduplication.
+func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
+	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:  tenantID,
-			FieldPath: fieldPath,
-			Value:     value,
+			TenantID:       tenantID,
+			FieldPath:      fieldPath,
+			Value:          value,
+			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
 	})
@@ -36,11 +87,16 @@ func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value
 // SetNull sets a configuration field to null.
 // Creates a new config version atomically.
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
-func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
+//
+// By default, SetNull does not retry on transient errors. Use [WithIdempotencyKey]
+// to opt in to safe retry with server-side deduplication.
+func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
+	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:  tenantID,
-			FieldPath: fieldPath,
+			TenantID:       tenantID,
+			FieldPath:      fieldPath,
+			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
 	})
@@ -49,8 +105,12 @@ func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string) error 
 // SetMany writes multiple configuration values atomically in a single version.
 // The description is optional — pass an empty string to omit it.
 // Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
-func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
+//
+// By default, SetMany does not retry on transient errors. Use [WithIdempotencyKey]
+// to opt in to safe retry with server-side deduplication.
+func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
+	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))
 		for path, val := range values {
 			v := StringVal(val)
@@ -60,9 +120,10 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 			})
 		}
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
-			TenantID:    tenantID,
-			Updates:     updates,
-			Description: description,
+			TenantID:       tenantID,
+			Updates:        updates,
+			Description:    description,
+			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
 	})
@@ -71,8 +132,12 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 // SetManyTyped writes multiple typed configuration values atomically in a single
 // version. The description is optional — pass an empty string to omit it.
 // Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
-func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
+//
+// By default, SetManyTyped does not retry on transient errors. Use [WithIdempotencyKey]
+// to opt in to safe retry with server-side deduplication.
+func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
+	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))
 		for path, v := range values {
 			updates = append(updates, FieldUpdate{
@@ -81,9 +146,10 @@ func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[s
 			})
 		}
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
-			TenantID:    tenantID,
-			Updates:     updates,
-			Description: description,
+			TenantID:       tenantID,
+			Updates:        updates,
+			Description:    description,
+			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
 	})
@@ -130,6 +196,9 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 // Set writes a new value for this field, but only if the value has not been
 // modified since the [LockedValue] was obtained via [Client.GetForUpdate].
 // Returns [ErrChecksumMismatch] if the value was changed by another writer.
+//
+// Because ExpectedChecksum makes this write idempotent, this method respects
+// the client's retry configuration.
 func (lv *LockedValue) Set(ctx context.Context, newValue string) error {
 	return retryDo(ctx, lv.client, func(ctx context.Context) error {
 		_, err := lv.client.transport.SetField(ctx, &SetFieldRequest{
@@ -163,37 +232,30 @@ func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateF
 // --- Type-specific setters ---
 
 // SetInt writes an integer configuration value.
-func (c *Client) SetInt(ctx context.Context, tenantID, fieldPath string, value int64) error {
-	return c.setTyped(ctx, tenantID, fieldPath, IntVal(value))
+func (c *Client) SetInt(ctx context.Context, tenantID, fieldPath string, value int64, opts ...WriteOption) error {
+	return c.setTyped(ctx, tenantID, fieldPath, IntVal(value), opts...)
 }
 
 // SetFloat writes a floating-point configuration value.
-func (c *Client) SetFloat(ctx context.Context, tenantID, fieldPath string, value float64) error {
-	return c.setTyped(ctx, tenantID, fieldPath, FloatVal(value))
+func (c *Client) SetFloat(ctx context.Context, tenantID, fieldPath string, value float64, opts ...WriteOption) error {
+	return c.setTyped(ctx, tenantID, fieldPath, FloatVal(value), opts...)
 }
 
 // SetBool writes a boolean configuration value.
-func (c *Client) SetBool(ctx context.Context, tenantID, fieldPath string, value bool) error {
-	return c.setTyped(ctx, tenantID, fieldPath, BoolVal(value))
+func (c *Client) SetBool(ctx context.Context, tenantID, fieldPath string, value bool, opts ...WriteOption) error {
+	return c.setTyped(ctx, tenantID, fieldPath, BoolVal(value), opts...)
 }
 
 // SetTime writes a timestamp configuration value.
-func (c *Client) SetTime(ctx context.Context, tenantID, fieldPath string, value time.Time) error {
-	return c.setTyped(ctx, tenantID, fieldPath, TimeVal(value))
+func (c *Client) SetTime(ctx context.Context, tenantID, fieldPath string, value time.Time, opts ...WriteOption) error {
+	return c.setTyped(ctx, tenantID, fieldPath, TimeVal(value), opts...)
 }
 
 // SetDuration writes a duration configuration value.
-func (c *Client) SetDuration(ctx context.Context, tenantID, fieldPath string, value time.Duration) error {
-	return c.setTyped(ctx, tenantID, fieldPath, DurationVal(value))
+func (c *Client) SetDuration(ctx context.Context, tenantID, fieldPath string, value time.Duration, opts ...WriteOption) error {
+	return c.setTyped(ctx, tenantID, fieldPath, DurationVal(value), opts...)
 }
 
-func (c *Client) setTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue) error {
-	return retryDo(ctx, c, func(ctx context.Context) error {
-		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:  tenantID,
-			FieldPath: fieldPath,
-			Value:     value,
-		})
-		return err
-	})
+func (c *Client) setTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue, opts ...WriteOption) error {
+	return c.SetTyped(ctx, tenantID, fieldPath, value, opts...)
 }

--- a/sdk/grpctransport/config_transport.go
+++ b/sdk/grpctransport/config_transport.go
@@ -112,6 +112,9 @@ func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFie
 	if req.Description != "" {
 		protoReq.Description = &req.Description
 	}
+	if req.IdempotencyKey != "" {
+		protoReq.IdempotencyKey = &req.IdempotencyKey
+	}
 	_, err = t.rpc.SetField(ctx, protoReq)
 	if err != nil {
 		return nil, mapConfigError(err)
@@ -138,6 +141,9 @@ func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFi
 	}
 	if req.Description != "" {
 		protoReq.Description = &req.Description
+	}
+	if req.IdempotencyKey != "" {
+		protoReq.IdempotencyKey = &req.IdempotencyKey
 	}
 	_, err = t.rpc.SetFields(ctx, protoReq)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `Set*`/`SetMany*` called `retryDo` unconditionally — a transient error after the server committed a write would replay the write on retry, creating duplicate config versions.
- Writes are now single-attempt by default. The new `WithIdempotencyKey` option opts in to safe retry with server-side deduplication within a 24-hour window.
- Server-side deduplication uses `MemoryIdempotencyCache` (dev/memory mode) or `RedisIdempotencyCache` (production); cache failures degrade gracefully and let the write proceed.

## Test plan

- [x] `TestSet_NoRetryEvenWithRetryEnabled` — confirms `Set` makes exactly one call even when the client has retry enabled, without an idempotency key
- [x] `TestSetMany_NoRetryEvenWithRetryEnabled` — same for `SetMany`
- [x] `TestSet_RetriesWithIdempotencyKey` — confirms retry fires when key is set and retry is configured
- [x] `TestSet_IdempotencyKeyPassedToTransport` — key propagates to the transport request
- [x] `TestSetMany_IdempotencyKeyPassedToTransport` — same for batch writes
- [x] All 34 test packages pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] Coverage thresholds met or improved (`sdk/configclient` 88.6% ≥ 87.1%)

Closes #482