### PR TITLE
feat(cache): add singleflight + negative caching to absorb thundering herd

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -16,6 +16,14 @@ type ConfigCache interface {
 
 	// Invalidate removes all cached config for a tenant.
 	Invalidate(ctx context.Context, tenantID string) error
+
+	// SetNegative marks a tenant:version as having no config for the given TTL.
+	// Prevents redundant DB reads when a tenant has no config at a version.
+	SetNegative(ctx context.Context, tenantID string, version int32, ttl time.Duration) error
+
+	// GetNegative reports whether tenant:version is in the negative cache.
+	// Returns (true, nil) on a negative hit; (false, nil) on miss; (false, err) on error.
+	GetNegative(ctx context.Context, tenantID string, version int32) (bool, error)
 }
 
 // IdempotencyCache deduplicates write operations by key.

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -17,7 +17,8 @@ const defaultMaxEntries = 10000
 type MemoryCache struct {
 	mu         sync.RWMutex
 	entries    map[string]memoryCacheEntry
-	order      []string // insertion order for eviction
+	negEntries map[string]time.Time // negative-cache: key → expiry
+	order      []string             // insertion order for eviction
 	maxEntries int
 	stopSweep  chan struct{}
 }
@@ -35,6 +36,7 @@ func NewMemoryCache(maxEntries int) *MemoryCache {
 	}
 	c := &MemoryCache{
 		entries:    make(map[string]memoryCacheEntry),
+		negEntries: make(map[string]time.Time),
 		maxEntries: maxEntries,
 		stopSweep:  make(chan struct{}),
 	}
@@ -98,8 +100,30 @@ func (c *MemoryCache) Invalidate(_ context.Context, tenantID string) error {
 			delete(c.entries, k)
 		}
 	}
+	for k := range c.negEntries {
+		if strings.HasPrefix(k, prefix) {
+			delete(c.negEntries, k)
+		}
+	}
 	c.rebuildOrder()
 	return nil
+}
+
+func (c *MemoryCache) SetNegative(_ context.Context, tenantID string, version int32, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.negEntries[c.key(tenantID, version)] = time.Now().Add(ttl)
+	return nil
+}
+
+func (c *MemoryCache) GetNegative(_ context.Context, tenantID string, version int32) (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	exp, ok := c.negEntries[c.key(tenantID, version)]
+	if !ok || time.Now().After(exp) {
+		return false, nil
+	}
+	return true, nil
 }
 
 // Len returns the number of entries in the cache.
