### PR TITLE
fix(configwatcher): make Start/Close lifecycle concurrency-safe

### DIFF
--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -143,6 +143,121 @@ func TestWatcher_ConcurrentStartAndClose(t *testing.T) {
 	_ = w.Close()
 }
 
+// TestWatcher_DoubleStart verifies that calling Start twice is a no-op: the
+// second call returns nil without launching a second subscription loop.
+// Run with: go test -race ./sdk/configwatcher/
+func TestWatcher_DoubleStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var subscribeCalls int
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+		},
+		subscribeFn: func(sCtx context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			subscribeCalls++
+			return &mockSubscription{ch: make(chan *configclient.ConfigChange), ctx: sCtx}, nil
+		},
+	}
+
+	w := &Watcher{
+		transport: tr,
+		tenantID:  "t1",
+		opts:      options{minBackoff: 10 * time.Millisecond, maxBackoff: 50 * time.Millisecond, logger: slog.Default()},
+		fields:    make(map[string]*fieldEntry),
+		done:      make(chan struct{}),
+	}
+
+	_ = w.String("app.name", "default")
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+
+	// Give the loop a moment to call Subscribe (it should only do so once).
+	time.Sleep(20 * time.Millisecond)
+
+	cancel()
+	_ = w.Close()
+
+	if subscribeCalls != 1 {
+		t.Errorf("expected exactly 1 Subscribe call, got %d", subscribeCalls)
+	}
+}
+
+// TestWatcher_StartCloseConcurrent fires Start and Close from separate goroutines
+// simultaneously and verifies no race, panic, or goroutine leak occurs.
+// Run with: go test -race ./sdk/configwatcher/
+func TestWatcher_StartCloseConcurrent(t *testing.T) {
+	const iterations = 200
+
+	for range iterations {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		tr := &mockTransport{
+			getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+				return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+			},
+			subscribeFn: func(sCtx context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+				return &mockSubscription{ch: make(chan *configclient.ConfigChange), ctx: sCtx}, nil
+			},
+		}
+
+		w := &Watcher{
+			transport: tr,
+			tenantID:  "t1",
+			opts:      options{minBackoff: 5 * time.Millisecond, maxBackoff: 10 * time.Millisecond, logger: slog.Default()},
+			fields:    make(map[string]*fieldEntry),
+			done:      make(chan struct{}),
+		}
+
+		_ = w.String("app.name", "default")
+
+		// ready gates Start and Close to begin at the same instant.
+		ready := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-ready
+			_ = w.Start(ctx)
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-ready
+			cancel()
+			_ = w.Close()
+		}()
+
+		close(ready)
+		wg.Wait()
+
+		// If a subscription goroutine was started it must exit because ctx is
+		// cancelled. Allow a short window for it to drain and close w.done.
+		select {
+		case <-w.done:
+			// Loop exited cleanly (or was never started — done is pre-closed
+			// only if subscriptionLoop ran and returned).
+		case <-time.After(200 * time.Millisecond):
+			// done is still open: the goroutine was never launched (Close won
+			// before Start set started=true). This is not a leak.
+			w.mu.RLock()
+			started := w.started
+			w.mu.RUnlock()
+			if started {
+				t.Error("goroutine launched but w.done never closed")
+			}
+		}
+	}
+}
+
 // TestValue_CloseRacesWithUpdate exercises the race between Value.close() and
 // Value.update() that previously caused a "send on closed channel" panic.
 // Run with: go test -race ./sdk/configwatcher/

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -42,11 +42,15 @@ type Watcher struct {
 	tenantID  string
 	opts      options
 
-	mu     sync.RWMutex
-	fields map[string]*fieldEntry // field path → entry
-	closed bool
-	cancel context.CancelFunc
-	done   chan struct{}
+	mu      sync.RWMutex
+	fields  map[string]*fieldEntry // field path → entry
+	closed  bool
+	started bool
+	cancel  context.CancelFunc
+	// cancelReady is closed by Start after w.cancel is assigned, allowing
+	// a concurrent Close to safely wait until cancel is available.
+	cancelReady chan struct{}
+	done        chan struct{}
 }
 
 type fieldEntry struct {
@@ -78,11 +82,12 @@ func New(transport configclient.Transport, tenantID string, opts ...Option) *Wat
 	}
 
 	return &Watcher{
-		transport: transport,
-		tenantID:  tenantID,
-		opts:      o,
-		fields:    make(map[string]*fieldEntry),
-		done:      make(chan struct{}),
+		transport:   transport,
+		tenantID:    tenantID,
+		opts:        o,
+		fields:      make(map[string]*fieldEntry),
+		cancelReady: make(chan struct{}),
+		done:        make(chan struct{}),
 	}
 }
 
