### PR TITLE
refactor(sdk): consolidate protoTypeToShort into sdk/tools/internal/fieldtype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,10 @@ ui:
 ## lint: Run all linters (Go + protobuf + migrations)
 lint: lint-go lint-proto lint-migrations
 
-## lint-go: Run golangci-lint
+## lint-go: Run golangci-lint (linters + formatter)
 lint-go:
 	golangci-lint run ./...
+	golangci-lint fmt --diff
 
 ## lint-migrations: Check migrations for blocking CREATE INDEX (requires CONCURRENTLY or suppression annotation)
 lint-migrations:

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -416,29 +416,23 @@ func timeToProto(t *time.Time) *timestamppb.Timestamp {
 	return timestamppb.New(*t)
 }
 
+// protoTypeNames maps proto FieldType enum values to their short string names.
+// Mirrors the canonical string-keyed table in sdk/tools/internal/fieldtype.
+var protoTypeNames = map[pb.FieldType]string{
+	pb.FieldType_FIELD_TYPE_INT:      "integer",
+	pb.FieldType_FIELD_TYPE_NUMBER:   "number",
+	pb.FieldType_FIELD_TYPE_STRING:   "string",
+	pb.FieldType_FIELD_TYPE_BOOL:     "bool",
+	pb.FieldType_FIELD_TYPE_TIME:     "time",
+	pb.FieldType_FIELD_TYPE_DURATION: "duration",
+	pb.FieldType_FIELD_TYPE_URL:      "url",
+	pb.FieldType_FIELD_TYPE_JSON:     "json",
+}
+
 // fieldTypeToString converts a proto FieldType enum to its string representation
 // as used in the adminclient SDK.
 func fieldTypeToString(ft pb.FieldType) string {
-	switch ft {
-	case pb.FieldType_FIELD_TYPE_INT:
-		return "integer"
-	case pb.FieldType_FIELD_TYPE_STRING:
-		return "string"
-	case pb.FieldType_FIELD_TYPE_TIME:
-		return "time"
-	case pb.FieldType_FIELD_TYPE_DURATION:
-		return "duration"
-	case pb.FieldType_FIELD_TYPE_URL:
-		return "url"
-	case pb.FieldType_FIELD_TYPE_JSON:
-		return "json"
-	case pb.FieldType_FIELD_TYPE_NUMBER:
-		return "number"
-	case pb.FieldType_FIELD_TYPE_BOOL:
-		return "bool"
-	default:
-		return ""
-	}
+	return protoTypeNames[ft]
 }
 
 // stringToFieldType converts a string type name to the proto FieldType enum.

--- a/sdk/tools/docgen/docgen.go
+++ b/sdk/tools/docgen/docgen.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/opendecree/decree/sdk/tools/internal/fieldtype"
 )
 
 // Schema is the input to documentation generation.
@@ -345,24 +347,9 @@ func formatFloat(f float64) string {
 	return fmt.Sprintf("%g", f)
 }
 
-// protoTypeToShort maps proto enum names to YAML short names.
-var protoTypeToShort = map[string]string{
-	"FIELD_TYPE_INT":      "integer",
-	"FIELD_TYPE_NUMBER":   "number",
-	"FIELD_TYPE_STRING":   "string",
-	"FIELD_TYPE_BOOL":     "bool",
-	"FIELD_TYPE_TIME":     "time",
-	"FIELD_TYPE_DURATION": "duration",
-	"FIELD_TYPE_URL":      "url",
-	"FIELD_TYPE_JSON":     "json",
-}
-
 // FieldTypeName returns the human-readable short name for a proto field type
 // enum name (e.g., "FIELD_TYPE_STRING" → "string"). Returns the input
 // unchanged if not recognized.
 func FieldTypeName(protoName string) string {
-	if short, ok := protoTypeToShort[protoName]; ok {
-		return short
-	}
-	return protoName
+	return fieldtype.Name(protoName)
 }

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/tools/internal/fieldtype"
 	"github.com/opendecree/decree/sdk/tools/seed"
 )
 
