### PR TITLE
feat(adminclient): type Field.Type as FieldType enum, not string

### DIFF
--- a/cmd/decree/docgen.go
+++ b/cmd/decree/docgen.go
@@ -102,7 +102,7 @@ func adminSchemaToDocgen(s *adminclient.Schema) docgen.Schema {
 	for i, f := range s.Fields {
 		ds.Fields[i] = docgen.Field{
 			Path:        f.Path,
-			Type:        docgen.FieldTypeName(f.Type),
+			Type:        string(f.Type),
 			Description: f.Description,
 			Default:     f.Default,
 			Nullable:    f.Nullable,

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -77,7 +77,7 @@ var schemaGetCmd = &cobra.Command{
 
 		rows := tableRows([]string{"PATH", "TYPE", "NULLABLE", "DEPRECATED", "DESCRIPTION"})
 		for _, f := range s.Fields {
-			rows = append(rows, []string{f.Path, f.Type, strconv.FormatBool(f.Nullable), strconv.FormatBool(f.Deprecated), f.Description})
+			rows = append(rows, []string{f.Path, string(f.Type), strconv.FormatBool(f.Nullable), strconv.FormatBool(f.Deprecated), f.Description})
 		}
 		fmt.Printf("Schema: %s (%s) v%d [published=%v]\n\n", s.Name, s.ID, s.Version, s.Published)
 		return printOutput(rows)

--- a/cmd/decree/typed.go
+++ b/cmd/decree/typed.go
@@ -74,7 +74,7 @@ func tenantFieldTypes(ctx context.Context, admin *adminclient.Client, tenantID s
 	}
 	types := make(map[string]string, len(s.Fields))
 	for _, f := range s.Fields {
-		types[f.Path] = f.Type
+		types[f.Path] = string(f.Type)
 	}
 	return types, nil
 }

--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -144,11 +144,11 @@ func bootstrapMatrixFixture(t *testing.T, namePrefix string) *matrixFixture {
 
 	schemaName := fmt.Sprintf("%s-%s", namePrefix, randSuffix())
 	s, err := admin.CreateSchema(ctx, schemaName, []adminclient.Field{
-		{Path: "app.name", Type: "FIELD_TYPE_STRING", Nullable: true},
-		{Path: "app.retries", Type: "FIELD_TYPE_INT", Nullable: true},
-		{Path: "app.rate", Type: "FIELD_TYPE_NUMBER"},
-		{Path: "app.enabled", Type: "FIELD_TYPE_BOOL"},
-		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "app.name", Type: adminclient.FieldTypeString, Nullable: true},
+		{Path: "app.retries", Type: adminclient.FieldTypeInteger, Nullable: true},
+		{Path: "app.rate", Type: adminclient.FieldTypeNumber},
+		{Path: "app.enabled", Type: adminclient.FieldTypeBool},
+		{Path: "app.timeout", Type: adminclient.FieldTypeDuration},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/bench_audit_test.go
+++ b/e2e/bench_audit_test.go
@@ -22,7 +22,7 @@ func benchAuditEnv(b *testing.B, name string, writes int) (*adminclient.Client, 
 	ctx := context.Background()
 
 	s, err := admin.CreateSchema(ctx, name, []adminclient.Field{
-		{Path: "bench.string", Type: "FIELD_TYPE_STRING"},
+		{Path: "bench.string", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(b, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/bench_schema_test.go
+++ b/e2e/bench_schema_test.go
@@ -29,7 +29,7 @@ func BenchmarkCreateSchema(b *testing.B) {
 	for i := 0; b.Loop(); i++ {
 		start := time.Now()
 		s, _ := admin.CreateSchema(ctx, fmt.Sprintf("bench-create-%d", i), []adminclient.Field{
-			{Path: "f.value", Type: "FIELD_TYPE_STRING"},
+			{Path: "f.value", Type: adminclient.FieldTypeString},
 		}, "")
 		latencies = append(latencies, float64(time.Since(start).Nanoseconds()))
 		if s != nil {
@@ -55,7 +55,7 @@ func BenchmarkPublishSchemaVersion(b *testing.B) {
 	for i := 0; b.Loop(); i++ {
 		b.StopTimer()
 		s, err := admin.CreateSchema(ctx, fmt.Sprintf("bench-pub-%d", i), []adminclient.Field{
-			{Path: "f.value", Type: "FIELD_TYPE_STRING"},
+			{Path: "f.value", Type: adminclient.FieldTypeString},
 		}, "")
 		if err != nil || s == nil {
 			b.StartTimer()

--- a/e2e/bench_test.go
+++ b/e2e/bench_test.go
@@ -24,10 +24,10 @@ func benchEnv(b *testing.B, name string) (*configclient.Client, string, func()) 
 	ctx := context.Background()
 
 	s, err := admin.CreateSchema(ctx, name, []adminclient.Field{
-		{Path: "bench.string", Type: "FIELD_TYPE_STRING"},
-		{Path: "bench.int", Type: "FIELD_TYPE_INT"},
-		{Path: "bench.bool", Type: "FIELD_TYPE_BOOL"},
-		{Path: "bench.number", Type: "FIELD_TYPE_NUMBER"},
+		{Path: "bench.string", Type: adminclient.FieldTypeString},
+		{Path: "bench.int", Type: adminclient.FieldTypeInteger},
+		{Path: "bench.bool", Type: adminclient.FieldTypeBool},
+		{Path: "bench.number", Type: adminclient.FieldTypeNumber},
 	}, "")
 	require.NoError(b, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
@@ -187,7 +187,7 @@ func benchGetFields(b *testing.B, name string, fieldCount int) {
 	paths := make([]string, fieldCount)
 	for i := range fields {
 		paths[i] = fmt.Sprintf("f.field_%d", i)
-		fields[i] = adminclient.Field{Path: paths[i], Type: "FIELD_TYPE_STRING"}
+		fields[i] = adminclient.Field{Path: paths[i], Type: adminclient.FieldTypeString}
 	}
 	s, err := admin.CreateSchema(ctx, name, fields, "")
 	require.NoError(b, err)
@@ -230,7 +230,7 @@ func benchImport(b *testing.B, name string, fieldCount int) {
 	// Create schema with N string fields.
 	fields := make([]adminclient.Field, fieldCount)
 	for i := range fields {
-		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: "FIELD_TYPE_STRING"}
+		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: adminclient.FieldTypeString}
 	}
 	s, err := admin.CreateSchema(ctx, name, fields, "")
 	require.NoError(b, err)

--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -25,9 +25,9 @@ func TestFullFlow(t *testing.T) {
 
 	// 1. Create and publish a schema.
 	s, err := admin.CreateSchema(ctx, "settlement-e2e", []adminclient.Field{
-		{Path: "settlement.window", Type: "FIELD_TYPE_DURATION"},
-		{Path: "settlement.currency", Type: "FIELD_TYPE_STRING"},
-		{Path: "settlement.fee", Type: "FIELD_TYPE_STRING"},
+		{Path: "settlement.window", Type: adminclient.FieldTypeDuration},
+		{Path: "settlement.currency", Type: adminclient.FieldTypeString},
+		{Path: "settlement.fee", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
@@ -151,11 +151,11 @@ func TestConfigExportImport(t *testing.T) {
 
 	// 1. Create and publish a schema with typed fields.
 	s, err := admin.CreateSchema(ctx, "config-export-e2e", []adminclient.Field{
-		{Path: "app.enabled", Type: "FIELD_TYPE_BOOL"},
-		{Path: "app.max_retries", Type: "FIELD_TYPE_INT"},
-		{Path: "app.fee_rate", Type: "FIELD_TYPE_NUMBER"},
-		{Path: "app.name", Type: "FIELD_TYPE_STRING"},
-		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "app.enabled", Type: adminclient.FieldTypeBool},
+		{Path: "app.max_retries", Type: adminclient.FieldTypeInteger},
+		{Path: "app.fee_rate", Type: adminclient.FieldTypeNumber},
+		{Path: "app.name", Type: adminclient.FieldTypeString},
+		{Path: "app.timeout", Type: adminclient.FieldTypeDuration},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/errors_test.go
+++ b/e2e/errors_test.go
@@ -28,7 +28,7 @@ func TestErrorCases(t *testing.T) {
 
 	t.Run("create tenant with unpublished schema", func(t *testing.T) {
 		s, err := admin.CreateSchema(ctx, "unpublished-e2e", []adminclient.Field{
-			{Path: "x", Type: "FIELD_TYPE_STRING"},
+			{Path: "x", Type: adminclient.FieldTypeString},
 		}, "")
 		require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestErrorCases(t *testing.T) {
 	t.Run("get nonexistent config field", func(t *testing.T) {
 		// Create schema + tenant to have a valid tenant ID.
 		s, err := admin.CreateSchema(ctx, "err-cfg-e2e", []adminclient.Field{
-			{Path: "x", Type: "FIELD_TYPE_STRING"},
+			{Path: "x", Type: adminclient.FieldTypeString},
 		}, "")
 		require.NoError(t, err)
 		_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/jwt_fixture_test.go
+++ b/e2e/jwt_fixture_test.go
@@ -209,11 +209,11 @@ func bootstrapJWTMatrixFixture(t *testing.T, issuer *jwtIssuer, conn *grpc.Clien
 
 	schemaName := fmt.Sprintf("%s-%s", namePrefix, randSuffix())
 	s, err := admin.CreateSchema(ctx, schemaName, []adminclient.Field{
-		{Path: "app.name", Type: "FIELD_TYPE_STRING", Nullable: true},
-		{Path: "app.retries", Type: "FIELD_TYPE_INT", Nullable: true},
-		{Path: "app.rate", Type: "FIELD_TYPE_NUMBER"},
-		{Path: "app.enabled", Type: "FIELD_TYPE_BOOL"},
-		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "app.name", Type: adminclient.FieldTypeString, Nullable: true},
+		{Path: "app.retries", Type: adminclient.FieldTypeInteger, Nullable: true},
+		{Path: "app.rate", Type: adminclient.FieldTypeNumber},
+		{Path: "app.enabled", Type: adminclient.FieldTypeBool},
+		{Path: "app.timeout", Type: adminclient.FieldTypeDuration},
 	}, "")
 	if err != nil {
 		t.Fatalf("bootstrapJWTMatrixFixture CreateSchema: %v", err)

--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -99,7 +99,7 @@ func allRPCs() []rpcSpec {
 			invoke: func(ctx context.Context, t *testing.T, c *clients, _ *matrixFixture) error {
 				s := mustCreateThrowawaySchema(ctx, t, c.bootstrapAdmin, "m1-update")
 				_, err := c.admin.UpdateSchema(ctx, s.ID,
-					[]adminclient.Field{{Path: "extra", Type: "FIELD_TYPE_STRING"}}, nil, "matrix update")
+					[]adminclient.Field{{Path: "extra", Type: adminclient.FieldTypeString}}, nil, "matrix update")
 				return err
 			},
 		},
@@ -412,7 +412,7 @@ func invokeSubscribe(c *clients, tenantID string) error {
 // --- shared throwaway helpers (used by matrix 1 + 2) ---
 
 func oneStringField() []adminclient.Field {
-	return []adminclient.Field{{Path: "x", Type: "FIELD_TYPE_STRING"}}
+	return []adminclient.Field{{Path: "x", Type: adminclient.FieldTypeString}}
 }
 
 func mustCreateThrowawaySchema(ctx context.Context, t *testing.T, admin *adminclient.Client, prefix string) *adminclient.Schema {

--- a/e2e/schema_test.go
+++ b/e2e/schema_test.go
@@ -22,9 +22,9 @@ func TestSchemaLifecycle(t *testing.T) {
 
 	// Create schema with fields.
 	s, err := admin.CreateSchema(ctx, "payments-e2e", []adminclient.Field{
-		{Path: "payments.fee", Type: "FIELD_TYPE_STRING", Description: "Transaction fee percentage"},
-		{Path: "payments.currency", Type: "FIELD_TYPE_STRING", Description: "Default currency"},
-		{Path: "payments.timeout", Type: "FIELD_TYPE_DURATION", Description: "Payment timeout"},
+		{Path: "payments.fee", Type: adminclient.FieldTypeString, Description: "Transaction fee percentage"},
+		{Path: "payments.currency", Type: adminclient.FieldTypeString, Description: "Default currency"},
+		{Path: "payments.timeout", Type: adminclient.FieldTypeDuration, Description: "Payment timeout"},
 	}, "E2E test schema")
 	require.NoError(t, err)
 	assert.NotEmpty(t, s.ID)
@@ -45,7 +45,7 @@ func TestSchemaLifecycle(t *testing.T) {
 
 	// Update schema — add a field, creates v2.
 	updated, err := admin.UpdateSchema(ctx, s.ID, []adminclient.Field{
-		{Path: "payments.max_retries", Type: "FIELD_TYPE_INT", Description: "Max retry count"},
+		{Path: "payments.max_retries", Type: adminclient.FieldTypeInteger, Description: "Max retry count"},
 	}, nil, "Add max_retries field")
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), updated.Version)
@@ -83,9 +83,9 @@ func TestSchemaExportImport(t *testing.T) {
 
 	// 1. Create a schema with fields.
 	s, err := admin.CreateSchema(ctx, "export-e2e", []adminclient.Field{
-		{Path: "trade.fee", Type: "FIELD_TYPE_STRING", Description: "Fee percentage"},
-		{Path: "trade.currency", Type: "FIELD_TYPE_STRING"},
-		{Path: "trade.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "trade.fee", Type: adminclient.FieldTypeString, Description: "Fee percentage"},
+		{Path: "trade.currency", Type: adminclient.FieldTypeString},
+		{Path: "trade.timeout", Type: adminclient.FieldTypeDuration},
 	}, "Schema for export testing")
 	require.NoError(t, err)
 

--- a/e2e/security_test.go
+++ b/e2e/security_test.go
@@ -97,7 +97,7 @@ func TestSecurity_SensitiveFieldRedacted(t *testing.T) {
 
 	// Create schema with one sensitive field.
 	s, err := admin.CreateSchema(ctx, "sec-sensitive-"+randSuffix(), []adminclient.Field{
-		{Path: "auth.token", Type: "FIELD_TYPE_STRING", Sensitive: true},
+		{Path: "auth.token", Type: adminclient.FieldTypeString, Sensitive: true},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
@@ -189,7 +189,7 @@ func TestSecurity_SchemaLimitsEnforced(t *testing.T) {
 		for i := range fields {
 			fields[i] = adminclient.Field{
 				Path: fmt.Sprintf("f.field_%d", i),
-				Type: "FIELD_TYPE_STRING",
+				Type: adminclient.FieldTypeString,
 			}
 		}
 		_, err := admin.CreateSchema(ctx, "sec-limits-fields-"+randSuffix(), fields, "")
@@ -221,7 +221,7 @@ func TestSecurity_SchemaLimitsEnforced(t *testing.T) {
 		s, err := admin.CreateSchema(ctx, "sec-json-depth-"+randSuffix(), []adminclient.Field{
 			{
 				Path: "data.payload",
-				Type: "FIELD_TYPE_JSON",
+				Type: adminclient.FieldTypeJSON,
 				Constraints: &adminclient.FieldConstraints{
 					JSONSchema: deepSchema,
 				},
@@ -347,8 +347,8 @@ func TestSecurity_ImportConfigSensitiveFieldRedacted(t *testing.T) {
 	const secretValue = "import-s3cr3t-abc123"
 
 	s, err := admin.CreateSchema(ctx, "sec-import-sensitive-"+randSuffix(), []adminclient.Field{
-		{Path: "auth.token", Type: "FIELD_TYPE_STRING", Sensitive: true},
-		{Path: "app.name", Type: "FIELD_TYPE_STRING"},
+		{Path: "auth.token", Type: adminclient.FieldTypeString, Sensitive: true},
+		{Path: "app.name", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/stream_test.go
+++ b/e2e/stream_test.go
@@ -26,8 +26,8 @@ func TestConfigSubscription(t *testing.T) {
 
 	// Setup: schema + tenant via adminclient.
 	s, err := admin.CreateSchema(ctx, "stream-e2e", []adminclient.Field{
-		{Path: "notify.enabled", Type: "FIELD_TYPE_STRING"},
-		{Path: "notify.channel", Type: "FIELD_TYPE_STRING"},
+		{Path: "notify.enabled", Type: adminclient.FieldTypeString},
+		{Path: "notify.channel", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/tenant_test.go
+++ b/e2e/tenant_test.go
@@ -38,7 +38,7 @@ func TestUpdateTenantName(t *testing.T) {
 	ctx := context.Background()
 
 	s, err := admin.CreateSchema(ctx, "rename-tenant-e2e", []adminclient.Field{
-		{Path: "x", Type: "FIELD_TYPE_STRING"},
+		{Path: "x", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
@@ -71,7 +71,7 @@ func TestUpdateTenantSchemaVersion(t *testing.T) {
 
 	// v1 has only `app.value` (string).
 	s, err := admin.CreateSchema(ctx, "tenant-upgrade-e2e", []adminclient.Field{
-		{Path: "app.value", Type: "FIELD_TYPE_STRING"},
+		{Path: "app.value", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
@@ -79,7 +79,7 @@ func TestUpdateTenantSchemaVersion(t *testing.T) {
 
 	// v2 drops `app.value`, adds `app.count`.
 	_, err = admin.UpdateSchema(ctx, s.ID,
-		[]adminclient.Field{{Path: "app.count", Type: "FIELD_TYPE_INT"}},
+		[]adminclient.Field{{Path: "app.count", Type: adminclient.FieldTypeInteger}},
 		[]string{"app.value"},
 		"v2: swap fields",
 	)
@@ -120,14 +120,14 @@ func TestUpdateTenantBothFields(t *testing.T) {
 	ctx := context.Background()
 
 	s, err := admin.CreateSchema(ctx, "tenant-both-e2e", []adminclient.Field{
-		{Path: "k", Type: "FIELD_TYPE_STRING"},
+		{Path: "k", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)
 	require.NoError(t, err)
 
 	_, err = admin.UpdateSchema(ctx, s.ID,
-		[]adminclient.Field{{Path: "k2", Type: "FIELD_TYPE_STRING"}},
+		[]adminclient.Field{{Path: "k2", Type: adminclient.FieldTypeString}},
 		nil,
 		"v2: add k2",
 	)
@@ -159,14 +159,14 @@ func TestListTenantsWithAccessFiltering(t *testing.T) {
 
 	// Two schemas so we can also test the SchemaId-filtered path.
 	sA, err := admin.CreateSchema(ctx, "tenant-filter-a", []adminclient.Field{
-		{Path: "f", Type: "FIELD_TYPE_STRING"},
+		{Path: "f", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, sA.ID, 1)
 	require.NoError(t, err)
 
 	sB, err := admin.CreateSchema(ctx, "tenant-filter-b", []adminclient.Field{
-		{Path: "f", Type: "FIELD_TYPE_STRING"},
+		{Path: "f", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, sB.ID, 1)

--- a/e2e/type_matrix_test.go
+++ b/e2e/type_matrix_test.go
@@ -42,7 +42,7 @@ var sampleSeq int64
 
 // typeCase describes one field type for matrix 3.
 type typeCase struct {
-	name      string                                       // "string", "integer", ...
+	name      string // "string", "integer", ...
 	fieldType adminclient.FieldType
 	sample    func() *configclient.TypedValue              // a fresh sample value
 	yamlValue func(sample *configclient.TypedValue) string // YAML literal for ImportConfig

--- a/e2e/type_matrix_test.go
+++ b/e2e/type_matrix_test.go
@@ -43,7 +43,7 @@ var sampleSeq int64
 // typeCase describes one field type for matrix 3.
 type typeCase struct {
 	name      string                                       // "string", "integer", ...
-	fieldType string                                       // "FIELD_TYPE_STRING"
+	fieldType adminclient.FieldType
 	sample    func() *configclient.TypedValue              // a fresh sample value
 	yamlValue func(sample *configclient.TypedValue) string // YAML literal for ImportConfig
 	verifyEq  func(t *testing.T, want, got *configclient.TypedValue)
@@ -52,7 +52,7 @@ type typeCase struct {
 func typeCases() []typeCase {
 	return []typeCase{
 		{
-			name: "string", fieldType: "FIELD_TYPE_STRING",
+			name: "string", fieldType: adminclient.FieldTypeString,
 			sample:    func() *configclient.TypedValue { return configclient.StringVal("hello-" + randSuffix()) },
 			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustStringValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
@@ -60,7 +60,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "integer", fieldType: "FIELD_TYPE_INT",
+			name: "integer", fieldType: adminclient.FieldTypeInteger,
 			sample: func() *configclient.TypedValue {
 				return configclient.IntVal(atomic.AddInt64(&sampleSeq, 1))
 			},
@@ -70,7 +70,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "number", fieldType: "FIELD_TYPE_NUMBER",
+			name: "number", fieldType: adminclient.FieldTypeNumber,
 			sample: func() *configclient.TypedValue {
 				return configclient.FloatVal(float64(atomic.AddInt64(&sampleSeq, 1)) / 100)
 			},
@@ -80,7 +80,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "bool", fieldType: "FIELD_TYPE_BOOL",
+			name: "bool", fieldType: adminclient.FieldTypeBool,
 			sample: func() *configclient.TypedValue {
 				return configclient.BoolVal(atomic.AddInt64(&sampleSeq, 1)%2 == 0)
 			},
@@ -90,7 +90,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "time", fieldType: "FIELD_TYPE_TIME",
+			name: "time", fieldType: adminclient.FieldTypeTime,
 			sample: func() *configclient.TypedValue {
 				return configclient.TimeVal(time.Unix(atomic.AddInt64(&sampleSeq, 1), 0).UTC())
 			},
@@ -103,7 +103,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "duration", fieldType: "FIELD_TYPE_DURATION",
+			name: "duration", fieldType: adminclient.FieldTypeDuration,
 			sample: func() *configclient.TypedValue {
 				return configclient.DurationVal(time.Duration(atomic.AddInt64(&sampleSeq, 1)) * time.Second)
 			},
@@ -113,7 +113,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "url", fieldType: "FIELD_TYPE_URL",
+			name: "url", fieldType: adminclient.FieldTypeURL,
 			sample:    func() *configclient.TypedValue { return configclient.URLVal("https://example.com/" + randSuffix()) },
 			yamlValue: func(tv *configclient.TypedValue) string { return fmt.Sprintf("%q", tv.MustURLValue()) },
 			verifyEq: func(t *testing.T, want, got *configclient.TypedValue) {
@@ -121,7 +121,7 @@ func typeCases() []typeCase {
 			},
 		},
 		{
-			name: "json", fieldType: "FIELD_TYPE_JSON",
+			name: "json", fieldType: adminclient.FieldTypeJSON,
 			sample: func() *configclient.TypedValue {
 				return configclient.JSONVal(fmt.Sprintf(`{"k":"v-%d"}`, atomic.AddInt64(&sampleSeq, 1)))
 			},

--- a/e2e/typed_test.go
+++ b/e2e/typed_test.go
@@ -23,11 +23,11 @@ func TestTypedValuesAndNull(t *testing.T) {
 
 	// 1. Create schema with all types.
 	s, err := admin.CreateSchema(ctx, "typed-e2e", []adminclient.Field{
-		{Path: "app.retries", Type: "FIELD_TYPE_INT", Nullable: true},
-		{Path: "app.rate", Type: "FIELD_TYPE_NUMBER"},
-		{Path: "app.name", Type: "FIELD_TYPE_STRING", Nullable: true},
-		{Path: "app.enabled", Type: "FIELD_TYPE_BOOL"},
-		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
+		{Path: "app.retries", Type: adminclient.FieldTypeInteger, Nullable: true},
+		{Path: "app.rate", Type: adminclient.FieldTypeNumber},
+		{Path: "app.name", Type: adminclient.FieldTypeString, Nullable: true},
+		{Path: "app.enabled", Type: adminclient.FieldTypeBool},
+		{Path: "app.timeout", Type: adminclient.FieldTypeDuration},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -27,8 +27,8 @@ func TestUpgrade_Populate(t *testing.T) {
 	ctx := context.Background()
 
 	s, err := admin.CreateSchema(ctx, upgradeSchemaName, []adminclient.Field{
-		{Path: "app.timeout", Type: "FIELD_TYPE_DURATION"},
-		{Path: "app.region", Type: "FIELD_TYPE_STRING"},
+		{Path: "app.timeout", Type: adminclient.FieldTypeDuration},
+		{Path: "app.region", Type: adminclient.FieldTypeString},
 	}, "upgrade e2e fixture")
 	require.NoError(t, err)
 

--- a/e2e/usage_test.go
+++ b/e2e/usage_test.go
@@ -21,9 +21,9 @@ func TestUsageTracking(t *testing.T) {
 
 	// 1. Create schema + tenant + set values.
 	s, err := admin.CreateSchema(ctx, "usage-e2e", []adminclient.Field{
-		{Path: "billing.fee", Type: "FIELD_TYPE_STRING"},
-		{Path: "billing.currency", Type: "FIELD_TYPE_STRING"},
-		{Path: "billing.unused", Type: "FIELD_TYPE_STRING"},
+		{Path: "billing.fee", Type: adminclient.FieldTypeString},
+		{Path: "billing.currency", Type: adminclient.FieldTypeString},
+		{Path: "billing.unused", Type: adminclient.FieldTypeString},
 	}, "")
 	require.NoError(t, err)
 	_, err = admin.PublishSchema(ctx, s.ID, 1)

--- a/e2e/validation_limits_test.go
+++ b/e2e/validation_limits_test.go
@@ -52,7 +52,7 @@ func TestValidationLimits_MaxFieldsRejected(t *testing.T) {
 	for i := range fields {
 		fields[i] = adminclient.Field{
 			Path: fmt.Sprintf("f.field_%d", i),
-			Type: "FIELD_TYPE_STRING",
+			Type: adminclient.FieldTypeString,
 		}
 	}
 
@@ -74,7 +74,7 @@ func TestValidationLimits_MaxFieldsAtLimitAccepted(t *testing.T) {
 	for i := range fields {
 		fields[i] = adminclient.Field{
 			Path: fmt.Sprintf("f.field_%d", i),
-			Type: "FIELD_TYPE_STRING",
+			Type: adminclient.FieldTypeString,
 		}
 	}
 
@@ -145,7 +145,7 @@ func TestValidationLimits_GetFields_AtLimitAccepted(t *testing.T) {
 
 	fields := make([]adminclient.Field, maxConfigListLen)
 	for i := range fields {
-		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: "FIELD_TYPE_STRING"}
+		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: adminclient.FieldTypeString}
 	}
 	s, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-get-%s", randSuffix()), fields, "")
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestValidationLimits_UpdateSchema_RemoveFields_ExceedsListLen(t *testing.T)
 
 	fields := make([]adminclient.Field, maxRemoveFields+1)
 	for i := range fields {
-		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: "FIELD_TYPE_STRING"}
+		fields[i] = adminclient.Field{Path: fmt.Sprintf("f.field_%d", i), Type: adminclient.FieldTypeString}
 	}
 	s, err := admin.CreateSchema(ctx, fmt.Sprintf("limits-rm-%s", randSuffix()), fields, "")
 	require.NoError(t, err)

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -24,26 +24,26 @@ func TestConstraintValidation(t *testing.T) {
 	// Create schema with constrained fields.
 	s, err := admin.CreateSchema(ctx, "validation-e2e", []adminclient.Field{
 		{
-			Path: "app.retries", Type: "FIELD_TYPE_INT",
+			Path: "app.retries", Type: adminclient.FieldTypeInteger,
 			Constraints: &adminclient.FieldConstraints{Min: ptr(0.0), Max: ptr(10.0)},
 		},
 		{
-			Path: "app.rate", Type: "FIELD_TYPE_NUMBER",
+			Path: "app.rate", Type: adminclient.FieldTypeNumber,
 			Constraints: &adminclient.FieldConstraints{Min: ptr(0.0), Max: ptr(1.0)},
 		},
 		{
-			Path: "app.name", Type: "FIELD_TYPE_STRING",
+			Path: "app.name", Type: adminclient.FieldTypeString,
 			Constraints: &adminclient.FieldConstraints{MinLength: ptr(int32(2)), MaxLength: ptr(int32(50))},
 		},
 		{
-			Path: "app.env", Type: "FIELD_TYPE_STRING",
+			Path: "app.env", Type: adminclient.FieldTypeString,
 			Constraints: &adminclient.FieldConstraints{Enum: []string{"dev", "staging", "prod"}},
 		},
 		{
-			Path: "app.webhook", Type: "FIELD_TYPE_URL",
+			Path: "app.webhook", Type: adminclient.FieldTypeURL,
 		},
 		{
-			Path: "app.enabled", Type: "FIELD_TYPE_BOOL",
+			Path: "app.enabled", Type: adminclient.FieldTypeBool,
 		},
 	}, "")
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestExclusiveConstraints(t *testing.T) {
 	// Schema with exclusiveMinimum/exclusiveMaximum.
 	s, err := admin.CreateSchema(ctx, "exclusive-e2e", []adminclient.Field{
 		{
-			Path: "app.rate", Type: "FIELD_TYPE_NUMBER",
+			Path: "app.rate", Type: adminclient.FieldTypeNumber,
 			Constraints: &adminclient.FieldConstraints{ExclusiveMin: ptr(0.0), ExclusiveMax: ptr(1.0)},
 		},
 	}, "")
@@ -210,7 +210,7 @@ func TestInvalidConstraintTypeCombinations(t *testing.T) {
 	t.Run("minimum on string rejected", func(t *testing.T) {
 		_, err := admin.CreateSchema(ctx, "bad-min-str-e2e", []adminclient.Field{
 			{
-				Path: "x", Type: "FIELD_TYPE_STRING",
+				Path: "x", Type: adminclient.FieldTypeString,
 				Constraints: &adminclient.FieldConstraints{Min: ptr(0.0)},
 			},
 		}, "")
@@ -221,7 +221,7 @@ func TestInvalidConstraintTypeCombinations(t *testing.T) {
 	t.Run("minLength on integer rejected", func(t *testing.T) {
 		_, err := admin.CreateSchema(ctx, "bad-minlen-int-e2e", []adminclient.Field{
 			{
-				Path: "x", Type: "FIELD_TYPE_INT",
+				Path: "x", Type: adminclient.FieldTypeInteger,
 				Constraints: &adminclient.FieldConstraints{MinLength: ptr(int32(2))},
 			},
 		}, "")
@@ -232,7 +232,7 @@ func TestInvalidConstraintTypeCombinations(t *testing.T) {
 	t.Run("pattern on bool rejected", func(t *testing.T) {
 		_, err := admin.CreateSchema(ctx, "bad-pattern-bool-e2e", []adminclient.Field{
 			{
-				Path: "x", Type: "FIELD_TYPE_BOOL",
+				Path: "x", Type: adminclient.FieldTypeBool,
 				Constraints: &adminclient.FieldConstraints{Pattern: "^true$"},
 			},
 		}, "")
@@ -243,7 +243,7 @@ func TestInvalidConstraintTypeCombinations(t *testing.T) {
 	t.Run("min greater than max rejected", func(t *testing.T) {
 		_, err := admin.CreateSchema(ctx, "bad-range-e2e", []adminclient.Field{
 			{
-				Path: "x", Type: "FIELD_TYPE_INT",
+				Path: "x", Type: adminclient.FieldTypeInteger,
 				Constraints: &adminclient.FieldConstraints{Min: ptr(10.0), Max: ptr(5.0)},
 			},
 		}, "")

--- a/sdk/adminclient/example_test.go
+++ b/sdk/adminclient/example_test.go
@@ -183,7 +183,7 @@ func ExampleClient_CreateSchema() {
 	ctx := context.Background()
 
 	schema, err := client.CreateSchema(ctx, "app-config", []adminclient.Field{
-		{Path: "app.env", Type: "FIELD_TYPE_STRING", Description: "Deployment environment"},
+		{Path: "app.env", Type: adminclient.FieldTypeString, Description: "Deployment environment"},
 	}, "initial schema")
 	if err != nil {
 		fmt.Println("error:", err)

--- a/sdk/adminclient/types.go
+++ b/sdk/adminclient/types.go
@@ -2,6 +2,20 @@ package adminclient
 
 import "time"
 
+// FieldType is the data type of a schema field.
+type FieldType string
+
+const (
+	FieldTypeInteger  FieldType = "integer"
+	FieldTypeNumber   FieldType = "number"
+	FieldTypeString   FieldType = "string"
+	FieldTypeBool     FieldType = "bool"
+	FieldTypeTime     FieldType = "time"
+	FieldTypeDuration FieldType = "duration"
+	FieldTypeURL      FieldType = "url"
+	FieldTypeJSON     FieldType = "json"
+)
+
 // Schema represents a configuration schema with its fields.
 type Schema struct {
 	ID                 string
@@ -35,7 +49,7 @@ type SchemaContact struct {
 // Field represents a single field definition within a schema.
 type Field struct {
 	Path         string
-	Type         string
+	Type         FieldType
 	Nullable     bool
 	Deprecated   bool
 	RedirectTo   string

--- a/sdk/adminclient/types_test.go
+++ b/sdk/adminclient/types_test.go
@@ -21,8 +21,8 @@ func TestSchema_Fields(t *testing.T) {
 		Checksum:           "abc123",
 		Published:          true,
 		Fields: []Field{
-			{Path: "fee", Type: "NUMBER"},
-			{Path: "name", Type: "STRING", Nullable: true},
+			{Path: "fee", Type: FieldTypeNumber},
+			{Path: "name", Type: FieldTypeString, Nullable: true},
 		},
 		CreatedAt: now,
 		Info: &SchemaInfo{
@@ -72,7 +72,7 @@ func TestSchema_Fields(t *testing.T) {
 func TestField_AllMetadata(t *testing.T) {
 	f := Field{
 		Path:        "payments.fee",
-		Type:        "NUMBER",
+		Type:        FieldTypeNumber,
 		Nullable:    true,
 		Deprecated:  true,
 		RedirectTo:  "payments.new_fee",

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -137,7 +137,7 @@ func fieldFromProto(f *pb.SchemaField) adminclient.Field {
 	}
 	field := adminclient.Field{
 		Path:       f.GetPath(),
-		Type:       fieldTypeToString(f.GetType()),
+		Type:       fieldTypeFromProto(f.GetType()),
 		Nullable:   f.GetNullable(),
 		Deprecated: f.GetDeprecated(),
 		Tags:       f.GetTags(),
@@ -229,7 +229,7 @@ func fieldsToProto(fields []adminclient.Field) []*pb.SchemaField {
 	for i, f := range fields {
 		sf := &pb.SchemaField{
 			Path:       f.Path,
-			Type:       stringToFieldType(f.Type),
+			Type:       fieldTypeToProto(f.Type),
 			Nullable:   f.Nullable,
 			Deprecated: f.Deprecated,
 			Tags:       f.Tags,
@@ -416,45 +416,46 @@ func timeToProto(t *time.Time) *timestamppb.Timestamp {
 	return timestamppb.New(*t)
 }
 
-// protoTypeNames maps proto FieldType enum values to their short string names.
-// Mirrors the canonical string-keyed table in sdk/tools/internal/fieldtype.
-var protoTypeNames = map[pb.FieldType]string{
-	pb.FieldType_FIELD_TYPE_INT:      "integer",
-	pb.FieldType_FIELD_TYPE_NUMBER:   "number",
-	pb.FieldType_FIELD_TYPE_STRING:   "string",
-	pb.FieldType_FIELD_TYPE_BOOL:     "bool",
-	pb.FieldType_FIELD_TYPE_TIME:     "time",
-	pb.FieldType_FIELD_TYPE_DURATION: "duration",
-	pb.FieldType_FIELD_TYPE_URL:      "url",
-	pb.FieldType_FIELD_TYPE_JSON:     "json",
+func fieldTypeFromProto(ft pb.FieldType) adminclient.FieldType {
+	switch ft {
+	case pb.FieldType_FIELD_TYPE_INT:
+		return adminclient.FieldTypeInteger
+	case pb.FieldType_FIELD_TYPE_STRING:
+		return adminclient.FieldTypeString
+	case pb.FieldType_FIELD_TYPE_TIME:
+		return adminclient.FieldTypeTime
+	case pb.FieldType_FIELD_TYPE_DURATION:
+		return adminclient.FieldTypeDuration
+	case pb.FieldType_FIELD_TYPE_URL:
+		return adminclient.FieldTypeURL
+	case pb.FieldType_FIELD_TYPE_JSON:
+		return adminclient.FieldTypeJSON
+	case pb.FieldType_FIELD_TYPE_NUMBER:
+		return adminclient.FieldTypeNumber
+	case pb.FieldType_FIELD_TYPE_BOOL:
+		return adminclient.FieldTypeBool
+	default:
+		return ""
+	}
 }
 
-// fieldTypeToString converts a proto FieldType enum to its string representation
-// as used in the adminclient SDK.
-func fieldTypeToString(ft pb.FieldType) string {
-	return protoTypeNames[ft]
-}
-
-// stringToFieldType converts a string type name to the proto FieldType enum.
-// Accepts both short names ("integer", "string") and proto enum names
-// ("FIELD_TYPE_INT", "FIELD_TYPE_STRING").
-func stringToFieldType(s string) pb.FieldType {
-	switch s {
-	case "integer", "INT", "FIELD_TYPE_INT":
+func fieldTypeToProto(ft adminclient.FieldType) pb.FieldType {
+	switch ft {
+	case adminclient.FieldTypeInteger:
 		return pb.FieldType_FIELD_TYPE_INT
-	case "string", "STRING", "FIELD_TYPE_STRING":
+	case adminclient.FieldTypeString:
 		return pb.FieldType_FIELD_TYPE_STRING
-	case "time", "TIME", "FIELD_TYPE_TIME":
+	case adminclient.FieldTypeTime:
 		return pb.FieldType_FIELD_TYPE_TIME
-	case "duration", "DURATION", "FIELD_TYPE_DURATION":
+	case adminclient.FieldTypeDuration:
 		return pb.FieldType_FIELD_TYPE_DURATION
-	case "url", "URL", "FIELD_TYPE_URL":
+	case adminclient.FieldTypeURL:
 		return pb.FieldType_FIELD_TYPE_URL
-	case "json", "JSON", "FIELD_TYPE_JSON":
+	case adminclient.FieldTypeJSON:
 		return pb.FieldType_FIELD_TYPE_JSON
-	case "number", "NUMBER", "FIELD_TYPE_NUMBER":
+	case adminclient.FieldTypeNumber:
 		return pb.FieldType_FIELD_TYPE_NUMBER
-	case "bool", "BOOL", "FIELD_TYPE_BOOL":
+	case adminclient.FieldTypeBool:
 		return pb.FieldType_FIELD_TYPE_BOOL
 	default:
 		return pb.FieldType_FIELD_TYPE_UNSPECIFIED

--- a/sdk/grpctransport/convert_test.go
+++ b/sdk/grpctransport/convert_test.go
@@ -141,56 +141,56 @@ func TestTypedValueFromProto_DurationValue_WithDuration(t *testing.T) {
 	}
 }
 
-// --- fieldTypeToString ---
+// --- fieldTypeFromProto ---
 
-func TestFieldTypeToString(t *testing.T) {
+func TestFieldTypeFromProto(t *testing.T) {
 	cases := []struct {
 		ft   pb.FieldType
-		want string
+		want adminclient.FieldType
 	}{
-		{pb.FieldType_FIELD_TYPE_INT, "integer"},
-		{pb.FieldType_FIELD_TYPE_STRING, "string"},
-		{pb.FieldType_FIELD_TYPE_TIME, "time"},
-		{pb.FieldType_FIELD_TYPE_DURATION, "duration"},
-		{pb.FieldType_FIELD_TYPE_URL, "url"},
-		{pb.FieldType_FIELD_TYPE_JSON, "json"},
-		{pb.FieldType_FIELD_TYPE_NUMBER, "number"},
-		{pb.FieldType_FIELD_TYPE_BOOL, "bool"},
+		{pb.FieldType_FIELD_TYPE_INT, adminclient.FieldTypeInteger},
+		{pb.FieldType_FIELD_TYPE_STRING, adminclient.FieldTypeString},
+		{pb.FieldType_FIELD_TYPE_TIME, adminclient.FieldTypeTime},
+		{pb.FieldType_FIELD_TYPE_DURATION, adminclient.FieldTypeDuration},
+		{pb.FieldType_FIELD_TYPE_URL, adminclient.FieldTypeURL},
+		{pb.FieldType_FIELD_TYPE_JSON, adminclient.FieldTypeJSON},
+		{pb.FieldType_FIELD_TYPE_NUMBER, adminclient.FieldTypeNumber},
+		{pb.FieldType_FIELD_TYPE_BOOL, adminclient.FieldTypeBool},
 		{pb.FieldType_FIELD_TYPE_UNSPECIFIED, ""},
 	}
 	for _, c := range cases {
-		if got := fieldTypeToString(c.ft); got != c.want {
-			t.Errorf("fieldTypeToString(%v) = %q, want %q", c.ft, got, c.want)
+		if got := fieldTypeFromProto(c.ft); got != c.want {
+			t.Errorf("fieldTypeFromProto(%v) = %q, want %q", c.ft, got, c.want)
 		}
 	}
 }
 
-// --- stringToFieldType ---
+// --- fieldTypeToProto ---
 
-func TestStringToFieldType(t *testing.T) {
+func TestFieldTypeToProto(t *testing.T) {
 	cases := []struct {
-		s    string
+		ft   adminclient.FieldType
 		want pb.FieldType
 	}{
-		{"integer", pb.FieldType_FIELD_TYPE_INT},
-		{"string", pb.FieldType_FIELD_TYPE_STRING},
-		{"time", pb.FieldType_FIELD_TYPE_TIME},
-		{"duration", pb.FieldType_FIELD_TYPE_DURATION},
-		{"url", pb.FieldType_FIELD_TYPE_URL},
-		{"json", pb.FieldType_FIELD_TYPE_JSON},
-		{"number", pb.FieldType_FIELD_TYPE_NUMBER},
-		{"bool", pb.FieldType_FIELD_TYPE_BOOL},
+		{adminclient.FieldTypeInteger, pb.FieldType_FIELD_TYPE_INT},
+		{adminclient.FieldTypeString, pb.FieldType_FIELD_TYPE_STRING},
+		{adminclient.FieldTypeTime, pb.FieldType_FIELD_TYPE_TIME},
+		{adminclient.FieldTypeDuration, pb.FieldType_FIELD_TYPE_DURATION},
+		{adminclient.FieldTypeURL, pb.FieldType_FIELD_TYPE_URL},
+		{adminclient.FieldTypeJSON, pb.FieldType_FIELD_TYPE_JSON},
+		{adminclient.FieldTypeNumber, pb.FieldType_FIELD_TYPE_NUMBER},
+		{adminclient.FieldTypeBool, pb.FieldType_FIELD_TYPE_BOOL},
 		{"unknown", pb.FieldType_FIELD_TYPE_UNSPECIFIED},
 		{"", pb.FieldType_FIELD_TYPE_UNSPECIFIED},
 	}
 	for _, c := range cases {
-		if got := stringToFieldType(c.s); got != c.want {
-			t.Errorf("stringToFieldType(%q) = %v, want %v", c.s, got, c.want)
+		if got := fieldTypeToProto(c.ft); got != c.want {
+			t.Errorf("fieldTypeToProto(%q) = %v, want %v", c.ft, got, c.want)
 		}
 	}
 }
 
-func TestFieldTypeStringRoundTrip(t *testing.T) {
+func TestFieldTypeRoundTrip(t *testing.T) {
 	types := []pb.FieldType{
 		pb.FieldType_FIELD_TYPE_INT,
 		pb.FieldType_FIELD_TYPE_STRING,
@@ -202,10 +202,10 @@ func TestFieldTypeStringRoundTrip(t *testing.T) {
 		pb.FieldType_FIELD_TYPE_BOOL,
 	}
 	for _, ft := range types {
-		s := fieldTypeToString(ft)
-		back := stringToFieldType(s)
+		sdk := fieldTypeFromProto(ft)
+		back := fieldTypeToProto(sdk)
 		if back != ft {
-			t.Errorf("round-trip %v: string=%q, back=%v", ft, s, back)
+			t.Errorf("round-trip %v: sdk=%q, back=%v", ft, sdk, back)
 		}
 	}
 }
@@ -216,7 +216,7 @@ func TestFieldsRoundTrip_Basic(t *testing.T) {
 	fields := []adminclient.Field{
 		{
 			Path:        "app.name",
-			Type:        "string",
+			Type:        adminclient.FieldTypeString,
 			Nullable:    true,
 			Deprecated:  false,
 			Tags:        []string{"core"},
@@ -338,7 +338,7 @@ func TestFieldsRoundTrip_OptionalFields(t *testing.T) {
 	fields := []adminclient.Field{
 		{
 			Path:       "alias",
-			Type:       "string",
+			Type:       adminclient.FieldTypeString,
 			RedirectTo: "canonical.path",
 			ExternalDocs: &adminclient.ExternalDocs{
 				Description: "See docs",

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/opendecree/decree/sdk/adminclient"
-	"github.com/opendecree/decree/sdk/tools/internal/fieldtype"
 	"github.com/opendecree/decree/sdk/tools/seed"
 )
 
@@ -120,7 +119,7 @@ func buildSchemaDef(s *adminclient.Schema) seed.SchemaDef {
 
 	for _, f := range s.Fields {
 		fd := seed.FieldDef{
-			Type:        fieldtype.Name(f.Type),
+			Type:        string(f.Type),
 			Description: f.Description,
 			Default:     f.Default,
 			Nullable:    f.Nullable,

--- a/sdk/tools/dump/dump_test.go
+++ b/sdk/tools/dump/dump_test.go
@@ -57,7 +57,7 @@ func baseMock() *mockClient {
 				},
 				Fields: []adminclient.Field{
 					{
-						Path: "rate", Type: "FIELD_TYPE_NUMBER", Description: "Rate",
+						Path: "rate", Type: adminclient.FieldTypeNumber, Description: "Rate",
 						Nullable: true, Title: "Fee Rate", Example: "0.025",
 						Format: "percentage", Tags: []string{"billing"},
 						ReadOnly: true, Sensitive: true,
@@ -69,7 +69,7 @@ func baseMock() *mockClient {
 						},
 						Constraints: &adminclient.FieldConstraints{Min: &min},
 					},
-					{Path: "name", Type: "FIELD_TYPE_STRING", Default: "default", WriteOnce: true},
+					{Path: "name", Type: adminclient.FieldTypeString, Default: "default", WriteOnce: true},
 				},
 			}, nil
 		},
@@ -323,14 +323,14 @@ func TestBuildSchemaDef(t *testing.T) {
 		Fields: []adminclient.Field{
 			{
 				Path:        "rate",
-				Type:        "FIELD_TYPE_NUMBER",
+				Type:        adminclient.FieldTypeNumber,
 				Description: "A rate",
 				Nullable:    true,
 				Constraints: &adminclient.FieldConstraints{Min: &min, Max: &max},
 			},
 			{
 				Path:       "name",
-				Type:       "FIELD_TYPE_STRING",
+				Type:       adminclient.FieldTypeString,
 				Default:    "default",
 				Deprecated: true,
 				RedirectTo: "new_name",


### PR DESCRIPTION
## Summary

- Eliminates stringly-typed field types in the adminclient SDK so the compiler rejects invalid values at the call site instead of failing at runtime.
- Introduces a typed `FieldType` string alias with eight constants aligned with the OAS type system (FieldTypeInteger, FieldTypeNumber, FieldTypeString, FieldTypeBool, FieldTypeTime, FieldTypeDuration, FieldTypeURL, FieldTypeJSON).
- Simplifies the grpctransport conversion layer and removes now-redundant proto-name-to-short-name mapping tables from the dump and docgen tools.

## Test plan

- [x] All existing unit tests pass (`make test`)
- [x] `sdk/adminclient` and `sdk/grpctransport` tests updated to use typed constants
- [x] `sdk/tools/dump` round-trip tests updated; `TestFieldTypeName` removed (function deleted)
- [x] CLI (`cmd/decree`) compiles and schema display uses `string(f.Type)`
- [x] All e2e call sites updated from proto-style string literals to typed constants

Closes #492