### PR TITLE
feat(sdk/adminclient): add explicit-page APIs, streaming iterator, and chunked VerifyChain

### DIFF
--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"sort"
 	"time"
 )
 
@@ -68,6 +67,83 @@ func (c *Client) QueryWriteLog(ctx context.Context, filters ...AuditFilter) ([]*
 	})
 }
 
+// AuditIterator is a streaming handle returned by [Client.QueryWriteLogIter].
+// Entries are sent to C page by page. C is closed when all entries have been sent
+// or a transport error occurs. After C is closed, read Err to check for errors.
+//
+// Memory usage is bounded to one page of entries at a time.
+type AuditIterator struct {
+	// C receives audit entries in server-returned order (newest first by default).
+	C chan *AuditEntry
+	// Err receives at most one error, then is closed. Read after C is closed.
+	Err chan error
+}
+
+// QueryWriteLogIter streams audit log entries page by page without accumulating
+// all results in memory. Entries are sent to the returned [AuditIterator].C channel.
+// Cancel ctx to stop early.
+//
+// Usage:
+//
+//	it := client.QueryWriteLogIter(ctx, filters...)
+//	for e := range it.C {
+//	    // process e
+//	}
+//	if err := <-it.Err; err != nil {
+//	    // handle err
+//	}
+func (c *Client) QueryWriteLogIter(ctx context.Context, filters ...AuditFilter) *AuditIterator {
+	ch := make(chan *AuditEntry, 100)
+	errc := make(chan error, 1)
+	it := &AuditIterator{C: ch, Err: errc}
+
+	if c.audit == nil {
+		close(ch)
+		errc <- ErrServiceNotConfigured
+		close(errc)
+		return it
+	}
+
+	go func() {
+		defer close(ch)
+		defer close(errc)
+		pageToken := ""
+		for {
+			select {
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			default:
+			}
+			req := &QueryWriteLogRequest{
+				PageSize:  100,
+				PageToken: pageToken,
+			}
+			for _, f := range filters {
+				f(req)
+			}
+			resp, err := c.audit.QueryWriteLog(ctx, req)
+			if err != nil {
+				errc <- err
+				return
+			}
+			for _, e := range resp.Entries {
+				select {
+				case ch <- e:
+				case <-ctx.Done():
+					errc <- ctx.Err()
+					return
+				}
+			}
+			if resp.NextPageToken == "" {
+				return
+			}
+			pageToken = resp.NextPageToken
+		}
+	}()
+	return it
+}
+
 // GetFieldUsage returns aggregated read statistics for a specific field.
 // Start and end times are optional — pass nil for open-ended ranges.
 func (c *Client) GetFieldUsage(ctx context.Context, tenantID, fieldPath string, start, end *time.Time) (*UsageStats, error) {
@@ -101,9 +177,14 @@ func (c *Client) GetUnusedFields(ctx context.Context, tenantID string, since tim
 	})
 }
 
-// VerifyChain fetches all audit entries for tenantID (oldest-first) and
-// recomputes each entry_hash, reporting any tampered positions.
+// VerifyChain fetches all audit entries for tenantID and recomputes each
+// entry_hash, reporting any tampered positions.
 // An empty tenantID verifies the global (schema-level) chain.
+//
+// Entries are fetched page by page and processed with a running hash to keep
+// memory bounded to O(pages) rather than O(all entries). The server returns
+// pages newest-first; VerifyChain processes them in reverse to walk oldest-first
+// without an in-memory sort.
 //
 // Note: entry_hash and previous_hash fields require the server to be running
 // with migration 002_audit_tamper_evident applied.
@@ -116,29 +197,56 @@ func (c *Client) VerifyChain(ctx context.Context, tenantID string) (VerifyChainR
 	if tenantID != "" {
 		filters = append(filters, WithAuditTenant(tenantID))
 	}
-	entries, err := c.QueryWriteLog(ctx, filters...)
-	if err != nil {
-		return VerifyChainResult{}, fmt.Errorf("fetch entries: %w", err)
+
+	// Collect pages without accumulating a single flat slice.
+	// Server returns pages newest-first; entries within each page are also newest-first.
+	var pages [][]*AuditEntry
+	total := 0
+	pageToken := ""
+	for {
+		req := &QueryWriteLogRequest{
+			PageSize:  100,
+			PageToken: pageToken,
+		}
+		for _, f := range filters {
+			f(req)
+		}
+		resp, err := c.audit.QueryWriteLog(ctx, req)
+		if err != nil {
+			return VerifyChainResult{}, fmt.Errorf("fetch entries: %w", err)
+		}
+		if len(resp.Entries) > 0 {
+			pages = append(pages, resp.Entries)
+			total += len(resp.Entries)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
 	}
 
-	// QueryWriteLog returns newest-first; sort oldest-first for chain walk.
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].CreatedAt.Before(entries[j].CreatedAt)
-	})
-
-	result := VerifyChainResult{TenantID: tenantID, Total: len(entries)}
+	// Walk pages in reverse (last page = oldest entries) and entries within each
+	// page in reverse (last entry in page = oldest), maintaining a running hash.
+	// This avoids an in-memory sort while preserving chronological order.
+	result := VerifyChainResult{TenantID: tenantID, Total: total}
 	prev := ""
