### PR TITLE
fix(server): take advisory lock on all audit-chain writes

### DIFF
--- a/internal/config/store_pg.go
+++ b/internal/config/store_pg.go
@@ -358,6 +358,13 @@ func (s *PGStore) BulkInsertAuditWriteLog(ctx context.Context, args []InsertAudi
 		return err
 	}
 
+	// Serialise all chain operations for this tenant so concurrent
+	// transactions queue up rather than forking the hash chain.
+	lockKey := "audit_chain:" + args[0].TenantID
+	if err := s.acquireChainLock(ctx, lockKey); err != nil {
+		return err
+	}
+
 	prevHash, err := s.write.GetLastAuditHashForTenant(ctx, tenantUUID)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return fmt.Errorf("get last audit hash: %w", err)
@@ -439,9 +446,35 @@ func configGenUUID() (pgtype.UUID, error) {
 	return id, nil
 }
 
+// acquireChainLock takes a pg_advisory_xact_lock for the given key within the
+// current transaction. The lock is released automatically when the transaction
+// commits or rolls back, serialising concurrent chain-append operations for
+// the same tenant.
+func (s *PGStore) acquireChainLock(ctx context.Context, lockKey string) error {
+	if s.tx != nil {
+		if _, err := s.tx.Exec(ctx, "SELECT pg_advisory_xact_lock(hashtext($1)::bigint)", lockKey); err != nil {
+			return fmt.Errorf("acquire audit chain lock: %w", err)
+		}
+		return nil
+	}
+	// Fallback: no active transaction; the caller must have called this outside
+	// RunInTx, which is unexpected but handled safely.
+	if _, err := s.writePool.Exec(ctx, "SELECT pg_advisory_xact_lock(hashtext($1)::bigint)", lockKey); err != nil {
+		return fmt.Errorf("acquire audit chain lock: %w", err)
+	}
+	return nil
+}
+
 func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteLogParams) error {
 	tenantUUID, err := pgconv.StringToUUID(arg.TenantID)
 	if err != nil {
+		return err
+	}
+
+	// Serialise all chain operations for this tenant so concurrent
+	// transactions queue up rather than forking the hash chain.
+	lockKey := "audit_chain:" + arg.TenantID
+	if err := s.acquireChainLock(ctx, lockKey); err != nil {
 		return err
 	}
 

--- a/internal/config/store_pg_integration_test.go
+++ b/internal/config/store_pg_integration_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/opendecree/decree/internal/schema"
+	"github.com/opendecree/decree/internal/storage/dbstore"
 	"github.com/opendecree/decree/internal/storage/domain"
+	"github.com/opendecree/decree/internal/storage/pgconv"
 	"github.com/opendecree/decree/internal/storage/pgtest"
 )
 
@@ -350,6 +352,70 @@ func TestConfigPGStore(t *testing.T) {
 		require.True(t, errors.As(deadlockErr, &pgErr), "expected pgconn.PgError, got: %T", deadlockErr)
 		assert.Equal(t, "40P01", pgErr.Code, "expected deadlock error code")
 	})
+}
+
+// TestAuditChainConcurrency verifies that concurrent same-tenant InsertAuditWriteLog
+// calls produce a single linear chain with no forked previous_hash values.
+func TestAuditChainConcurrency(t *testing.T) {
+	pool := pgtest.NewPool(t)
+	store := NewPGStore(pool, pool)
+	schStore := schema.NewPGStore(pool, pool)
+	ctx := context.Background()
+
+	_, _, tenant := setupFixture(t, schStore, t.Name())
+
+	const workers = 5
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	errs := make([]error, workers)
+
+	for i := range workers {
+		i := i
+		go func() {
+			defer wg.Done()
+			errs[i] = store.RunInTx(ctx, func(txStore Store) error {
+				fp := fmt.Sprintf("app.field%d", i)
+				val := fmt.Sprintf("v%d", i)
+				return txStore.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+					TenantID:   tenant.ID,
+					Actor:      "concurrent-writer",
+					Action:     "set_field",
+					ObjectKind: "field",
+					FieldPath:  &fp,
+					NewValue:   &val,
+				})
+			})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "worker %d failed", i)
+	}
+
+	// Read the chain in insertion order and verify it is linear.
+	tenantUUID, err := pgconv.StringToUUID(tenant.ID)
+	require.NoError(t, err)
+	entries, err := dbstore.New(pool).GetAuditWriteLogOrdered(ctx, tenantUUID)
+	require.NoError(t, err)
+	require.Len(t, entries, workers, "expected exactly %d entries", workers)
+
+	// Build a set of all entry_hash values to detect forking:
+	// if two entries share the same previous_hash, the chain is forked.
+	prevHashCount := make(map[string]int, workers)
+	for _, e := range entries {
+		prevHashCount[e.PreviousHash]++
+	}
+	for ph, count := range prevHashCount {
+		assert.Equal(t, 1, count, "previous_hash %q appears %d times — chain is forked", ph, count)
+	}
+
+	// Verify the linked-list structure.
+	assert.Empty(t, entries[0].PreviousHash, "first entry must have empty previous_hash")
+	for i := 1; i < len(entries); i++ {
+		assert.Equal(t, entries[i-1].EntryHash, entries[i].PreviousHash,
+			"entry[%d].PreviousHash must equal entry[%d].EntryHash", i, i-1)
+	}
 }
 
 // TestConnPoolExhaustionBehavior demonstrates pool exhaustion error semantics

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -72,6 +72,25 @@ func schemaGenUUID() (pgtype.UUID, error) {
 	return id, nil
 }
 
