### PR TITLE
Add WithDefaultTimeout server option for per-call deadline fallback

### DIFF
--- a/.agents/context/completed.md
+++ b/.agents/context/completed.md
@@ -216,3 +216,7 @@ Two bugs fixed together:
 - **Regression test** — `TestSetField_PreCommitInvalidationClosesStaleWindow` asserts `Invalidate` is called exactly twice per successful `SetField`.
 
 Pre-commit invalidation fires on all four write paths: `SetField`, `SetFields`, `RollbackToVersion`, `ImportConfig`.
+
+## Per-Call Default Timeout (#458)
+
+`server.WithDefaultTimeout(d time.Duration)` option adds a server-side deadline interceptor. When a client sends no deadline, the interceptor wraps the context with `context.WithTimeout(ctx, d)` before passing it to the handler chain. Existing client deadlines are left untouched. Enabled via `GRPC_DEFAULT_TIMEOUT` env var (e.g. `30s`); zero value disables. Interceptor runs immediately after the recovery interceptor so the deadline covers auth, rate limiting, and all handlers. `timeoutStream` wraps `grpc.ServerStream` with the deadline context for streaming RPCs.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -515,6 +515,7 @@ type serverConfig struct {
 	EnableReflection            bool
 	EnableUI                    bool
 	GatewayTrustedProxy         bool
+	GRPCDefaultTimeout          time.Duration // 0 = disabled
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
@@ -617,6 +618,7 @@ func loadConfig() serverConfig {
 		EnableReflection:            getEnv("ENABLE_REFLECTION", "") == "1",
 		EnableUI:                    getEnv("ENABLE_UI", "") == "1",
 		GatewayTrustedProxy:         getEnv("DECREE_GATEWAY_TRUSTED_PROXY", "") == "1",
+		GRPCDefaultTimeout:          parseEnvDuration("GRPC_DEFAULT_TIMEOUT", 0),
 	}
 }
 

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -20,6 +20,7 @@ type serverOptionsBuild struct {
 	HasPreAuthLimiter bool
 	HasRateLimiter    bool
 	HasReflection     bool
+	HasDefaultTimeout bool
 }
 
 func buildServerOptions(
@@ -57,6 +58,10 @@ func buildServerOptions(
 	if cfg.EnableReflection {
 		out.Opts = append(out.Opts, server.WithReflection())
 		out.HasReflection = true
+	}
+	if cfg.GRPCDefaultTimeout > 0 {
+		out.Opts = append(out.Opts, server.WithDefaultTimeout(cfg.GRPCDefaultTimeout))
+		out.HasDefaultTimeout = true
 	}
 	return out
 }

--- a/cmd/server/options_test.go
+++ b/cmd/server/options_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
@@ -116,6 +117,27 @@ func TestBuildServerOptions_ExtraGRPCOpts(t *testing.T) {
 	got := buildServerOptions(cfg, discardLogger(), extra, nil, nil, nil)
 
 	assert.Len(t, got.Opts, 6, "extra grpc opts go inside WithGRPCServerOptions, not as separate options")
+}
+
+func TestBuildServerOptions_DefaultTimeoutWired(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+	cfg.GRPCDefaultTimeout = 30 * time.Second
+
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
+
+	assert.True(t, got.HasDefaultTimeout, "non-zero GRPCDefaultTimeout must be wired")
+	assert.Len(t, got.Opts, 7, "5 base options + Insecure + DefaultTimeout")
+}
+
+func TestBuildServerOptions_DefaultTimeoutAbsent(t *testing.T) {
+	cfg := baseServerCfg()
+	cfg.InsecureListen = true
+
+	got := buildServerOptions(cfg, discardLogger(), nil, nil, nil, nil)
+
+	assert.False(t, got.HasDefaultTimeout, "zero GRPCDefaultTimeout must not produce an option")
+	assert.Len(t, got.Opts, 6)
 }
 
 func TestBuildGatewayOptions_TLS(t *testing.T) {

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log/slog"
+	"time"
 
 	"google.golang.org/grpc"
 )
@@ -20,6 +21,7 @@ type options struct {
 	preAuthLimiter   GRPCInterceptor // optional; runs before auth (unauthenticated flood protection)
 	rateLimiter      GRPCInterceptor // optional; runs after auth
 	enableReflection bool
+	defaultTimeout   time.Duration // optional; applied when client sends no deadline
 }
 
 // WithLogger sets the server logger. Defaults to slog.Default() when unset.
@@ -80,4 +82,10 @@ func WithRateLimiter(rl GRPCInterceptor) Option {
 // local dev or tooling environments (grpcurl, grpc-gateway introspection).
 func WithReflection() Option {
 	return func(o *options) { o.enableReflection = true }
+}
+
+// WithDefaultTimeout sets a server-side deadline applied to every request
+// whose client did not supply one. Zero or negative disables the feature.
+func WithDefaultTimeout(d time.Duration) Option {
+	return func(o *options) { o.defaultTimeout = d }
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,15 +74,20 @@ func New(grpcPort string, auth GRPCInterceptor, opts ...Option) (*Server, error)
 		}
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 	}
-	// Recovery wraps all middleware. Pre-auth limiter (when set) runs second to
-	// shed unauthenticated floods before JWT/JWKS validation. Auth runs third.
-	// Log-fields runs fourth to pull identity into context for the slog handler.
-	// Post-auth rate limiter (when set) runs last.
+	// Recovery wraps all middleware. Default timeout (when set) runs second so
+	// every subsequent interceptor and handler respects the deadline. Pre-auth
+	// limiter (when set) runs third to shed unauthenticated floods before
+	// JWT/JWKS validation. Auth runs fourth. Log-fields runs fifth. Post-auth
+	// rate limiter (when set) runs last.
 	unaryChain := []grpc.UnaryServerInterceptor{
 		recoveryUnaryInterceptor(o.logger),
 	}
 	streamChain := []grpc.StreamServerInterceptor{
 		recoveryStreamInterceptor(o.logger),
+	}
+	if o.defaultTimeout > 0 {
+		unaryChain = append(unaryChain, defaultTimeoutUnaryInterceptor(o.defaultTimeout))
+		streamChain = append(streamChain, defaultTimeoutStreamInterceptor(o.defaultTimeout))
 	}
 	if o.preAuthLimiter != nil {
 		unaryChain = append(unaryChain, o.preAuthLimiter.UnaryInterceptor())

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -455,9 +455,10 @@ func pollReflection(ctx context.Context, conn *grpc.ClientConn) error {
 	}
 }
 
-// slowServiceDesc registers a unary RPC that blocks until its context is done.
-// The handler threads through the gRPC interceptor chain so that server-side
-// interceptors (including the default-timeout interceptor) are exercised.
+// slowServiceDesc registers a unary RPC and a bidirectional streaming RPC that
+// each block until their context is done. The unary handler threads through the
+// gRPC interceptor chain; the stream handler blocks on ss.Context() (the
+// framework applies stream interceptors before invoking the handler).
 var slowServiceDesc = grpc.ServiceDesc{
 	ServiceName: "test.Slow",
 	HandlerType: (*any)(nil),
@@ -479,6 +480,17 @@ var slowServiceDesc = grpc.ServiceDesc{
 				info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/test.Slow/Wait"}
 				return interceptor(ctx, in, info, inner)
 			},
+		},
+	},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName: "WaitStream",
+			Handler: func(_ any, ss grpc.ServerStream) error {
+				<-ss.Context().Done()
+				return ss.Context().Err()
+			},
+			ClientStreams: true,
+			ServerStreams: true,
 		},
 	},
 }
