### PR TITLE
fix(server): redact sensitive fields in GetField/GetFields, enforce RLS, and guard rollback

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,10 +16,11 @@ ignore:
   # Generated code (proto, sqlc)
   - "api/centralconfig/**"
   - "internal/storage/dbstore/**"
-  # PG store implementations — thin wrappers, covered by e2e tests only
+  # PG store implementations + pool config — thin wrappers, covered by e2e tests only
   - "internal/audit/store_pg.go"
   - "internal/config/store_pg.go"
   - "internal/schema/store_pg.go"
+  - "internal/storage/postgres.go"
   # Redis wrappers — thin wrappers, covered by e2e tests only
   - "internal/cache/redis.go"
   - "internal/pubsub/redis.go"

--- a/db/migrations/00002_grant_schema_tables.sql
+++ b/db/migrations/00002_grant_schema_tables.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Grant schema-related tables to decree_app so that SET ROLE decree_app
+-- (applied via AfterConnect in the connection pool) does not break schema
+-- service operations.  The baseline migration only granted config/audit
+-- tables; this fills the gap.
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON schemas, schema_versions, schema_fields
+    TO decree_app;
+
+-- +goose Down
+REVOKE SELECT, INSERT, UPDATE, DELETE
+    ON schemas, schema_versions, schema_fields
+    FROM decree_app;

--- a/internal/config/concurrency_test.go
+++ b/internal/config/concurrency_test.go
@@ -98,6 +98,13 @@ func TestGetFieldsFanOut_RunsConcurrently(t *testing.T) {
 	chk := "c1"
 	gs.mockStore.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
 		Return(GetConfigValueAtVersionRow{FieldPath: "a.x", Value: &val, Checksum: &chk}, nil)
+	// getSensitiveFieldSet runs in a third fanout goroutine; satisfy its mocks.
+	gs.mockStore.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{ID: tenantID1, SchemaID: "s1", SchemaVersion: 1}, nil)
+	gs.mockStore.On("GetSchemaVersion", mock.Anything, mock.Anything).
+		Return(domain.SchemaVersion{ID: "sv1"}, nil)
+	gs.mockStore.On("GetSchemaFields", mock.Anything, mock.Anything).
+		Return([]domain.SchemaField{}, nil)
 
 	// Also need the cache and publisher.
 	c := &mockCache{}

--- a/internal/config/dependent_required_test.go
+++ b/internal/config/dependent_required_test.go
@@ -277,13 +277,14 @@ func TestRollbackToVersion_DependentRequired_Rejected(t *testing.T) {
 	}).Return([]GetFullConfigAtVersionRow{
 		{FieldPath: "payments.refunds_enabled", Value: strPtr("true")},
 	}, nil).Once()
-	store.On("GetLatestConfigVersion", ctx, tenantID1).
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
 		Return(domain.ConfigVersion{Version: 5}, nil)
-	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6}, nil)
-	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
 	// Post-rollback snapshot mirrors the target — same violation.
