### PR TITLE
feat(sdk/configclient): expose description, value_description, and expected_checksum on write operations

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -834,3 +834,94 @@ func (t *countingWriteTransport) SetField(_ context.Context, _ *SetFieldRequest)
 	}
 	return &SetFieldResponse{}, nil
 }
+
+// --- WriteOption tests ---
+
+func TestSet_WithDescription(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		return r.Description == "why" && r.ValueDescription == "what"
+	}, &SetFieldResponse{}, nil)
+
+	err := client.Set(ctx, "t1", "a", "v", WithDescription("why"), WithValueDescription("what"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSet_WithExpectedChecksum(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		return r.ExpectedChecksum != nil && *r.ExpectedChecksum == "abc"
+	}, &SetFieldResponse{}, nil)
+
+	err := client.Set(ctx, "t1", "a", "v", WithExpectedChecksum("abc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetMany_WithValueDescriptionsAndChecksums(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		if len(r.Updates) != 2 {
+			return false
+		}
+		byPath := map[string]FieldUpdate{}
+		for _, u := range r.Updates {
+			byPath[u.FieldPath] = u
+		}
+		aOK := byPath["a"].ValueDescription == "desc-a" &&
+			byPath["a"].ExpectedChecksum != nil && *byPath["a"].ExpectedChecksum == "chk-a"
+		bOK := byPath["b"].ValueDescription == "" && byPath["b"].ExpectedChecksum == nil
+		return aOK && bOK
+	}, &SetFieldsResponse{}, nil)
+
+	err := client.SetMany(ctx, "t1",
+		map[string]string{"a": "1", "b": "2"},
+		"batch",
+		WithValueDescriptions(map[string]string{"a": "desc-a"}),
+		WithFieldChecksums(map[string]string{"a": "chk-a"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLockedValue_Set_WithDescription(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{
+		FieldPath: "x", Value: StringVal("old"), Checksum: "chk",
+	}, nil)
+
+	lv, err := client.GetForUpdate(ctx, "t1", "x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		return r.Description == "my reason" && r.ValueDescription == "my val desc" &&
+			r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk"
+	}, &SetFieldResponse{}, nil)
+
+	err = lv.Set(ctx, "new", WithDescription("my reason"), WithValueDescription("my val desc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/sdk/configclient/transport.go
+++ b/sdk/configclient/transport.go
@@ -73,6 +73,7 @@ type SetFieldRequest struct {
 	Value            *TypedValue // nil sets the field to null
 	ExpectedChecksum *string
 	Description      string
+	ValueDescription string
 	IdempotencyKey   string
 }
 
@@ -84,6 +85,7 @@ type FieldUpdate struct {
 	FieldPath        string
 	Value            *TypedValue // nil sets the field to null
 	ExpectedChecksum *string
+	ValueDescription string
 }
 
 // SetFieldsRequest is the input for [Transport.SetFields].

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -14,7 +14,12 @@ import (
 type WriteOption func(*writeOptions)
 
 type writeOptions struct {
-	idempotencyKey string
+	idempotencyKey    string
+	description       string
+	valueDescription  string
+	expectedChecksum  string
+	valueDescriptions map[string]string // per-field value descriptions for batch writes
+	fieldChecksums    map[string]string // per-field expected checksums for batch writes
 }
 
 func applyWriteOptions(opts []WriteOption) writeOptions {
@@ -36,11 +41,42 @@ func WithIdempotencyKey(key string) WriteOption {
 	return func(o *writeOptions) { o.idempotencyKey = key }
 }
 
-// doWrite executes a write operation. Without an idempotency key, the call
-// is made exactly once regardless of retry configuration. With an idempotency
-// key and retry enabled on the client, transient errors trigger retry.
+// WithDescription sets a version-level description explaining why the change was made.
+func WithDescription(desc string) WriteOption {
+	return func(o *writeOptions) { o.description = desc }
+}
+
+// WithValueDescription sets a field-level description explaining what the value means.
+// Retrievable via include_description in read requests.
+func WithValueDescription(desc string) WriteOption {
+	return func(o *writeOptions) { o.valueDescription = desc }
+}
+
+// WithExpectedChecksum makes the write conditional: it succeeds only if the
+// field's current checksum matches the provided value. Returns [ErrChecksumMismatch]
+// on conflict. Use [Client.GetForUpdate] to obtain the current checksum.
+func WithExpectedChecksum(checksum string) WriteOption {
+	return func(o *writeOptions) { o.expectedChecksum = checksum }
+}
+
+// WithValueDescriptions sets per-field value descriptions for batch write operations
+// ([Client.SetMany], [Client.SetManyTyped]). The map key is the field path.
+func WithValueDescriptions(descs map[string]string) WriteOption {
+	return func(o *writeOptions) { o.valueDescriptions = descs }
+}
+
+// WithFieldChecksums sets per-field expected checksums for batch write operations
+// ([Client.SetMany], [Client.SetManyTyped]). The write fails with [ErrChecksumMismatch]
+// if any field's current checksum does not match. The map key is the field path.
+func WithFieldChecksums(checksums map[string]string) WriteOption {
+	return func(o *writeOptions) { o.fieldChecksums = checksums }
+}
+
+// doWrite executes a write operation. Without an idempotency key or expected
+// checksum, the call is made exactly once. With either (both make the write
+// idempotent) and retry enabled on the client, transient errors trigger retry.
 func doWrite(ctx context.Context, c *Client, wo writeOptions, fn func(ctx context.Context) error) error {
-	if wo.idempotencyKey != "" && c.opts.retryEnabled {
+	if (wo.idempotencyKey != "" || wo.expectedChecksum != "") && c.opts.retryEnabled {
 		return retryDo(ctx, c, fn)
 	}
 	return fn(ctx)
@@ -55,12 +91,18 @@ func doWrite(ctx context.Context, c *Client, wo writeOptions, fn func(ctx contex
 func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
-		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:       tenantID,
-			FieldPath:      fieldPath,
-			Value:          StringVal(value),
-			IdempotencyKey: wo.idempotencyKey,
-		})
+		req := &SetFieldRequest{
+			TenantID:         tenantID,
+			FieldPath:        fieldPath,
+			Value:            StringVal(value),
+			Description:      wo.description,
+			ValueDescription: wo.valueDescription,
+			IdempotencyKey:   wo.idempotencyKey,
+		}
+		if wo.expectedChecksum != "" {
+			req.ExpectedChecksum = &wo.expectedChecksum
+		}
+		_, err := c.transport.SetField(ctx, req)
 		return err
 	})
 }
@@ -74,12 +116,18 @@ func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opt
 func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
-		_, err := c.transport.SetField(ctx, &SetFieldRequest{
-			TenantID:       tenantID,
-			FieldPath:      fieldPath,
-			Value:          value,
-			IdempotencyKey: wo.idempotencyKey,
-		})
+		req := &SetFieldRequest{
+			TenantID:         tenantID,
+			FieldPath:        fieldPath,
+			Value:            value,
+			Description:      wo.description,
+			ValueDescription: wo.valueDescription,
+			IdempotencyKey:   wo.idempotencyKey,
+		}
+		if wo.expectedChecksum != "" {
+			req.ExpectedChecksum = &wo.expectedChecksum
+		}
+		_, err := c.transport.SetField(ctx, req)
 		return err
 	})
 }
@@ -93,11 +141,16 @@ func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value
 func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
-		_, err := c.transport.SetField(ctx, &SetFieldRequest{
+		req := &SetFieldRequest{
 			TenantID:       tenantID,
 			FieldPath:      fieldPath,
+			Description:    wo.description,
 			IdempotencyKey: wo.idempotencyKey,
-		})
+		}
+		if wo.expectedChecksum != "" {
+			req.ExpectedChecksum = &wo.expectedChecksum
+		}
+		_, err := c.transport.SetField(ctx, req)
 		return err
 	})
 }