@@ -198,6 +222,11 @@ func (c *MemoryCache) sweep() {
 	for k, e := range c.entries {
 		if now.After(e.expiresAt) {
 			delete(c.entries, k)
+		}
+	}
+	for k, exp := range c.negEntries {
+		if now.After(exp) {
+			delete(c.negEntries, k)
 		}
 	}
 	c.rebuildOrder()

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -213,3 +213,91 @@ func TestMemoryIdempotencyCache_DifferentKeysAreIndependent(t *testing.T) {
 	assert.True(t, a)
 	assert.True(t, b)
 }
+
+// --- Negative cache ---
+
+func TestMemoryCache_NegativeCache_SetAndGet(t *testing.T) {
+	c := NewMemoryCache(0)
+	ctx := context.Background()
+
+	neg, err := c.GetNegative(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.False(t, neg, "miss before set")
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Minute))
+
+	neg, err = c.GetNegative(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.True(t, neg, "hit after set")
+}
+
+func TestMemoryCache_NegativeCache_TTLExpiry(t *testing.T) {
+	c := NewMemoryCache(0)
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Millisecond))
+	time.Sleep(5 * time.Millisecond)
+
+	neg, err := c.GetNegative(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.False(t, neg, "expired entry must report miss")
+}
+
+func TestMemoryCache_NegativeCache_InvalidateClears(t *testing.T) {
+	c := NewMemoryCache(0)
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Minute))
+	require.NoError(t, c.SetNegative(ctx, "t1", 2, time.Minute))
+	require.NoError(t, c.SetNegative(ctx, "t2", 1, time.Minute))
+
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	neg, _ := c.GetNegative(ctx, "t1", 1)
+	assert.False(t, neg, "t1:v1 must be cleared")
+	neg, _ = c.GetNegative(ctx, "t1", 2)
+	assert.False(t, neg, "t1:v2 must be cleared")
+
+	neg, _ = c.GetNegative(ctx, "t2", 1)
+	assert.True(t, neg, "t2 must be unaffected")
+}
+
+func TestMemoryCache_NegativeCache_Sweep_RemovesExpired(t *testing.T) {
+	c := NewMemoryCache(0)
+	defer c.Stop()
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Millisecond))
+	require.NoError(t, c.SetNegative(ctx, "t2", 1, time.Hour))
+
+	time.Sleep(5 * time.Millisecond)
+	c.sweep()
+
+	neg, _ := c.GetNegative(ctx, "t1", 1)
+	assert.False(t, neg, "expired t1 swept")
+	neg, _ = c.GetNegative(ctx, "t2", 1)
+	assert.True(t, neg, "live t2 remains")
+}
+
+func TestMemoryCache_NegativeCache_IndependentFromPositive(t *testing.T) {
+	c := NewMemoryCache(0)
+	ctx := context.Background()
+
+	// Set positive entry and negative entry for same key.
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+	require.NoError(t, c.SetNegative(ctx, "t1", 2, time.Minute))
+
+	// Positive entry not affected by negative check.
+	pos, _ := c.Get(ctx, "t1", 1)
+	assert.NotNil(t, pos)
+
+	// Negative entry not affected by positive set.
+	neg, _ := c.GetNegative(ctx, "t1", 2)
+	assert.True(t, neg)
+
+	// v1 has no negative entry; v2 has no positive entry.
+	neg1, _ := c.GetNegative(ctx, "t1", 1)
+	assert.False(t, neg1)
+	pos2, _ := c.Get(ctx, "t1", 2)
+	assert.Nil(t, pos2)
+}

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -37,9 +37,10 @@ func (c *RedisCache) indexKey(tenantID string) string {
 }
 
 // negKey returns the Redis key for a negative-cache entry.