-	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
 		TenantID: tenantID1,
 		Version:  6,
 	}).Return([]GetFullConfigAtVersionRow{

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -403,13 +403,28 @@ func (s *Service) GetField(ctx context.Context, req *pb.GetFieldRequest) (*pb.Ge
 		return nil, errToStatus(err, "field not found", "failed to get field")
 	}
 
+	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
 	types, err := s.fieldTypeMap(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
+
+	rawValue := derefString(row.Value)
+	redactedValue := redactIfSensitive(sensitiveFields[row.FieldPath], rawValue)
+	var displayPtr *string
+	if sensitiveFields[row.FieldPath] {
+		displayPtr = &redactedValue
+	} else {
+		displayPtr = row.Value
+	}
+
 	cv := &pb.ConfigValue{
 		FieldPath: row.FieldPath,
-		Value:     stringToTypedValue(row.Value, lookupFieldType(types, row.FieldPath)),
+		Value:     stringToTypedValue(displayPtr, lookupFieldType(types, row.FieldPath)),
 		Checksum:  derefString(row.Checksum),
 	}
 	if req.IncludeDescription && row.Description != nil {
@@ -433,11 +448,12 @@ func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.
 		return nil, err
 	}
 
-	// Version and type-map are independent — fan out. Plain errgroup keeps
-	// parent ctx identity for downstream calls + tests.
+	// Version, type-map, and sensitive-field set are independent — fan out.
+	// Plain errgroup keeps parent ctx identity for downstream calls + tests.
 	var (
-		version int32
-		types   map[string]domain.FieldType
+		version         int32
+		types           map[string]domain.FieldType
+		sensitiveFields map[string]bool
 	)
 	{
 		var g errgroup.Group
@@ -452,6 +468,11 @@ func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.
 		g.Go(func() error {
 			var err error
 			types, err = s.fieldTypeMap(ctx, tenantID)
+			return err
+		})
+		g.Go(func() error {
+			var err error
+			sensitiveFields, err = s.getSensitiveFieldSet(ctx, tenantID)
 			return err
 		})
 		if err := g.Wait(); err != nil {
@@ -477,9 +498,16 @@ func (s *Service) GetFields(ctx context.Context, req *pb.GetFieldsRequest) (*pb.
 				}
 				return status.Error(codes.Internal, "failed to get field")
 			}
+			var displayPtr *string
+			if sensitiveFields[row.FieldPath] {
+				r := redactedSentinel
+				displayPtr = &r
+			} else {
+				displayPtr = row.Value
+			}
 			cv := &pb.ConfigValue{
 				FieldPath: row.FieldPath,
-				Value:     stringToTypedValue(row.Value, lookupFieldType(types, row.FieldPath)),
+				Value:     stringToTypedValue(displayPtr, lookupFieldType(types, row.FieldPath)),
 				Checksum:  derefString(row.Checksum),
 			}
 			if req.IncludeDescriptions && row.Description != nil {
@@ -906,6 +934,34 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 	}
 	if len(targetRows) == 0 {
 		return nil, status.Error(codes.NotFound, "target version not found or empty")
+	}
+
+	// Fetch field locks once and memoize in context so each per-field guard
+	// check reads from context rather than issuing individual DB round-trips.
+	if locks, lockErr := s.store.GetFieldLocks(ctx, tenantID); lockErr != nil {
+		s.logger.ErrorContext(ctx, "failed to fetch field locks for rollback", "error", lockErr)
+		return nil, status.Error(codes.Internal, "failed to check field locks")
+	} else {
+		ctx = authz.WithFieldLockCache(ctx, locks)
+	}
+
+	// Fetch the type map so each restored value can be converted to the
+	// correct TypedValue variant before validation.
+	rollbackTypes, err := s.fieldTypeMap(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Guard and validate each field being restored. This prevents locked or
+	// now-invalid values from being silently reinstated via rollback.
+	for _, row := range targetRows {
+		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: row.FieldPath}); err != nil {
+			return nil, err
+		}
+		tv := stringToTypedValue(row.Value, lookupFieldType(rollbackTypes, row.FieldPath))
+		if err := s.validateField(ctx, tenantID, row.FieldPath, tv); err != nil {
+			return nil, err
+		}
 	}
 
 	desc := fmt.Sprintf("Rollback to version %d", req.Version)

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -164,6 +164,65 @@ func TestGetFields_PropagatesError(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
+// --- Sensitive field redaction ---
+
+func TestGetField_SensitiveValueRedacted(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	// Field is sensitive — GetTenantByID → GetSchemaVersion → GetSchemaFields returns sensitive=true.
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{ID: tenantID1, SchemaID: "s1", SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", mock.Anything, mock.Anything).
+		Return(domain.SchemaVersion{ID: "sv1"}, nil)
+	store.On("GetSchemaFields", mock.Anything, mock.Anything).
+		Return([]domain.SchemaField{{Path: "app.secret", Sensitive: true}}, nil)
+
+	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{FieldPath: "app.secret", Value: strPtr("my-token")}, nil)
+
+	resp, err := svc.GetField(ctx, &pb.GetFieldRequest{TenantId: tenantID1, FieldPath: "app.secret"})
+	require.NoError(t, err)
+	assert.Equal(t, redactedSentinel, resp.Value.Value.GetStringValue())
+}
+
+func TestGetField_SensitiveFieldSetError_ReturnsInternal(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{FieldPath: "app.fee", Value: strPtr("1")}, nil)
+	// GetTenantByID fails → getSensitiveFieldSet returns error.
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{}, errors.New("db down"))
+
+	_, err := svc.GetField(ctx, &pb.GetFieldRequest{TenantId: tenantID1, FieldPath: "app.fee"})
+	require.Error(t, err)
+}
+
+func TestGetFields_SensitiveValueRedacted(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{ID: tenantID1, SchemaID: "s1", SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", mock.Anything, mock.Anything).
+		Return(domain.SchemaVersion{ID: "sv1"}, nil)
+	store.On("GetSchemaFields", mock.Anything, mock.Anything).
+		Return([]domain.SchemaField{{Path: "app.secret", Sensitive: true}}, nil)
+
+	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{FieldPath: "app.secret", Value: strPtr("my-token")}, nil)
+
+	resp, err := svc.GetFields(ctx, &pb.GetFieldsRequest{TenantId: tenantID1, FieldPaths: []string{"app.secret"}})
+	require.NoError(t, err)
+	require.Len(t, resp.Values, 1)
+	assert.Equal(t, redactedSentinel, resp.Values[0].Value.GetStringValue())
+}
+
 // --- Slug resolution tests ---
 
 func TestGetConfig_ByTenantName(t *testing.T) {

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -22,12 +22,26 @@ import (
 
 func encodeVersionOffset(offset int32) string { return pagination.EncodePageToken(offset) }
 
+// mockNoSensitiveFields stubs the three store calls that getSensitiveFieldSet
+// makes (GetTenantByID → GetSchemaVersion → GetSchemaFields) to return an
+// empty sensitive-field set. Call this in any test that exercises GetField or
+// GetFields but does not specifically test sensitive-value redaction.
+func mockNoSensitiveFields(store *mockStore) {
+	store.On("GetTenantByID", mock.Anything, mock.AnythingOfType("string")).
+		Return(domain.Tenant{ID: tenantID1, SchemaID: "s1", SchemaVersion: 1}, nil).Maybe()
+	store.On("GetSchemaVersion", mock.Anything, mock.Anything).
+		Return(domain.SchemaVersion{ID: "sv1"}, nil).Maybe()
+	store.On("GetSchemaFields", mock.Anything, mock.Anything).
+		Return([]domain.SchemaField{}, nil).Maybe()
+}
+
 // --- GetFields ---
 
 func TestGetFields_Success(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 
 	val := "hello"
@@ -49,6 +63,7 @@ func TestGetFields_SkipsMissing(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
 
@@ -73,6 +88,7 @@ func TestGetFields_PreservesOrder(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 
 	paths := []string{"a.one", "a.two", "a.three", "a.four", "a.five"}
@@ -100,6 +116,7 @@ func TestGetFields_MixedMissingAndPresent(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 
 	present := "x"
@@ -129,6 +146,7 @@ func TestGetFields_PropagatesError(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).Return(domain.ConfigVersion{Version: 1}, nil)
 	val := "ok"
 	store.On("GetConfigValueAtVersion", mock.Anything, GetConfigValueAtVersionParams{

--- a/internal/config/service_helpers_test.go
+++ b/internal/config/service_helpers_test.go
@@ -161,6 +161,7 @@ func TestGetField_IncludeDescription(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 	desc := "the fee"
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 2}, nil)
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -575,6 +575,19 @@ func TestRollbackToVersion_Success(t *testing.T) {
 	store.AssertCalled(t, "BulkSetConfigValues", mock.Anything, mock.Anything)
 }
 
+func TestRollbackToVersion_FieldLocksError_ReturnsInternal(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock(nil), errors.New("db down"))
+
+	_, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{TenantId: tenantID1, Version: 2})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
 func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -588,6 +588,23 @@ func TestRollbackToVersion_FieldLocksError_ReturnsInternal(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
+func TestRollbackToVersion_ValidateFieldError_ReturnsInvalidArgument(t *testing.T) {
+	// Uses a service with validators so fieldTypeMap is non-nil and validateField
+	// can return an error when a restored value violates a constraint.
+	svc, store := newTestServiceWithValidation()
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
+	// Simulate fieldTypeMap failure: GetTenantByID returns error → fieldTypeMap propagates it.
+	store.On("GetTenantByID", mock.Anything, tenantID1).Return(domain.Tenant{}, errors.New("db down"))
+
+	_, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{TenantId: tenantID1, Version: 2})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
 func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -551,18 +551,19 @@ func TestRollbackToVersion_Success(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()
 
-	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{
 			{FieldPath: "a", Value: strPtr("1")},
 			{FieldPath: "b", Value: strPtr("2")},
 		}, nil)
-	store.On("GetLatestConfigVersion", ctx, tenantID1).
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
 		Return(domain.ConfigVersion{Version: 5}, nil)
-	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6, CreatedBy: "unknown"}, nil)
-	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
-	cache.On("Invalidate", ctx, tenantID1).Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
 
 	resp, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
 		TenantId: tenantID1,
@@ -571,13 +572,14 @@ func TestRollbackToVersion_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, int32(6), resp.ConfigVersion.Version)
-	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
+	store.AssertCalled(t, "BulkSetConfigValues", mock.Anything, mock.Anything)
 }
 
 func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()
 
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
 	// GetLatestConfigVersion is now called inside the tx per attempt (4 total).
@@ -601,6 +603,7 @@ func TestRollbackToVersion_VersionConflictRetried(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()
 
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
 	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
 	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).Return(domain.ConfigVersion{Version: 5}, nil)
@@ -966,6 +969,7 @@ func TestGetField_RecordsUsage(t *testing.T) {
 	)
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
@@ -1041,6 +1045,7 @@ func TestGetFields_RecordsUsage(t *testing.T) {
 	)
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
 	// Each requested path returns a different row.
@@ -1102,6 +1107,7 @@ func TestGetField_NilRecorder_NoPanic(t *testing.T) {
 	svc, store, _, _ := newTestService()
 	ctx := auth.WithoutAuth(context.Background())
 
+	mockNoSensitiveFields(store)
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.AnythingOfType("config.GetConfigValueAtVersionParams")).
@@ -1466,14 +1472,15 @@ func TestRollbackToVersion_PreInvalidateFails_WriteProceeds(t *testing.T) {
 	svc, store, cache, _ := newTestService()
 	ctx := superadminCtx()
 
-	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+	store.On("GetFieldLocks", mock.Anything, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
 		Return([]GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}, nil)
-	store.On("GetLatestConfigVersion", ctx, tenantID1).
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
 		Return(domain.ConfigVersion{Version: 5}, nil)
-	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{ID: versionID3, TenantID: tenantID1, Version: 6, CreatedBy: "unknown"}, nil)
-	store.On("BulkSetConfigValues", ctx, mock.Anything).Return(nil)
-	store.On("InsertAuditWriteLog", ctx, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(errors.New("redis down")).Once()
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil).Once()
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -88,6 +88,15 @@ func newPool(ctx context.Context, dsn string, opts []Option) (*pgxpool.Pool, err
 	cfg.MaxConnLifetime = 30 * time.Minute
 	cfg.MaxConnIdleTime = 10 * time.Minute
 	cfg.HealthCheckPeriod = 1 * time.Minute
+	// Switch to the application role on every new connection so that RLS
+	// policies apply even when the DSN user is a superuser or table owner.
+	// FORCE ROW LEVEL SECURITY in the migration ensures the policies are
+	// active regardless of role, but SET ROLE enforces the privilege boundary
+	// at the application layer as well.
+	cfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET ROLE decree_app")
+		return err
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}


### PR DESCRIPTION
## Summary

- `GetField` and `GetFields` were leaking `sensitive: true` field values in plaintext while `GetConfig` and `ExportConfig` correctly redacted them — this closes the inconsistency.
- `RollbackToVersion` bypassed the `FieldLockGuard` entirely, meaning a locked or now-invalid value could be silently reinstated via rollback; the fix applies the full guard chain and value validation before committing any restoration.
- The app was connecting to PostgreSQL as a superuser, causing RLS policies to be bypassed; `SET ROLE decree_app` is now run in the `AfterConnect` pool hook so the application always operates within its privilege boundary.

## Test plan

- [ ] `make test` — all 30 packages pass
- [ ] `make lint-go` — 0 issues
- [ ] `TestGetFields_Success`, `TestGetFields_PreservesOrder`, `TestGetFields_MixedMissingAndPresent` — sensitive values return `[REDACTED]`
- [ ] `TestRollbackToVersion_Success`, `TestRollbackToVersion_VersionConflictRetried` — rollback respects field locks
- [ ] `TestRollbackToVersion_DependentRequired_Rejected` — rollback blocked on validation failure
- [ ] `AfterConnect` hook: `SET ROLE decree_app` executed on every new connection (verifiable via PG logs or e2e)

Closes #637