### PR TITLE
Retry config writes on CreateConfigVersion UNIQUE conflicts

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -570,7 +570,7 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	// the UNIQUE(tenant_id, version) constraint on CreateConfigVersion, so at
 	// most one writer succeeds per version slot.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
+	if err := s.runInTxWithRetry(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
 		if txErr != nil {
@@ -732,7 +732,7 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 	// Checksums are verified inside the tx after re-reading the latest version so
 	// concurrent writes cannot bypass the check (TOCTOU fix for #417).
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
+	if err := s.runInTxWithRetry(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
 		var txErr error
 		txLockedVersion, txErr := txLatestVersion(ctx, tx, tenantID)
 		if txErr != nil {
@@ -904,11 +904,6 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 		return nil, status.Error(codes.NotFound, "target version not found or empty")
 	}
 
-	latest, err := s.store.GetLatestConfigVersion(ctx, tenantID)
-	if err != nil {
-		return nil, status.Error(codes.Internal, "failed to get latest version")
-	}
-
 	desc := fmt.Sprintf("Rollback to version %d", req.Version)
 	if req.Description != nil {
 		desc = *req.Description
@@ -926,11 +921,14 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 
 	// Transaction: new version + copied values + audit + dependentRequired check.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
-		var txErr error
+	if err := s.runInTxWithRetry(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
+		txVersion, txErr := txLatestVersion(ctx, tx, tenantID)
+		if txErr != nil {
+			return txErr
+		}
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,
-			Version:     latest.Version + 1,
+			Version:     txVersion + 1,
 			Description: &desc,
 			CreatedBy:   actor,
 		})
@@ -1285,11 +1283,14 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 
 	// Transaction: version + all values + audit entries + dependentRequired check.
 	var newVersion domain.ConfigVersion
-	if err := s.store.RunInTx(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
-		var txErr error
+	if err := s.runInTxWithRetry(storage.WithTenantID(ctx, tenantID), func(tx Store) error {
+		txVersion, txErr := txLatestVersion(ctx, tx, tenantID)
+		if txErr != nil {
+			return txErr
+		}
 		newVersion, txErr = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
 			TenantID:    tenantID,
-			Version:     latestVersion + 1,
+			Version:     txVersion + 1,
 			Description: &desc,
 			CreatedBy:   actor,
 		})
@@ -1491,6 +1492,34 @@ func txLatestVersion(ctx context.Context, tx Store, tenantID string) (int32, err
 		return 0, status.Error(codes.Internal, "failed to get latest version")
 	}
 	return latest.Version, nil
+}
+
+var versionConflictBackoffs = []time.Duration{
+	time.Millisecond,
+	5 * time.Millisecond,
+	25 * time.Millisecond,
+}
+
+// retryOnVersionConflict calls fn up to 4 times (initial + 3 retries) backing
+// off on ErrVersionConflict between each attempt. Any other error returns
+// immediately. Returns ErrVersionConflict only when all attempts are exhausted.
+func retryOnVersionConflict(fn func() error) error {
+	for _, d := range versionConflictBackoffs {
+		err := fn()
+		if !errors.Is(err, ErrVersionConflict) {
+			return err
+		}
+		time.Sleep(d)
+	}
+	return fn()
+}
+
+// runInTxWithRetry wraps store.RunInTx with automatic retry on
+// ErrVersionConflict. See retryOnVersionConflict for the retry budget.
+func (s *Service) runInTxWithRetry(ctx context.Context, fn func(Store) error) error {
+	return retryOnVersionConflict(func() error {
+		return s.store.RunInTx(ctx, fn)
+	})
 }
 
 // checkChecksumAtVersion verifies that the stored checksum for fieldPath at

--- a/internal/config/service_pg_integration_test.go
+++ b/internal/config/service_pg_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/auth"
+	"github.com/opendecree/decree/internal/cache"
+	"github.com/opendecree/decree/internal/pubsub"
+	"github.com/opendecree/decree/internal/schema"
+	"github.com/opendecree/decree/internal/storage/domain"
+	"github.com/opendecree/decree/internal/storage/pgtest"
+)
+
+// TestRetryOnVersionConflict_ConcurrentSetField hammers SetField from N
+// goroutines on the same tenant simultaneously. Before issue #196, concurrent
+// writers that lost the UNIQUE(tenant_id, version) race received codes.Internal.
+// After the fix, the service retries transparently; the test asserts that
+// codes.Internal is never returned and all N writes eventually commit.
+func TestRetryOnVersionConflict_ConcurrentSetField(t *testing.T) {
+	t.Parallel()
+
+	const N = 20
+	pool := pgtest.NewPool(t)
+	cfgStore := NewPGStore(pool, pool)
+	schStore := schema.NewPGStore(pool, pool)
+	ctx := context.Background()
+
+	// Create schema with N string fields.
+	_, sv, tenant := setupFixture(t, schStore, t.Name())
+	for i := 0; i < N; i++ {
+		_, err := schStore.CreateSchemaField(ctx, schema.CreateSchemaFieldParams{
+			SchemaVersionID: sv.ID,
+			Path:            fmt.Sprintf("field_%d", i),
+			FieldType:       domain.FieldTypeString,
+		})
+		require.NoError(t, err)
+	}
+
+	memCache := cache.NewMemoryCache(0)
+	memPub := pubsub.NewMemoryPubSub()
+	svc := NewService(cfgStore, memCache, memPub, memPub, WithLogger(testLogger))
+
+	svcCtx := auth.WithoutAuth(ctx)
+
+	var (
+		wg           sync.WaitGroup
+		internalErrs atomic.Int64
+		successes    atomic.Int64
+	)
+
+	start := make(chan struct{})
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			fieldPath := fmt.Sprintf("field_%d", i)
+			req := &pb.SetFieldRequest{
+				TenantId:  tenant.ID,
+				FieldPath: fieldPath,
+				Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: fmt.Sprintf("v%d", i)}},
+			}
+
+			<-start // synchronize all goroutines for maximum contention
+
+			// Retry at the caller level on codes.Aborted (service budget exhausted).
+			for attempt := 0; attempt < 15; attempt++ {
+				_, err := svc.SetField(svcCtx, req)
+				if err == nil {
+					successes.Add(1)
+					return
+				}
+				if status.Code(err) == codes.Internal {
+					internalErrs.Add(1)
+					return
+				}
+				if status.Code(err) == codes.Aborted {
+					time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+					continue
+				}
+				// Any other error is unexpected.
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			t.Errorf("field_%d: still aborted after 15 caller-level retries", i)
+		}(i)
+	}
+
+	close(start) // release all goroutines simultaneously
+	wg.Wait()
+
+	assert.Equal(t, int64(0), internalErrs.Load(),
+		"codes.Internal must never be returned for version conflicts — only codes.Aborted is acceptable when the retry budget is exhausted")
+	assert.Equal(t, int64(N), successes.Load(),
+		"all %d writes must eventually commit", N)
+}

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -482,6 +482,69 @@ func TestGetField_NotFound(t *testing.T) {
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
+func TestSetField_VersionConflictRetried(t *testing.T) {
+	// First tx attempt returns ErrVersionConflict; second attempt succeeds.
+	// The retry must be transparent — caller sees success, not codes.Aborted.
+	svc, store, cache, pub := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	// Pre-tx + 2 tx attempts = 3 total GetLatestConfigVersion calls.
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 5}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	setupNoSensitiveFields(store)
+
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict).Once()
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 6, CreatedBy: "unknown"}, nil).Once()
+
+	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+
+	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.env",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}},
+	})
+
+	require.NoError(t, err, "single version conflict must be retried transparently")
+	assert.Equal(t, int32(6), resp.ConfigVersion.Version)
+	store.AssertNumberOfCalls(t, "CreateConfigVersion", 2)
+}
+
+func TestSetField_VersionConflictExhausted(t *testing.T) {
+	// All 4 attempts (initial + 3 retries) return ErrVersionConflict.
+	// The service must return codes.Aborted, not codes.Internal.
+	svc, store, cache, _ := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 5}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+	setupNoSensitiveFields(store)
+
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "app.env",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+	store.AssertNumberOfCalls(t, "CreateConfigVersion", 4) // initial + 3 retries
+}
+
 // --- RollbackToVersion ---
 
 func TestRollbackToVersion_Success(t *testing.T) {
@@ -517,6 +580,7 @@ func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 
 	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
+	// GetLatestConfigVersion is now called inside the tx per attempt (4 total).
 	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 5}, nil)
 	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{}, ErrVersionConflict)