-// Uses the same tenant:* prefix so Invalidate clears it automatically.
+// Uses the same {tenantID} hashtag so it lands on the same cluster slot as
+// the version keys and the index, enabling atomic pipeline operations.
 func (c *RedisCache) negKey(tenantID string, version int32) string {
-	return fmt.Sprintf("%s%s:neg:v%d", c.prefix, tenantID, version)
+	return fmt.Sprintf("%s{%s}:neg:v%d", c.prefix, tenantID, version)
 }
 
 func (c *RedisCache) Get(ctx context.Context, tenantID string, version int32) (map[string]string, error) {
@@ -90,7 +91,12 @@ func (c *RedisCache) Invalidate(ctx context.Context, tenantID string) error {
 }
 
 func (c *RedisCache) SetNegative(ctx context.Context, tenantID string, version int32, ttl time.Duration) error {
-	if err := c.client.Set(ctx, c.negKey(tenantID, version), 1, ttl).Err(); err != nil {
+	nk := c.negKey(tenantID, version)
+	idx := c.indexKey(tenantID)
+	pipe := c.client.Pipeline()
+	pipe.Set(ctx, nk, 1, ttl)
+	pipe.SAdd(ctx, idx, nk)
+	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("cache set negative: %w", err)
 	}
 	return nil

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -33,6 +34,12 @@ func (c *RedisCache) key(tenantID string, version int32) string {
 // Shares the same {tenantID} hashtag as key() so both land on the same slot.
 func (c *RedisCache) indexKey(tenantID string) string {
 	return fmt.Sprintf("config-idx:{%s}", tenantID)
+}
+
+// negKey returns the Redis key for a negative-cache entry.
+// Uses the same tenant:* prefix so Invalidate clears it automatically.
+func (c *RedisCache) negKey(tenantID string, version int32) string {
+	return fmt.Sprintf("%s%s:neg:v%d", c.prefix, tenantID, version)
 }
 
 func (c *RedisCache) Get(ctx context.Context, tenantID string, version int32) (map[string]string, error) {
@@ -80,6 +87,24 @@ func (c *RedisCache) Invalidate(ctx context.Context, tenantID string) error {
 		return fmt.Errorf("cache invalidate del: %w", err)
 	}
 	return nil
+}
+
+func (c *RedisCache) SetNegative(ctx context.Context, tenantID string, version int32, ttl time.Duration) error {
+	if err := c.client.Set(ctx, c.negKey(tenantID, version), 1, ttl).Err(); err != nil {
+		return fmt.Errorf("cache set negative: %w", err)
+	}
+	return nil
+}
+
+func (c *RedisCache) GetNegative(ctx context.Context, tenantID string, version int32) (bool, error) {
+	err := c.client.Get(ctx, c.negKey(tenantID, version)).Err()
+	if errors.Is(err, redis.Nil) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("cache get negative: %w", err)
+	}
+	return true, nil
 }
 
 // RedisIdempotencyCache implements IdempotencyCache using Redis SET NX.

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -265,6 +265,84 @@ func TestRedisCache_Invalidate_DelError(t *testing.T) {
 	require.ErrorContains(t, err, "cache invalidate del")
 }
 
+// --- Negative cache ---
+
+func TestRedisCache_NegKey(t *testing.T) {
+	c := &RedisCache{prefix: "config:"}
+	require.Equal(t, "config:{tenant-1}:neg:v3", c.negKey("tenant-1", 3))
+}
+
+func TestRedisCache_NegativeCache_Miss(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	neg, err := c.GetNegative(context.Background(), "t1", 1)
+	require.NoError(t, err)
+	assert.False(t, neg, "miss before any SetNegative")
+}
+
+func TestRedisCache_NegativeCache_SetAndGet(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Minute))
+
+	neg, err := c.GetNegative(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.True(t, neg)
+}
+
+func TestRedisCache_NegativeCache_TTLExpiry(t *testing.T) {
+	c, mr := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Second))
+	mr.FastForward(2 * time.Second)
+
+	neg, err := c.GetNegative(ctx, "t1", 1)
+	require.NoError(t, err)
+	assert.False(t, neg, "expired negative entry must report miss")
+}
+
+func TestRedisCache_NegativeCache_InvalidateClears(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.SetNegative(ctx, "t1", 1, time.Minute))
+	require.NoError(t, c.SetNegative(ctx, "t1", 2, time.Minute))
+	require.NoError(t, c.SetNegative(ctx, "t2", 1, time.Minute))
+
+	require.NoError(t, c.Invalidate(ctx, "t1"))
+
+	neg, _ := c.GetNegative(ctx, "t1", 1)
+	assert.False(t, neg, "t1:v1 neg must be cleared")
+	neg, _ = c.GetNegative(ctx, "t1", 2)
+	assert.False(t, neg, "t1:v2 neg must be cleared")
+
+	neg, _ = c.GetNegative(ctx, "t2", 1)
+	assert.True(t, neg, "t2 must be unaffected")
+}
+
+func TestRedisCache_NegativeCache_RedisDownOnSet(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr(), MaxRetries: 0})
+	t.Cleanup(func() { _ = client.Close() })
+	c := NewRedisCache(client)
+	mr.Close()
+
+	err := c.SetNegative(context.Background(), "t1", 1, time.Minute)
+	require.Error(t, err)
+}
+
+func TestRedisCache_NegativeCache_RedisDownOnGet(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr(), MaxRetries: 0})
+	t.Cleanup(func() { _ = client.Close() })
+	c := NewRedisCache(client)
+	mr.Close()
+
+	_, err := c.GetNegative(context.Background(), "t1", 1)
+	require.Error(t, err)
+}
+
 // --- RedisIdempotencyCache ---
 
 func newTestRedisIdempotencyCache(t *testing.T) (*RedisIdempotencyCache, *miniredis.Miniredis) {

--- a/internal/config/mock_deps_test.go
+++ b/internal/config/mock_deps_test.go
@@ -33,6 +33,17 @@ func (m *mockCache) Invalidate(ctx context.Context, tenantID string) error {
 	return args.Error(0)
 }
 
+// SetNegative and GetNegative are no-ops in the test mock; existing tests don't
+// exercise negative-cache paths. Tests that need control over negative caching
+// use the real MemoryCache.
+func (m *mockCache) SetNegative(_ context.Context, _ string, _ int32, _ time.Duration) error {
+	return nil
+}
+
+func (m *mockCache) GetNegative(_ context.Context, _ string, _ int32) (bool, error) {
+	return false, nil
+}
+
 // mockPublisher implements pubsub.Publisher for testing.
 type mockPublisher struct {
 	mock.Mock

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/google/cel-go/cel"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -47,7 +49,8 @@ func (e *validationError) Error() string { return e.err.Error() }
 func (e *validationError) Unwrap() error { return e.err }
 
 const (
-	defaultCacheTTL = 5 * time.Minute
+	defaultCacheTTL  = 5 * time.Minute
+	negativeCacheTTL = 30 * time.Second
 
 	// getFieldsConcurrency caps in-flight per-field reads in GetFields.
 	// Bounded so a large FieldPaths request cannot exhaust the DB pool.
@@ -119,6 +122,7 @@ type Service struct {
 	pb.UnimplementedConfigServiceServer
 	store            Store
 	cache            cache.ConfigCache
+	sfGroup          singleflight.Group
 	idempotencyCache cache.IdempotencyCache
 	publisher        pubsub.Publisher
 	subscriber       pubsub.Subscriber
@@ -241,8 +245,8 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 		return nil, err
 	}
 
-	// If descriptions not requested, try cache.
 	if !req.IncludeDescriptions {
+		// Positive cache.
 		if cached, err := s.cache.Get(ctx, tenantID, version); err == nil && cached != nil {
 			s.cacheMetrics.Hit(ctx)
 			values := make([]*pb.ConfigValue, 0, len(cached))
@@ -261,10 +265,46 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 				Config: &pb.Config{TenantId: tenantID, Version: version, Values: values},
 			}, nil
 		}
+		// Negative cache: tenant has no config at this version.
+		if neg, _ := s.cache.GetNegative(ctx, tenantID, version); neg {
+			s.cacheMetrics.NegativeHit(ctx)
+			return &pb.GetConfigResponse{
+				Config: &pb.Config{TenantId: tenantID, Version: version},
+			}, nil
+		}
 		s.cacheMetrics.Miss(ctx)
+
+		// Singleflight: collapse concurrent DB fetches on cache miss to one.
+		sfKey := tenantID + ":" + strconv.FormatInt(int64(version), 10)
+		resultI, err, shared := s.sfGroup.Do(sfKey, func() (any, error) {
+			return s.fetchAndCacheConfig(ctx, tenantID, version)
+		})
+		if err != nil {
+			return nil, err
+		}
+		if shared {
+			s.cacheMetrics.SingleflightDedup(ctx)
+		}
+		cacheMap := resultI.(map[string]string)
+
+		values := make([]*pb.ConfigValue, 0, len(cacheMap))
+		paths := make([]string, 0, len(cacheMap))
+		for path, val := range cacheMap {
+			v := val
+			values = append(values, &pb.ConfigValue{
+				FieldPath: path,
+				Value:     stringToTypedValue(&v, lookupFieldType(types, path)),
+				Checksum:  computeChecksum(val),
+			})
+			paths = append(paths, path)
+		}
+		s.recorder.RecordReads(tenantID, paths, s.actorPtr(ctx))
+		return &pb.GetConfigResponse{
+			Config: &pb.Config{TenantId: tenantID, Version: version, Values: values},
+		}, nil
 	}
 
-	// Fetch from DB.
+	// IncludeDescriptions = true: always fetch from DB, no cache.
 	rows, err := s.store.GetFullConfigAtVersion(ctx, GetFullConfigAtVersionParams{
 		TenantID: tenantID,
 		Version:  version,
@@ -279,7 +319,6 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 	}
 
 	values := make([]*pb.ConfigValue, 0, len(rows))
-	cacheMap := make(map[string]string, len(rows))
 	for _, row := range rows {
 		displayValue := redactIfSensitive(sensitiveFields[row.FieldPath], derefString(row.Value))
 		cv := &pb.ConfigValue{
@@ -287,30 +326,55 @@ func (s *Service) GetConfig(ctx context.Context, req *pb.GetConfigRequest) (*pb.
 			Value:     stringToTypedValue(&displayValue, lookupFieldType(types, row.FieldPath)),
 			Checksum:  derefString(row.Checksum),
 		}
-		if req.IncludeDescriptions && row.Description != nil {
+		if row.Description != nil {
 			cv.Description = row.Description
 		}
 		values = append(values, cv)
-		cacheMap[row.FieldPath] = displayValue
 	}
 
-	// Populate cache (values only, no descriptions).
-	if !req.IncludeDescriptions {
-		if err := s.cache.Set(ctx, tenantID, version, cacheMap, defaultCacheTTL); err != nil {
-			s.logger.WarnContext(ctx, "failed to populate cache", "error", err)
-		}
-	}
-
-	// Record usage for all returned fields.
 	paths := make([]string, 0, len(values))
 	for _, v := range values {
 		paths = append(paths, v.FieldPath)
 	}
 	s.recorder.RecordReads(tenantID, paths, s.actorPtr(ctx))
-
 	return &pb.GetConfigResponse{
 		Config: &pb.Config{TenantId: tenantID, Version: version, Values: values},
 	}, nil
+}
+
+// fetchAndCacheConfig fetches config values from the DB for tenantID at version,
+// populates the positive or negative cache, and returns the redacted value map.
+// It is the singleflight work function — concurrent callers share one DB fetch.
+func (s *Service) fetchAndCacheConfig(ctx context.Context, tenantID string, version int32) (map[string]string, error) {
+	rows, err := s.store.GetFullConfigAtVersion(ctx, GetFullConfigAtVersionParams{
+		TenantID: tenantID,
+		Version:  version,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get config")
+	}
+
+	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	cacheMap := make(map[string]string, len(rows))
+	for _, row := range rows {
+		cacheMap[row.FieldPath] = redactIfSensitive(sensitiveFields[row.FieldPath], derefString(row.Value))
+	}
+
+	if len(cacheMap) == 0 {
+		if err := s.cache.SetNegative(ctx, tenantID, version, negativeCacheTTL); err != nil {
+			s.logger.WarnContext(ctx, "failed to set negative cache", "error", err)
+		}
+	} else {
+		if err := s.cache.Set(ctx, tenantID, version, cacheMap, defaultCacheTTL); err != nil {
+			s.logger.WarnContext(ctx, "failed to populate cache", "error", err)
+		}
+	}
+
+	return cacheMap, nil
 }
 
 func (s *Service) GetField(ctx context.Context, req *pb.GetFieldRequest) (*pb.GetFieldResponse, error) {

--- a/internal/config/setfields_bench_test.go
+++ b/internal/config/setfields_bench_test.go
@@ -87,7 +87,9 @@ func (noopCache) Get(_ context.Context, _ string, _ int32) (map[string]string, e
 func (noopCache) Set(_ context.Context, _ string, _ int32, _ map[string]string, _ time.Duration) error {
 	return nil
 }
-func (noopCache) Invalidate(_ context.Context, _ string) error { return nil }
+func (noopCache) Invalidate(_ context.Context, _ string) error                            { return nil }
+func (noopCache) SetNegative(_ context.Context, _ string, _ int32, _ time.Duration) error { return nil }
+func (noopCache) GetNegative(_ context.Context, _ string, _ int32) (bool, error)          { return false, nil }
 
 type noopPublisher struct{}
 

--- a/internal/config/singleflight_test.go
+++ b/internal/config/singleflight_test.go
@@ -1,0 +1,110 @@
+package config
+
+// TestGetConfig_SingleflightDeduplicatesDBFetches proves that N concurrent
+// GetConfig calls on the same cache-miss key collapse to exactly one DB fetch.
+//
+// Pattern:
+//  1. Gate GetFullConfigAtVersion so it blocks until the test releases it.
+//  2. Launch N goroutines; all miss the cache and enter singleflight.Do.
+//  3. Wait for the gate to receive exactly one DB-fetch entry.
+//  4. Release the gate; assert all N goroutines complete successfully.
+//  5. Verify GetFullConfigAtVersion was called exactly once.
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/cache"
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+func TestGetConfig_SingleflightDeduplicatesDBFetches(t *testing.T) {
+	t.Parallel()
+
+	const N = 10
+
+	// Gate synchronization: first goroutine to enter GetFullConfigAtVersion
+	// signals started (capacity 1); all goroutines then block on proceed.
+	started := make(chan struct{}, 1)
+	proceed := make(chan struct{})
+	var dbFetches atomic.Int32
+
+	store := &mockStore{}
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
+		TenantID: tenantID1,
+		Version:  1,
+	}).
+		Run(func(_ mock.Arguments) {
+			dbFetches.Add(1)
+			select {
+			case started <- struct{}{}: // signal first entry (non-blocking)
+			default:
+			}
+			<-proceed // block until test releases
+		}).
+		Return([]GetFullConfigAtVersionRow{
+			{FieldPath: "app.env", Value: strPtr("production")},
+		}, nil)
+	setupNoSensitiveFields(store)
+
+	c := cache.NewMemoryCache(0)
+	defer c.Stop()
+
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	svc := NewService(store, c, pub, sub, WithLogger(testLogger))
+
+	ctx := auth.WithoutAuth(context.Background())
+
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
+			errs <- err
+		}()
+	}
+
+	// Wait for the DB fetch to start.
+	select {
+	case <-started:
+	case <-time.After(testTimeout):
+		t.Fatal("DB fetch never started — goroutines may not have reached singleflight")
+	}
+
+	// Give the remaining goroutines time to queue inside singleflight.Do.
+	time.Sleep(20 * time.Millisecond)
+
+	// Only 1 DB fetch should be in progress; the rest wait in singleflight.
+	assert.Equal(t, int32(1), dbFetches.Load(), "singleflight must collapse N misses to 1 DB fetch")
+
+	// Release the DB fetch so all goroutines can complete.
+	close(proceed)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(testTimeout):
+		t.Fatal("goroutines did not complete after proceeding")
+	}
+
+	for i := 0; i < N; i++ {
+		require.NoError(t, <-errs, "all goroutines must succeed")
+	}
+
+	assert.Equal(t, int32(1), dbFetches.Load(), "DB fetch count must remain 1 after all goroutines complete")
+}

--- a/internal/config/singleflight_test.go
+++ b/internal/config/singleflight_test.go
@@ -27,6 +27,62 @@ import (
 	"github.com/opendecree/decree/internal/storage/domain"
 )
 
+func TestGetConfig_NegativeCacheHit(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{}
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+
+	c := cache.NewMemoryCache(0)
+	defer c.Stop()
+	ctx := auth.WithoutAuth(context.Background())
+	require.NoError(t, c.SetNegative(ctx, tenantID1, 1, time.Minute))
+
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	svc := NewService(store, c, pub, sub, WithLogger(testLogger))
+
+	resp, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.Config.Values, "negative cache hit must return empty values")
+	store.AssertNotCalled(t, "GetFullConfigAtVersion")
+}
+
+func TestGetConfig_EmptyConfig_SetsNegativeCache(t *testing.T) {
+	t.Parallel()
+
+	store := &mockStore{}
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
+		TenantID: tenantID1,
+		Version:  1,
+	}).Return([]GetFullConfigAtVersionRow{}, nil)
+	setupNoSensitiveFields(store)
+
+	c := cache.NewMemoryCache(0)
+	defer c.Stop()
+	ctx := auth.WithoutAuth(context.Background())
+
+	pub := &mockPublisher{}
+	sub := &mockSubscriber{}
+	svc := NewService(store, c, pub, sub, WithLogger(testLogger))
+
+	// First call: cache miss → DB fetch (empty) → sets negative cache.
+	resp, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Config.Values)
+
+	// Second call: served from negative cache — DB must not be called again.
+	resp2, err := svc.GetConfig(ctx, &pb.GetConfigRequest{TenantId: tenantID1})
+	require.NoError(t, err)
+	assert.Empty(t, resp2.Config.Values)
+
+	store.AssertNumberOfCalls(t, "GetFullConfigAtVersion", 1)
+}
+
 func TestGetConfig_SingleflightDeduplicatesDBFetches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -14,8 +14,10 @@ const meterName = "decree"
 
 // CacheMetrics records cache hit/miss counters.
 type CacheMetrics struct {
-	hits   metric.Int64Counter
-	misses metric.Int64Counter
+	hits              metric.Int64Counter
+	misses            metric.Int64Counter
+	singleflightDedup metric.Int64Counter
+	negativeHits      metric.Int64Counter
 }
 
 // NewCacheMetrics creates cache metrics. Returns nil if not enabled.