+// acquireChainLock takes a pg_advisory_xact_lock for the given key within the
+// current transaction. The lock is released automatically when the transaction
+// commits or rolls back, serialising concurrent chain-append operations for
+// the same tenant.
+func (s *PGStore) acquireChainLock(ctx context.Context, lockKey string) error {
+	if s.tx != nil {
+		if _, err := s.tx.Exec(ctx, "SELECT pg_advisory_xact_lock(hashtext($1)::bigint)", lockKey); err != nil {
+			return fmt.Errorf("acquire audit chain lock: %w", err)
+		}
+		return nil
+	}
+	// Fallback: no active transaction; the caller must have called this outside
+	// RunInTx, which is unexpected but handled safely.
+	if _, err := s.writePool.Exec(ctx, "SELECT pg_advisory_xact_lock(hashtext($1)::bigint)", lockKey); err != nil {
+		return fmt.Errorf("acquire audit chain lock: %w", err)
+	}
+	return nil
+}
+
 // InsertAuditWriteLog writes an admin audit entry, computing the hash chain
 // relative to the last entry for the same tenant (or global chain if tenantID is empty).
 func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteLogParams) error {
@@ -82,6 +101,16 @@ func (s *PGStore) InsertAuditWriteLog(ctx context.Context, arg InsertAuditWriteL
 		if err != nil {
 			return err
 		}
+	}
+
+	// Serialise all chain operations for this tenant so concurrent
+	// transactions queue up rather than forking the hash chain.
+	lockKey := "audit_chain:" + arg.TenantID
+	if arg.TenantID == "" {
+		lockKey = "audit_chain:global"
+	}
+	if err := s.acquireChainLock(ctx, lockKey); err != nil {
+		return err
 	}
 
 	prevHash, err := s.write.GetLastAuditHashForTenant(ctx, tenantUUID)

--- a/internal/schema/store_pg_integration_test.go
+++ b/internal/schema/store_pg_integration_test.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/opendecree/decree/internal/storage/dbstore"
 	"github.com/opendecree/decree/internal/storage/domain"
+	"github.com/opendecree/decree/internal/storage/pgconv"
 	"github.com/opendecree/decree/internal/storage/pgtest"
 )
 
@@ -312,4 +315,82 @@ func TestSchemaPGStore(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+// TestSchemaAuditChainConcurrency verifies that concurrent InsertAuditWriteLog
+// calls for the same tenant (via RunInTx) produce a single linear chain.
+func TestSchemaAuditChainConcurrency(t *testing.T) {
+	pool := pgtest.NewPool(t)
+	store := NewPGStore(pool, pool)
+	ctx := context.Background()
+
+	// Create a real tenant so entries are isolated from the global chain.
+	sch, err := store.CreateSchema(ctx, CreateSchemaParams{
+		Name: fmt.Sprintf("concurrency-schema-%s", t.Name()),
+	})
+	require.NoError(t, err)
+
+	sv, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: sch.ID,
+		Version:  1,
+		Checksum: "x",
+	})
+	require.NoError(t, err)
+
+	tenant, err := store.CreateTenant(ctx, CreateTenantParams{
+		Name:          fmt.Sprintf("concurrency-tenant-%s", t.Name()),
+		SchemaID:      sch.ID,
+		SchemaVersion: sv.Version,
+	})
+	require.NoError(t, err)
+
+	const workers = 5
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	errs := make([]error, workers)
+
+	for i := range workers {
+		i := i
+		go func() {
+			defer wg.Done()
+			errs[i] = store.RunInTx(ctx, func(txStore Store) error {
+				newVal := fmt.Sprintf("schema-%d", i)
+				return txStore.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+					TenantID:   tenant.ID,
+					Actor:      "concurrent-writer",
+					Action:     "update_tenant",
+					ObjectKind: "tenant",
+					NewValue:   &newVal,
+				})
+			})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "worker %d failed", i)
+	}
+
+	// Read all chain entries for this tenant and verify linearity.
+	tenantUUID, err := pgconv.StringToUUID(tenant.ID)
+	require.NoError(t, err)
+	entries, err := dbstore.New(pool).GetAuditWriteLogOrdered(ctx, tenantUUID)
+	require.NoError(t, err)
+	require.Len(t, entries, workers, "expected exactly %d entries", workers)
+
+	// No two entries may share the same previous_hash (would indicate a fork).
+	prevHashCount := make(map[string]int, workers)
+	for _, e := range entries {
+		prevHashCount[e.PreviousHash]++
+	}
+	for ph, count := range prevHashCount {
+		assert.Equal(t, 1, count, "previous_hash %q appears %d times — chain is forked", ph, count)
+	}
+
+	// Verify the linked-list structure.
+	assert.Empty(t, entries[0].PreviousHash, "first entry must have empty previous_hash")
+	for i := 1; i < len(entries); i++ {
+		assert.Equal(t, entries[i-1].EntryHash, entries[i].PreviousHash,
+			"entry[%d].PreviousHash must equal entry[%d].EntryHash", i, i-1)
+	}
 }


### PR DESCRIPTION
## Summary
- Add `pg_advisory_xact_lock` to `config.PGStore.InsertAuditWriteLog` and `BulkInsertAuditWriteLog` before reading `GetLastAuditHashForTenant`
- Add `pg_advisory_xact_lock` to `schema.PGStore.InsertAuditWriteLog` before reading `GetLastAuditHashForTenant`
- Prevents chain forking when concurrent transactions write to the same tenant's audit chain

## Test plan
- [ ] `TestAuditChainConcurrency` (config): 5 concurrent same-tenant `InsertAuditWriteLog` calls via `RunInTx` produce a linear chain with no forked `previous_hash`
- [ ] `TestSchemaAuditChainConcurrency` (schema): same assertion for schema store
- [ ] `make test` passes (all unit tests green)

Closes #642
🤖 Generated with [Claude Code](https://claude.com/claude-code)