### PR TITLE
fix(configclient): honor WriteOptions in LockedValue.Set

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -951,3 +951,52 @@ func TestLockedValue_Set_ForwardsIdempotencyKey(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLockedValue_Set_RejectsUnsupportedOptions(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	makeLockedValue := func(t *testing.T) *LockedValue {
+		t.Helper()
+		tr.on("GetField", nil, &GetFieldResponse{
+			FieldPath: "x", Value: StringVal("old"), Checksum: "chk",
+		}, nil)
+		lv, err := client.GetForUpdate(ctx, "t1", "x")
+		if err != nil {
+			t.Fatalf("GetForUpdate: unexpected error: %v", err)
+		}
+		return lv
+	}
+
+	tests := []struct {
+		name string
+		opt  WriteOption
+	}{
+		{
+			name: "WithExpectedChecksum",
+			opt:  WithExpectedChecksum("some-checksum"),
+		},
+		{
+			name: "WithValueDescriptions",
+			opt:  WithValueDescriptions(map[string]string{"x": "desc"}),
+		},
+		{
+			name: "WithFieldChecksums",
+			opt:  WithFieldChecksums(map[string]string{"x": "chk2"}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lv := makeLockedValue(t)
+			err := lv.Set(ctx, "new", tc.opt)
+			if err == nil {
+				t.Fatalf("expected ErrInvalidArgument for %s, got nil", tc.name)
+			}
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("expected errors.Is(err, ErrInvalidArgument), got: %v", err)
+			}
+		})
+	}
+}

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -2,6 +2,7 @@ package configclient
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -261,8 +262,21 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 //
 // Because ExpectedChecksum makes this write idempotent, this method respects
 // the client's retry configuration.
+//
+// [WithExpectedChecksum], [WithValueDescriptions], and [WithFieldChecksums] are
+// not applicable to LockedValue.Set and return [ErrInvalidArgument] if supplied.
+// Use [WithIdempotencyKey], [WithDescription], and [WithValueDescription] instead.
 func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
+	if wo.expectedChecksum != "" {
+		return fmt.Errorf("%w: WithExpectedChecksum is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
+	}
+	if len(wo.valueDescriptions) > 0 {
+		return fmt.Errorf("%w: WithValueDescriptions is not supported on LockedValue.Set; use WithValueDescription for a single field", ErrInvalidArgument)
+	}
+	if len(wo.fieldChecksums) > 0 {
+		return fmt.Errorf("%w: WithFieldChecksums is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
+	}
 	// LockedValue.Set is always safe to retry: the checksum acts as an implicit
 	// idempotency guard. Use retryDo directly to preserve that guarantee.
 	return retryDo(ctx, lv.client, func(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- Reject `WithExpectedChecksum`, `WithValueDescriptions`, and `WithFieldChecksums` with `ErrInvalidArgument` — these are either managed by the lock or batch-only options that don't apply to a single-field locked write
- `WithIdempotencyKey`, `WithDescription`, and `WithValueDescription` were already forwarded correctly
- Add test table (`TestLockedValue_Set_RejectsUnsupportedOptions`) covering all three rejected options

## Test plan
- [ ] `TestLockedValue_Set_RejectsUnsupportedOptions` covers all three rejected options and asserts `errors.Is(err, ErrInvalidArgument)`
- [ ] `TestLockedValue_Set_ForwardsIdempotencyKey` (pre-existing) still passes
- [ ] `make test` passes
- [ ] `make lint-go` clean

Closes #656
🤖 Generated with [Claude Code](https://claude.com/claude-code)