@@ -28,7 +30,11 @@ func NewCacheMetrics(cfg Config) *CacheMetrics {
 		metric.WithDescription("Number of cache hits"))
 	misses, _ := meter.Int64Counter("config.cache.misses",
 		metric.WithDescription("Number of cache misses"))
-	return &CacheMetrics{hits: hits, misses: misses}
+	sfDedup, _ := meter.Int64Counter("cache_singleflight_dedup_total",
+		metric.WithDescription("Number of GetConfig calls that shared a singleflight DB fetch"))
+	negHits, _ := meter.Int64Counter("cache_negative_hits_total",
+		metric.WithDescription("Number of GetConfig calls served from the negative cache (tenant has no config at version)"))
+	return &CacheMetrics{hits: hits, misses: misses, singleflightDedup: sfDedup, negativeHits: negHits}
 }
 
 // Hit records a cache hit.
@@ -42,6 +48,20 @@ func (m *CacheMetrics) Hit(ctx context.Context) {
 func (m *CacheMetrics) Miss(ctx context.Context) {
 	if m != nil {
 		m.misses.Add(ctx, 1)
+	}
+}
+
+// SingleflightDedup records a GetConfig call that shared a singleflight DB fetch.
+func (m *CacheMetrics) SingleflightDedup(ctx context.Context) {
+	if m != nil {
+		m.singleflightDedup.Add(ctx, 1)
+	}
+}
+
+// NegativeHit records a GetConfig call served from the negative cache.
+func (m *CacheMetrics) NegativeHit(ctx context.Context) {
+	if m != nil {
+		m.negativeHits.Add(ctx, 1)
 	}
 }
 

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -21,12 +21,20 @@ func TestCacheMetrics_NilSafe(t *testing.T) {
 	var m *CacheMetrics
 	m.Hit(context.Background())
 	m.Miss(context.Background())
+	m.SingleflightDedup(context.Background())
+	m.NegativeHit(context.Background())
 }
 
 func TestCacheMetrics_Hit_Miss(t *testing.T) {
 	m := NewCacheMetrics(Config{Enabled: true, MetricsCache: true})
 	m.Hit(context.Background())
 	m.Miss(context.Background())
+}
+
+func TestCacheMetrics_SingleflightDedup_NegativeHit(t *testing.T) {
+	m := NewCacheMetrics(Config{Enabled: true, MetricsCache: true})
+	m.SingleflightDedup(context.Background())
+	m.NegativeHit(context.Background())
 }
 
 func TestNewConfigMetrics_Disabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Eliminates thundering-herd DB spikes by collapsing N concurrent cache misses on the same `tenant:version` key into a single DB round-trip via `singleflight`.
- Prevents repeated DB hits for tenants with no config by caching NotFound results with a 30 s TTL (negative cache), auto-cleared on any write.
- Adds OTel counters (`cache_singleflight_dedup_total`, `cache_negative_hits_total`) so both effects are observable in production.

## Test plan

- [x] `TestGetConfig_SingleflightDeduplicatesDBFetches` — gate-pattern load test (N=10 goroutines) proves exactly 1 DB fetch per singleflight group
- [x] 5 `MemoryCache` negative-cache unit tests: set/get, TTL expiry, invalidate clears, sweep removes expired, independent from positive cache
- [x] `BenchmarkSetFields_50Fields` updated to satisfy the extended `ConfigCache` interface
- [x] `make test` and `make lint` pass clean

Closes #429