### PR TITLE
fix(cache): make Set atomic with TxPipeline (MULTI/EXEC)

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -62,7 +62,9 @@ func (c *RedisCache) Set(ctx context.Context, tenantID string, version int32, va
 	}
 	k := c.key(tenantID, version)
 	idx := c.indexKey(tenantID)
-	pipe := c.client.Pipeline()
+	// TxPipeline wraps commands in MULTI/EXEC so HSET + EXPIRE are atomic;
+	// a crash between the two cannot leave a TTL-less key.
+	pipe := c.client.TxPipeline()
 	pipe.HSet(ctx, k, values)
 	pipe.Expire(ctx, k, ttl)
 	pipe.SAdd(ctx, idx, k)

--- a/internal/cache/redis_test.go
+++ b/internal/cache/redis_test.go
@@ -100,6 +100,19 @@ func TestRedisCache_Invalidate_Happy(t *testing.T) {
 	assert.Equal(t, "3", got["c"])
 }
 
+// TestRedisCache_Set_KeyHasTTL guards against regression where EXPIRE is
+// skipped or decoupled from HSET, leaving a persistent (TTL-less) key.
+func TestRedisCache_Set_KeyHasTTL(t *testing.T) {
+	c, _ := newTestRedisCache(t)
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Minute))
+
+	ttl, err := c.client.TTL(ctx, c.key("t1", 1)).Result()
+	require.NoError(t, err)
+	assert.Positive(t, ttl, "key must have a TTL set atomically with HSET")
+}
+
 func TestRedisCache_TTLBoundary(t *testing.T) {
 	c, mr := newTestRedisCache(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- A pipeline of HSET + EXPIRE is not atomic: a crash between the two commands leaves a key in Redis with no TTL, causing stale cache entries that never expire.
- Switching to `TxPipeline()` wraps all three commands (HSET, EXPIRE, SADD) in a MULTI/EXEC transaction, so the key is either fully written with a TTL or not written at all.

## Test plan

- [ ] `TestRedisCache_Set_KeyHasTTL` — new regression test; asserts the key has a positive TTL immediately after `Set`, catching any future decoupling of HSET and EXPIRE.
- [ ] All existing `internal/cache` tests pass (`make test`).

Closes #450