### PR TITLE
docs(schema): document computeChecksum truncation as non-cryptographic

### DIFF
--- a/internal/schema/convert.go
+++ b/internal/schema/convert.go
@@ -142,6 +142,7 @@ func computeChecksum(fields []*pb.SchemaField) string {
 			h.Write(data)
 		}
 	}
+	// Truncate to 16 hex chars (64 bits): sufficient for collision detection, not cryptographic.
 	return fmt.Sprintf("%x", h.Sum(nil))[:16]
 }
 


### PR DESCRIPTION
## Summary

- The `computeChecksum` function truncates its SHA-256 digest to 16 hex characters (64 bits) before storing the schema checksum, but this was not documented.
- Without a comment, a future reader might mistake this for a bug or attempt to change it to a full hash, not realizing the truncation is intentional.

## Test plan

- [ ] Lint passes (`make lint-go`)
- [ ] All tests pass (`make test`)

Closes #460