### PR TITLE
fix(server): use epoch-1 hash for config/schema audit writes

### DIFF
--- a/internal/audit/chain.go
+++ b/internal/audit/chain.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -63,11 +64,17 @@ func ComputeEntryHash(in ChainInput) string {
 	writeNullableStr(h, in.OldValue)
 	writeNullableStr(h, in.NewValue)
 	writeNullableI32(h, in.ConfigVersion)
-	if len(in.Metadata) == 0 {
+	// Normalize Metadata JSON before hashing so the result is independent of
+	// formatting differences between the writer (Go's compact json.Marshal)
+	// and the reader (PostgreSQL JSONB text output, which adds spaces after
+	// colons and commas). Both forms parse to the same Go value and then
+	// re-marshal to the same compact representation.
+	meta := normalizeJSON(in.Metadata)
+	if len(meta) == 0 {
 		_, _ = h.Write([]byte{0x00})
 	} else {
 		_, _ = h.Write([]byte{0x01})
-		_, _ = fmt.Fprint(h, hex.EncodeToString(in.Metadata))
+		_, _ = fmt.Fprint(h, hex.EncodeToString(meta))
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
@@ -87,4 +94,26 @@ func writeNullableI32(h io.Writer, v *int32) {
 	} else {
 		_, _ = fmt.Fprintf(h, "\x01%d\x00", *v)
 	}
+}
+
+// normalizeJSON parses b as JSON and re-marshals it into compact form.
+// This makes the hash independent of formatting differences: Go's json.Marshal
+// emits compact JSON without spaces, while PostgreSQL's JSONB text output adds
+// a space after every colon and comma.  Both forms parse to the same value and
+// then re-marshal to the same compact representation.
+//
+// If b is empty or not valid JSON, b is returned unchanged.
+func normalizeJSON(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return b // not valid JSON — hash raw bytes unchanged
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return b
+	}
+	return out
 }

--- a/internal/audit/chain_test.go
+++ b/internal/audit/chain_test.go
@@ -126,3 +126,30 @@ func TestComputeEntryHash_Epoch1_NilVsEmpty(t *testing.T) {
 	// nil and empty string must produce different hashes.
 	assert.NotEqual(t, ComputeEntryHash(withNil), ComputeEntryHash(withEmpty))
 }
+
+// TestComputeEntryHash_Epoch1_MetadataJSONNormalization verifies that Go's
+// compact json.Marshal output and PostgreSQL's JSONB text output (which adds
+// a space after each colon and comma) produce the same hash.  This prevents
+// chain breaks when VerifyChain reads Metadata back from a JSONB column.
+func TestComputeEntryHash_Epoch1_MetadataJSONNormalization(t *testing.T) {
+	base := ChainInput{
+		Epoch: 1, ID: "id-1", Actor: "a", Action: "set_field", ObjectKind: "field",
+		CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Go's compact form (no spaces) — written to DB at audit-entry creation time.
+	compact := base
+	compact.Metadata = []byte(`{"name":"sec-audit","schema_id":"abc","schema_version":1}`)
+
+	// PostgreSQL JSONB text form (space after : and ,) — returned by DB on read.
+	pgForm := base
+	pgForm.Metadata = []byte(`{"name": "sec-audit", "schema_id": "abc", "schema_version": 1}`)
+
+	assert.Equal(t, ComputeEntryHash(compact), ComputeEntryHash(pgForm),
+		"compact JSON and PostgreSQL JSONB text output must produce the same hash")
+
+	// A different value must still produce a different hash.
+	different := base
+	different.Metadata = []byte(`{"name":"other"}`)
+	assert.NotEqual(t, ComputeEntryHash(compact), ComputeEntryHash(different))
+}

--- a/internal/audit/chain_test.go
+++ b/internal/audit/chain_test.go
@@ -152,4 +152,11 @@ func TestComputeEntryHash_Epoch1_MetadataJSONNormalization(t *testing.T) {
 	different := base
 	different.Metadata = []byte(`{"name":"other"}`)
 	assert.NotEqual(t, ComputeEntryHash(compact), ComputeEntryHash(different))
+
+	// Invalid JSON bytes are hashed unchanged (fallback path).
+	invalidJSON := base
+	invalidJSON.Metadata = []byte(`not-json`)
+	assert.NotPanics(t, func() { ComputeEntryHash(invalidJSON) })
+	// Two calls with the same invalid bytes produce the same hash.
+	assert.Equal(t, ComputeEntryHash(invalidJSON), ComputeEntryHash(invalidJSON))
 }

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -177,6 +177,94 @@ func TestVerifyChain_DetectsPayloadTampering(t *testing.T) {
 	assert.NotEmpty(t, result.Breaks, "should report at least one break")
 }
 
+// TestVerifyChain_ConfigWriterPayloadTampering verifies that audit entries written
+// with the full epoch-1 payload (as config/schema stores now produce) are detected
+// when any payload field is tampered.  Regression test for issue #641.
+func TestVerifyChain_ConfigWriterPayloadTampering(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	tenantID := "cfg00000-0000-0000-0000-000000000001"
+
+	fp := "app.timeout"
+	oldVal := "30"
+	newVal := "60"
+	ver := int32(2)
+
+	// Simulate three entries as a config writer would produce (Epoch 1, full payload).
+	for i := range 3 {
+		nv := string(rune('0'+i)) + "0"
+		err := store.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+			TenantID:      tenantID,
+			Actor:         "alice",
+			Action:        "set_field",
+			ObjectKind:    "field",
+			FieldPath:     &fp,
+			OldValue:      &oldVal,
+			NewValue:      &nv,
+			ConfigVersion: &ver,
+		})
+		require.NoError(t, err)
+		oldVal = nv
+	}
+	_ = newVal // suppress unused warning
+
+	// Tamper the OldValue of the first entry — hash stays unchanged.
+	store.mu.Lock()
+	for i, e := range store.writeLogs {
+		if e.TenantID == tenantID {
+			tampered := "TAMPERED_OLD"
+			store.writeLogs[i].OldValue = &tampered
+			break
+		}
+	}
+	store.mu.Unlock()
+
+	result, err := VerifyChain(ctx, store, tenantID)
+	require.NoError(t, err)
+	assert.False(t, result.OK, "VerifyChain must detect OldValue tamper on epoch-1 config entry")
+	assert.NotEmpty(t, result.Breaks)
+}
+
+// TestVerifyChain_SchemaWriterPayloadTampering verifies that schema-level audit
+// entries (no ConfigVersion) also detect payload tampering with epoch-1.
+// Regression test for issue #641.
+func TestVerifyChain_SchemaWriterPayloadTampering(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	tenantID := "" // schema entries use the global chain
+
+	fp := "schemas.my-schema"
+	old := `{"version":1}`
+	new := `{"version":2}`
+
+	err := store.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+		TenantID:   tenantID,
+		Actor:      "admin",
+		Action:     "publish_schema",
+		ObjectKind: "schema",
+		FieldPath:  &fp,
+		OldValue:   &old,
+		NewValue:   &new,
+	})
+	require.NoError(t, err)
+
+	// Tamper NewValue — hash must no longer match.
+	store.mu.Lock()
+	for i, e := range store.writeLogs {
+		if e.TenantID == tenantID {
+			tampered := "TAMPERED_NEW"
+			store.writeLogs[i].NewValue = &tampered
+			break
+		}
+	}
+	store.mu.Unlock()
+
+	result, err := VerifyChain(ctx, store, tenantID)
+	require.NoError(t, err)
+	assert.False(t, result.OK, "VerifyChain must detect NewValue tamper on epoch-1 schema entry")
+	assert.NotEmpty(t, result.Breaks)
+}
+
 // TestConcurrentInserts_ChainIsLinear fires N concurrent writes and asserts the
 // resulting chain has no forks — every entry except the first has a unique
 // PreviousHash that matches exactly the preceding entry's EntryHash.

