### PR TITLE
fix(server): disable WriteTimeout for streaming Subscribe routes

### DIFF
--- a/internal/server/gateway.go
+++ b/internal/server/gateway.go
@@ -172,6 +172,12 @@ func NewGateway(ctx context.Context, httpPort, grpcAddr string, opts ...GatewayO
 		handler = corsMiddleware(o.corsOrigins)(handler)
 	}
 
+	// Streaming routes (e.g. /v1/tenants/{id}/config:subscribe) must not be
+	// terminated by the server-level WriteTimeout. Wrap the handler so that
+	// those requests clear their write deadline immediately after headers are
+	// received, while all other routes keep the 60 s timeout enforced below.
+	handler = clearWriteDeadlineMiddleware(handler)
+
 	httpServer := &http.Server{
 		Addr:              listenerAddr,
 		Handler:           handler,
@@ -284,6 +290,33 @@ func requireAuth(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// clearWriteDeadlineMiddleware clears the HTTP write deadline for streaming
+// routes so that the server-level WriteTimeout does not terminate long-lived
+// SSE / gRPC-gateway server-stream responses. Non-streaming routes are
+// unaffected: their write deadline is already set by net/http before the
+// handler is called and remains in place.
+//
+// Streaming routes are identified by paths that end with ":subscribe"
+// (the gRPC-gateway URL verb convention, e.g. /v1/tenants/{id}/config:subscribe).
+func clearWriteDeadlineMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isStreamingPath(r.URL.Path) {
+			// ResponseController wraps the underlying net.Conn so we can call
+			// SetWriteDeadline. A zero time value disables the deadline.
+			rc := http.NewResponseController(w)
+			_ = rc.SetWriteDeadline(time.Time{})
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isStreamingPath reports whether path corresponds to a server-streaming RPC.
+// Currently the only streaming endpoint exposed via the REST gateway is the
+// Subscribe action, which uses the gRPC-gateway "verb" suffix ":subscribe".
+func isStreamingPath(path string) bool {
+	return strings.HasSuffix(path, ":subscribe")
 }
 
 // spaHandler serves an embedded filesystem for a single-page application.

--- a/internal/server/gateway_test.go
+++ b/internal/server/gateway_test.go
@@ -448,3 +448,63 @@ func TestIsLoopbackAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestIsStreamingPath(t *testing.T) {
+	tests := []struct {
+		path       string
+		wantStream bool
+	}{
+		{"/v1/tenants/abc/config:subscribe", true},
+		{"/v1/tenants/00000000-0000-0000-0000-000000000001/config:subscribe", true},
+		{"/v1/tenants/abc/config", false},
+		{"/v1/tenants/abc/config:get", false},
+		{"/v1/schemas", false},
+		{"/docs", false},
+		{"", false},
+		// Must not match a path that merely contains ":subscribe" mid-segment.
+		{"/v1/config:subscribe/extra", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.wantStream, isStreamingPath(tt.path))
+		})
+	}
+}
+
+// clearWriteDeadlineMiddleware_NonStreamingPassthrough verifies that non-streaming
+// routes pass through without modification.
+func TestClearWriteDeadlineMiddleware_NonStreamingPassthrough(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := clearWriteDeadlineMiddleware(inner)
+	req := httptest.NewRequest("GET", "/v1/tenants/abc/config", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestClearWriteDeadlineMiddleware_StreamingPath verifies that streaming routes
+// clear the write deadline (SetWriteDeadline is called on the ResponseController).
+// httptest.ResponseRecorder does not implement SetWriteDeadline, so the error is
+// silently ignored by the middleware — the key check is that the inner handler
+// is still called and the response completes.
+func TestClearWriteDeadlineMiddleware_StreamingPath(t *testing.T) {
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := clearWriteDeadlineMiddleware(inner)
+	req := httptest.NewRequest("GET", "/v1/tenants/abc/config:subscribe", nil)
+	w := httptest.NewRecorder()
+	// The middleware calls rc.SetWriteDeadline on the recorder; ResponseRecorder
+	// does not implement net.Conn so the call returns an unsupported error that is
+	// intentionally ignored. The important invariant is that the inner handler runs.
+	h.ServeHTTP(w, req)
+	assert.True(t, called, "inner handler must still be called for streaming paths")
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
## Summary

- The server-level `WriteTimeout: 60s` was silently terminating long-lived REST Subscribe streams (SSE / gRPC-gateway server-streaming) after 60 seconds, making the feature unusable for anything beyond a minute.
- Adds `clearWriteDeadlineMiddleware` that calls `SetWriteDeadline(zero)` via `http.ResponseController` for paths ending in `:subscribe`, clearing the deadline just before the handler runs.
- All non-streaming routes retain the existing 60s write timeout; read/header/idle timeouts are unchanged.

## Test plan

- [x] `TestIsStreamingPath` — covers subscribe, non-subscribe, and mid-segment false-positive paths
- [x] `TestClearWriteDeadlineMiddleware_StreamingPath` — inner handler still called, response completes
- [x] `TestClearWriteDeadlineMiddleware_NonStreamingPassthrough` — non-streaming routes unaffected
- [x] Existing `TestNewGateway_HTTPServerTimeoutsSet` still passes (WriteTimeout field unchanged on the server struct)
- [x] `make test` passes (all packages, race detector)
- [x] `make lint-go` clean

Closes #670