### PR TITLE
Add cursor-based pagination to ListFieldLocks

### DIFF
--- a/api/centralconfig/v1/schema_service.pb.go
+++ b/api/centralconfig/v1/schema_service.pb.go
@@ -1342,7 +1342,11 @@ func (*UnlockFieldResponse) Descriptor() ([]byte, []int) {
 type ListFieldLocksRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Tenant ID (UUID).
-	TenantId      string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	// Maximum number of locks to return. Defaults to 50, max 200.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// Pagination token from a previous ListFieldLocksResponse.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1384,10 +1388,26 @@ func (x *ListFieldLocksRequest) GetTenantId() string {
 	return ""
 }
 
+func (x *ListFieldLocksRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListFieldLocksRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListFieldLocksResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// All active field locks for the tenant.
-	Locks         []*FieldLock `protobuf:"bytes,1,rep,name=locks,proto3" json:"locks,omitempty"`
+	// Active field locks for the tenant (up to page_size).
+	Locks []*FieldLock `protobuf:"bytes,1,rep,name=locks,proto3" json:"locks,omitempty"`
+	// Token for the next page; empty when no more results.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1427,6 +1447,13 @@ func (x *ListFieldLocksResponse) GetLocks() []*FieldLock {
 		return x.Locks
 	}
 	return nil