--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -383,13 +383,19 @@ func (s *PGStore) BulkInsertAuditWriteLog(ctx context.Context, args []InsertAudi
 		}
 		now := time.Now().Truncate(time.Microsecond)
 		hash := audit.ComputeEntryHash(audit.ChainInput{
-			PreviousHash: prevHash,
-			ID:           pgconv.UUIDToString(id),
-			TenantID:     arg.TenantID,
-			Actor:        arg.Actor,
-			Action:       arg.Action,
-			ObjectKind:   kind,
-			CreatedAt:    now,
+			PreviousHash:  prevHash,
+			ID:            pgconv.UUIDToString(id),
+			TenantID:      arg.TenantID,
+			Actor:         arg.Actor,
+			Action:        arg.Action,
+			ObjectKind:    kind,
+			CreatedAt:     now,
+			Epoch:         1,
+			FieldPath:     arg.FieldPath,
+			OldValue:      arg.OldValue,
+			NewValue:      arg.NewValue,
+			ConfigVersion: arg.ConfigVersion,
+			Metadata:      arg.Metadata,
 		})
 		rows[i] = row{
 			id:        id,
@@ -407,7 +413,7 @@ func (s *PGStore) BulkInsertAuditWriteLog(ctx context.Context, args []InsertAudi
 		batch.Queue(bulkInsertAuditWriteLogSQL,
 			r.id, tenantUUID, r.arg.Actor, r.arg.Action,
 			r.arg.FieldPath, r.arg.OldValue, r.arg.NewValue, r.arg.ConfigVersion,
-			r.arg.Metadata, r.kind, r.prevHash, r.entryHash, r.now, int32(0),
+			r.arg.Metadata, r.kind, r.prevHash, r.entryHash, r.now, int32(1),
 		)
 	}
 	br := s.batcher().SendBatch(ctx, batch)
@@ -458,13 +464,19 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 	// verification both use the same CreatedAt value.
 	now := time.Now().Truncate(time.Microsecond)
 	hash := audit.ComputeEntryHash(audit.ChainInput{
-		PreviousHash: prevHash,
-		ID:           pgconv.UUIDToString(id),
-		TenantID:     arg.TenantID,
-		Actor:        arg.Actor,
-		Action:       arg.Action,
-		ObjectKind:   kind,
-		CreatedAt:    now,
+		PreviousHash:  prevHash,
+		ID:            pgconv.UUIDToString(id),
+		TenantID:      arg.TenantID,
+		Actor:         arg.Actor,
+		Action:        arg.Action,
+		ObjectKind:    kind,
+		CreatedAt:     now,
+		Epoch:         1,
+		FieldPath:     arg.FieldPath,
+		OldValue:      arg.OldValue,
+		NewValue:      arg.NewValue,
+		ConfigVersion: arg.ConfigVersion,
+		Metadata:      arg.Metadata,
 	})
 
 	return s.write.InsertAuditWriteLog(ctx, dbstore.InsertAuditWriteLogParams{
@@ -481,6 +493,7 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		PreviousHash:  prevHash,
 		EntryHash:     hash,
 		CreatedAt:     pgconv.TimeToTimestamptz(now),
+		ChainEpoch:    1,
 	})
 }
 

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -106,6 +106,11 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		Action:       arg.Action,
 		ObjectKind:   arg.ObjectKind,
 		CreatedAt:    now,
