### PR TITLE
fix(ratelimit): quarantine evicted keys to prevent free-burst churn

### DIFF
--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"container/list"
 	"sync"
+	"time"
 
 	"golang.org/x/time/rate"
 )
@@ -18,6 +19,12 @@ type Limiter interface {
 // InProcessLimiter is a per-key token-bucket limiter backed by golang.org/x/time/rate.
 // Each unique key gets its own bucket, allocated on first use. Buckets are evicted
 // via LRU when the cache reaches capacity, preventing unbounded memory growth.
+//
+// Eviction footgun: a key that falls off the LRU would normally re-enter with a full
+// burst on its next request, letting an attacker cycle keys to bypass the rate limit.
+// To close this, evicted keys are tracked in a quarantine log (same capacity as the
+// main cache). A key that re-enters from quarantine starts with zero tokens; it must
+// wait for the normal refill interval before making progress.
 type InProcessLimiter struct {
 	limit      rate.Limit
 	burst      int
@@ -25,6 +32,9 @@ type InProcessLimiter struct {
 	mu         sync.Mutex
 	ll         *list.List
 	keys       map[string]*list.Element
+	// qll/qmap: quarantine log for recently-evicted keys.
+	qll  *list.List
+	qmap map[string]*list.Element
 }
 
 type lruEntry struct {
@@ -37,7 +47,8 @@ type InProcessOption func(*InProcessLimiter)
 
 // WithMaxBuckets sets the maximum number of key buckets held in memory.
 // When the cap is reached the least-recently-used bucket is evicted; the next
-// request for that key starts a fresh full bucket. Defaults to 100_000.
+// request for that key starts a fresh full bucket unless the key is in the
+// quarantine log, in which case it starts with zero tokens. Defaults to 100_000.
 func WithMaxBuckets(n int) InProcessOption {
 	return func(l *InProcessLimiter) { l.maxBuckets = n }
 }
@@ -48,12 +59,14 @@ func NewInProcess(limit rate.Limit, burst int, opts ...InProcessOption) *InProce
 		limit:      limit,
 		burst:      burst,
 		maxBuckets: defaultMaxBuckets,
-		ll:         list.New(),
-		keys:       make(map[string]*list.Element),
 	}
 	for _, o := range opts {
 		o(l)
 	}
+	l.ll = list.New()
+	l.keys = make(map[string]*list.Element)
+	l.qll = list.New()
+	l.qmap = make(map[string]*list.Element)
 	return l
 }
 
@@ -67,13 +80,34 @@ func (l *InProcessLimiter) Allow(key string) bool {
 		return rl.Allow()
 	}
 	rl := rate.NewLimiter(l.limit, l.burst)
+	if _, quarantined := l.qmap[key]; quarantined {
+		// Drain initial tokens so the re-entering key cannot exploit the free burst.
+		rl.AllowN(time.Now(), l.burst)
+	}
 	el := l.ll.PushFront(&lruEntry{key: key, rl: rl})
 	l.keys[key] = el
 	if l.ll.Len() > l.maxBuckets {
 		back := l.ll.Back()
 		l.ll.Remove(back)
-		delete(l.keys, back.Value.(*lruEntry).key)
+		evicted := back.Value.(*lruEntry).key
+		delete(l.keys, evicted)
+		l.quarantine(evicted)
 	}
 	l.mu.Unlock()
 	return rl.Allow()
+}
+
+// quarantine adds key to the eviction log, evicting the oldest entry if full.
+// Caller must hold l.mu.
+func (l *InProcessLimiter) quarantine(key string) {
+	if _, ok := l.qmap[key]; ok {
+		return // already present; no-op
+	}
+	qel := l.qll.PushFront(key)
+	l.qmap[key] = qel
+	if l.qll.Len() > l.maxBuckets {
+		qback := l.qll.Back()
+		l.qll.Remove(qback)
+		delete(l.qmap, qback.Value.(string))
+	}
 }

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 // TestInProcessLimiter_LRUEviction verifies that inserting cap+1 unique keys evicts
-// the least-recently-used bucket, and the evicted key gets a fresh full bucket on reuse.
+// the least-recently-used bucket, and that the evicted key is quarantined on re-entry
+// (starts with zero tokens, no free burst).
 func TestInProcessLimiter_LRUEviction(t *testing.T) {
 	const cap = 3
 	// rate=0: no token replenishment; burst=1: one token per fresh bucket.
@@ -22,10 +23,38 @@ func TestInProcessLimiter_LRUEviction(t *testing.T) {
 	lim.Allow("key-1")
 	lim.Allow("key-2")
 
-	// Inserting key-3 evicts key-0 (LRU).
+	// Inserting key-3 evicts key-0 (LRU) into quarantine.
 	lim.Allow("key-3")
 
-	// key-0 was evicted; requesting it yields a fresh bucket with 1 token.
-	assert.True(t, lim.Allow("key-0"), "evicted key should get a fresh bucket")
-	assert.False(t, lim.Allow("key-0"), "fresh bucket has only one token")
+	// key-0 re-enters from quarantine: burst is drained, so the first call is denied.
+	assert.False(t, lim.Allow("key-0"), "quarantined key must not get a free burst on re-entry")
+}
+
+// TestInProcessLimiter_QuarantineBlocksFreeBurst verifies the security property:
+// cycling keys through LRU eviction cannot be used to reset token buckets.
+func TestInProcessLimiter_QuarantineBlocksFreeBurst(t *testing.T) {
+	const cap = 2
+	// burst=5, rate=0 (no refill): an attacker hoping to cycle keys gets no extra tokens.
+	lim := ratelimit.NewInProcess(rate.Limit(0), 5, ratelimit.WithMaxBuckets(cap))
+
+	// Consume all tokens for key-a.
+	for range 5 {
+		lim.Allow("key-a")
+	}
+	assert.False(t, lim.Allow("key-a"), "key-a should be exhausted")
+
+	// Evict key-a by filling the cache with other keys.
+	lim.Allow("key-b")
+	lim.Allow("key-c") // key-a is now evicted (LRU)
+
+	// key-a re-enters: quarantine must prevent the free burst.
+	assert.False(t, lim.Allow("key-a"), "evicted key must not regain burst tokens via re-entry")
+}
+
+// TestInProcessLimiter_NonEvictedKeyGetsFreshBucket verifies that a key that was never
+// evicted (i.e. not in quarantine) still gets a normal full bucket on first use.
+func TestInProcessLimiter_NonEvictedKeyGetsFreshBucket(t *testing.T) {
+	lim := ratelimit.NewInProcess(rate.Limit(0), 1, ratelimit.WithMaxBuckets(10))
+	assert.True(t, lim.Allow("fresh-key"), "unseen key should get a full burst")
+	assert.False(t, lim.Allow("fresh-key"), "burst of 1 should be exhausted")
 }

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -58,3 +58,52 @@ func TestInProcessLimiter_NonEvictedKeyGetsFreshBucket(t *testing.T) {
 	assert.True(t, lim.Allow("fresh-key"), "unseen key should get a full burst")
 	assert.False(t, lim.Allow("fresh-key"), "burst of 1 should be exhausted")
 }
+
+// TestInProcessLimiter_QuarantineLogOverflow verifies that the quarantine log itself
+// evicts its oldest entry when it reaches capacity, allowing that key to regain a
+// fresh burst as if it had never been seen.
+func TestInProcessLimiter_QuarantineLogOverflow(t *testing.T) {
+	const cap = 2
+	lim := ratelimit.NewInProcess(rate.Limit(0), 1, ratelimit.WithMaxBuckets(cap))
+
+	// Fill and overflow the quarantine (cap=2) by evicting three distinct keys.
+	// Sequence (main LRU cap=2):
+	//   Allow a, b       → main: [b, a]
+	//   Allow c          → evicts a → quarantine: [a]
+	//   Allow d          → evicts b → quarantine: [b, a]  (full)
+	//   Allow e          → evicts c → quarantine: [c, b]  (a evicted from quarantine)
+	lim.Allow("key-a")
+	lim.Allow("key-b")
+	lim.Allow("key-c") // evicts key-a into quarantine
+	lim.Allow("key-d") // evicts key-b into quarantine (quarantine full)
+	lim.Allow("key-e") // evicts key-c; key-a rolls off the quarantine
+
+	// key-a is no longer quarantined — it should receive a fresh full burst.
+	assert.True(t, lim.Allow("key-a"), "key-a rolled off quarantine and should get a fresh burst")
+}
+
+// TestInProcessLimiter_QuarantineDuplicateEviction verifies that evicting an
+// already-quarantined key is a no-op (no duplicate entry, key stays quarantined).
+func TestInProcessLimiter_QuarantineDuplicateEviction(t *testing.T) {
+	const cap = 3
+	lim := ratelimit.NewInProcess(rate.Limit(0), 1, ratelimit.WithMaxBuckets(cap))
+
+	// Evict key-a into quarantine.
+	lim.Allow("key-a")
+	lim.Allow("key-b")
+	lim.Allow("key-c")
+	lim.Allow("key-d") // evicts key-a → quarantine: [a]
+
+	// key-a re-enters main from quarantine (burst drained; still in quarantine).
+	lim.Allow("key-a") // evicts key-b → quarantine: [b, a]
+
+	// Touch key-d and key-c to push key-a to the back of the main LRU.
+	lim.Allow("key-d")
+	lim.Allow("key-c")
+
+	// Adding key-e evicts key-a from main again; quarantine() must no-op (a already present).
+	lim.Allow("key-e")
+
+	// key-a is still quarantined — no free burst.
+	assert.False(t, lim.Allow("key-a"), "doubly-evicted key must remain quarantined")
+}


### PR DESCRIPTION
## Summary
- An attacker could cycle unique keys through the LRU to repeatedly evict them, receiving a fresh full burst on every re-entry — bypassing the rate limit entirely.
- Evicted keys are now tracked in a bounded quarantine log (same capacity as the main cache); any key re-entering from quarantine has its initial tokens drained, forcing it to wait for the normal token-refill interval.

## Test plan
- [ ] `TestInProcessLimiter_LRUEviction` — evicted key no longer gets a free burst on re-entry
- [ ] `TestInProcessLimiter_QuarantineBlocksFreeBurst` — exhausted key cannot reset by cycling through eviction
- [ ] `TestInProcessLimiter_NonEvictedKeyGetsFreshBucket` — unseen keys still receive a full initial burst
- [ ] `make test` passes with `-race` flag

Closes #455