### PR TITLE
Document Subscribe stream-end reconnect semantics

### DIFF
--- a/api/centralconfig/v1/config_service_grpc.pb.go
+++ b/api/centralconfig/v1/config_service_grpc.pb.go
@@ -65,8 +65,18 @@ type ConfigServiceClient interface {
 	// copies the target's values.
 	RollbackToVersion(ctx context.Context, in *RollbackToVersionRequest, opts ...grpc.CallOption) (*RollbackToVersionResponse, error)
 	// Subscribe opens a server-streaming connection that pushes ConfigChange events
-	// whenever the tenant's configuration is modified. The stream remains open until
-	// the client disconnects or the server shuts down.
+	// whenever the tenant's configuration is modified.
+	//
+	// Stream lifetime:
+	//   - Client disconnect: stream ends immediately.
+	//   - Server closes with OK status: the server-side pub/sub backend restarted
+	//     (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff;
+	//     an OK close does NOT indicate the subscription is permanently gone.
+	//   - Server closes with error status: treat as a transient failure and reconnect
+	//     with backoff.
+	//
+	// Use the configwatcher package for a high-level client that handles reconnection
+	// automatically.
 	Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
 	// ExportConfig serializes a tenant's configuration to YAML.
 	ExportConfig(ctx context.Context, in *ExportConfigRequest, opts ...grpc.CallOption) (*ExportConfigResponse, error)
@@ -234,8 +244,18 @@ type ConfigServiceServer interface {
 	// copies the target's values.
 	RollbackToVersion(context.Context, *RollbackToVersionRequest) (*RollbackToVersionResponse, error)
 	// Subscribe opens a server-streaming connection that pushes ConfigChange events
-	// whenever the tenant's configuration is modified. The stream remains open until
-	// the client disconnects or the server shuts down.
+	// whenever the tenant's configuration is modified.
+	//
+	// Stream lifetime:
+	//   - Client disconnect: stream ends immediately.
+	//   - Server closes with OK status: the server-side pub/sub backend restarted
+	//     (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff;
+	//     an OK close does NOT indicate the subscription is permanently gone.
+	//   - Server closes with error status: treat as a transient failure and reconnect
+	//     with backoff.
+	//
+	// Use the configwatcher package for a high-level client that handles reconnection
+	// automatically.
 	Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error
 	// ExportConfig serializes a tenant's configuration to YAML.
 	ExportConfig(context.Context, *ExportConfigRequest) (*ExportConfigResponse, error)

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -961,7 +961,8 @@
     },
     "/v1/tenants/{tenantId}/config:subscribe": {
       "get": {
-        "summary": "Subscribe opens a server-streaming connection that pushes ConfigChange events\nwhenever the tenant's configuration is modified. The stream remains open until\nthe client disconnects or the server shuts down.",
+        "summary": "Subscribe opens a server-streaming connection that pushes ConfigChange events\nwhenever the tenant's configuration is modified.",
+        "description": "Stream lifetime:\n  - Client disconnect: stream ends immediately.\n  - Server closes with OK status: the server-side pub/sub backend restarted\n    (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff;\n    an OK close does NOT indicate the subscription is permanently gone.\n  - Server closes with error status: treat as a transient failure and reconnect\n    with backoff.\n\nUse the configwatcher package for a high-level client that handles reconnection\nautomatically.",
         "operationId": "ConfigService_Subscribe",
         "responses": {
           "200": {

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1231,7 +1231,11 @@ bypasses the cache and reads directly from the database.
 | ListVersions | [ListVersionsRequest](#centralconfig-v1-ListVersionsRequest) | [ListVersionsResponse](#centralconfig-v1-ListVersionsResponse) | ListVersions returns config version history for a tenant (newest first). |
 | GetVersion | [GetVersionRequest](#centralconfig-v1-GetVersionRequest) | [GetVersionResponse](#centralconfig-v1-GetVersionResponse) | GetVersion retrieves metadata for a specific config version. |
 | RollbackToVersion | [RollbackToVersionRequest](#centralconfig-v1-RollbackToVersionRequest) | [RollbackToVersionResponse](#centralconfig-v1-RollbackToVersionResponse) | RollbackToVersion creates a new version with the same values as the target version. This does not delete intermediate versions — it creates a new version that copies the target&#39;s values. |
-| Subscribe | [SubscribeRequest](#centralconfig-v1-SubscribeRequest) | [SubscribeResponse](#centralconfig-v1-SubscribeResponse) stream | Subscribe opens a server-streaming connection that pushes ConfigChange events whenever the tenant&#39;s configuration is modified. The stream remains open until the client disconnects or the server shuts down. |
+| Subscribe | [SubscribeRequest](#centralconfig-v1-SubscribeRequest) | [SubscribeResponse](#centralconfig-v1-SubscribeResponse) stream | Subscribe opens a server-streaming connection that pushes ConfigChange events whenever the tenant&#39;s configuration is modified.
+
+Stream lifetime: - Client disconnect: stream ends immediately. - Server closes with OK status: the server-side pub/sub backend restarted (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff; an OK close does NOT indicate the subscription is permanently gone. - Server closes with error status: treat as a transient failure and reconnect with backoff.
+
+Use the configwatcher package for a high-level client that handles reconnection automatically. |
 | ExportConfig | [ExportConfigRequest](#centralconfig-v1-ExportConfigRequest) | [ExportConfigResponse](#centralconfig-v1-ExportConfigResponse) | ExportConfig serializes a tenant&#39;s configuration to YAML. |
 | ImportConfig | [ImportConfigRequest](#centralconfig-v1-ImportConfigRequest) | [ImportConfigResponse](#centralconfig-v1-ImportConfigResponse) | ImportConfig applies configuration values from YAML. |
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -961,7 +961,8 @@
     },
     "/v1/tenants/{tenantId}/config:subscribe": {
       "get": {
-        "summary": "Subscribe opens a server-streaming connection that pushes ConfigChange events\nwhenever the tenant's configuration is modified. The stream remains open until\nthe client disconnects or the server shuts down.",
+        "summary": "Subscribe opens a server-streaming connection that pushes ConfigChange events\nwhenever the tenant's configuration is modified.",
+        "description": "Stream lifetime:\n  - Client disconnect: stream ends immediately.\n  - Server closes with OK status: the server-side pub/sub backend restarted\n    (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff;\n    an OK close does NOT indicate the subscription is permanently gone.\n  - Server closes with error status: treat as a transient failure and reconnect\n    with backoff.\n\nUse the configwatcher package for a high-level client that handles reconnection\nautomatically.",
         "operationId": "ConfigService_Subscribe",
         "responses": {
           "200": {

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1064,6 +1064,8 @@ func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamin
 			return nil
 		case event, ok := <-events:
 			if !ok {
+				// Pub/sub channel closed (e.g. Redis reconnect). Return nil (OK status)
+				// so clients receive a clean stream-end and know to reconnect with backoff.
 				return nil
 			}
 

--- a/proto/centralconfig/v1/config_service.proto
+++ b/proto/centralconfig/v1/config_service.proto
@@ -84,8 +84,18 @@ service ConfigService {
   // Real-time subscriptions via server-streaming.
 
   // Subscribe opens a server-streaming connection that pushes ConfigChange events
-  // whenever the tenant's configuration is modified. The stream remains open until
-  // the client disconnects or the server shuts down.
+  // whenever the tenant's configuration is modified.
+  //
+  // Stream lifetime:
+  //   - Client disconnect: stream ends immediately.
+  //   - Server closes with OK status: the server-side pub/sub backend restarted
+  //     (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff;
+  //     an OK close does NOT indicate the subscription is permanently gone.
+  //   - Server closes with error status: treat as a transient failure and reconnect
+  //     with backoff.
+  //
+  // Use the configwatcher package for a high-level client that handles reconnection
+  // automatically.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse) {
     option (google.api.http) = {
       get: "/v1/tenants/{tenant_id}/config:subscribe"

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -264,8 +264,13 @@ func (w *Watcher) subscriptionLoop(ctx context.Context, snapshotVersion int32) {
 			return // Context cancelled — clean shutdown.
 		}
 
-		w.opts.logger.WarnContext(ctx, "subscription stream ended, reconnecting",
-			"error", err, "backoff", backoff)
+		if err == nil || err == io.EOF {
+			w.opts.logger.InfoContext(ctx, "subscription stream closed by server, reconnecting",
+				"backoff", backoff)
+		} else {
+			w.opts.logger.WarnContext(ctx, "subscription stream error, reconnecting",
+				"error", err, "backoff", backoff)
+		}
 
 		select {
 		case <-ctx.Done():

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -534,6 +534,66 @@ func TestWatcher_ReconnectVersionCursor(t *testing.T) {
 	_ = w.Close()
 }
 
+// TestWatcher_CleanStreamEndReconnects verifies that when the server closes the
+// stream with io.EOF (OK status, no error), the watcher reconnects with backoff
+// rather than treating it as a permanent shutdown.
+func TestWatcher_CleanStreamEndReconnects(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var subscribeCount atomic.Int32
+
+	// firstSub closes immediately with io.EOF (no context cancel — pure channel close).
+	firstSubCh := make(chan *configclient.ConfigChange)
+	close(firstSubCh) // closed at construction: Recv returns io.EOF immediately
+
+	// secondSub stays open until the watcher is shut down.
+	secondSubCh := make(chan *configclient.ConfigChange)
+
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+		},
+		subscribeFn: func(subCtx context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			call := int(subscribeCount.Add(1))
+			if call == 1 {
+				// Return the pre-closed channel — Recv will return io.EOF immediately.
+				return &mockSubscription{ch: firstSubCh, ctx: subCtx}, nil
+			}
+			return &mockSubscription{ch: secondSubCh, ctx: subCtx}, nil
+		},
+	}
+
+	w := &Watcher{
+		transport: tr,
+		tenantID:  "t1",
+		opts: options{
+			minBackoff:      5 * time.Millisecond,
+			maxBackoff:      20 * time.Millisecond,
+			snapshotTimeout: 100 * time.Millisecond,
+			logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		},
+		fields: make(map[string]*fieldEntry),
+		done:   make(chan struct{}),
+	}
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for the second Subscribe call — proves reconnect happened.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for int(subscribeCount.Load()) < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for reconnect after clean stream-end")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	cancel()
+	_ = w.Close()
+}
+
 func TestWatcher_TimeField(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

- The \`Subscribe\` RPC could close with an OK status when the server-side pub/sub backend restarts (e.g. Redis reconnect), but the proto comment and server code gave no indication that clients should treat this as a reconnect signal rather than a permanent stream end.
- Clarifies the full stream-lifetime contract in the proto comment so SDK implementors know an OK close requires backoff reconnect.
- Improves watcher diagnostic quality by logging clean server-initiated closes at Info and actual errors at Warn.

## Test plan

- [ ] `make test` passes (all modules, race detector)
- [ ] `make lint` passes (golangci-lint, buf lint, buf breaking)
- [ ] `make generate` regenerates pb.go with updated comment
- [ ] New test `TestWatcher_CleanStreamEndReconnects` verifies io.EOF triggers reconnect without context cancellation

Closes #462