+}
+
+func (x *ListFieldLocksResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
 }
 
 type ExportSchemaRequest struct {
@@ -1736,11 +1763,15 @@ const file_centralconfig_v1_schema_service_proto_rawDesc = "" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1d\n" +
 	"\n" +
 	"field_path\x18\x02 \x01(\tR\tfieldPath\"\x15\n" +
-	"\x13UnlockFieldResponse\"4\n" +
+	"\x13UnlockFieldResponse\"p\n" +
 	"\x15ListFieldLocksRequest\x12\x1b\n" +
-	"\ttenant_id\x18\x01 \x01(\tR\btenantId\"K\n" +
+	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"s\n" +
 	"\x16ListFieldLocksResponse\x121\n" +
-	"\x05locks\x18\x01 \x03(\v2\x1b.centralconfig.v1.FieldLockR\x05locks\"\x89\x01\n" +
+	"\x05locks\x18\x01 \x03(\v2\x1b.centralconfig.v1.FieldLockR\x05locks\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x89\x01\n" +
 	"\x13ExportSchemaRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\aversion\x18\x02 \x01(\x05H\x00R\aversion\x88\x01\x01\x12&\n" +

--- a/api/centralconfig/v1/schema_service.pb.gw.go
+++ b/api/centralconfig/v1/schema_service.pb.gw.go
@@ -564,6 +564,8 @@ func local_request_SchemaService_UnlockField_0(ctx context.Context, marshaler ru
 	return msg, metadata, err
 }
 
+var filter_SchemaService_ListFieldLocks_0 = &utilities.DoubleArray{Encoding: map[string]int{"tenant_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+
 func request_SchemaService_ListFieldLocks_0(ctx context.Context, marshaler runtime.Marshaler, client SchemaServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq ListFieldLocksRequest
@@ -580,6 +582,12 @@ func request_SchemaService_ListFieldLocks_0(ctx context.Context, marshaler runti
 	protoReq.TenantId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_SchemaService_ListFieldLocks_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := client.ListFieldLocks(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -598,6 +606,12 @@ func local_request_SchemaService_ListFieldLocks_0(ctx context.Context, marshaler
 	protoReq.TenantId, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_SchemaService_ListFieldLocks_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	msg, err := server.ListFieldLocks(ctx, &protoReq)
 	return msg, metadata, err

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -1045,6 +1045,21 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "description": "Maximum number of locks to return. Defaults to 50, max 200.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "Pagination token from a previous ListFieldLocksResponse.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -2181,7 +2196,11 @@
             "type": "object",
             "$ref": "#/definitions/v1FieldLock"
           },
-          "description": "All active field locks for the tenant."
+          "description": "Active field locks for the tenant (up to page_size)."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "Token for the next page; empty when no more results."
         }
       }
     },

--- a/db/queries/tenants.sql
+++ b/db/queries/tenants.sql
@@ -63,3 +63,9 @@ WHERE tenant_id = $1 AND field_path = $2;
 SELECT * FROM tenant_field_locks
 WHERE tenant_id = $1
 ORDER BY field_path;
+
+-- name: ListFieldLocks :many
+SELECT * FROM tenant_field_locks
+WHERE tenant_id = $1
+ORDER BY field_path
+LIMIT $2 OFFSET $3;

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -1501,6 +1501,8 @@ Imported versions are created as drafts (unpublished) unless auto_publish is tru
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | tenant_id | [string](#string) |  | Tenant ID (UUID). |
+| page_size | [int32](#int32) |  | Maximum number of locks to return. Defaults to 50, max 200. |
+| page_token | [string](#string) |  | Pagination token from a previous ListFieldLocksResponse. |
 
 
 
@@ -1515,7 +1517,8 @@ Imported versions are created as drafts (unpublished) unless auto_publish is tru
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| locks | [FieldLock](#centralconfig-v1-FieldLock) | repeated | All active field locks for the tenant. |
+| locks | [FieldLock](#centralconfig-v1-FieldLock) | repeated | Active field locks for the tenant (up to page_size). |
+| next_page_token | [string](#string) |  | Token for the next page; empty when no more results. |
 
 
 

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -1045,6 +1045,21 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "pageSize",
+            "description": "Maximum number of locks to return. Defaults to 50, max 200.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "pageToken",
+            "description": "Pagination token from a previous ListFieldLocksResponse.",
+            "in": "query",
+            "required": false,
+            "type": "string"
           }
         ],
         "tags": [
@@ -2181,7 +2196,11 @@
             "type": "object",
             "$ref": "#/definitions/v1FieldLock"
           },
-          "description": "All active field locks for the tenant."
+          "description": "Active field locks for the tenant (up to page_size)."
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "Token for the next page; empty when no more results."
         }
       }
     },

--- a/internal/schema/mock_store_test.go
+++ b/internal/schema/mock_store_test.go
@@ -155,3 +155,8 @@ func (m *mockStore) GetFieldLocks(ctx context.Context, tenantID string) ([]domai
 	args := m.Called(ctx, tenantID)
 	return args.Get(0).([]domain.TenantFieldLock), args.Error(1)
 }
+
+func (m *mockStore) ListFieldLocks(ctx context.Context, tenantID string, arg ListFieldLocksParams) ([]domain.TenantFieldLock, error) {
+	args := m.Called(ctx, tenantID, arg)
+	return args.Get(0).([]domain.TenantFieldLock), args.Error(1)
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -849,9 +849,24 @@ func (s *Service) ListFieldLocks(ctx context.Context, req *pb.ListFieldLocksRequ
 		return nil, err
 	}
 
-	locks, err := s.store.GetFieldLocks(ctx, tenant.ID)
+	pageSize := pagination.ClampPageSize(req.PageSize, 50, 200)
+
+	offset, err := pagination.DecodePageToken(req.PageToken)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid page token")
+	}
+
+	locks, err := s.store.ListFieldLocks(ctx, tenant.ID, ListFieldLocksParams{
+		Limit:  pageSize + 1,
+		Offset: offset,
+	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list field locks")
+	}
+
+	nextToken := pagination.NextPageToken(pageSize, int32(len(locks)), offset)
+	if int32(len(locks)) > pageSize {
+		locks = locks[:pageSize]
 	}
 
 	pbLocks := make([]*pb.FieldLock, 0, len(locks))
@@ -860,7 +875,8 @@ func (s *Service) ListFieldLocks(ctx context.Context, req *pb.ListFieldLocksRequ
 	}
 
 	return &pb.ListFieldLocksResponse{
-		Locks: pbLocks,
+		Locks:         pbLocks,
+		NextPageToken: nextToken,
 	}, nil
 }
 

--- a/internal/schema/service_extended_test.go
+++ b/internal/schema/service_extended_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -380,7 +381,7 @@ func TestListFieldLocks_Success(t *testing.T) {
 	svc := NewService(store, WithLogger(testLogger))
 
 	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
-	store.On("GetFieldLocks", mock.Anything, testTenantID).Return([]domain.TenantFieldLock{
+	store.On("ListFieldLocks", mock.Anything, testTenantID, mock.AnythingOfType("schema.ListFieldLocksParams")).Return([]domain.TenantFieldLock{
 		{TenantID: testTenantID, FieldPath: "app.fee"},
 	}, nil)
 
@@ -388,6 +389,7 @@ func TestListFieldLocks_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, resp.Locks, 1)
 	assert.Equal(t, "app.fee", resp.Locks[0].FieldPath)
+	assert.Empty(t, resp.NextPageToken)
 }
 
 // otherTenantID is a tenant id distinct from testTenantID, used to scope
@@ -438,6 +440,59 @@ func TestListFieldLocks_DeniedForOutOfScopeAdmin(t *testing.T) {
 	_, err := svc.ListFieldLocks(outOfScopeAdminCtx(), &pb.ListFieldLocksRequest{TenantId: testTenantID})
 	require.Error(t, err)
 	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestListFieldLocks_Pagination_NextToken(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
+
+	// Return pageSize+1 rows so the service knows there's a next page.
+	locks := make([]domain.TenantFieldLock, 3)
+	for i := range locks {
+		locks[i] = domain.TenantFieldLock{TenantID: testTenantID, FieldPath: fmt.Sprintf("app.field%d", i)}
+	}
+	store.On("ListFieldLocks", mock.Anything, testTenantID, ListFieldLocksParams{Limit: 3, Offset: 0}).Return(locks, nil)
+
+	resp, err := svc.ListFieldLocks(auth.WithoutAuth(context.Background()), &pb.ListFieldLocksRequest{
+		TenantId: testTenantID,
+		PageSize: 2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Locks, 2)
+	assert.NotEmpty(t, resp.NextPageToken)
+}
+
+func TestListFieldLocks_Pagination_LastPage(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
+
+	locks := []domain.TenantFieldLock{
+		{TenantID: testTenantID, FieldPath: "app.fee"},
+	}
+	store.On("ListFieldLocks", mock.Anything, testTenantID, mock.AnythingOfType("schema.ListFieldLocksParams")).Return(locks, nil)
+
+	resp, err := svc.ListFieldLocks(auth.WithoutAuth(context.Background()), &pb.ListFieldLocksRequest{
+		TenantId: testTenantID,
+		PageSize: 2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Locks, 1)
+	assert.Empty(t, resp.NextPageToken)
+}
+
+func TestListFieldLocks_InvalidPageToken(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	store.On("GetTenantByID", mock.Anything, testTenantID).Return(testTenant(), nil)
+
+	_, err := svc.ListFieldLocks(auth.WithoutAuth(context.Background()), &pb.ListFieldLocksRequest{
+		TenantId:  testTenantID,
+		PageToken: "not-a-valid-token",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // --- UpdateTenant ---

--- a/internal/schema/store.go
+++ b/internal/schema/store.go
@@ -40,6 +40,12 @@ type ListSchemasParams struct {
 	Offset int32
 }
 
+// ListFieldLocksParams contains pagination parameters for listing field locks.
+type ListFieldLocksParams struct {
+	Limit  int32
+	Offset int32
+}
+
 // CreateSchemaFieldParams contains parameters for creating a schema field.
 type CreateSchemaFieldParams struct {
 	SchemaVersionID string
@@ -182,4 +188,5 @@ type Store interface {
 	CreateFieldLock(ctx context.Context, arg CreateFieldLockParams) error
 	DeleteFieldLock(ctx context.Context, arg DeleteFieldLockParams) error
 	GetFieldLocks(ctx context.Context, tenantID string) ([]domain.TenantFieldLock, error)
+	ListFieldLocks(ctx context.Context, tenantID string, arg ListFieldLocksParams) ([]domain.TenantFieldLock, error)
 }

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -531,6 +531,16 @@ func (m *MemoryStore) GetFieldLocks(_ context.Context, tenantID string) ([]domai
 	return result, nil
 }
 
+func (m *MemoryStore) ListFieldLocks(_ context.Context, tenantID string, arg ListFieldLocksParams) ([]domain.TenantFieldLock, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	locks := m.fieldLocks[tenantID]
+	all := make([]domain.TenantFieldLock, len(locks))
+	copy(all, locks)
+	return paginate(all, int(arg.Offset), int(arg.Limit)), nil
+}
+
 // paginate applies offset and limit to a sorted slice.
 func paginate[T any](items []T, offset, limit int) []T {
 	if offset >= len(items) {

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -342,6 +342,40 @@ func TestMemoryStore_FieldLocks(t *testing.T) {
 	assert.True(t, errors.Is(err, domain.ErrNotFound))
 }
 
+func TestMemoryStore_ListFieldLocks_Pagination(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "lock-page-test"})
+	require.NoError(t, err)
+	tenant, err := store.CreateTenant(ctx, CreateTenantParams{
+		Name: "lock-pager", SchemaID: s.ID, SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+
+	for _, path := range []string{"a.x", "b.y", "c.z"} {
+		require.NoError(t, store.CreateFieldLock(ctx, CreateFieldLockParams{TenantID: tenant.ID, FieldPath: path}))
+	}
+
+	// First page.
+	page1, err := store.ListFieldLocks(ctx, tenant.ID, ListFieldLocksParams{Limit: 2, Offset: 0})
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+	assert.Equal(t, "a.x", page1[0].FieldPath)
+	assert.Equal(t, "b.y", page1[1].FieldPath)
+
+	// Second page.
+	page2, err := store.ListFieldLocks(ctx, tenant.ID, ListFieldLocksParams{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Len(t, page2, 1)
+	assert.Equal(t, "c.z", page2[0].FieldPath)
+
+	// Offset past end.
+	empty, err := store.ListFieldLocks(ctx, tenant.ID, ListFieldLocksParams{Limit: 2, Offset: 10})
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
 func TestMemoryStore_Pagination(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryStore()

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -590,6 +590,30 @@ func (s *PGStore) GetFieldLocks(ctx context.Context, tenantID string) ([]domain.
 	return result, nil
 }
 
+func (s *PGStore) ListFieldLocks(ctx context.Context, tenantID string, arg ListFieldLocksParams) ([]domain.TenantFieldLock, error) {
+	pgID, err := pgconv.StringToUUID(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.read.ListFieldLocks(ctx, dbstore.ListFieldLocksParams{
+		TenantID: pgID,
+		Limit:    arg.Limit,
+		Offset:   arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]domain.TenantFieldLock, len(rows))
+	for i, r := range rows {
+		result[i] = domain.TenantFieldLock{
+			TenantID:     pgconv.UUIDToString(r.TenantID),
+			FieldPath:    r.FieldPath,
+			LockedValues: r.LockedValues,
+		}
+	}
+	return result, nil
+}
+
 // --- DB → domain conversion helpers ---
 
 func schemaFromDB(r dbstore.Schema) domain.Schema {

--- a/internal/storage/dbstore/tenants.sql.gen.go
+++ b/internal/storage/dbstore/tenants.sql.gen.go
@@ -167,6 +167,39 @@ func (q *Queries) GetTenantsByNames(ctx context.Context, names []string) ([]Tena
 	return items, nil
 }
 
+const listFieldLocks = `-- name: ListFieldLocks :many
+SELECT tenant_id, field_path, locked_values FROM tenant_field_locks
+WHERE tenant_id = $1
+ORDER BY field_path
+LIMIT $2 OFFSET $3
+`
+
+type ListFieldLocksParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	Limit    int32       `json:"limit"`
+	Offset   int32       `json:"offset"`
+}
+
+func (q *Queries) ListFieldLocks(ctx context.Context, arg ListFieldLocksParams) ([]TenantFieldLock, error) {
+	rows, err := q.db.Query(ctx, listFieldLocks, arg.TenantID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []TenantFieldLock{}
+	for rows.Next() {
+		var i TenantFieldLock
+		if err := rows.Scan(&i.TenantID, &i.FieldPath, &i.LockedValues); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTenants = `-- name: ListTenants :many
 SELECT id, name, schema_id, schema_version, created_at, updated_at, deleted_at FROM tenants
 WHERE deleted_at IS NULL

--- a/proto/centralconfig/v1/schema_service.proto
+++ b/proto/centralconfig/v1/schema_service.proto
@@ -323,11 +323,20 @@ message UnlockFieldResponse {}
 message ListFieldLocksRequest {
   // Tenant ID (UUID).
   string tenant_id = 1;
+
+  // Maximum number of locks to return. Defaults to 50, max 200.
+  int32 page_size = 2;
+
+  // Pagination token from a previous ListFieldLocksResponse.
+  string page_token = 3;
 }
 
 message ListFieldLocksResponse {
-  // All active field locks for the tenant.
+  // Active field locks for the tenant (up to page_size).
   repeated FieldLock locks = 1;
+
+  // Token for the next page; empty when no more results.
+  string next_page_token = 2;
 }
 
 // --- Import/export ---


### PR DESCRIPTION
## Summary

- `ListFieldLocks` previously returned all locks for a tenant in a single unbounded response, which would not scale for tenants with many locked fields.
- Adds `page_size` and `page_token` request fields and `next_page_token` to the response, matching the existing `ListSchemas`/`ListTenants` pagination pattern (opaque offset-encoded token, clamped page size, fetch pageSize+1 to detect next page).
- A new `ListFieldLocks` SQL query with `LIMIT`/`OFFSET` is introduced alongside the existing `GetFieldLocks` query, which is retained for internal authz and config-service use cases that need all locks for authorization checking.

## Test plan

- [x] Existing `TestListFieldLocks_Success` updated for new store call and asserts `next_page_token` is empty on single-page result
- [x] `TestListFieldLocks_Pagination_NextToken` — returns pageSize items and non-empty token when store returns pageSize+1 rows
- [x] `TestListFieldLocks_Pagination_LastPage` — returns empty token when fewer than pageSize rows are returned
- [x] `TestListFieldLocks_InvalidPageToken` — returns `InvalidArgument` for a malformed token
- [x] `make test` passes (all packages)
- [x] `make lint-go` passes (0 issues)

Closes #456