### PR TITLE
fix(cli): default to TLS; make --insecure opt-in with warning

### DIFF
--- a/cmd/decree/connect.go
+++ b/cmd/decree/connect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"google.golang.org/grpc"
 
@@ -13,6 +14,7 @@ import (
 func dialServer() (*grpc.ClientConn, error) {
 	var opts []grpctransport.DialOption
 	if flagInsecure {
+		fmt.Fprintln(os.Stderr, "Warning: --insecure flag is set; connection is not encrypted")
 		opts = append(opts, grpctransport.WithInsecure())
 	}
 	conn, err := grpctransport.Dial(flagServer, opts...)

--- a/cmd/decree/connect_test.go
+++ b/cmd/decree/connect_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +30,44 @@ func TestDialServer_TLS(t *testing.T) {
 	conn.Close()
 }
 
+// TestDialServer_TLS_NoWarning verifies that no warning is printed to stderr
+// when --insecure is not set (the default, secure path).
+func TestDialServer_TLS_NoWarning(t *testing.T) {
+	orig := flagServer
+	origInsecure := flagInsecure
+	t.Cleanup(func() {
+		flagServer = orig
+		flagInsecure = origInsecure
+	})
+
+	flagServer = "passthrough:///localhost:9999"
+	flagInsecure = false
+
+	// Capture stderr.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	conn, dialErr := dialServer()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+
+	if dialErr != nil {
+		t.Fatalf("dialServer (TLS path) unexpected error: %v", dialErr)
+	}
+	conn.Close()
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no stderr output on TLS path, got: %q", buf.String())
+	}
+}
+
 // TestDialServer_Insecure verifies that dialServer succeeds on the insecure path
 // (--insecure flag set), which passes WithInsecure() to grpctransport.Dial.
 func TestDialServer_Insecure(t *testing.T) {
@@ -44,4 +86,61 @@ func TestDialServer_Insecure(t *testing.T) {
 		t.Fatalf("dialServer (insecure path) unexpected error: %v", err)
 	}
 	conn.Close()
+}
+
+// TestDialServer_Insecure_PrintsWarning verifies that a warning is printed to
+// stderr when --insecure is set.
+func TestDialServer_Insecure_PrintsWarning(t *testing.T) {
+	orig := flagServer
+	origInsecure := flagInsecure
+	t.Cleanup(func() {
+		flagServer = orig
+		flagInsecure = origInsecure
+	})
+
+	flagServer = "passthrough:///localhost:9999"
+	flagInsecure = true
+
+	// Capture stderr.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	conn, dialErr := dialServer()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+
+	if dialErr != nil {
+		t.Fatalf("dialServer (insecure path) unexpected error: %v", dialErr)
+	}
+	conn.Close()
+
+	got := buf.String()
+	if !strings.Contains(got, "Warning") {
+		t.Errorf("expected warning on stderr for --insecure path, got: %q", got)
+	}
+	if !strings.Contains(got, "--insecure") {
+		t.Errorf("expected warning to mention --insecure, got: %q", got)
+	}
+	if !strings.Contains(got, "not encrypted") {
+		t.Errorf("expected warning to mention encryption, got: %q", got)
+	}
+}
+
+// TestFlagInsecure_DefaultIsFalse verifies the --insecure flag defaults to false,
+// ensuring TLS is used by default.
+func TestFlagInsecure_DefaultIsFalse(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("insecure")
+	if f == nil {
+		t.Fatal("--insecure flag not registered on rootCmd")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--insecure default = %q, want %q", f.DefValue, "false")
+	}
 }


### PR DESCRIPTION
## Summary

- The CLI was already defaulting to TLS (false), but using `--insecure` produced no visible signal, making it easy to run unencrypted connections silently in production.
- This commit adds a loud stderr warning whenever `--insecure` is set, so operators cannot accidentally leave the flag on in a production environment.

## Test plan

- [ ] `--insecure` flag default is `false` (asserted by `TestFlagInsecure_DefaultIsFalse`)
- [ ] Warning printed to stderr when `--insecure` is used (asserted by `TestDialServer_Insecure_PrintsWarning`)
- [ ] No output on stderr on the secure (default) path (asserted by `TestDialServer_TLS_NoWarning`)
- [ ] `make test` passes with coverage above 85.7% threshold
- [ ] `make lint-go` reports no issues

Closes #650