### PR TITLE
Batch publishChange calls into one event per RPC

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -636,10 +636,11 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	if err := s.cache.Invalidate(ctx, tenantID); err != nil {
 		s.logger.WarnContext(ctx, "failed to invalidate cache", "error", err)
 	}
-	s.publishChange(ctx, tenantID, newVersion.Version, req.FieldPath,
-		redactIfSensitive(sensitiveFields[req.FieldPath], oldValue),
-		redactIfSensitive(sensitiveFields[req.FieldPath], typedValueToDisplayString(req.Value)),
-		actor)
+	s.publishChanges(ctx, tenantID, newVersion.Version, []pubsub.FieldChange{{
+		FieldPath: req.FieldPath,
+		OldValue:  redactIfSensitive(sensitiveFields[req.FieldPath], oldValue),
+		NewValue:  redactIfSensitive(sensitiveFields[req.FieldPath], typedValueToDisplayString(req.Value)),
+	}}, actor)
 
 	s.metrics.RecordWrite(ctx, tenantID, "set_field")
 	s.metrics.RecordVersion(ctx, tenantID, int64(newVersion.Version))
@@ -805,12 +806,15 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 	if err := s.cache.Invalidate(ctx, tenantID); err != nil {
 		s.logger.WarnContext(ctx, "failed to invalidate cache", "error", err)
 	}
-	for _, ch := range changes {
-		s.publishChange(ctx, tenantID, newVersion.Version, ch.fieldPath,
-			redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.oldValue),
-			redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.newValue),
-			actor)
+	fieldChanges := make([]pubsub.FieldChange, len(changes))
+	for i, ch := range changes {
+		fieldChanges[i] = pubsub.FieldChange{
+			FieldPath: ch.fieldPath,
+			OldValue:  redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.oldValue),
+			NewValue:  redactIfSensitive(sensitiveFieldsMulti[ch.fieldPath], ch.newValue),
+		}
 	}
+	s.publishChanges(ctx, tenantID, newVersion.Version, fieldChanges, actor)
 
 	s.metrics.RecordWrite(ctx, tenantID, "set_fields")
 	s.metrics.RecordVersion(ctx, tenantID, int64(newVersion.Version))
@@ -1077,25 +1081,26 @@ func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamin
 				continue
 			}
 
