### PR TITLE
fix(schema): prevent tenant slug enumeration via NotFound collapse

### DIFF
--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -86,11 +86,17 @@ func scopedClients(t *testing.T, conn *grpc.ClientConn, role roleName, tenantIDs
 	}
 }
 
-// isAuthDenied reports whether err is a gRPC status with PermissionDenied
-// or Unauthenticated — the two codes the auth layer surfaces. NotFound,
-// InvalidArgument, and other domain errors do NOT count: matrix 1 cares
-// only about whether the auth gate fired, not whether the request was
-// otherwise valid.
+// isAuthDenied reports whether err is a gRPC status that indicates an auth
+// gate fired. The auth layer surfaces:
+//   - codes.Unauthenticated — no valid credentials
+//   - codes.PermissionDenied — role or non-tenant-scoped access denied
+//   - codes.NotFound — tenant-scoped access denied, collapsed from
+//     PermissionDenied to prevent slug enumeration (see decree#454)
+//
+// InvalidArgument and other domain errors do NOT count: matrices care only
+// about whether the auth gate fired, not whether the request was otherwise
+// valid. In the tenant-access matrices the fixture always creates the target
+// tenant, so NotFound can only mean the access check fired (not a real miss).
 //
 // It also treats configclient.ErrPermissionDenied as an auth denial.
 // The configclient SDK maps codes.PermissionDenied to ErrPermissionDenied
@@ -109,7 +115,7 @@ func isAuthDenied(err error) bool {
 	if !ok {
 		return false
 	}
-	return st.Code() == codes.PermissionDenied || st.Code() == codes.Unauthenticated
+	return st.Code() == codes.PermissionDenied || st.Code() == codes.Unauthenticated || st.Code() == codes.NotFound
 }
 
 // matrixFixture is a shared schema + tenant used by matrix cells that need

--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -111,6 +111,12 @@ func isAuthDenied(err error) bool {
 	if errors.Is(err, configclient.ErrPermissionDenied) {
 		return true
 	}
+	// adminclient SDK maps codes.NotFound → adminclient.ErrNotFound (a plain sentinel,
+	// not a gRPC status). Accept it as an auth denial: tenant-scoped RPCs return
+	// NotFound for access denials to prevent slug enumeration (decree#454).
+	if errors.Is(err, adminclient.ErrNotFound) {
+		return true
+	}
 	st, ok := status.FromError(err)
 	if !ok {
 		return false

--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -8,7 +8,10 @@ package e2e
 //
 //   - in-scope caller (admin role, tenant in x-tenant-id) is allowed
 //   - out-of-scope caller (admin role, tenant NOT in x-tenant-id) is denied
-//     with codes.PermissionDenied
+//     (codes.NotFound or codes.PermissionDenied — see isAuthDenied)
+//
+// Tenant-scoped RPCs surface NotFound (not PermissionDenied) for access
+// denials to prevent slug enumeration (decree#454). isAuthDenied accepts both.
 //
 // This is the regression net for "someone added a new write RPC and
 // forgot to call auth.CheckTenantAccess at the top of the handler."

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -50,6 +50,11 @@ func (s *Service) resolveTenantWithAccess(ctx context.Context, idOrName string) 
 		return domain.Tenant{}, status.Error(codes.Internal, "failed to resolve tenant")
 	}
 	if err := s.guard.Check(ctx, authz.ActionRead, authz.Resource{TenantID: tenant.ID}); err != nil {
+		// Collapse PermissionDenied → NotFound to prevent slug enumeration:
+		// callers must not be able to distinguish "no such tenant" from "exists but no access".
+		if status.Code(err) == codes.PermissionDenied {
+			return domain.Tenant{}, status.Error(codes.NotFound, "tenant not found")
+		}
 		return domain.Tenant{}, err
 	}
 	return tenant, nil

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -414,7 +414,7 @@ func TestLockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 		FieldPath: "app.fee",
 	})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func TestUnlockField_DeniedForOutOfScopeAdmin(t *testing.T) {
@@ -427,7 +427,7 @@ func TestUnlockField_DeniedForOutOfScopeAdmin(t *testing.T) {
 		FieldPath: "app.fee",
 	})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func TestListFieldLocks_DeniedForOutOfScopeAdmin(t *testing.T) {
@@ -437,7 +437,7 @@ func TestListFieldLocks_DeniedForOutOfScopeAdmin(t *testing.T) {
 
 	_, err := svc.ListFieldLocks(outOfScopeAdminCtx(), &pb.ListFieldLocksRequest{TenantId: testTenantID})
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 // --- UpdateTenant ---

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -357,6 +357,25 @@ func TestSchemaService_RequiresAuth(t *testing.T) {
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
+// --- Tenant enumeration protection (issue #454) ---
+
+func TestGetTenant_CrossTenantReturnsNotFound(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	// Admin scoped to testTenantID; looks up testOtherTenantID.
+	// Must get NotFound (not PermissionDenied) to prevent slug enumeration.
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testOtherTenantID).
+		Return(domain.Tenant{ID: testOtherTenantID, Name: "other"}, nil)
+
+	_, err := svc.GetTenant(ctx, &pb.GetTenantRequest{Id: testOtherTenantID})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+	store.AssertExpectations(t)
+}
+
 // --- Cross-tenant write rejection (issue #422) ---
 
 const testOtherTenantID = "00000000-0000-0000-0000-000000000099"
@@ -373,6 +392,7 @@ func TestLockField_CrossTenantRejected(t *testing.T) {
 	store := &mockStore{}
 	svc := NewService(store, WithLogger(testLogger))
 	// Admin scoped to testTenantID; tries to lock a field on testOtherTenantID.
+	// Returns NotFound (not PermissionDenied) to prevent slug enumeration.
 	ctx := adminCtxWithTenants(testTenantID)
 
 	store.On("GetTenantByID", ctx, testOtherTenantID).
@@ -384,7 +404,7 @@ func TestLockField_CrossTenantRejected(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 	store.AssertExpectations(t)
 }
 
@@ -402,7 +422,7 @@ func TestUnlockField_CrossTenantRejected(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 	store.AssertExpectations(t)
 }
 
@@ -417,7 +437,7 @@ func TestUpdateTenant_CrossTenantRejected(t *testing.T) {
 	_, err := svc.UpdateTenant(ctx, &pb.UpdateTenantRequest{Id: testOtherTenantID})
 
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 	store.AssertExpectations(t)
 }
 
@@ -432,7 +452,7 @@ func TestDeleteTenant_CrossTenantRejected(t *testing.T) {
 	_, err := svc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: testOtherTenantID})
 
 	require.Error(t, err)
-	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, codes.NotFound, status.Code(err))
 	store.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

- Tenant access checks in `resolveTenantWithAccess` previously returned `PermissionDenied` when a caller lacked access to an existing tenant, allowing callers to distinguish "no such tenant" from "exists but no access" and enumerate valid tenant slugs.
- Collapse any `PermissionDenied` from the access guard to `NotFound` so both outcomes are indistinguishable to the caller.
- Update all cross-tenant rejection tests to assert `NotFound` instead of `PermissionDenied`; add an explicit `TestGetTenant_CrossTenantReturnsNotFound` to pin the anti-enumeration contract.

## Test plan

- [x] `go test ./internal/schema/...` — all schema tests pass
- [x] New test `TestGetTenant_CrossTenantReturnsNotFound` verifies `NotFound` is returned when an out-of-scope admin requests another tenant
- [x] Existing cross-tenant rejection tests (`LockField`, `UnlockField`, `UpdateTenant`, `DeleteTenant`, `ListFieldLocks`) updated and passing

Closes #454