@@ -507,6 +519,20 @@ func startTimeoutTestServer(t *testing.T, defaultTimeout time.Duration) (*grpc.C
 		srv.GracefulStop(context.Background())
 	}
 	return conn, cleanup
+}
+
+func TestDefaultTimeout_Stream_AppliedWhenClientSendsNoDeadline(t *testing.T) {
+	conn, cleanup := startTimeoutTestServer(t, 100*time.Millisecond)
+	defer cleanup()
+
+	desc := &grpc.StreamDesc{StreamName: "WaitStream", ClientStreams: true, ServerStreams: true}
+	stream, err := conn.NewStream(context.Background(), desc, "/test.Slow/WaitStream")
+	require.NoError(t, err)
+
+	out := &wrapperspb.BytesValue{}
+	err = stream.RecvMsg(out)
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 }
 
 func TestDefaultTimeout_AppliedWhenClientSendsNoDeadline(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -455,6 +455,104 @@ func pollReflection(ctx context.Context, conn *grpc.ClientConn) error {
 	}
 }
 
+// slowServiceDesc registers a unary RPC that blocks until its context is done.
+// The handler threads through the gRPC interceptor chain so that server-side
+// interceptors (including the default-timeout interceptor) are exercised.
+var slowServiceDesc = grpc.ServiceDesc{
+	ServiceName: "test.Slow",
+	HandlerType: (*any)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Wait",
+			Handler: func(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+				in := &wrapperspb.BytesValue{}
+				if err := dec(in); err != nil {
+					return nil, err
+				}
+				inner := func(ctx context.Context, _ any) (any, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+				if interceptor == nil {
+					return inner(ctx, in)
+				}
+				info := &grpc.UnaryServerInfo{Server: srv, FullMethod: "/test.Slow/Wait"}
+				return interceptor(ctx, in, info, inner)
+			},
+		},
+	},
+}
+
+func startTimeoutTestServer(t *testing.T, defaultTimeout time.Duration) (*grpc.ClientConn, func()) {
+	t.Helper()
+	opts := []Option{
+		WithLogger(slog.Default()),
+		WithInsecure(),
+	}
+	if defaultTimeout > 0 {
+		opts = append(opts, WithDefaultTimeout(defaultTimeout))
+	}
+	srv, err := New("0", &noopInterceptor{}, opts...)
+	require.NoError(t, err)
+	srv.grpcServer.RegisterService(&slowServiceDesc, struct{}{})
+
+	addr := srv.listener.Addr().String()
+	go func() { _ = srv.Serve(context.Background()) }()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = conn.Close()
+		srv.GracefulStop(context.Background())
+	}
+	return conn, cleanup
+}
+
+func TestDefaultTimeout_AppliedWhenClientSendsNoDeadline(t *testing.T) {
+	conn, cleanup := startTimeoutTestServer(t, 100*time.Millisecond)
+	defer cleanup()
+
+	// No deadline on the client context — server default should fire.
+	out := &wrapperspb.BytesValue{}
+	err := conn.Invoke(context.Background(), "/test.Slow/Wait", wrapperspb.Bytes([]byte{}), out)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
+func TestDefaultTimeout_NotAppliedWhenClientHasDeadline(t *testing.T) {
+	// Server default is long (1 s); client deadline is short (50 ms).
+	// Client deadline must win — we must not replace an existing deadline.
+	conn, cleanup := startTimeoutTestServer(t, time.Second)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	out := &wrapperspb.BytesValue{}
+	err := conn.Invoke(ctx, "/test.Slow/Wait", wrapperspb.Bytes([]byte{}), out)
+
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
+func TestDefaultTimeout_DisabledWhenNotSet(t *testing.T) {
+	// No WithDefaultTimeout — server must not impose any deadline.
+	conn, cleanup := startTimeoutTestServer(t, 0)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	out := &wrapperspb.BytesValue{}
+	err := conn.Invoke(ctx, "/test.Slow/Wait", wrapperspb.Bytes([]byte{}), out)
+
+	// The client's own 200 ms deadline fires; server imposed nothing extra.
+	require.Error(t, err)
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+}
+
 func TestReflection_DisabledByDefault_ReturnsUnimplemented(t *testing.T) {
 	conn, cleanup := startReflectionTestServer(t, false)
 	defer cleanup()

--- a/internal/server/timeout.go
+++ b/internal/server/timeout.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+func defaultTimeoutUnaryInterceptor(d time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, d)
+			defer cancel()
+		}
+		return handler(ctx, req)
+	}
+}
+
+func defaultTimeoutStreamInterceptor(d time.Duration) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if _, ok := ss.Context().Deadline(); !ok {
+			ctx, cancel := context.WithTimeout(ss.Context(), d)
+			defer cancel()
+			ss = &timeoutStream{ServerStream: ss, ctx: ctx}
+		}
+		return handler(srv, ss)
+	}
+}
+
+type timeoutStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *timeoutStream) Context() context.Context { return s.ctx }


### PR DESCRIPTION
## Summary

- Operators have no way to protect the server from clients that never set a deadline, which can hold handler goroutines indefinitely; this adds a configurable fallback.
- `WithDefaultTimeout(d)` applies `context.WithTimeout` server-side only when the client sent no deadline, leaving explicit client deadlines untouched.
- Enabled via `GRPC_DEFAULT_TIMEOUT` env var (e.g. `30s`); zero or unset disables the feature.

## Test plan

- `TestDefaultTimeout_AppliedWhenClientSendsNoDeadline` — server fires deadline when client sends none.
- `TestDefaultTimeout_NotAppliedWhenClientHasDeadline` — client's shorter deadline wins; server default is not imposed.
- `TestDefaultTimeout_DisabledWhenNotSet` — no `WithDefaultTimeout` → no server-side deadline applied.
- `TestBuildServerOptions_DefaultTimeoutWired` / `TestBuildServerOptions_DefaultTimeoutAbsent` — env-var wiring verified via `buildServerOptions`.
- All existing tests pass (`make test` green, `-race`).

Closes #458