-			// Filter by field paths if specified.
-			if len(filterPaths) > 0 {
-				if _, ok := filterPaths[event.FieldPath]; !ok {
-					continue
+			// Expand batched changes into individual gRPC messages, filtering as needed.
+			for _, fc := range event.Changes {
+				if len(filterPaths) > 0 {
+					if _, ok := filterPaths[fc.FieldPath]; !ok {
+						continue
+					}
 				}
-			}
-
-			if err := stream.Send(&pb.SubscribeResponse{
-				Change: &pb.ConfigChange{
-					TenantId:  event.TenantID,
-					Version:   event.Version,
-					FieldPath: event.FieldPath,
-					OldValue:  stringToTypedValue(ptrString(event.OldValue), lookupFieldType(types, event.FieldPath)),
-					NewValue:  stringToTypedValue(strPtr(event.NewValue), lookupFieldType(types, event.FieldPath)),
-					ChangedBy: event.ChangedBy,
-					ChangedAt: timestamppb.New(event.ChangedAt),
-				},
-			}); err != nil {
-				return err
+				if err := stream.Send(&pb.SubscribeResponse{
+					Change: &pb.ConfigChange{
+						TenantId:  event.TenantID,
+						Version:   event.Version,
+						FieldPath: fc.FieldPath,
+						OldValue:  stringToTypedValue(ptrString(fc.OldValue), lookupFieldType(types, fc.FieldPath)),
+						NewValue:  stringToTypedValue(strPtr(fc.NewValue), lookupFieldType(types, fc.FieldPath)),
+						ChangedBy: event.ChangedBy,
+						ChangedAt: timestamppb.New(event.ChangedAt),
+					},
+				}); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -1342,12 +1347,15 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 	if err := s.cache.Invalidate(ctx, tenantID); err != nil {
 		s.logger.WarnContext(ctx, "failed to invalidate cache", "error", err)
 	}
-	for _, ch := range changes {
-		s.publishChange(ctx, tenantID, newVersion.Version, ch.fieldPath,
-			redactIfSensitive(sensitiveFields[ch.fieldPath], ch.oldValue),
-			redactIfSensitive(sensitiveFields[ch.fieldPath], ch.newValue),
-			actor)
+	importChanges := make([]pubsub.FieldChange, len(changes))
+	for i, ch := range changes {
+		importChanges[i] = pubsub.FieldChange{
+			FieldPath: ch.fieldPath,
+			OldValue:  redactIfSensitive(sensitiveFields[ch.fieldPath], ch.oldValue),
+			NewValue:  redactIfSensitive(sensitiveFields[ch.fieldPath], ch.newValue),
+		}
 	}
+	s.publishChanges(ctx, tenantID, newVersion.Version, importChanges, actor)
 
 	s.metrics.RecordWrite(ctx, tenantID, "import")
 	s.metrics.RecordVersion(ctx, tenantID, int64(newVersion.Version))
@@ -1765,13 +1773,11 @@ func lookupFieldType(types map[string]domain.FieldType, fieldPath string) domain
 	return domain.FieldTypeString
 }
 
-func (s *Service) publishChange(ctx context.Context, tenantID string, version int32, fieldPath, oldValue, newValue, actor string) {
+func (s *Service) publishChanges(ctx context.Context, tenantID string, version int32, changes []pubsub.FieldChange, actor string) {
 	event := pubsub.ConfigChangeEvent{
 		TenantID:  tenantID,
 		Version:   version,
-		FieldPath: fieldPath,
-		OldValue:  oldValue,
-		NewValue:  newValue,
+		Changes:   changes,
 		ChangedBy: actor,
 		ChangedAt: time.Now(),
 	}

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -196,6 +196,126 @@ func TestGetConfig_TenantNameNotFound(t *testing.T) {
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
+// --- Batch publish ---
+
+// TestSetField_PublishesOneEvent verifies that a single-field update emits
+// exactly one pubsub event carrying a one-element Changes slice.
+func TestSetField_PublishesOneEvent(t *testing.T) {
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.Anything).Return(domain.ConfigVersion{
+		ID: versionID2, Version: 2, CreatedAt: time.Now(),
+	}, nil)
+	store.On("SetConfigValue", mock.Anything, mock.Anything).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.Anything).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	setupNoSensitiveFields(store)
+
+	var captured pubsub.ConfigChangeEvent
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(pubsub.ConfigChangeEvent)
+		}).
+		Return(nil)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.name",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}},
+	})
+	require.NoError(t, err)
+
+	pub.AssertNumberOfCalls(t, "Publish", 1)
+	require.Len(t, captured.Changes, 1)
+	assert.Equal(t, "app.name", captured.Changes[0].FieldPath)
+	assert.Equal(t, "hello", captured.Changes[0].NewValue)
+}
+
+// TestSetFields_PublishesOneEventWithAllChanges verifies that a multi-field
+// update emits exactly one pubsub event carrying all changes in order.
+func TestSetFields_PublishesOneEventWithAllChanges(t *testing.T) {
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.Anything).Return(domain.ConfigVersion{
+		ID: versionID2, Version: 2, CreatedAt: time.Now(),
+	}, nil)
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	store.On("BulkInsertAuditWriteLog", mock.Anything, mock.Anything).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	setupNoSensitiveFields(store)
+
+	var captured pubsub.ConfigChangeEvent
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).
+		Run(func(args mock.Arguments) {
+			captured = args.Get(1).(pubsub.ConfigChangeEvent)
+		}).
+		Return(nil)
+
+	_, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "app.name", Value: &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "v1"}}},
+			{FieldPath: "app.port", Value: &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 9090}}},
+		},
+	})
+	require.NoError(t, err)
+
+	// Exactly one publish for two field changes.
+	pub.AssertNumberOfCalls(t, "Publish", 1)
+	require.Len(t, captured.Changes, 2)
+	assert.Equal(t, "app.name", captured.Changes[0].FieldPath)
+	assert.Equal(t, "app.port", captured.Changes[1].FieldPath)
+}
+
+// TestSubscribe_BatchEventExpandedToPerFieldMessages verifies that a single
+// batched pubsub event with multiple fields fans out to one gRPC message per field.
+func TestSubscribe_BatchEventExpandedToPerFieldMessages(t *testing.T) {
+	svc, _, _, _ := newTestService()
+	sub := &mockSubscriber{}
+	svc.subscriber = sub
+
+	ch := make(chan pubsub.ConfigChangeEvent, 1)
+	cancel := func() {}
+
+	ctx, ctxCancel := context.WithCancel(auth.WithoutAuth(context.Background()))
+	stream := &mockServerStream{ctx: ctx}
+
+	sub.On("Subscribe", mock.Anything, tenantID1).
+		Return((<-chan pubsub.ConfigChangeEvent)(ch), context.CancelFunc(cancel), nil)
+
+	now := time.Now()
+	ch <- pubsub.ConfigChangeEvent{
+		TenantID: tenantID1,
+		Version:  3,
+		Changes: []pubsub.FieldChange{
+			{FieldPath: "app.name", OldValue: "old", NewValue: "new"},
+			{FieldPath: "app.port", OldValue: "8080", NewValue: "9090"},
+		},
+		ChangedBy: "admin",
+		ChangedAt: now,
+	}
+	close(ch)
+
+	err := svc.Subscribe(&pb.SubscribeRequest{TenantId: tenantID1}, stream)
+	require.NoError(t, err)
+
+	// One pubsub event with two fields → two gRPC messages.
+	require.Len(t, stream.sent, 2)
+	assert.Equal(t, "app.name", stream.sent[0].Change.FieldPath)
+	assert.Equal(t, int32(3), stream.sent[0].Change.Version)
+	assert.Equal(t, "app.port", stream.sent[1].Change.FieldPath)
+	assert.Equal(t, int32(3), stream.sent[1].Change.Version)
+
+	ctxCancel()
+}
+
 // --- SetFields ---
 
 func TestSetFields_Success(t *testing.T) {
@@ -466,18 +586,14 @@ func TestSubscribe_ForwardsEvents(t *testing.T) {
 	ch <- pubsub.ConfigChangeEvent{
 		TenantID:  tenantID1,
 		Version:   1,
-		FieldPath: "app.name",
-		OldValue:  "",
-		NewValue:  "hello",
+		Changes:   []pubsub.FieldChange{{FieldPath: "app.name", OldValue: "", NewValue: "hello"}},
 		ChangedBy: "admin",
 		ChangedAt: now,
 	}
 	ch <- pubsub.ConfigChangeEvent{
 		TenantID:  tenantID1,
 		Version:   2,
-		FieldPath: "app.port",
-		OldValue:  "8080",
-		NewValue:  "9090",
+		Changes:   []pubsub.FieldChange{{FieldPath: "app.port", OldValue: "8080", NewValue: "9090"}},
 		ChangedBy: "admin",
 		ChangedAt: now,
 	}
@@ -514,9 +630,9 @@ func TestSubscribe_FiltersByFieldPaths(t *testing.T) {
 		Return((<-chan pubsub.ConfigChangeEvent)(ch), context.CancelFunc(cancel), nil)
 
 	now := time.Now()
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 1, FieldPath: "app.name", NewValue: "v1", ChangedAt: now}
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 2, FieldPath: "app.port", NewValue: "9090", ChangedAt: now}
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 3, FieldPath: "app.name", NewValue: "v2", ChangedAt: now}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 1, Changes: []pubsub.FieldChange{{FieldPath: "app.name", NewValue: "v1"}}, ChangedAt: now}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 2, Changes: []pubsub.FieldChange{{FieldPath: "app.port", NewValue: "9090"}}, ChangedAt: now}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 3, Changes: []pubsub.FieldChange{{FieldPath: "app.name", NewValue: "v2"}}, ChangedAt: now}
 	close(ch)
 
 	err := svc.Subscribe(&pb.SubscribeRequest{
@@ -568,7 +684,7 @@ func TestSubscribe_SendError(t *testing.T) {
 	sub.On("Subscribe", mock.Anything, tenantID1).
 		Return((<-chan pubsub.ConfigChangeEvent)(ch), context.CancelFunc(cancel), nil)
 
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 1, FieldPath: "x", NewValue: "y", ChangedAt: time.Now()}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 1, Changes: []pubsub.FieldChange{{FieldPath: "x", NewValue: "y"}}, ChangedAt: time.Now()}
 	close(ch)
 
 	err := svc.Subscribe(&pb.SubscribeRequest{TenantId: tenantID1}, stream)
@@ -700,8 +816,8 @@ func TestSubscribe_WatermarkDeduplicatesReplayedVersions(t *testing.T) {
 	setupNoSensitiveFields(store)
 
 	// Pubsub delivers version 4 (duplicate of replay) and version 5 (new).
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 4, FieldPath: "app.name", NewValue: "v4-dup", ChangedAt: now}
-	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 5, FieldPath: "app.name", NewValue: "v5", ChangedAt: now}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 4, Changes: []pubsub.FieldChange{{FieldPath: "app.name", NewValue: "v4-dup"}}, ChangedAt: now}
+	ch <- pubsub.ConfigChangeEvent{TenantID: tenantID1, Version: 5, Changes: []pubsub.FieldChange{{FieldPath: "app.name", NewValue: "v5"}}, ChangedAt: now}
 	close(ch)
 
 	startVersion := int32(3)

