### PR TITLE
fix(server): pick max LastReadAt in GetFieldUsage aggregation

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -178,13 +178,13 @@ func (s *Service) GetFieldUsage(ctx context.Context, req *pb.GetFieldUsageReques
 	var totalReads int64
 	var lastReadBy *string
 	var lastReadAt *timestamppb.Timestamp
+	var maxLastReadAt *time.Time
 	for _, stat := range stats {
 		totalReads += stat.ReadCount
-		if stat.LastReadBy != nil {
-			lastReadBy = stat.LastReadBy
-		}
-		if stat.LastReadAt != nil {
+		if stat.LastReadAt != nil && (maxLastReadAt == nil || stat.LastReadAt.After(*maxLastReadAt)) {
+			maxLastReadAt = stat.LastReadAt
 			lastReadAt = timestamppb.New(*stat.LastReadAt)
+			lastReadBy = stat.LastReadBy
 		}
 	}
 

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -242,6 +242,30 @@ func TestGetFieldUsage_Success(t *testing.T) {
 	assert.Equal(t, "reader", *resp.Stats.LastReadBy)
 }
 
+func TestGetFieldUsage_PicksMaxLastReadAt(t *testing.T) {
+	svc, store := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	// older is listed last in the slice — bug would have returned "older-reader".
+	olderReader := "older-reader"
+	newerReader := "newer-reader"
+	older := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	store.On("GetFieldUsage", ctx, mock.Anything).Return([]domain.UsageStat{
+		{ReadCount: 5, LastReadBy: &newerReader, LastReadAt: &newer},
+		{ReadCount: 10, LastReadBy: &olderReader, LastReadAt: &older},
+	}, nil)
+
+	resp, err := svc.GetFieldUsage(ctx, &pb.GetFieldUsageRequest{
+		TenantId:  "22222222-2222-2222-2222-222222222222",
+		FieldPath: "app.fee",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), resp.Stats.ReadCount)
+	assert.Equal(t, "newer-reader", *resp.Stats.LastReadBy)
+	assert.Equal(t, newer.Unix(), resp.Stats.LastReadAt.AsTime().Unix())
+}
+
 func TestGetFieldUsage_InvalidTenantID(t *testing.T) {
 	svc, _ := newTestService()
 	_, err := svc.GetFieldUsage(auth.WithoutAuth(context.Background()), &pb.GetFieldUsageRequest{TenantId: "bad"})


### PR DESCRIPTION
## Summary

- Fix GetFieldUsage to pick the row with the greatest `LastReadAt` for last-read attribution, rather than whichever row is last in the slice.
- Previously, `LastReadBy` and `LastReadAt` were updated by two independent nil-checks, so period order in the returned slice determined the winner instead of the actual timestamp.

## Test plan

- [ ] `TestGetFieldUsage_PicksMaxLastReadAt`: two periods returned out of order (newer first, older last); asserts `LastReadBy` and `LastReadAt` match the newer period.
- [ ] `make test` passes (all packages).
- [ ] `make lint-go` reports 0 issues.

Closes #671