### PR TITLE
perf(cache): replace SCAN-based invalidation with per-tenant index

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -22,12 +22,17 @@ func NewRedisCache(client *redis.Client) *RedisCache {
 	}
 }
 
+// key returns the Redis key for a tenant's config at a specific version.
+// The {tenantID} hashtag pins all per-tenant keys to the same cluster slot,
+// which is required for the pipeline DEL in Invalidate to work on Redis Cluster.
 func (c *RedisCache) key(tenantID string, version int32) string {
-	return fmt.Sprintf("%s%s:v%d", c.prefix, tenantID, version)
+	return fmt.Sprintf("%s{%s}:v%d", c.prefix, tenantID, version)
 }
 
-func (c *RedisCache) tenantPattern(tenantID string) string {
-	return fmt.Sprintf("%s%s:*", c.prefix, tenantID)
+// indexKey returns the Redis SET that tracks every version key for a tenant.
+// Shares the same {tenantID} hashtag as key() so both land on the same slot.
+func (c *RedisCache) indexKey(tenantID string) string {
+	return fmt.Sprintf("config-idx:{%s}", tenantID)
 }
 
 func (c *RedisCache) Get(ctx context.Context, tenantID string, version int32) (map[string]string, error) {
@@ -47,10 +52,12 @@ func (c *RedisCache) Set(ctx context.Context, tenantID string, version int32, va
 	if len(values) == 0 {
 		return nil
 	}
-	key := c.key(tenantID, version)
+	k := c.key(tenantID, version)
+	idx := c.indexKey(tenantID)
 	pipe := c.client.Pipeline()
-	pipe.HSet(ctx, key, values)
-	pipe.Expire(ctx, key, ttl)
+	pipe.HSet(ctx, k, values)
+	pipe.Expire(ctx, k, ttl)
+	pipe.SAdd(ctx, idx, k)
 	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("cache set: %w", err)
@@ -59,18 +66,18 @@ func (c *RedisCache) Set(ctx context.Context, tenantID string, version int32, va
 }
 
 func (c *RedisCache) Invalidate(ctx context.Context, tenantID string) error {
-	iter := c.client.Scan(ctx, 0, c.tenantPattern(tenantID), 100).Iterator()
-	var keys []string
-	for iter.Next(ctx) {
-		keys = append(keys, iter.Val())
+	idx := c.indexKey(tenantID)
+	keys, err := c.client.SMembers(ctx, idx).Result()
+	if err != nil {
+		return fmt.Errorf("cache invalidate smembers: %w", err)
 	}
-	if err := iter.Err(); err != nil {
-		return fmt.Errorf("cache invalidate scan: %w", err)
+	if len(keys) == 0 {
+		return nil
 	}
-	if len(keys) > 0 {
-		if err := c.client.Del(ctx, keys...).Err(); err != nil {
-			return fmt.Errorf("cache invalidate del: %w", err)
-		}
+	// DEL all version keys and the index itself in one call.
+	keys = append(keys, idx)
+	if err := c.client.Del(ctx, keys...).Err(); err != nil {
+		return fmt.Errorf("cache invalidate del: %w", err)
 	}
 	return nil
 }

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -2,10 +2,12 @@ package cache
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/alicebob/miniredis/v2/server"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -222,6 +224,45 @@ func TestRedisCache_Invalidate_StaleIndexEntryIsNoOp(t *testing.T) {
 	n, err := c.client.Exists(ctx, c.indexKey("t1")).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), n)
+}
+
+func TestRedisCache_Invalidate_SmembersError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr(), MaxRetries: 0})
+	t.Cleanup(func() { _ = client.Close() })
+	c := NewRedisCache(client)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+
+	mr.Close()
+
+	err := c.Invalidate(ctx, "t1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cache invalidate smembers")
+}
+
+func TestRedisCache_Invalidate_DelError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr(), MaxRetries: 0})
+	t.Cleanup(func() { _ = client.Close() })
+	c := NewRedisCache(client)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+
+	// Inject an error only for DEL so that SMEMBERS succeeds first.
+	mr.Server().SetPreHook(server.Hook(func(p *server.Peer, cmd string, args ...string) bool {
+		if strings.EqualFold(cmd, "del") {
+			p.WriteError("READONLY forced")
+			return true
+		}
+		return false
+	}))
+
+	err := c.Invalidate(ctx, "t1")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cache invalidate del")
 }
 
 // --- RedisIdempotencyCache ---

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -34,13 +34,13 @@ func TestNewRedisCache(t *testing.T) {
 
 func TestRedisCache_Key(t *testing.T) {
 	c := &RedisCache{prefix: "config:"}
-	require.Equal(t, "config:tenant-1:v7", c.key("tenant-1", 7))
-	require.Equal(t, "config:t:v0", c.key("t", 0))
+	require.Equal(t, "config:{tenant-1}:v7", c.key("tenant-1", 7))
+	require.Equal(t, "config:{t}:v0", c.key("t", 0))
 }
 
-func TestRedisCache_TenantPattern(t *testing.T) {
+func TestRedisCache_IndexKey(t *testing.T) {
 	c := &RedisCache{prefix: "config:"}
-	require.Equal(t, "config:tenant-1:*", c.tenantPattern("tenant-1"))
+	require.Equal(t, "config-idx:{tenant-1}", c.indexKey("tenant-1"))
 }
 
 // --- miniredis integration tests ---
@@ -182,6 +182,46 @@ func TestRedisCache_KeyCollisionAcrossTenants(t *testing.T) {
 	gotB, err = c.Get(ctx, "tenant-b", 1)
 	require.NoError(t, err)
 	assert.Equal(t, "b", gotB["x"])
+}
+
+func TestRedisCache_Invalidate_EmptyTenantIsNoOp(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	require.NoError(t, c.Invalidate(context.Background(), "no-such-tenant"))
+}
+
+func TestRedisCache_Invalidate_IndexCleanedUp(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+	require.NoError(t, c.Set(ctx, "t1", 2, map[string]string{"b": "2"}, time.Minute))
+
+	members, err := c.client.SMembers(ctx, c.indexKey("t1")).Result()
+	require.NoError(t, err)
+	require.Len(t, members, 2, "index should hold both version keys before invalidation")
+
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	n, err := c.client.Exists(ctx, c.indexKey("t1")).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "index must be deleted after invalidation")
+}
+
+func TestRedisCache_Invalidate_StaleIndexEntryIsNoOp(t *testing.T) {
+	c, mr := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Second))
+
+	mr.FastForward(2 * time.Second) // data key expired; index still holds the reference
+
+	// Invalidate must succeed even when all indexed keys have already expired.
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	// Index itself is cleaned up.
+	n, err := c.client.Exists(ctx, c.indexKey("t1")).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
 }
 
 // --- RedisIdempotencyCache ---


