### PR TITLE
fix(server): return error from Subscribe when replay setup fails

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1085,9 +1085,10 @@ func (s *Service) Subscribe(req *pb.SubscribeRequest, stream grpc.ServerStreamin
 	if req.StartVersion != nil {
 		// Determine the latest version at subscribe time so we know where replay ends.
 		latestCV, latestErr := s.store.GetLatestConfigVersion(ctx, tenantID)
-		if latestErr == nil {
-			watermark = latestCV.Version
+		if latestErr != nil {
+			return status.Error(codes.Internal, "failed to determine latest version for replay")
 		}
+		watermark = latestCV.Version
 
 		rows, replayErr := s.store.GetConfigValuesSince(ctx, GetConfigValuesSinceParams{
 			TenantID:     tenantID,

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -909,3 +909,33 @@ func TestSubscribe_WatermarkDeduplicatesReplayedVersions(t *testing.T) {
 	assert.Equal(t, int32(4), stream.sent[0].Change.Version) // replay
 	assert.Equal(t, int32(5), stream.sent[1].Change.Version) // live, new
 }
+
+// TestSubscribe_VersionLookupError ensures that when GetLatestConfigVersion
+// fails during replay setup the Subscribe call returns codes.Internal and does
+// not swallow the error (which would leave watermark at 0 and deliver all live
+// events as duplicates).
+func TestSubscribe_VersionLookupError(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	sub := &mockSubscriber{}
+	svc.subscriber = sub
+
+	ch := make(chan pubsub.ConfigChangeEvent)
+	cancel := func() {}
+
+	ctx := auth.WithoutAuth(context.Background())
+	stream := &mockServerStream{ctx: ctx}
+
+	sub.On("Subscribe", mock.Anything, tenantID1).
+		Return((<-chan pubsub.ConfigChangeEvent)(ch), context.CancelFunc(cancel), nil)
+
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{}, errors.New("db unavailable"))
+
+	setupNoSensitiveFields(store)
+
+	startVersion := int32(1)
+	err := svc.Subscribe(&pb.SubscribeRequest{TenantId: tenantID1, StartVersion: &startVersion}, stream)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	// No events must have been sent.
+	assert.Empty(t, stream.sent)
+}


### PR DESCRIPTION
## Summary

- When `GetLatestConfigVersion` failed during `Subscribe` replay setup, the error was silently discarded and `watermark` stayed 0, causing every subsequent live event to pass the de-dup filter and be delivered as a duplicate.
- Return `codes.Internal` immediately on version lookup failure so the client receives a clear error and can reconnect rather than receiving incorrect duplicated data.

## Test plan

- [ ] `TestSubscribe_VersionLookupError` asserts that `Subscribe` returns `codes.Internal` and sends no events when the version lookup fails during replay setup.
- [ ] `make test` passes across all modules.
- [ ] `make lint-go` reports zero issues.

Closes #672