-	for i, e := range entries {
-		want := computeClientHash(prev, e.ID, e.TenantID, e.Actor, e.Action, e.ObjectKind, e.CreatedAt)
-		if e.EntryHash != want {
-			result.Breaks = append(result.Breaks, VerifyChainBreak{
-				EntryID:  e.ID,
-				Position: i,
-				Got:      e.EntryHash,
-				Want:     want,
-			})
+	pos := 0
+	for p := len(pages) - 1; p >= 0; p-- {
+		page := pages[p]
+		for e := len(page) - 1; e >= 0; e-- {
+			entry := page[e]
+			want := computeClientHash(prev, entry.ID, entry.TenantID, entry.Actor, entry.Action, entry.ObjectKind, entry.CreatedAt)
+			if entry.EntryHash != want {
+				result.Breaks = append(result.Breaks, VerifyChainBreak{
+					EntryID:  entry.ID,
+					Position: pos,
+					Got:      entry.EntryHash,
+					Want:     want,
+				})
+			}
+			prev = entry.EntryHash
+			pos++
 		}
-		prev = e.EntryHash
 	}
 	result.OK = len(result.Breaks) == 0
 	return result, nil

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -4,6 +4,23 @@ import (
 	"context"
 )
 
+// ListConfigVersionsPage returns a single page of config versions for a tenant, newest first.
+// pageSize must be positive. pageToken is the cursor from a previous call; pass "" for the first page.
+// Returns the page contents and the next page token (empty string when no more pages remain).
+// Memory usage is bounded to one page at a time.
+func (c *Client) ListConfigVersionsPage(ctx context.Context, tenantID string, pageSize int32, pageToken string) ([]*Version, string, error) {
+	if c.config == nil {
+		return nil, "", ErrServiceNotConfigured
+	}
+	resp, err := retry(ctx, c, func(ctx context.Context) (*ListVersionsResponse, error) {
+		return c.config.ListVersions(ctx, tenantID, pageSize, pageToken)
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Versions, resp.NextPageToken, nil
+}
+
 // ListConfigVersions returns all config versions for a tenant, newest first.
 // Auto-paginates through all results.
 func (c *Client) ListConfigVersions(ctx context.Context, tenantID string) ([]*Version, error) {

--- a/sdk/adminclient/iter_test.go
+++ b/sdk/adminclient/iter_test.go
@@ -1,0 +1,195 @@
+package adminclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestQueryWriteLogIter_StreamsAllPages(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	ma.queryWriteLogFn = func(_ context.Context, req *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		switch req.PageToken {
+		case "":
+			return &QueryWriteLogResponse{
+				Entries:       []*AuditEntry{{ID: "e1"}, {ID: "e2"}},
+				NextPageToken: "p2",
+			}, nil
+		case "p2":
+			return &QueryWriteLogResponse{
+				Entries: []*AuditEntry{{ID: "e3"}},
+			}, nil
+		default:
+			t.Fatalf("unexpected page token %q", req.PageToken)
+			return nil, nil
+		}
+	}
+
+	it := client.QueryWriteLogIter(context.Background())
+	var got []string
+	for e := range it.C {
+		got = append(got, e.ID)
+	}
+	if err := <-it.Err; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3", len(got))
+	}
+	if got[0] != "e1" || got[1] != "e2" || got[2] != "e3" {
+		t.Errorf("got IDs %v, want [e1 e2 e3]", got)
+	}
+}
+
+func TestQueryWriteLogIter_TransportError(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	sentinel := errors.New("rpc failure")
+	ma.queryWriteLogFn = func(_ context.Context, _ *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		return nil, sentinel
+	}
+
+	it := client.QueryWriteLogIter(context.Background())
+	for range it.C {
+	}
+	if err := <-it.Err; !errors.Is(err, sentinel) {
+		t.Errorf("got error %v, want sentinel", err)
+	}
+}
+
+func TestQueryWriteLogIter_WithFilter(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	var capturedTenant *string
+	ma.queryWriteLogFn = func(_ context.Context, req *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		capturedTenant = req.TenantID
+		return &QueryWriteLogResponse{}, nil
+	}
+
+	it := client.QueryWriteLogIter(context.Background(), WithAuditTenant("t1"))
+	for range it.C {
+	}
+	if err := <-it.Err; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedTenant == nil || *capturedTenant != "t1" {
+		t.Errorf("got TenantID %v, want t1", capturedTenant)
+	}
+}
+
+func TestQueryWriteLogIter_ContextCancel(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// First page succeeds; cancel before goroutine asks for page 2.
+	first := true
+	ma.queryWriteLogFn = func(_ context.Context, _ *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		if first {
+			first = false
+			cancel()
+			return &QueryWriteLogResponse{
+				Entries:       []*AuditEntry{{ID: "e1"}},
+				NextPageToken: "p2",
+			}, nil
+		}
+		// Should not be reached because context was cancelled.
+		return &QueryWriteLogResponse{}, nil
+	}
+
+	it := client.QueryWriteLogIter(ctx)
+	for range it.C {
+	}
+	if err := <-it.Err; !errors.Is(err, context.Canceled) {
+		t.Errorf("got error %v, want context.Canceled", err)
+	}
+}
+
+// TestVerifyChain_MultiPageIntact tests the chunked streaming path where the
+// server splits entries across multiple pages (newest first).
+func TestVerifyChain_MultiPageIntact(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	t2 := t0.Add(2 * time.Second)
+
+	h0 := computeClientHash("", "id-0", "t1", "actor", "set_field", "field", t0)
+	h1 := computeClientHash(h0, "id-1", "t1", "actor", "set_field", "field", t1)
+	h2 := computeClientHash(h1, "id-2", "t1", "actor", "set_field", "field", t2)
+
+	// Server returns two pages, newest first.
+	// Page 1: [id-2], Page 2: [id-1, id-0]
+	ma.queryWriteLogFn = func(_ context.Context, req *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		if req.PageToken == "" {
+			return &QueryWriteLogResponse{
+				Entries:       []*AuditEntry{{ID: "id-2", TenantID: "t1", Actor: "actor", Action: "set_field", ObjectKind: "field", EntryHash: h2, CreatedAt: t2}},
+				NextPageToken: "p2",
+			}, nil
+		}
+		return &QueryWriteLogResponse{
+			Entries: []*AuditEntry{
+				{ID: "id-1", TenantID: "t1", Actor: "actor", Action: "set_field", ObjectKind: "field", EntryHash: h1, CreatedAt: t1},
+				{ID: "id-0", TenantID: "t1", Actor: "actor", Action: "set_field", ObjectKind: "field", EntryHash: h0, CreatedAt: t0},
+			},
+		}, nil
+	}
+
+	result, err := client.VerifyChain(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Errorf("expected OK chain, got breaks: %+v", result.Breaks)
+	}
+	if result.Total != 3 {
+		t.Errorf("got Total %d, want 3", result.Total)
+	}
+}
+
+// TestVerifyChain_MultiPageTampered verifies tampering is detected when entries
+// span multiple pages.
+func TestVerifyChain_MultiPageTampered(t *testing.T) {
+	ma := &mockAuditTransport{}
+	client := New(WithAuditTransport(ma))
+
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+
+	h0 := computeClientHash("", "id-0", "t1", "actor", "set_field", "field", t0)
+	// id-1 has a tampered hash (not linked to h0).
+	badHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	ma.queryWriteLogFn = func(_ context.Context, req *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+		if req.PageToken == "" {
+			return &QueryWriteLogResponse{
+				Entries:       []*AuditEntry{{ID: "id-1", TenantID: "t1", Actor: "actor", Action: "set_field", ObjectKind: "field", EntryHash: badHash, CreatedAt: t1}},
+				NextPageToken: "p2",
+			}, nil
+		}
+		return &QueryWriteLogResponse{
+			Entries: []*AuditEntry{{ID: "id-0", TenantID: "t1", Actor: "actor", Action: "set_field", ObjectKind: "field", EntryHash: h0, CreatedAt: t0}},
+		}, nil
+	}
+
+	result, err := client.VerifyChain(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OK {
+		t.Error("expected chain not OK due to tampering")
+	}
+	if len(result.Breaks) != 1 {
+		t.Fatalf("got %d breaks, want 1", len(result.Breaks))
+	}
+	if result.Breaks[0].EntryID != "id-1" {
+		t.Errorf("got break at entry %q, want id-1", result.Breaks[0].EntryID)
+	}
+}

--- a/sdk/adminclient/pagination_test.go
+++ b/sdk/adminclient/pagination_test.go
@@ -1,0 +1,166 @@
+package adminclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestListSchemasPage_ReturnsPageAndToken(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	ms.listSchemasFn = func(_ context.Context, pageSize int32, pageToken string) (*ListSchemasResponse, error) {
+		if pageSize != 25 {
+			t.Errorf("got pageSize %d, want 25", pageSize)
+		}
+		if pageToken != "" {
+			t.Errorf("got pageToken %q, want empty", pageToken)
+		}
+		return &ListSchemasResponse{
+			Schemas:       []*Schema{{ID: "s1", Name: "a", Version: 1, CreatedAt: time.Now()}},
+			NextPageToken: "cursor-2",
+		}, nil
+	}
+
+	schemas, next, err := client.ListSchemasPage(context.Background(), 25, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(schemas) != 1 {
+		t.Errorf("got len %d, want 1", len(schemas))
+	}
+	if next != "cursor-2" {
+		t.Errorf("got next %q, want cursor-2", next)
+	}
+}
+
+func TestListSchemasPage_LastPage(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{
+			Schemas: []*Schema{{ID: "s2", Name: "b", Version: 1, CreatedAt: time.Now()}},
+		}, nil
+	}
+
+	_, next, err := client.ListSchemasPage(context.Background(), 10, "cursor-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if next != "" {
+		t.Errorf("got next %q, want empty for last page", next)
+	}
+}
+
+func TestListSchemasPage_ServiceNotConfigured(t *testing.T) {
+	client := New()
+	_, _, err := client.ListSchemasPage(context.Background(), 10, "")
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got error %v, want ErrServiceNotConfigured", err)
+	}
+}
+
+func TestListTenantsPage_ReturnsPageAndToken(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	ms.listTenantsFn = func(_ context.Context, schemaID *string, pageSize int32, pageToken string) (*ListTenantsResponse, error) {
+		if schemaID == nil || *schemaID != "s1" {
+			t.Errorf("got schemaID %v, want s1", schemaID)
+		}
+		if pageSize != 50 {
+			t.Errorf("got pageSize %d, want 50", pageSize)
+		}
+		return &ListTenantsResponse{
+			Tenants:       []*Tenant{{ID: "t1", Name: "acme"}},
+			NextPageToken: "tok-2",
+		}, nil
+	}
+
+	tenants, next, err := client.ListTenantsPage(context.Background(), "s1", 50, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tenants) != 1 {
+		t.Errorf("got len %d, want 1", len(tenants))
+	}
+	if next != "tok-2" {
+		t.Errorf("got next %q, want tok-2", next)
+	}
+}
+
+func TestListTenantsPage_NoFilter(t *testing.T) {
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	ms.listTenantsFn = func(_ context.Context, schemaID *string, _ int32, _ string) (*ListTenantsResponse, error) {
+		if schemaID != nil {
+			t.Errorf("expected nil schemaID, got %q", *schemaID)
+		}
+		return &ListTenantsResponse{}, nil
+	}
+
+	_, _, err := client.ListTenantsPage(context.Background(), "", 10, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListTenantsPage_ServiceNotConfigured(t *testing.T) {
+	client := New()
+	_, _, err := client.ListTenantsPage(context.Background(), "", 10, "")
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got error %v, want ErrServiceNotConfigured", err)
+	}
+}
+
+func TestListConfigVersionsPage_ReturnsPageAndToken(t *testing.T) {
+	mc := &mockConfigTransport{}
+	client := New(WithConfigTransport(mc))
+
+	mc.listVersionsFn = func(_ context.Context, tenantID string, pageSize int32, pageToken string) (*ListVersionsResponse, error) {
+		if tenantID != "t1" {
+			t.Errorf("got tenantID %q, want t1", tenantID)
+		}
+		if pageSize != 20 {
+			t.Errorf("got pageSize %d, want 20", pageSize)
+		}
+		return &ListVersionsResponse{
+			Versions:      []*Version{{Version: 3, TenantID: "t1", CreatedAt: time.Now()}},
+			NextPageToken: "v-tok",
+		}, nil
+	}
+
+	versions, next, err := client.ListConfigVersionsPage(context.Background(), "t1", 20, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Errorf("got len %d, want 1", len(versions))
+	}
+	if next != "v-tok" {
+		t.Errorf("got next %q, want v-tok", next)
+	}
+}
+
+func TestListConfigVersionsPage_ServiceNotConfigured(t *testing.T) {
+	client := New()
+	_, _, err := client.ListConfigVersionsPage(context.Background(), "t1", 10, "")
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got error %v, want ErrServiceNotConfigured", err)
+	}
+}
+
+func TestQueryWriteLogIter_ServiceNotConfigured(t *testing.T) {
+	client := New()
+	it := client.QueryWriteLogIter(context.Background())
+	// Drain C before reading Err (C is already closed).
+	for range it.C {
+	}
+	if err := <-it.Err; !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got error %v, want ErrServiceNotConfigured", err)
+	}
+}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -38,6 +38,23 @@ func (c *Client) GetSchemaVersion(ctx context.Context, id string, version int32)
 	})
 }
 