@@ -113,11 +166,15 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))
 		for path, val := range values {
-			v := StringVal(val)
-			updates = append(updates, FieldUpdate{
-				FieldPath: path,
-				Value:     v,
-			})
+			u := FieldUpdate{
+				FieldPath:        path,
+				Value:            StringVal(val),
+				ValueDescription: wo.valueDescriptions[path],
+			}
+			if chk := wo.fieldChecksums[path]; chk != "" {
+				u.ExpectedChecksum = &chk
+			}
+			updates = append(updates, u)
 		}
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
 			TenantID:       tenantID,
@@ -140,10 +197,15 @@ func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[s
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		updates := make([]FieldUpdate, 0, len(values))
 		for path, v := range values {
-			updates = append(updates, FieldUpdate{
-				FieldPath: path,
-				Value:     v,
-			})
+			u := FieldUpdate{
+				FieldPath:        path,
+				Value:            v,
+				ValueDescription: wo.valueDescriptions[path],
+			}
+			if chk := wo.fieldChecksums[path]; chk != "" {
+				u.ExpectedChecksum = &chk
+			}
+			updates = append(updates, u)
 		}
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
 			TenantID:       tenantID,
@@ -199,13 +261,16 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 //
 // Because ExpectedChecksum makes this write idempotent, this method respects
 // the client's retry configuration.
-func (lv *LockedValue) Set(ctx context.Context, newValue string) error {
+func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOption) error {
+	wo := applyWriteOptions(opts)
 	return retryDo(ctx, lv.client, func(ctx context.Context) error {
 		_, err := lv.client.transport.SetField(ctx, &SetFieldRequest{
 			TenantID:         lv.tenantID,
 			FieldPath:        lv.FieldPath,
 			Value:            StringVal(newValue),
 			ExpectedChecksum: &lv.Checksum,
+			Description:      wo.description,
+			ValueDescription: wo.valueDescription,
 		})
 		return err
 	})

--- a/sdk/grpctransport/config_transport.go
+++ b/sdk/grpctransport/config_transport.go
@@ -112,6 +112,9 @@ func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFie
 	if req.Description != "" {
 		protoReq.Description = &req.Description
 	}
+	if req.ValueDescription != "" {
+		protoReq.ValueDescription = &req.ValueDescription
+	}
 	if req.IdempotencyKey != "" {
 		protoReq.IdempotencyKey = &req.IdempotencyKey
 	}
@@ -129,11 +132,15 @@ func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFi
 	}
 	updates := make([]*pb.FieldUpdate, len(req.Updates))
 	for i, u := range req.Updates {
-		updates[i] = &pb.FieldUpdate{
+		fu := &pb.FieldUpdate{
 			FieldPath:        u.FieldPath,
 			Value:            typedValueToProto(u.Value),
 			ExpectedChecksum: u.ExpectedChecksum,
 		}
+		if u.ValueDescription != "" {
+			fu.ValueDescription = &u.ValueDescription
+		}
+		updates[i] = fu
 	}
 	protoReq := &pb.SetFieldsRequest{
 		TenantId: req.TenantID,


### PR DESCRIPTION
## Summary

- The Go SDK write operations were missing three proto fields, making optimistic concurrency and annotated writes impossible without dropping to the lower-level grpctransport layer.
- Adds five new `WriteOption` functions (`WithDescription`, `WithValueDescription`, `WithExpectedChecksum`, `WithValueDescriptions`, `WithFieldChecksums`) that cover all missing fields for both single-field and batch writes.
- `LockedValue.Set` now accepts optional `WriteOption` args so CAS writes can carry description and value_description without a separate call.

## Test plan

- [ ] `TestSet_WithDescription` — verifies `description` and `value_description` reach the transport on `Set`
- [ ] `TestSet_WithExpectedChecksum` — verifies `expected_checksum` is set and enables retry in `doWrite`
- [ ] `TestSetMany_WithValueDescriptionsAndChecksums` — verifies per-field `value_description` and `expected_checksum` are set correctly in batch writes, with unspecified fields left nil
- [ ] `TestLockedValue_Set_WithDescription` — verifies `description` and `value_description` pass through `LockedValue.Set`
- [ ] All existing SDK and grpctransport tests continue to pass (`make test`)

Closes #491