### PR TITLE
fix(server): log parse errors in stringToTypedValue

### DIFF
--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -100,28 +101,49 @@ func typedValueToString(tv *pb.TypedValue) *string {
 }
 
 // stringToTypedValue converts a DB string value to a TypedValue using the field type.
-// Returns nil for a nil (null) string.
+// Returns nil for a nil (null) string. Parse errors are logged as warnings and the
+// zero value for the target type is returned rather than silently discarding the error.
 func stringToTypedValue(s *string, ft domain.FieldType) *pb.TypedValue {
 	if s == nil {
 		return nil
 	}
 	switch ft {
 	case domain.FieldTypeInteger:
-		v, _ := strconv.ParseInt(*s, 10, 64)
+		v, err := strconv.ParseInt(*s, 10, 64)
+		if err != nil {
+			slog.Default().Warn("stringToTypedValue: failed to parse integer DB value",
+				"raw", *s, "error", err)
+		}
 		return &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: v}}
 	case domain.FieldTypeNumber:
-		v, _ := strconv.ParseFloat(*s, 64)
+		v, err := strconv.ParseFloat(*s, 64)
+		if err != nil {
+			slog.Default().Warn("stringToTypedValue: failed to parse number DB value",
+				"raw", *s, "error", err)
+		}
 		return &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: v}}
 	case domain.FieldTypeString:
 		return &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: *s}}
 	case domain.FieldTypeBool:
-		v, _ := strconv.ParseBool(*s)
+		v, err := strconv.ParseBool(*s)
+		if err != nil {
+			slog.Default().Warn("stringToTypedValue: failed to parse bool DB value",
+				"raw", *s, "error", err)
+		}
 		return &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: v}}
 	case domain.FieldTypeTime:
-		t, _ := time.Parse(time.RFC3339Nano, *s)
+		t, err := time.Parse(time.RFC3339Nano, *s)
+		if err != nil {
+			slog.Default().Warn("stringToTypedValue: failed to parse time DB value",
+				"raw", *s, "error", err)
+		}
 		return &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(t)}}
 	case domain.FieldTypeDuration:
-		d, _ := time.ParseDuration(*s)
+		d, err := time.ParseDuration(*s)
+		if err != nil {
+			slog.Default().Warn("stringToTypedValue: failed to parse duration DB value",
+				"raw", *s, "error", err)
+		}
 		return &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(d)}}
 	case domain.FieldTypeURL:
 		return &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: *s}}

--- a/internal/config/convert_test.go
+++ b/internal/config/convert_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -88,13 +90,41 @@ func TestStringToTypedValue_UnknownTypeFallsBackToString(t *testing.T) {
 }
 
 func TestStringToTypedValue_ParseErrorsYieldZeroValues(t *testing.T) {
-	// Malformed numeric/bool/time/duration strings: parse errors are swallowed and
+	// Malformed numeric/bool/time/duration strings: parse errors are logged and
 	// the zero value is returned (never a nil TypedValue for a non-nil input).
 	assert.Equal(t, int64(0), stringToTypedValue(strPtr("notint"), domain.FieldTypeInteger).GetIntegerValue())
 	assert.Equal(t, float64(0), stringToTypedValue(strPtr("notfloat"), domain.FieldTypeNumber).GetNumberValue())
 	assert.False(t, stringToTypedValue(strPtr("notbool"), domain.FieldTypeBool).GetBoolValue())
 	assert.True(t, stringToTypedValue(strPtr("nottime"), domain.FieldTypeTime).GetTimeValue().AsTime().IsZero())
 	assert.Equal(t, time.Duration(0), stringToTypedValue(strPtr("notdur"), domain.FieldTypeDuration).GetDurationValue().AsDuration())
+}
+
+func TestStringToTypedValue_ParseErrorsAreLogged(t *testing.T) {
+	// Corrupt DB values must produce a log warning instead of being silently swallowed.
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cases := []struct {
+		raw string
+		ft  domain.FieldType
+	}{
+		{"not-an-int", domain.FieldTypeInteger},
+		{"not-a-float", domain.FieldTypeNumber},
+		{"not-a-bool", domain.FieldTypeBool},
+		{"not-a-time", domain.FieldTypeTime},
+		{"not-a-duration", domain.FieldTypeDuration},
+	}
+	for _, c := range cases {
+		buf.Reset()
+		tv := stringToTypedValue(strPtr(c.raw), c.ft)
+		require.NotNil(t, tv, "expected non-nil TypedValue for field type %s", c.ft)
+		logged := buf.String()
+		assert.Contains(t, logged, "stringToTypedValue", "expected warning log for field type %s", c.ft)
+		assert.Contains(t, logged, c.raw, "expected raw value in log for field type %s", c.ft)
+	}
 }
 
 func TestTypedValueToString_Nil(t *testing.T) {


### PR DESCRIPTION
## Summary
- Corrupt or type-migrated DB values were silently returning zero without any signal — this makes production incidents nearly impossible to diagnose.
- Capture parse errors in `stringToTypedValue` for all parse-capable field types (integer, number, bool, time, duration) and emit a `slog.Warn` with the raw string and error.

## Test plan
- [x] `TestStringToTypedValue_ParseErrorsAreLogged` asserts each affected field type emits a warning log entry containing the corrupt raw value
- [x] Existing zero-value tests still pass — behavior is preserved, errors are now visible
- [x] `make test` passes (all packages, with race detector)
- [x] `make lint-go` reports zero issues

Closes #673