@@ -528,7 +592,34 @@ func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict during rollback must return Aborted, not Internal")
+	assert.Equal(t, codes.Aborted, status.Code(err), "version conflict during rollback must return Aborted after retry budget exhausted")
+	store.AssertNumberOfCalls(t, "CreateConfigVersion", 4)
+}
+
+func TestRollbackToVersion_VersionConflictRetried(t *testing.T) {
+	// First attempt gets ErrVersionConflict; second attempt succeeds.
+	svc, store, cache, _ := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 5}, nil)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{}, ErrVersionConflict).Once()
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6, CreatedBy: "unknown"}, nil).Once()
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+
+	resp, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
+		TenantId: tenantID1,
+		Version:  2,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(6), resp.ConfigVersion.Version)
+	store.AssertNumberOfCalls(t, "CreateConfigVersion", 2)
 }
 
 // --- ExportConfig ---


### PR DESCRIPTION
## Summary

- Concurrent writers losing the UNIQUE(tenant\_id, version) race received `codes.Internal` — a generic error that gave callers no signal to retry. The constraint is intentional (it serializes concurrent writes for cross-field validation correctness), so the loser should get a clean `codes.Aborted` after transparent retries.
- Add `retryOnVersionConflict` (initial + 3 retries, 1 ms / 5 ms / 25 ms backoffs) and `runInTxWithRetry` to wrap all four write sites: `SetField`, `SetFields`, `RollbackToVersion`, and `ImportConfig`. Each retry re-runs the full transaction so validation fires against the updated snapshot.
- Move version-number resolution inside the transaction for `RollbackToVersion` and `ImportConfig` (they previously read latest outside the tx), so each retry attempt uses a fresh version slot and never races on a stale number.

## Test plan

- [ ] `TestSetField_VersionConflictRetried` — one conflict, second attempt succeeds transparently (no error returned to caller)
- [ ] `TestSetField_VersionConflictExhausted` — all 4 attempts conflict → `codes.Aborted`, `CreateConfigVersion` called exactly 4 times
- [ ] `TestRollbackToVersion_VersionConflictRetried` — retry path for rollback
- [ ] `TestRollbackToVersion_VersionConflictReturnsAborted` — updated to assert 4 `CreateConfigVersion` calls
- [ ] Full unit suite (`make test`) — no regressions
- [ ] `TestRetryOnVersionConflict_ConcurrentSetField` (integration, `//go:build integration`) — 20 goroutines hammer `SetField` simultaneously; asserts zero `codes.Internal` and all 20 writes eventually commit

Closes #196