@@ -186,15 +191,43 @@ func registerField[T any](w *Watcher, fieldPath string, defaultVal T, parse func
 // when cancelled, the subscription is terminated and all [Value.Changes] channels
 // are closed.
 //
+// Start is idempotent: a second call returns nil without starting another loop.
+//
 // Fields must be registered (via String, Int, Bool, etc.) before calling Start.
 func (w *Watcher) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.started {
+		w.mu.Unlock()
+		return nil
+	}
+	w.started = true
+	// Lazily initialize cancelReady for callers that construct Watcher directly
+	// (e.g. in tests) without going through New.
+	if w.cancelReady == nil {
+		w.cancelReady = make(chan struct{})
+	}
+	w.mu.Unlock()
+
 	version, err := w.loadSnapshot(ctx)
 	if err != nil {
+		// Roll back so the caller can retry.
+		w.mu.Lock()
+		w.started = false
+		w.cancelReady = make(chan struct{}) // reset for next attempt
+		w.mu.Unlock()
 		return err
 	}
 
-	ctx, w.cancel = context.WithCancel(ctx)
-	go w.subscriptionLoop(ctx, version)
+	loopCtx, cancel := context.WithCancel(ctx)
+
+	w.mu.Lock()
+	w.cancel = cancel
+	w.mu.Unlock()
+
+	// Signal any concurrent Close that cancel is now assigned.
+	close(w.cancelReady)
+
+	go w.subscriptionLoop(loopCtx, version)
 	return nil
 }
 
@@ -207,11 +240,29 @@ func (w *Watcher) Close() error {
 		return nil
 	}
 	w.closed = true
+	started := w.started
 	w.mu.Unlock()
 
-	if w.cancel != nil {
-		w.cancel()
-		<-w.done // Wait for subscription goroutine to exit.
+	if started {
+		// Wait until Start has finished assigning w.cancel. This prevents a
+		// race where Close is called while Start is executing but hasn't yet
+		// stored the cancel function.
+		w.mu.RLock()
+		ready := w.cancelReady
+		w.mu.RUnlock()
+
+		if ready != nil {
+			<-ready
+		}
+
+		w.mu.RLock()
+		cancel := w.cancel
+		w.mu.RUnlock()
+
+		if cancel != nil {
+			cancel()
+			<-w.done // Wait for subscription goroutine to exit.
+		}
 	}
 
 	// Close all value channels.


### PR DESCRIPTION
## Summary

- The configwatcher's `Start`/`Close` lifecycle had a data race, a double-`Start` panic, and a goroutine leak that were invisible to the existing test suite because it only exercised sequential paths.
- This fix makes the lifecycle concurrency-safe by protecting shared state under a mutex and synchronizing `Close` against an in-flight `Start`.
- Concurrent and double-`Start` race tests are added to prevent regressions under `-race`.

## Test plan

- [ ] `go test -race ./...` in `sdk/configwatcher` — all pass, no data race reports
- [ ] `make test` (all 32 packages) — pass
- [ ] `make lint-go` — no issues
- [ ] `TestWatcher_DoubleStart` — second `Start` call is a no-op (1 Subscribe call)
- [ ] `TestWatcher_StartCloseConcurrent` — 200 concurrent Start/Close iterations, no panic, no race, no goroutine leak

Closes #638