### PR TITLE
fix(tools/validate): accept uint64 in integer and number validation

### DIFF
--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -276,6 +276,10 @@ func validateInteger(result *Result, path string, value any, c *ConstraintsDef) 
 		n = float64(v)
 	case int64:
 		n = float64(v)
+	case uint:
+		n = float64(v)
+	case uint64:
+		n = float64(v)
 	case float64:
 		if v != math.Trunc(v) {
 			result.add(path, fmt.Sprintf("expected integer, got %v", v))
@@ -297,6 +301,10 @@ func validateNumber(result *Result, path string, value any, c *ConstraintsDef) {
 	case int:
 		n = float64(v)
 	case int64:
+		n = float64(v)
+	case uint:
+		n = float64(v)
+	case uint64:
 		n = float64(v)
 	case float64:
 		n = v
@@ -424,6 +432,10 @@ func stringifyForEnum(value any) string {
 		return strconv.Itoa(v)
 	case int64:
 		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
 	case float64:
 		return formatFloat(v)
 	default:

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -1,6 +1,7 @@
 package validate
 
 import (
+	"math"
 	"testing"
 )
 
@@ -457,6 +458,79 @@ values:
 	}
 	if !result.IsValid() {
 		t.Errorf("expected valid (3.0 is a whole number), got: %s", result.Error())
+	}
+}
+
+func TestValidate_Uint64AcceptedByInteger(t *testing.T) {
+	schema := &SchemaFile{
+		SpecVersion: "v1",
+		Name:        "test",
+		Fields: map[string]FieldDef{
+			"count": {Type: "integer"},
+		},
+	}
+	// uint64 value above int64 max (yaml.v3 decodes large integers as uint64).
+	aboveInt64Max := uint64(math.MaxInt64) + 1
+	for _, val := range []any{aboveInt64Max, uint(42)} {
+		config := &ConfigFile{
+			SpecVersion: "v1",
+			Values: map[string]ConfigValueDef{
+				"count": {Value: val},
+			},
+		}
+		result := ValidateParsed(schema, config)
+		if !result.IsValid() {
+			t.Errorf("expected valid for %T(%v), got: %s", val, val, result.Error())
+		}
+	}
+}
+
+func TestValidate_Uint64AcceptedByNumber(t *testing.T) {
+	schema := &SchemaFile{
+		SpecVersion: "v1",
+		Name:        "test",
+		Fields: map[string]FieldDef{
+			"rate": {Type: "number"},
+		},
+	}
+	aboveInt64Max := uint64(math.MaxInt64) + 1
+	for _, val := range []any{aboveInt64Max, uint(99)} {
+		config := &ConfigFile{
+			SpecVersion: "v1",
+			Values: map[string]ConfigValueDef{
+				"rate": {Value: val},
+			},
+		}
+		result := ValidateParsed(schema, config)
+		if !result.IsValid() {
+			t.Errorf("expected valid for %T(%v), got: %s", val, val, result.Error())
+		}
+	}
+}
+
+func TestValidate_Uint64EnumMatch(t *testing.T) {
+	schema := &SchemaFile{
+		SpecVersion: "v1",
+		Name:        "test",
+		Fields: map[string]FieldDef{
+			"level": {
+				Type: "integer",
+				Constraints: &ConstraintsDef{
+					Enum: []string{"9223372036854775808"}, // math.MaxInt64 + 1
+				},
+			},
+		},
+	}
+	aboveInt64Max := uint64(math.MaxInt64) + 1
+	config := &ConfigFile{
+		SpecVersion: "v1",
+		Values: map[string]ConfigValueDef{
+			"level": {Value: aboveInt64Max},
+		},
+	}
+	result := ValidateParsed(schema, config)
+	if !result.IsValid() {
+		t.Errorf("expected enum match for uint64 above int64 max, got: %s", result.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- yaml.v3 decodes integers above int64 max as uint64, causing validateInteger and validateNumber to wrongly reject them through the default error case.
- Add uint/uint64 cases to validateInteger, validateNumber, and stringifyForEnum so large integers pass both type and enum checks.

## Test plan

- [ ] TestValidate_Uint64AcceptedByInteger: uint64 above int64 max and plain uint pass integer validation
- [ ] TestValidate_Uint64AcceptedByNumber: same values pass number validation
- [ ] TestValidate_Uint64EnumMatch: uint64 above int64 max matches a string enum entry
- [ ] make test passes (all modules)
- [ ] make lint-go passes clean
- [ ] Coverage: sdk/tools remains at 96.1% (meets threshold)

Closes #665