### PR TITLE
test(storage): assert AfterConnect pool hook sets decree_app role

### DIFF
--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -61,6 +61,29 @@ func TestDB_Close(t *testing.T) {
 	assert.Error(t, db.WritePool.Ping(ctx))
 }
 
+// TestNewDB_AfterConnectSetsRole verifies that every connection acquired from
+// the pool created by NewDB runs as decree_app (the non-superuser application
+// role), which is required for PostgreSQL Row-Level Security policies to be
+// effective on tables guarded with FORCE ROW LEVEL SECURITY.  This is the
+// central acceptance test for issue #659.
+func TestNewDB_AfterConnectSetsRole(t *testing.T) {
+	connStr := pgtest.ConnStr(t)
+	ctx := context.Background()
+
+	db, err := storage.NewDB(ctx, connStr, "")
+	require.NoError(t, err)
+	t.Cleanup(db.Close)
+
+	conn, err := db.WritePool.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	var role string
+	require.NoError(t, conn.QueryRow(ctx, "SELECT current_role").Scan(&role))
+	assert.Equal(t, "decree_app", role,
+		"every connection in the pool must run as decree_app so RLS policies are enforced")
+}
+
 func TestConnPoolExhaustion(t *testing.T) {
 	connStr := pgtest.ConnStr(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Adds a direct acceptance test for issue #659: verifies that every connection acquired from the pool created by \`NewDB\` runs as \`decree_app\`, the non-superuser application role.
- Without this test, the \`AfterConnect\` hook (\`SET ROLE decree_app\`) was exercised only implicitly by the RLS integration test via a manual \`SET SESSION AUTHORIZATION\`, not through the actual pool code path.
- Closes the final gap in the RLS enforcement story: the implementation (hook + \`FORCE ROW LEVEL SECURITY\` in migration) was already in main; this PR adds the explicit pool-level role assertion required by the acceptance criteria.

## Test plan
- [ ] \`TestNewDB_AfterConnectSetsRole\` (integration build tag) acquires a connection from the \`NewDB\` pool and asserts \`SELECT current_role\` returns \`decree_app\`
- [ ] \`make test\` passes
- [ ] \`make lint-go\` clean

Closes #659