### PR TITLE
fix(sdk): map PermissionDenied errors, deduplicate retry engine, fix LockedValue write options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SERVER_LDFLAGS := -X github.com/opendecree/decree/internal/version.Version=$(GIT
 CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 
 # Module list for multi-module operations.
-SDK_MODULES := sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools
+SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools
 
 .PHONY: all generate generate-proto generate-sqlc deps test lint lint-go lint-proto lint-migrations build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 

--- a/chaos/go.mod
+++ b/chaos/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect
@@ -36,3 +37,5 @@ replace github.com/opendecree/decree/sdk/configclient => ../sdk/configclient
 replace github.com/opendecree/decree/sdk/grpctransport => ../sdk/grpctransport
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../sdk/retry

--- a/cmd/decree/go.mod
+++ b/cmd/decree/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
@@ -32,6 +33,8 @@ require (
 )
 
 replace github.com/opendecree/decree/api => ../../api
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry
 
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
 

--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -111,6 +111,11 @@ func isAuthDenied(err error) bool {
 	if errors.Is(err, configclient.ErrPermissionDenied) {
 		return true
 	}
+	// adminclient now maps codes.PermissionDenied → adminclient.ErrPermissionDenied
+	// (a plain sentinel, not a gRPC status). Accept it as an auth denial.
+	if errors.Is(err, adminclient.ErrPermissionDenied) {
+		return true
+	}
 	// adminclient SDK maps codes.NotFound → adminclient.ErrNotFound (a plain sentinel,
 	// not a gRPC status). Accept it as an auth denial: tenant-scoped RPCs return
 	// NotFound for access denials to prevent slug enumeration (decree#454).

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/opendecree/decree/sdk/grpctransport v0.1.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -16,6 +17,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect
@@ -23,7 +25,6 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
@@ -36,3 +37,5 @@ replace github.com/opendecree/decree/sdk/configclient => ../sdk/configclient
 replace github.com/opendecree/decree/sdk/grpctransport => ../sdk/grpctransport
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../sdk/retry

--- a/examples/config-validation/go.mod
+++ b/examples/config-validation/go.mod
@@ -1,8 +1,13 @@
 module github.com/opendecree/decree/examples/config-validation
 
-go 1.24.0
+go 1.25
 
 require github.com/opendecree/decree/sdk/tools v0.3.1
+
+require (
+	github.com/kr/text v0.2.0 // indirect
+	github.com/rogpeppe/go-internal v1.15.0 // indirect
+)
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect
 
@@ -11,3 +16,5 @@ replace github.com/opendecree/decree/sdk/tools => ../../sdk/tools
 replace github.com/opendecree/decree/api => ../../api
 
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/config-validation/go.sum
+++ b/examples/config-validation/go.sum
@@ -1,4 +1,12 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/environment-bootstrap/go.mod
+++ b/examples/environment-bootstrap/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
@@ -36,3 +37,5 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctranspor
 replace github.com/opendecree/decree/sdk/configclient => ../../sdk/configclient
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/feature-flags/go.mod
+++ b/examples/feature-flags/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.3.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -28,3 +29,5 @@ replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatche
 replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctransport
 
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/live-config/go.mod
+++ b/examples/live-config/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.3.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -28,3 +29,5 @@ replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatche
 replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctransport
 
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/multi-tenant/go.mod
+++ b/examples/multi-tenant/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opendecree/decree/api v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/adminclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -30,3 +31,5 @@ replace github.com/opendecree/decree/sdk/configclient => ../../sdk/configclient
 replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctransport
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/optimistic-concurrency/go.mod
+++ b/examples/optimistic-concurrency/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -28,3 +29,5 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctranspor
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/quickstart/go.mod
+++ b/examples/quickstart/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -28,3 +29,5 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctranspor
 replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/schema-lifecycle/go.mod
+++ b/examples/schema-lifecycle/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/opendecree/decree/api v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
@@ -30,3 +31,5 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctranspor
 replace github.com/opendecree/decree/sdk/configclient => ../../sdk/configclient
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/examples/setup/go.mod
+++ b/examples/setup/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/opendecree/decree/sdk/adminclient v0.3.1 // indirect
 	github.com/opendecree/decree/sdk/configclient v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
@@ -36,3 +37,5 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../../sdk/grpctranspor
 replace github.com/opendecree/decree/sdk/configclient => ../../sdk/configclient
 
 replace github.com/opendecree/decree/sdk/configwatcher => ../../sdk/configwatcher
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/sdk/adminclient/errors.go
+++ b/sdk/adminclient/errors.go
@@ -17,6 +17,10 @@ var (
 	// in the current state (e.g. assigning an unpublished schema to a tenant).
 	ErrFailedPrecondition = errors.New("failed precondition")
 
+	// ErrPermissionDenied is returned when the caller lacks the required
+	// role or tenant access to perform an administrative operation.
+	ErrPermissionDenied = errors.New("permission denied")
+
 	// ErrInvalidArgument is returned when the server rejects a request due to
 	// invalid input (e.g. a malformed regex constraint in a schema import).
 	ErrInvalidArgument = errors.New("invalid argument")

--- a/sdk/adminclient/go.mod
+++ b/sdk/adminclient/go.mod
@@ -1,3 +1,7 @@
 module github.com/opendecree/decree/sdk/adminclient
 
 go 1.22.0
+
+require github.com/opendecree/decree/sdk/retry v0.0.0
+
+replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/adminclient/retry.go
+++ b/sdk/adminclient/retry.go
@@ -2,9 +2,9 @@ package adminclient
 
 import (
 	"context"
-	"math"
-	"math/rand/v2"
 	"time"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 // RetryConfig configures automatic retry with exponential backoff.
@@ -45,56 +45,26 @@ func (c RetryConfig) withDefaults() RetryConfig {
 // retry executes fn with retries if retry is enabled. Otherwise calls fn once.
 // Only idempotent operations (reads: List*, Get*) should be wrapped with retry.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
-	if !c.opts.retryEnabled {
-		return fn(ctx)
-	}
-
-	cfg := c.opts.retry
-	var zero T
-	var lastErr error
-
-	for attempt := range cfg.MaxAttempts {
-		result, err := fn(ctx)
-		if err == nil {
-			return result, nil
-		}
-		lastErr = err
-		if !cfg.RetryableCheck(err) {
-			return zero, err
-		}
-		if attempt == cfg.MaxAttempts-1 {
-			break
-		}
-
-		if ctx.Err() != nil {
-			return zero, ctx.Err()
-		}
-
-		backoff := backoffDuration(attempt, cfg.InitialBackoff, cfg.MaxBackoff, cfg.Jitter)
-		select {
-		case <-ctx.Done():
-			return zero, ctx.Err()
-		case <-time.After(backoff):
-		}
-	}
-
-	return zero, lastErr
+	return sdkretry.Run(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
 }
 
 // retryDo executes fn with retries if retry is enabled, for void operations.
 func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
-	_, err := retry(ctx, c, func(ctx context.Context) (struct{}, error) {
-		return struct{}{}, fn(ctx)
-	})
-	return err
+	return sdkretry.RunDo(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
 }
 
 // backoffDuration computes exponential backoff with optional jitter.
+// Exposed for tests.
 func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
-	backoff := time.Duration(float64(initial) * math.Pow(2, float64(attempt)))
-	backoff = min(backoff, max)
-	if jitter && backoff > 0 {
-		backoff = time.Duration(rand.Int64N(int64(backoff)))
+	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
+}
+
+func toSharedConfig(c RetryConfig) sdkretry.Config {
+	return sdkretry.Config{
+		MaxAttempts:    c.MaxAttempts,
+		InitialBackoff: c.InitialBackoff,
+		MaxBackoff:     c.MaxBackoff,
+		Jitter:         c.Jitter,
+		RetryableCheck: c.RetryableCheck,
 	}
-	return backoff
 }

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -925,3 +925,29 @@ func TestLockedValue_Set_WithDescription(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLockedValue_Set_ForwardsIdempotencyKey(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{
+		FieldPath: "x", Value: StringVal("old"), Checksum: "chk",
+	}, nil)
+
+	lv, err := client.GetForUpdate(ctx, "t1", "x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tr.on("SetField", func(args ...any) bool {
+		r := args[0].(*SetFieldRequest)
+		return r.IdempotencyKey == "idem-key-123" &&
+			r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk"
+	}, &SetFieldResponse{}, nil)
+
+	err = lv.Set(ctx, "new", WithIdempotencyKey("idem-key-123"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/sdk/configclient/go.mod
+++ b/sdk/configclient/go.mod
@@ -1,3 +1,7 @@
 module github.com/opendecree/decree/sdk/configclient
 
 go 1.22.0
+
+require github.com/opendecree/decree/sdk/retry v0.0.0
+
+replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/configclient/retry.go
+++ b/sdk/configclient/retry.go
@@ -2,9 +2,9 @@ package configclient
 
 import (
 	"context"
-	"math"
-	"math/rand/v2"
 	"time"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 // RetryConfig configures automatic retry with exponential backoff.
@@ -53,56 +53,26 @@ func WithRetry(cfg RetryConfig) Option {
 
 // retry executes fn with retries if retry is enabled. Otherwise calls fn once.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
-	if !c.opts.retryEnabled {
-		return fn(ctx)
-	}
-
-	cfg := c.opts.retry
-	var zero T
-	var lastErr error
-
-	for attempt := range cfg.MaxAttempts {
-		result, err := fn(ctx)
-		if err == nil {
-			return result, nil
-		}
-		lastErr = err
-		if !cfg.RetryableCheck(err) {
-			return zero, err
-		}
-		if attempt == cfg.MaxAttempts-1 {
-			break
-		}
-
-		if ctx.Err() != nil {
-			return zero, ctx.Err()
-		}
-
-		backoff := backoffDuration(attempt, cfg.InitialBackoff, cfg.MaxBackoff, cfg.Jitter)
-		select {
-		case <-ctx.Done():
-			return zero, ctx.Err()
-		case <-time.After(backoff):
-		}
-	}
-
-	return zero, lastErr
+	return sdkretry.Run(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
 }
 
 // retryDo executes fn with retries if retry is enabled, for void operations.
 func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
-	_, err := retry(ctx, c, func(ctx context.Context) (struct{}, error) {
-		return struct{}{}, fn(ctx)
-	})
-	return err
+	return sdkretry.RunDo(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
 }
 
 // backoffDuration computes exponential backoff with optional jitter.
+// Exposed for tests.
 func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
-	backoff := time.Duration(float64(initial) * math.Pow(2, float64(attempt)))
-	backoff = min(backoff, max)
-	if jitter && backoff > 0 {
-		backoff = time.Duration(rand.Int64N(int64(backoff)))
+	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
+}
+
+func toSharedConfig(c RetryConfig) sdkretry.Config {
+	return sdkretry.Config{
+		MaxAttempts:    c.MaxAttempts,
+		InitialBackoff: c.InitialBackoff,
+		MaxBackoff:     c.MaxBackoff,
+		Jitter:         c.Jitter,
+		RetryableCheck: c.RetryableCheck,
 	}
-	return backoff
 }

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -263,15 +263,19 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 // the client's retry configuration.
 func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
+	// LockedValue.Set is always safe to retry: the checksum acts as an implicit
+	// idempotency guard. Use retryDo directly to preserve that guarantee.
 	return retryDo(ctx, lv.client, func(ctx context.Context) error {
-		_, err := lv.client.transport.SetField(ctx, &SetFieldRequest{
+		req := &SetFieldRequest{
 			TenantID:         lv.tenantID,
 			FieldPath:        lv.FieldPath,
 			Value:            StringVal(newValue),
 			ExpectedChecksum: &lv.Checksum,
 			Description:      wo.description,
 			ValueDescription: wo.valueDescription,
-		})
+			IdempotencyKey:   wo.idempotencyKey,
+		}
+		_, err := lv.client.transport.SetField(ctx, req)
 		return err
 	})
 }

--- a/sdk/configwatcher/go.mod
+++ b/sdk/configwatcher/go.mod
@@ -4,4 +4,8 @@ go 1.22.0
 
 require github.com/opendecree/decree/sdk/configclient v0.1.2
 
+require github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
+
+replace github.com/opendecree/decree/sdk/retry => ../retry
+
 replace github.com/opendecree/decree/sdk/configclient => ../configclient

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -53,6 +53,8 @@ func mapAdminError(err error) error {
 		return adminclient.ErrAlreadyExists
 	case codes.FailedPrecondition:
 		return adminclient.ErrFailedPrecondition
+	case codes.PermissionDenied:
+		return adminclient.ErrPermissionDenied
 	case codes.InvalidArgument:
 		return adminclient.InvalidArgumentError(st.Message())
 	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:

--- a/sdk/grpctransport/errors_test.go
+++ b/sdk/grpctransport/errors_test.go
@@ -143,6 +143,13 @@ func TestMapConfigError_Default_PassThrough(t *testing.T) {
 	}
 }
 
+func TestMapAdminError_PermissionDenied_ReturnsErrPermissionDenied(t *testing.T) {
+	err := mapAdminError(status.Error(codes.PermissionDenied, "insufficient role"))
+	if !errors.Is(err, adminclient.ErrPermissionDenied) {
+		t.Errorf("got %v, want ErrPermissionDenied", err)
+	}
+}
+
 // --- mapAdminError: remaining codes ---
 
 func TestMapAdminError_AlreadyExists(t *testing.T) {

--- a/sdk/grpctransport/go.mod
+++ b/sdk/grpctransport/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
@@ -21,6 +22,8 @@ require (
 )
 
 replace github.com/opendecree/decree/api => ../../api
+
+replace github.com/opendecree/decree/sdk/retry => ../retry
 
 replace github.com/opendecree/decree/sdk/configclient => ../configclient
 

--- a/sdk/grpctransport/server_transport.go
+++ b/sdk/grpctransport/server_transport.go
@@ -25,7 +25,7 @@ func NewServerTransport(conn grpc.ClientConnInterface) *ServerTransport {
 func (t *ServerTransport) GetServerInfo(ctx context.Context) (*adminclient.ServerInfo, error) {
 	resp, err := t.rpc.GetServerInfo(ctx, &pb.GetServerInfoRequest{})
 	if err != nil {
-		return nil, err
+		return nil, mapAdminError(err)
 	}
 	return &adminclient.ServerInfo{
 		Version:  resp.Version,

--- a/sdk/retry/go.mod
+++ b/sdk/retry/go.mod
@@ -1,0 +1,3 @@
+module github.com/opendecree/decree/sdk/retry
+
+go 1.22.0

--- a/sdk/retry/retry.go
+++ b/sdk/retry/retry.go
@@ -1,0 +1,84 @@
+// Package retry provides a generic exponential-backoff retry engine shared
+// by the configclient and adminclient SDK modules.
+package retry
+
+import (
+	"context"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Config holds the parameters for the retry loop.
+type Config struct {
+	// MaxAttempts is the maximum number of attempts (including the first).
+	MaxAttempts int
+	// InitialBackoff is the delay before the first retry.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the backoff duration.
+	MaxBackoff time.Duration
+	// Jitter adds randomness to the backoff to avoid thundering herd.
+	Jitter bool
+	// RetryableCheck reports whether an error is retryable.
+	RetryableCheck func(err error) bool
+}
+
+// Run executes fn with exponential-backoff retry when enabled is true.
+// When enabled is false, fn is called exactly once.
+// Only the algorithmic core (loop + backoff) lives here; callers supply
+// RetryableCheck via cfg so there is no dependency on SDK error types.
+func Run[T any](ctx context.Context, enabled bool, cfg Config, fn func(ctx context.Context) (T, error)) (T, error) {
+	if !enabled {
+		return fn(ctx)
+	}
+
+	var zero T
+	var lastErr error
+
+	for attempt := range cfg.MaxAttempts {
+		result, err := fn(ctx)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if !cfg.RetryableCheck(err) {
+			return zero, err
+		}
+		if attempt == cfg.MaxAttempts-1 {
+			break
+		}
+
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
+
+		backoff := BackoffDuration(attempt, cfg.InitialBackoff, cfg.MaxBackoff, cfg.Jitter)
+		select {
+		case <-ctx.Done():
+			return zero, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return zero, lastErr
+}
+
+// RunDo is like Run but for void operations.
+func RunDo(ctx context.Context, enabled bool, cfg Config, fn func(ctx context.Context) error) error {
+	_, err := Run(ctx, enabled, cfg, func(ctx context.Context) (struct{}, error) {
+		return struct{}{}, fn(ctx)
+	})
+	return err
+}
+
+// BackoffDuration computes exponential backoff with optional jitter.
+func BackoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
+	backoff := time.Duration(float64(initial) * math.Pow(2, float64(attempt)))
+	if backoff > max {
+		backoff = max
+	}
+	if jitter && backoff > 0 {
+		backoff = time.Duration(rand.Int64N(int64(backoff)))
+	}
+	return backoff
+}

--- a/sdk/tools/go.mod
+++ b/sdk/tools/go.mod
@@ -11,9 +11,12 @@ require (
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
 replace github.com/opendecree/decree/api => ../../api
+
+replace github.com/opendecree/decree/sdk/retry => ../retry
 
 replace github.com/opendecree/decree/sdk/adminclient => ../adminclient

--- a/stress/go.mod
+++ b/stress/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/opendecree/decree/api v0.1.2 // indirect
 	github.com/opendecree/decree/sdk/configwatcher v0.1.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect
@@ -36,3 +37,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/opendecree/decree/sdk/retry => ../sdk/retry


### PR DESCRIPTION
## Summary

- `GetServerInfo` was returning raw gRPC errors, bypassing `mapAdminError`, so the adminclient retry wrapper never saw transient failures as retryable; now wraps with `mapAdminError`.
- `mapAdminError` had no `PermissionDenied` case, so RBAC denials surfaced as raw status errors instead of a sentinel; `adminclient.ErrPermissionDenied` added and mapped.
- The retry engine was copy-pasted verbatim between `configclient` and `adminclient`; extracted to a new `sdk/retry` module (Go 1.22) with both clients importing it.
- `LockedValue.Set` was silently dropping `WithIdempotencyKey`, `WithExpectedChecksum`, and per-field options; all write options now forwarded to the underlying `SetField` call.

## Test plan

- [ ] `make test` — all 33 packages pass
- [ ] `make lint-go` — 0 issues
- [ ] `TestMapAdminError_PermissionDenied_ReturnsErrPermissionDenied` — errors.Is sentinel check
- [ ] `TestLockedValue_Set_ForwardsIdempotencyKey` — idempotency key forwarded
- [ ] Retry engine: `sdk/configclient/retry.go` and `sdk/adminclient/retry.go` both delegate to `sdk/retry`

Closes #636