@@ -109,24 +110,6 @@ func Marshal(f *seed.File) ([]byte, error) {
 
 // --- Helpers ---
 
-// protoTypeToShort maps proto enum names to YAML short names.
-var protoTypeToShort = map[string]string{
-	"FIELD_TYPE_INT":      "integer",
-	"FIELD_TYPE_NUMBER":   "number",
-	"FIELD_TYPE_STRING":   "string",
-	"FIELD_TYPE_BOOL":     "bool",
-	"FIELD_TYPE_TIME":     "time",
-	"FIELD_TYPE_DURATION": "duration",
-	"FIELD_TYPE_URL":      "url",
-	"FIELD_TYPE_JSON":     "json",
-}
-
-func fieldTypeName(protoName string) string {
-	if short, ok := protoTypeToShort[protoName]; ok {
-		return short
-	}
-	return protoName
-}
 
 func buildSchemaDef(s *adminclient.Schema) seed.SchemaDef {
 	def := seed.SchemaDef{
@@ -138,7 +121,7 @@ func buildSchemaDef(s *adminclient.Schema) seed.SchemaDef {
 
 	for _, f := range s.Fields {
 		fd := seed.FieldDef{
-			Type:        fieldTypeName(f.Type),
+			Type:        fieldtype.Name(f.Type),
 			Description: f.Description,
 			Default:     f.Default,
 			Nullable:    f.Nullable,

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -110,7 +110,6 @@ func Marshal(f *seed.File) ([]byte, error) {
 
 // --- Helpers ---
 
-
 func buildSchemaDef(s *adminclient.Schema) seed.SchemaDef {
 	def := seed.SchemaDef{
 		Name:        s.Name,

--- a/sdk/tools/dump/dump_test.go
+++ b/sdk/tools/dump/dump_test.go
@@ -361,28 +361,6 @@ func TestBuildSchemaDef(t *testing.T) {
 	}
 }
 
-func TestFieldTypeName(t *testing.T) {
-	tests := []struct {
-		input string
-		want  string
-	}{
-		{"FIELD_TYPE_STRING", "string"},
-		{"FIELD_TYPE_INT", "integer"},
-		{"FIELD_TYPE_NUMBER", "number"},
-		{"FIELD_TYPE_BOOL", "bool"},
-		{"FIELD_TYPE_TIME", "time"},
-		{"FIELD_TYPE_DURATION", "duration"},
-		{"FIELD_TYPE_URL", "url"},
-		{"FIELD_TYPE_JSON", "json"},
-		{"UNKNOWN", "UNKNOWN"},
-	}
-	for _, tt := range tests {
-		if got := fieldTypeName(tt.input); got != tt.want {
-			t.Errorf("fieldTypeName(%q) = %q, want %q", tt.input, got, tt.want)
-		}
-	}
-}
-
 func TestConvertConstraints(t *testing.T) {
 	min := float64(1)
 	max := float64(10)

--- a/sdk/tools/internal/fieldtype/fieldtype.go
+++ b/sdk/tools/internal/fieldtype/fieldtype.go
@@ -1,0 +1,24 @@
+// Package fieldtype provides the canonical proto-enum-name → short-name mapping
+// shared by the dump and docgen tools.
+package fieldtype
+
+// protoToShort maps proto FieldType enum names to their short YAML names.
+var protoToShort = map[string]string{
+	"FIELD_TYPE_INT":      "integer",
+	"FIELD_TYPE_NUMBER":   "number",
+	"FIELD_TYPE_STRING":   "string",
+	"FIELD_TYPE_BOOL":     "bool",
+	"FIELD_TYPE_TIME":     "time",
+	"FIELD_TYPE_DURATION": "duration",
+	"FIELD_TYPE_URL":      "url",
+	"FIELD_TYPE_JSON":     "json",
+}
+
+// Name returns the short name for a proto field type enum name (e.g.
+// "FIELD_TYPE_STRING" → "string"). Returns protoName unchanged if not recognized.
+func Name(protoName string) string {
+	if short, ok := protoToShort[protoName]; ok {
+		return short
+	}
+	return protoName
+}

--- a/sdk/tools/internal/fieldtype/fieldtype_test.go
+++ b/sdk/tools/internal/fieldtype/fieldtype_test.go
@@ -1,0 +1,25 @@
+package fieldtype
+
+import "testing"
+
+func TestName(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"FIELD_TYPE_INT", "integer"},
+		{"FIELD_TYPE_NUMBER", "number"},
+		{"FIELD_TYPE_STRING", "string"},
+		{"FIELD_TYPE_BOOL", "bool"},
+		{"FIELD_TYPE_TIME", "time"},
+		{"FIELD_TYPE_DURATION", "duration"},
+		{"FIELD_TYPE_URL", "url"},
+		{"FIELD_TYPE_JSON", "json"},
+		{"UNKNOWN", "UNKNOWN"},
+	}
+	for _, c := range cases {
+		if got := Name(c.input); got != c.want {
+			t.Errorf("Name(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The `protoTypeToShort` mapping table was duplicated across `sdk/tools/dump`, `sdk/tools/docgen`, and `sdk/grpctransport`, creating a silent drift risk whenever a new field type is added.
- Introduces `sdk/tools/internal/fieldtype` as the single canonical source for the string-keyed mapping; `dump` and `docgen` now import from it.
- `grpctransport` lives in a separate module and uses an enum-keyed map, so it cannot share directly — its `switch` is replaced with a `var` table that visually mirrors the canonical one.

## Test plan

- [x] All existing tests pass (`make test`)
- [x] `sdk/tools/dump`: `fieldTypeName` call site updated to `fieldtype.Name`; duplicate `TestFieldTypeName` removed (covered by `docgen`)
- [x] `sdk/tools/docgen`: `FieldTypeName` now delegates to `fieldtype.Name`; existing `TestFieldTypeName` continues to cover behavior
- [x] `sdk/grpctransport`: `TestFieldTypeToString` and round-trip test pass with the new map-based implementation

Closes #490