+		Epoch:        1,
+		FieldPath:    arg.FieldPath,
+		OldValue:     arg.OldValue,
+		NewValue:     arg.NewValue,
+		Metadata:     arg.Metadata,
 	})
 
 	return s.write.InsertAuditWriteLog(ctx, dbstore.InsertAuditWriteLogParams{
@@ -121,6 +126,7 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		PreviousHash: prevHash,
 		EntryHash:    hash,
 		CreatedAt:    pgconv.TimeToTimestamptz(now),
+		ChainEpoch:   1,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Config and schema audit writers were hashing only structural fields (Epoch 0), leaving payload fields unprotected — a tampered old_value or new_value was invisible to VerifyChain.
- Both writers now compute the chain hash with Epoch 1 (full payload: field_path, old_value, new_value, config_version, metadata) and store chain_epoch=1 in the DB row.
- Two regression tests tamper OldValue / NewValue on epoch-1 entries and assert VerifyChain reports a break.

## Test plan
- [x] `TestVerifyChain_ConfigWriterPayloadTampering` — tampers OldValue on a config-style entry; VerifyChain must report a break
- [x] `TestVerifyChain_SchemaWriterPayloadTampering` — tampers NewValue on a schema-style entry; VerifyChain must report a break
- [x] `make test` passes (all packages, race detector)
- [x] `make lint-go` clean

Closes #641