### PR DESCRIPTION
## Summary

- Invalidation latency was O(total Redis keys) because `Invalidate` used `SCAN` across the entire keyspace. On a shared instance with many tenants this becomes unbounded.
- Replace with a per-tenant index: `Set` now atomically adds each version key to a Redis SET (`config-idx:{tenantID}`) in the same pipeline. `Invalidate` reads the index with `SMEMBERS` then deletes everything in one `DEL` call — O(tenant keys).
- Key format updated to use Redis 7 hashtag clustering (`config:{tenantID}:v{version}` + `config-idx:{tenantID}`) so data keys and index always land on the same cluster slot, making the multi-key `DEL` valid in clustered deployments.

## Test plan

- [x] `TestRedisCache_Invalidate_Happy` — multi-version invalidation, other tenants unaffected
- [x] `TestRedisCache_Invalidate_EmptyTenantIsNoOp` — no error when tenant has no cached data
- [x] `TestRedisCache_Invalidate_IndexCleanedUp` — index SET is deleted after invalidation
- [x] `TestRedisCache_Invalidate_StaleIndexEntryIsNoOp` — expired data key in index doesn't cause error
- [x] `TestRedisCache_Key` — verifies new `config:{tenantID}:v{version}` format
- [x] `TestRedisCache_IndexKey` — verifies `config-idx:{tenantID}` format
- [x] Full `make test` green

Closes #430