### PR TITLE
fix(tools/validate): validate time and duration syntax offline

### DIFF
--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -349,17 +350,29 @@ func validateBool(result *Result, path string, value any) {
 }
 
 func validateStringType(result *Result, path string, value any, typeName string) {
-	if _, ok := value.(string); !ok {
+	s, ok := value.(string)
+	if !ok {
 		result.add(path, fmt.Sprintf("expected %s (string), got %T", typeName, value))
+		return
+	}
+	if typeName == "time" {
+		if _, err := time.Parse(time.RFC3339, s); err != nil {
+			result.add(path, fmt.Sprintf("invalid time value %q: must be RFC3339 format", s))
+		}
 	}
 }
 
 func validateDuration(result *Result, path string, value any, _ *ConstraintsDef) {
-	if _, ok := value.(string); !ok {
+	s, ok := value.(string)
+	if !ok {
 		result.add(path, fmt.Sprintf("expected duration (string), got %T", value))
+		return
+	}
+	if _, err := time.ParseDuration(s); err != nil {
+		result.add(path, fmt.Sprintf("invalid duration value %q: %v", s, err))
 	}
 	// Numeric constraints on duration are validated server-side after parsing;
-	// offline validation only checks the type.
+	// offline validation only checks the type and syntax.
 }
 
 func validateURL(result *Result, path string, value any) {

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -104,6 +104,14 @@ values:
 values:
   timeout:
     value: 123`, "timeout", "expected duration"},
+		{"time gets invalid string", `spec_version: "v1"
+values:
+  start_time:
+    value: "not-a-time"`, "start_time", "invalid time value"},
+		{"duration gets invalid string", `spec_version: "v1"
+values:
+  timeout:
+    value: "not-a-duration"`, "timeout", "invalid duration value"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Time and duration fields previously accepted any string without syntax checking, allowing invalid values to pass offline validation silently.
- Parse time values with `time.RFC3339` and duration values with `time.ParseDuration`; emit a violation when either parse fails.

## Test plan
- [x] Invalid timestamp (`"not-a-time"`) returns a violation
- [x] Invalid duration (`"not-a-duration"`) returns a violation
- [x] Valid time (`"2024-01-01T00:00:00Z"`) passes without violations
- [x] Valid duration (`"30s"`) passes without violations
- [x] `make test` passes (all modules)
- [x] `make lint-go` passes
- [x] Coverage: sdk/tools 96.2% (threshold: 96.1%)

Closes #666