### PR TITLE
perf(auth): batch-resolve tenant IDs in metadata interceptor

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -382,7 +382,15 @@ func run() int {
 	}
 	if srv.IsServiceEnabled("audit") {
 		auditSvc := audit.NewService(auditStoreVal, logger, func(ctx context.Context, idOrName string) (string, error) {
-			return tenantResolver(schemaStoreVal)(ctx, idOrName)
+			resolved, err := tenantResolver(schemaStoreVal)(ctx, []string{idOrName})
+			if err != nil {
+				return "", err
+			}
+			r, ok := resolved[idOrName]
+			if !ok {
+				return "", fmt.Errorf("tenant not found: %s", idOrName)
+			}
+			return r, nil
 		})
 		pb.RegisterAuditServiceServer(srv.GRPCServer(), auditSvc)
 		srv.SetServiceHealthy("centralconfig.v1.AuditService")
@@ -519,17 +527,29 @@ type serverConfig struct {
 }
 
 // tenantResolver creates an auth.TenantResolver from a schema store.
-// Resolves tenant name slugs to UUIDs so x-tenant-id headers accept both.
+// UUIDs pass through; name slugs are resolved in a single batch query.
 func tenantResolver(store schema.Store) auth.TenantResolver {
-	return func(ctx context.Context, idOrName string) (string, error) {
-		if domain.IsUUID(idOrName) {
-			return idOrName, nil
+	return func(ctx context.Context, ids []string) (map[string]string, error) {
+		result := make(map[string]string, len(ids))
+		var slugs []string
+		for _, id := range ids {
+			if domain.IsUUID(id) {
+				result[id] = id
+			} else {
+				slugs = append(slugs, id)
+			}
 		}
-		tenant, err := store.GetTenantByName(ctx, idOrName)
+		if len(slugs) == 0 {
+			return result, nil
+		}
+		tenants, err := store.GetTenantsByNames(ctx, slugs)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return tenant.ID, nil
+		for _, t := range tenants {
+			result[t.Name] = t.ID
+		}
+		return result, nil
 	}
 }
 

--- a/db/queries/tenants.sql
+++ b/db/queries/tenants.sql
@@ -9,6 +9,10 @@ SELECT * FROM tenants WHERE id = $1 AND deleted_at IS NULL;
 -- name: GetTenantByName :one
 SELECT * FROM tenants WHERE name = $1 AND deleted_at IS NULL;
 
+-- name: GetTenantsByNames :many
+SELECT * FROM tenants
+WHERE name = ANY(@names::text[]) AND deleted_at IS NULL;
+
 -- name: ListTenants :many
 SELECT * FROM tenants
 WHERE deleted_at IS NULL

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -43,9 +43,10 @@ const (
 	maxRoleLen    = 64
 )
 
-// TenantResolver resolves a tenant identifier (UUID or name slug) to a UUID.
-// Used by MetadataInterceptor to normalize x-tenant-id header values.
-type TenantResolver func(ctx context.Context, idOrName string) (string, error)
+// TenantResolver batch-resolves tenant identifiers (UUID or name slug) to UUIDs.
+// The returned map must contain an entry for every input ID.
+// Used by MetadataInterceptor to normalize x-tenant-id header values in one query.
+type TenantResolver func(ctx context.Context, ids []string) (map[string]string, error)
 
 // MetadataInterceptor extracts identity from gRPC metadata headers
 // instead of JWT tokens. Used when JWT auth is disabled.
@@ -163,7 +164,7 @@ func (m *MetadataInterceptor) extractClaims(ctx context.Context) (context.Contex
 	}
 
 	// Parse tenant IDs — comma-separated in x-tenant-id header.
-	// If a resolver is configured, slugs are resolved to UUIDs.
+	// If a resolver is configured, all IDs are resolved in a single call.
 	rawTenantID := firstMetadataValue(md, headerTenantID)
 	if len(rawTenantID) > maxHeaderLen {
 		return nil, status.Errorf(codes.InvalidArgument, "%s header exceeds %d bytes", headerTenantID, maxHeaderLen)
@@ -179,15 +180,22 @@ func (m *MetadataInterceptor) extractClaims(ctx context.Context) (context.Contex
 			if id == "" {
 				continue
 			}
-			if m.resolveTenant != nil {
-				resolved, err := m.resolveTenant(ctx, id)
-				if err != nil {
-					m.logger.WarnContext(ctx, "metadata auth: tenant resolution failed", "tenant", id, "error", err)
+			tenantIDs = append(tenantIDs, id)
+		}
+		if m.resolveTenant != nil && len(tenantIDs) > 0 {
+			resolved, err := m.resolveTenant(ctx, tenantIDs)
+			if err != nil {
+				m.logger.WarnContext(ctx, "metadata auth: tenant resolution failed", "error", err)
+				return nil, status.Error(codes.InvalidArgument, "failed to resolve tenant")
+			}
+			for i, id := range tenantIDs {
+				r, ok := resolved[id]
+				if !ok {
+					m.logger.WarnContext(ctx, "metadata auth: tenant not found", "tenant", id)
 					return nil, status.Error(codes.InvalidArgument, "failed to resolve tenant")
 				}
-				id = resolved
+				tenantIDs[i] = r
 			}
-			tenantIDs = append(tenantIDs, id)
 		}
 	}
 	if role != RoleSuperAdmin && len(tenantIDs) == 0 {

--- a/internal/auth/metadata_test.go
+++ b/internal/auth/metadata_test.go
@@ -311,8 +311,8 @@ func TestMetadata_TenantResolverErrorSanitised(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	resolver := func(_ context.Context, _ string) (string, error) {
-		return "", errors.New("pq: relation \"tenants\" does not exist")
+	resolver := func(_ context.Context, _ []string) (map[string]string, error) {
+		return nil, errors.New("pq: relation \"tenants\" does not exist")
 	}
 	interceptor := NewMetadataInterceptor(resolver, WithMetadataLogger(logger))
 	unary := interceptor.UnaryInterceptor()
@@ -334,6 +334,48 @@ func TestMetadata_TenantResolverErrorSanitised(t *testing.T) {
 	logged := logBuf.String()
 	assert.Contains(t, logged, "tenant resolution failed")
 	assert.Contains(t, logged, "pq: relation")
+}
+
+func TestMetadata_TenantResolverBatchedSingleCall(t *testing.T) {
+	calls := 0
+	resolver := func(_ context.Context, ids []string) (map[string]string, error) {
+		calls++
+		result := make(map[string]string, len(ids))
+		for _, id := range ids {
+			result[id] = "00000000-0000-0000-0000-00000000000" + id[len(id)-1:]
+		}
+		return result, nil
+	}
+	interceptor := NewMetadataInterceptor(resolver)
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithMetadata(map[string]string{
+		"x-subject":   "admin@example.com",
+		"x-role":      "admin",
+		"x-tenant-id": "slug-a,slug-b,slug-c",
+	})
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "resolver must be called exactly once for multiple tenant IDs")
+}
+
+func TestMetadata_TenantResolverMissingResult(t *testing.T) {
+	resolver := func(_ context.Context, ids []string) (map[string]string, error) {
+		// Return a map missing one of the requested IDs.
+		return map[string]string{ids[0]: "some-uuid"}, nil
+	}
+	interceptor := NewMetadataInterceptor(resolver)
+	unary := interceptor.UnaryInterceptor()
+
+	ctx := ctxWithMetadata(map[string]string{
+		"x-subject":   "admin@example.com",
+		"x-role":      "admin",
+		"x-tenant-id": "slug-a,slug-b",
+	})
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}, noopHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, "failed to resolve tenant", status.Convert(err).Message())
 }
 
 func TestMetadata_UnknownRoleSanitised(t *testing.T) {

--- a/internal/schema/mock_store_test.go
+++ b/internal/schema/mock_store_test.go
@@ -111,6 +111,11 @@ func (m *mockStore) GetTenantByName(ctx context.Context, name string) (domain.Te
 	return args.Get(0).(domain.Tenant), args.Error(1)
 }
 
+func (m *mockStore) GetTenantsByNames(ctx context.Context, names []string) ([]domain.Tenant, error) {
+	args := m.Called(ctx, names)
+	return args.Get(0).([]domain.Tenant), args.Error(1)
+}
+
 func (m *mockStore) ListTenants(ctx context.Context, arg ListTenantsParams) ([]domain.Tenant, error) {
 	args := m.Called(ctx, arg)
 	return args.Get(0).([]domain.Tenant), args.Error(1)

--- a/internal/schema/store.go
+++ b/internal/schema/store.go
@@ -171,6 +171,7 @@ type Store interface {
 	CreateTenant(ctx context.Context, arg CreateTenantParams) (domain.Tenant, error)
 	GetTenantByID(ctx context.Context, id string) (domain.Tenant, error)
 	GetTenantByName(ctx context.Context, name string) (domain.Tenant, error)
+	GetTenantsByNames(ctx context.Context, names []string) ([]domain.Tenant, error)
 	ListTenants(ctx context.Context, arg ListTenantsParams) ([]domain.Tenant, error)
 	ListTenantsBySchema(ctx context.Context, arg ListTenantsBySchemaParams) ([]domain.Tenant, error)
 	UpdateTenantName(ctx context.Context, arg UpdateTenantNameParams) (domain.Tenant, error)

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -383,6 +383,26 @@ func (m *MemoryStore) GetTenantByName(_ context.Context, name string) (domain.Te
 	return domain.Tenant{}, domain.ErrNotFound
 }
 
+func (m *MemoryStore) GetTenantsByNames(_ context.Context, names []string) ([]domain.Tenant, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	nameSet := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameSet[n] = struct{}{}
+	}
+	var result []domain.Tenant
+	for _, t := range m.tenants {
+		if t.DeletedAt != nil {
+			continue
+		}
+		if _, ok := nameSet[t.Name]; ok {
+			result = append(result, t)
+		}
+	}
+	return result, nil
+}
+
 func (m *MemoryStore) ListTenants(_ context.Context, arg ListTenantsParams) ([]domain.Tenant, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -223,6 +223,22 @@ func TestMemoryStore_TenantCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// GetTenantsByNames — batch lookup.
+	batch, err := store.GetTenantsByNames(ctx, []string{"acme", "globex"})
+	require.NoError(t, err)
+	assert.Len(t, batch, 2)
+
+	// Partial match (one known, one unknown) returns only the found tenants.
+	partial, err := store.GetTenantsByNames(ctx, []string{"acme", "unknown"})
+	require.NoError(t, err)
+	assert.Len(t, partial, 1)
+	assert.Equal(t, tenant.ID, partial[0].ID)
+
+	// Empty input returns empty slice.
+	empty, err := store.GetTenantsByNames(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
 	list, err := store.ListTenants(ctx, ListTenantsParams{Limit: 10, Offset: 0})
 	require.NoError(t, err)
 	assert.Len(t, list, 2)

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -441,6 +441,14 @@ func (s *PGStore) GetTenantByName(ctx context.Context, name string) (domain.Tena
 	return tenantFromDB(row), nil
 }
 
+func (s *PGStore) GetTenantsByNames(ctx context.Context, names []string) ([]domain.Tenant, error) {
+	rows, err := s.read.GetTenantsByNames(ctx, names)
+	if err != nil {
+		return nil, err
+	}
+	return tenantsFromDB(rows), nil
+}
+
 func (s *PGStore) ListTenants(ctx context.Context, arg ListTenantsParams) ([]domain.Tenant, error) {
 	if arg.AllowedTenantIDs != nil {
 		pgIDs, err := stringsToUUIDs(arg.AllowedTenantIDs)

--- a/internal/storage/dbstore/tenants.sql.gen.go
+++ b/internal/storage/dbstore/tenants.sql.gen.go
@@ -134,6 +134,39 @@ func (q *Queries) GetTenantByName(ctx context.Context, name string) (Tenant, err
 	return i, err
 }
 
+const getTenantsByNames = `-- name: GetTenantsByNames :many
+SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
+WHERE name = ANY($1::text[]) AND deleted_at IS NULL
+`
+
+func (q *Queries) GetTenantsByNames(ctx context.Context, names []string) ([]Tenant, error) {
+	rows, err := q.db.Query(ctx, getTenantsByNames, names)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Tenant{}
+	for rows.Next() {
+		var i Tenant
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.SchemaID,
+			&i.SchemaVersion,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTenants = `-- name: ListTenants :many
 SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
 WHERE deleted_at IS NULL


### PR DESCRIPTION
## Summary

- The metadata interceptor was resolving each tenant ID in the `x-tenant-id` header with a separate store call in a loop, causing N database round trips per authenticated request when clients pass multiple tenant IDs as name slugs.
- `TenantResolver` is now a batch interface, and a new `GetTenantsByNames` SQL query (`ANY($1::text[])`) resolves all slugs in a single query regardless of how many are present.
- UUID-format IDs are short-circuited on the Go side (no DB call needed), keeping the common case free of any extra overhead.

## Test plan

- All existing unit tests pass (`make test`).
- `TestMetadata_TenantResolverBatchedSingleCall` verifies the resolver is called exactly once for a comma-separated list of three slugs.
- `TestMetadata_TenantResolverMissingResult` verifies that a resolver returning an incomplete map produces a clean `InvalidArgument` error.
- `TestMetadata_TenantResolverErrorSanitised` updated to match the new batch signature.

Closes #457