--- a/internal/config/service_helpers_test.go
+++ b/internal/config/service_helpers_test.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/auth"
 	"github.com/opendecree/decree/internal/cache"
+	"github.com/opendecree/decree/internal/pubsub"
 	celpkg "github.com/opendecree/decree/internal/schema/cel"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
@@ -134,12 +135,14 @@ func TestCelArtifactsTenantBinding(t *testing.T) {
 	assert.Equal(t, "acme", tb.Name)
 }
 
-func TestPublishChange_PublishErrorIsSwallowed(t *testing.T) {
+func TestPublishChanges_PublishErrorIsSwallowed(t *testing.T) {
 	svc, _, _, pub := newTestService()
 	pub.On("Publish", mock.Anything, mock.Anything).Return(errors.New("broker down"))
 	// A publish failure must not panic — it is logged and ignored.
 	assert.NotPanics(t, func() {
-		svc.publishChange(context.Background(), tenantID1, 1, "a.b", "old", "new", "alice")
+		svc.publishChanges(context.Background(), tenantID1, 1,
+			[]pubsub.FieldChange{{FieldPath: "a.b", OldValue: "old", NewValue: "new"}},
+			"alice")
 	})
 	pub.AssertExpectations(t)
 }

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1196,8 +1196,9 @@ func TestSetField_PublishRedactsSensitiveField(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, redactedSentinel, capturedEvent.OldValue)
-	assert.Equal(t, redactedSentinel, capturedEvent.NewValue)
+	require.Len(t, capturedEvent.Changes, 1)
+	assert.Equal(t, redactedSentinel, capturedEvent.Changes[0].OldValue)
+	assert.Equal(t, redactedSentinel, capturedEvent.Changes[0].NewValue)
 }
 
 func TestExportConfig_RedactsSensitiveFields(t *testing.T) {

--- a/internal/pubsub/memory.go
+++ b/internal/pubsub/memory.go
@@ -70,7 +70,7 @@ func (ps *MemoryPubSub) Publish(_ context.Context, event ConfigChangeEvent) erro
 		default:
 			ps.logger.Debug("pubsub: dropped event — subscriber channel full",
 				"tenant_id", event.TenantID,
-				"field_path", event.FieldPath,
+				"change_count", len(event.Changes),
 			)
 			if ps.dropsOK {
 				ps.drops.Add(context.Background(), 1)

--- a/internal/pubsub/memory_test.go
+++ b/internal/pubsub/memory_test.go
@@ -33,9 +33,7 @@ func TestMemoryPubSub_PublishSubscribe(t *testing.T) {
 	event := ConfigChangeEvent{
 		TenantID:  "t1",
 		Version:   1,
-		FieldPath: "app.fee",
-		OldValue:  "0.01",
-		NewValue:  "0.02",
+		Changes:   []FieldChange{{FieldPath: "app.fee", OldValue: "0.01", NewValue: "0.02"}},
 		ChangedBy: "admin",
 		ChangedAt: time.Now(),
 	}
@@ -43,8 +41,9 @@ func TestMemoryPubSub_PublishSubscribe(t *testing.T) {
 
 	select {
 	case got := <-ch:
-		assert.Equal(t, "app.fee", got.FieldPath)
-		assert.Equal(t, "0.02", got.NewValue)
+		require.Len(t, got.Changes, 1)
+		assert.Equal(t, "app.fee", got.Changes[0].FieldPath)
+		assert.Equal(t, "0.02", got.Changes[0].NewValue)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("expected event")
 	}
@@ -59,7 +58,7 @@ func TestMemoryPubSub_TenantIsolation(t *testing.T) {
 	ch2, cancel2, _ := ps.Subscribe(ctx, "t2")
 	defer cancel2()
 
-	require.NoError(t, ps.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "a"}))
+	require.NoError(t, ps.Publish(ctx, ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "a"}}}))
 
 	select {
 	case <-ch1:
@@ -83,7 +82,7 @@ func TestMemoryPubSub_MultipleSubscribers(t *testing.T) {
 	ch2, cancel2, _ := ps.Subscribe(ctx, "t1")
 	defer cancel2()
 
-	require.NoError(t, ps.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "a"}))
+	require.NoError(t, ps.Publish(ctx, ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "a"}}}))
 
 	select {
 	case <-ch1:
@@ -138,7 +137,7 @@ func TestMemoryPubSub_DropCounter(t *testing.T) {
 
 	// Overflow the 64-deep buffer.
 	for i := range 70 {
-		_ = ps.Publish(context.Background(), ConfigChangeEvent{TenantID: "t1", FieldPath: "a", Version: int32(i)})
+		_ = ps.Publish(context.Background(), ConfigChangeEvent{TenantID: "t1", Version: int32(i), Changes: []FieldChange{{FieldPath: "a"}}})
 	}
 	assert.Greater(t, counter.n.Load(), int64(0))
 }
@@ -147,7 +146,7 @@ func TestMemoryPubSub_PayloadTooLarge(t *testing.T) {
 	ps := NewMemoryPubSub()
 	big := ConfigChangeEvent{
 		TenantID: "t1",
-		NewValue: strings.Repeat("x", MaxPayloadBytes+1),
+		Changes:  []FieldChange{{NewValue: strings.Repeat("x", MaxPayloadBytes+1)}},
 	}
 	err := ps.Publish(context.Background(), big)
 	assert.ErrorIs(t, err, ErrPayloadTooLarge)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -19,8 +19,8 @@
 // # Payload size
 //
 // Publishers reject events whose serialised size exceeds MaxPayloadBytes.
-// Callers storing large values should keep OldValue/NewValue short and fetch
-// the full value by (TenantID, FieldPath, Version) from the config store.
+// Callers storing large values should keep FieldChange.OldValue/NewValue short
+// and fetch the full value by (TenantID, FieldPath, Version) from the config store.
 package pubsub
 
 import (
@@ -37,17 +37,23 @@ const MaxPayloadBytes = 65536
 // ErrPayloadTooLarge is returned by Publish when the serialised event exceeds MaxPayloadBytes.
 var ErrPayloadTooLarge = errors.New("pubsub: event payload exceeds maximum size")
 
-// ConfigChangeEvent represents a change to a config value.
+// FieldChange holds the per-field data for a single field within a batched event.
+type FieldChange struct {
+	FieldPath string `json:"field_path"`
+	OldValue  string `json:"old_value"`
+	NewValue  string `json:"new_value"`
+}
+
+// ConfigChangeEvent represents one or more config-value changes committed in a single version.
+// Changes always contains at least one entry; single-field RPCs produce a one-element slice.
 type ConfigChangeEvent struct {
-	EventID   string    `json:"event_id"` // UUID v4, unique per event
-	Seq       int64     `json:"seq"`      // monotonic per-publisher sequence
-	TenantID  string    `json:"tenant_id"`
-	Version   int32     `json:"version"`
-	FieldPath string    `json:"field_path"`
-	OldValue  string    `json:"old_value"`
-	NewValue  string    `json:"new_value"`
-	ChangedBy string    `json:"changed_by"`
-	ChangedAt time.Time `json:"changed_at"`
+	EventID   string        `json:"event_id"` // UUID v4, unique per event
+	Seq       int64         `json:"seq"`      // monotonic per-publisher sequence
+	TenantID  string        `json:"tenant_id"`
+	Version   int32         `json:"version"`
+	Changes   []FieldChange `json:"changes"`
+	ChangedBy string        `json:"changed_by"`
+	ChangedAt time.Time     `json:"changed_at"`
 }
 
 // Publisher publishes config change events.

--- a/internal/pubsub/pubsub_bench_test.go
+++ b/internal/pubsub/pubsub_bench_test.go
@@ -14,9 +14,7 @@ import (
 var benchEvent = ConfigChangeEvent{
 	TenantID:  "bench-t1",
 	Version:   1,
-	FieldPath: "app.rate_limit",
-	OldValue:  "100",
-	NewValue:  "200",
+	Changes:   []FieldChange{{FieldPath: "app.rate_limit", OldValue: "100", NewValue: "200"}},
 	ChangedBy: "bench",
 	ChangedAt: time.Now(),
 }

--- a/internal/pubsub/redis_test.go
+++ b/internal/pubsub/redis_test.go
@@ -61,13 +61,14 @@ func TestRedisPubSub_PublishSubscribe_Happy(t *testing.T) {
 	require.NoError(t, err)
 	defer cancel()
 
-	event := ConfigChangeEvent{TenantID: "t1", FieldPath: "app.fee", NewValue: "0.02"}
+	event := ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "app.fee", NewValue: "0.02"}}}
 	require.NoError(t, pub.Publish(ctx, event))
 
 	select {
 	case got := <-ch:
-		assert.Equal(t, "app.fee", got.FieldPath)
-		assert.Equal(t, "0.02", got.NewValue)
+		require.Len(t, got.Changes, 1)
+		assert.Equal(t, "app.fee", got.Changes[0].FieldPath)
+		assert.Equal(t, "0.02", got.Changes[0].NewValue)
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event")
 	}
@@ -87,7 +88,7 @@ func TestRedisPubSub_TenantIsolation(t *testing.T) {
 	require.NoError(t, err)
 	defer cancel2()
 
-	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "a"}))
+	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "a"}}}))
 
 	select {
 	case <-ch1:
@@ -114,7 +115,7 @@ func TestRedisPubSub_SlowSubscriber(t *testing.T) {
 	// Publish several messages without reading; the 64-slot buffer absorbs them.
 	const n = 5
 	for range n {
-		require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "x"}))
+		require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "x"}}}))
 	}
 
 	// Slow consumer reads all messages after a delay.
