### PR TITLE
docs(sdk): add Go OTel instrumentation guide

### DIFF
--- a/.agents/context/sdk-instrumentation.md
+++ b/.agents/context/sdk-instrumentation.md
@@ -12,11 +12,10 @@ Optional extra: `pip install opendecree[otel]`. Constructor flag `otel=True` wir
 
 ### Go SDKs (`decree`)
 
-Docs-only — users pass their own `grpc.ClientConn`, add OTel interceptors themselves:
+Docs-only — users pass their own `grpc.ClientConn`, add OTel via stats handler (preferred over deprecated interceptor API):
 ```go
 conn, _ := grpc.NewClient(target,
-    grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-    grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
+    grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 )
 ```
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -37,3 +37,26 @@ Reusable power tools for config management — importable as Go packages for int
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/tools](https://pkg.go.dev/github.com/opendecree/decree/sdk/tools)
 
 Packages: `diff` (config version diffing), `docgen` (schema → markdown), `validate` (offline YAML validation), `seed` (bootstrap from YAML), `dump` (full tenant backup). Offline tools have zero gRPC/proto dependencies.
+
+## OpenTelemetry instrumentation (Go)
+
+The Go SDKs accept a `grpc.ClientConn` that callers construct themselves. Wire an OTel interceptor at connection time:
+
+```go
+import (
+    "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+    "google.golang.org/grpc"
+    "github.com/opendecree/decree/sdk/configclient"
+)
+
+conn, err := grpc.NewClient(
+    "localhost:9090",
+    grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+)
+// conn is passed to the SDK client
+client := configclient.New(conn, ...)
+```
+
+`otelgrpc.NewClientHandler()` uses the stats handler API (preferred over deprecated interceptors) and records spans for every RPC. The same pattern applies to `adminclient` and the watcher's underlying connection.
+
+Install: `go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`


### PR DESCRIPTION
## Summary

- Documents the recommended pattern for wiring OpenTelemetry into Go SDK connections using `otelgrpc.NewClientHandler()`, the stats handler API that supersedes the now-deprecated unary/stream interceptor functions.
- Updates the agent context brief (`sdk-instrumentation.md`) to reflect the correct modern approach so future agents don't generate deprecated code.

## Test plan

- [ ] Docs-only change — no code modified.
- [ ] Go snippet compiles against `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` (stats handler API, available since otelgrpc v0.46.0).
- [ ] Related Python SDK work tracked in opendecree/decree-python#117.

Refs opendecree/decree-python#23