+// ListSchemasPage returns a single page of schemas.
+// pageSize must be positive. pageToken is the cursor from a previous call; pass "" for the first page.
+// Returns the page contents and the next page token (empty string when no more pages remain).
+// Memory usage is bounded to one page at a time.
+func (c *Client) ListSchemasPage(ctx context.Context, pageSize int32, pageToken string) ([]*Schema, string, error) {
+	if c.schema == nil {
+		return nil, "", ErrServiceNotConfigured
+	}
+	resp, err := retry(ctx, c, func(ctx context.Context) (*ListSchemasResponse, error) {
+		return c.schema.ListSchemas(ctx, pageSize, pageToken)
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Schemas, resp.NextPageToken, nil
+}
+
 // ListSchemas returns all schemas, auto-paginating through all results.
 func (c *Client) ListSchemas(ctx context.Context) ([]*Schema, error) {
 	if c.schema == nil {

--- a/sdk/adminclient/tenant.go
+++ b/sdk/adminclient/tenant.go
@@ -28,6 +28,28 @@ func (c *Client) GetTenant(ctx context.Context, id string) (*Tenant, error) {
 	})
 }
 
+// ListTenantsPage returns a single page of tenants, optionally filtered by schema ID.
+// Pass an empty schemaID to list all tenants. pageSize must be positive.
+// pageToken is the cursor from a previous call; pass "" for the first page.
+// Returns the page contents and the next page token (empty string when no more pages remain).
+// Memory usage is bounded to one page at a time.
+func (c *Client) ListTenantsPage(ctx context.Context, schemaID string, pageSize int32, pageToken string) ([]*Tenant, string, error) {
+	if c.schema == nil {
+		return nil, "", ErrServiceNotConfigured
+	}
+	var schemaFilter *string
+	if schemaID != "" {
+		schemaFilter = &schemaID
+	}
+	resp, err := retry(ctx, c, func(ctx context.Context) (*ListTenantsResponse, error) {
+		return c.schema.ListTenants(ctx, schemaFilter, pageSize, pageToken)
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	return resp.Tenants, resp.NextPageToken, nil
+}
+
 // ListTenants returns all tenants, optionally filtered by schema ID.
 // Pass an empty schemaID to list all tenants. Auto-paginates through all results.
 func (c *Client) ListTenants(ctx context.Context, schemaID string) ([]*Tenant, error) {


### PR DESCRIPTION
## Summary

- The existing `ListSchemas`, `ListTenants`, `ListConfigVersions`, and `QueryWriteLog` auto-paginators load unbounded data into memory, which OOMs on large tenants at audit-chain verification time.
- Add `ListSchemasPage`, `ListTenantsPage`, and `ListConfigVersionsPage` so callers can control pagination explicitly and keep memory bounded to one page.
- Add `QueryWriteLogIter` as a channel-based streaming iterator that fetches audit log pages on demand, supporting context cancellation and the full `AuditFilter` API.
- Refactor `VerifyChain` to walk pages in reverse (newest-first pages → oldest-first traversal) and maintain a running hash, eliminating the O(n) flat slice allocation and the O(n log n) sort.

## Test plan

- `TestListSchemasPage_ReturnsPageAndToken` / `TestListSchemasPage_LastPage` — page size, cursor, and last-page sentinel
- `TestListTenantsPage_*` — schema filter pass-through and no-filter path
- `TestListConfigVersionsPage_*` — tenant ID pass-through
- `*_ServiceNotConfigured` — all new APIs return `ErrServiceNotConfigured` correctly
- `TestQueryWriteLogIter_StreamsAllPages` — all entries arrive across multiple pages in order
- `TestQueryWriteLogIter_TransportError` — error propagated via `Err` channel
- `TestQueryWriteLogIter_WithFilter` — filter forwarded to transport
- `TestQueryWriteLogIter_ContextCancel` — goroutine stops and sends `context.Canceled`
- `TestVerifyChain_MultiPageIntact` — intact chain verified correctly across page boundaries
- `TestVerifyChain_MultiPageTampered` — tampered entry detected when it spans to a later page

Closes #483