@@ -175,11 +176,12 @@ func TestRedisPubSub_DuplicateDeliverySemantics(t *testing.T) {
 	require.NoError(t, err)
 	defer cancel()
 
-	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", FieldPath: "x"}))
+	require.NoError(t, pub.Publish(ctx, ConfigChangeEvent{TenantID: "t1", Changes: []FieldChange{{FieldPath: "x"}}}))
 
 	select {
 	case got := <-ch:
-		assert.Equal(t, "x", got.FieldPath)
+		require.Len(t, got.Changes, 1)
+		assert.Equal(t, "x", got.Changes[0].FieldPath)
 	case <-time.After(time.Second):
 		t.Fatal("no event received")
 	}


### PR DESCRIPTION
## Summary

- SetFields and ImportConfig serialised N pubsub round-trips (one per field), amplifying tail latency for any multi-field update — this batches all field changes from a single RPC into one publish call.
- Introduces `FieldChange` struct and replaces the flat `FieldPath`/`OldValue`/`NewValue` fields on `ConfigChangeEvent` with a `Changes []FieldChange` slice; `publishChange` is replaced by `publishChanges`.
- The external gRPC `SubscribeResponse` shape is unchanged — the Subscribe handler expands batched events back into one message per field.

## Test plan

- [x] `TestSetField_PublishesOneEvent` — single-field update emits exactly one pubsub event with a one-element `Changes` slice
- [x] `TestSetFields_PublishesOneEventWithAllChanges` — two-field update emits one event carrying both changes in order
- [x] `TestSubscribe_BatchEventExpandedToPerFieldMessages` — one batched event fans out to two gRPC stream messages
- [x] All existing Subscribe filter/watermark/replay tests updated and passing
- [x] `make test` green across all modules
- [x] `make lint-go` clean

> **Consumer migration note:** subscribers reading the Redis/memory pubsub payload directly must migrate from the old flat `field_path`/`old_value`/`new_value` JSON fields to the `changes` array. The gRPC `SubscribeResponse` is unaffected.

Closes #251