### PR TITLE
feat(cache): make MemoryCache sweep interval configurable with jitter

### DIFF
--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -4,24 +4,44 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
 )
 
-const defaultMaxEntries = 10000
+const (
+	defaultMaxEntries    = 10000
+	defaultSweepInterval = time.Minute
+)
+
+// MemoryCacheOption configures optional MemoryCache settings.
+type MemoryCacheOption func(*memoryCacheConfig)
+
+type memoryCacheConfig struct {
+	sweepInterval time.Duration
+}
+
+// WithSweepInterval sets the base interval between background sweep passes.
+// Each pass adds ±10% jitter to prevent synchronized sweeps across instances.
+func WithSweepInterval(d time.Duration) MemoryCacheOption {
+	return func(cfg *memoryCacheConfig) {
+		cfg.sweepInterval = d
+	}
+}
 
 // MemoryCache implements ConfigCache using an in-memory map with TTL and
 // bounded size. When the cache is full, expired entries are evicted first,
 // then the oldest entry is removed. A background goroutine periodically
 // sweeps expired entries.
 type MemoryCache struct {
-	mu         sync.RWMutex
-	entries    map[string]memoryCacheEntry
-	negEntries map[string]time.Time // negative-cache: key → expiry
-	order      []string             // insertion order for eviction
-	maxEntries int
-	stopSweep  chan struct{}
+	mu            sync.RWMutex
+	entries       map[string]memoryCacheEntry
+	negEntries    map[string]time.Time // negative-cache: key → expiry
+	order         []string             // insertion order for eviction
+	maxEntries    int
+	sweepInterval time.Duration
+	stopSweep     chan struct{}
 }
 
 type memoryCacheEntry struct {
@@ -31,15 +51,20 @@ type memoryCacheEntry struct {
 
 // NewMemoryCache creates a new in-memory config cache.
 // maxEntries sets the upper bound on cached entries (0 uses default of 10000).
-func NewMemoryCache(maxEntries int) *MemoryCache {
+func NewMemoryCache(maxEntries int, opts ...MemoryCacheOption) *MemoryCache {
 	if maxEntries <= 0 {
 		maxEntries = defaultMaxEntries
 	}
+	cfg := memoryCacheConfig{sweepInterval: defaultSweepInterval}
+	for _, o := range opts {
+		o(&cfg)
+	}
 	c := &MemoryCache{
-		entries:    make(map[string]memoryCacheEntry),
-		negEntries: make(map[string]time.Time),
-		maxEntries: maxEntries,
-		stopSweep:  make(chan struct{}),
+		entries:       make(map[string]memoryCacheEntry),
+		negEntries:    make(map[string]time.Time),
+		maxEntries:    maxEntries,
+		sweepInterval: cfg.sweepInterval,
+		stopSweep:     make(chan struct{}),
 	}
 	go c.sweepLoop()
 	return c
@@ -197,15 +222,19 @@ func (c *MemoryIdempotencyCache) Claim(_ context.Context, key string, ttl time.D
 	return true, nil
 }
 
-// sweepLoop periodically removes expired entries.
+// sweepLoop periodically removes expired entries. Each iteration adds ±10%
+// jitter to the configured interval to prevent synchronized sweeps when many
+// instances share the same configuration.
 func (c *MemoryCache) sweepLoop() {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
 	for {
+		half := c.sweepInterval / 10
+		jitter := time.Duration(rand.Int64N(int64(2*half))) - half
+		timer := time.NewTimer(c.sweepInterval + jitter)
 		select {
-		case <-ticker.C:
+		case <-timer.C:
 			c.sweep()
 		case <-c.stopSweep:
+			timer.Stop()
 			return
 		}
 	}

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -176,6 +176,23 @@ func TestMemoryCache_UpdateExistingDoesNotGrow(t *testing.T) {
 	assert.Equal(t, "2", got["a"])
 }
 
+func TestMemoryCache_WithSweepInterval_SweepsOnSchedule(t *testing.T) {
+	interval := 50 * time.Millisecond
+	c := NewMemoryCache(0, WithSweepInterval(interval))
+	defer c.Stop()
+	ctx := context.Background()
+
+	require.NoError(t, c.Set(ctx, "t1", 1, map[string]string{"a": "1"}, time.Millisecond))
+	require.NoError(t, c.Set(ctx, "t2", 1, map[string]string{"a": "2"}, time.Hour))
+
+	// Wait long enough for at least one sweep (interval + max jitter = 55ms).
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, c.Len(), "expired entry should be swept by background goroutine")
+	got, _ := c.Get(ctx, "t2", 1)
+	assert.Equal(t, "2", got["a"], "live entry must remain")
+}
+
 // --- MemoryIdempotencyCache ---
 
 func TestMemoryIdempotencyCache_FirstClaimReturnsTrue(t *testing.T) {


### PR DESCRIPTION
## Summary

- The memory cache swept on a fixed 1-minute cadence with no jitter, causing all instances to synchronize and hit the same peak load simultaneously.
- Adds `WithSweepInterval` functional option so callers can tune the sweep cadence without touching the implementation.
- Replaces the fixed ticker with a per-iteration timer that applies ±10% random jitter, spreading sweeps across the fleet.

## Test plan

- [x] All existing cache tests pass unchanged (backward-compatible signature).
- [x] `TestMemoryCache_WithSweepInterval_SweepsOnSchedule` — creates a cache with a 50 ms interval and verifies the background goroutine sweeps an expired entry within 200 ms while leaving a live entry intact.
- [x] Full `make test` suite passes.

Closes #451