### PR TITLE
fix(server): require superadmin for tenant delete and rename

### DIFF
--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -167,7 +167,7 @@ func allRPCs() []rpcSpec {
 		},
 		{
 			name:   "UpdateTenant",
-			policy: adminOrAbove,
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				newName := fmt.Sprintf("m1-upd-%s", randSuffix())
 				_, err := c.admin.UpdateTenant(ctx, fx.tenantID, adminclient.WithTenantName(newName))
@@ -176,7 +176,7 @@ func allRPCs() []rpcSpec {
 		},
 		{
 			name:   "DeleteTenant",
-			policy: adminOrAbove,
+			policy: superadminOnly,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
 				// Delete a throwaway tenant. Rebuild the caller's scope to
 				// include the throwaway tenant UUID so CheckTenantAccess passes;

--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -70,20 +70,6 @@ func writeRPCs() []writeRPCSpec {
 			},
 		},
 		{
-			name: "UpdateTenant",
-			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
-				newName := fmt.Sprintf("m2-rename-%s", randSuffix())
-				_, err := c.admin.UpdateTenant(ctx, tenantID, adminclient.WithTenantName(newName))
-				return err
-			},
-		},
-		{
-			name: "DeleteTenant",
-			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
-				return c.admin.DeleteTenant(ctx, tenantID)
-			},
-		},
-		{
 			name: "RollbackToVersion",
 			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
 				_, err := c.admin.RollbackConfig(ctx, tenantID, 1, "matrix2 rollback")
@@ -109,9 +95,9 @@ func TestTenantAccessMatrix(t *testing.T) {
 		spec := spec
 		t.Run(spec.name, func(t *testing.T) {
 			t.Run("in_scope_allowed", func(t *testing.T) {
-				// Every cell gets a fresh tenant: some RPCs (DeleteTenant,
-				// LockField/UnlockField pair, RollbackToVersion) mutate or
-				// destroy state that would interfere with later cells.
+				// Every cell gets a fresh tenant: some RPCs (LockField/UnlockField
+				// pair, RollbackToVersion) mutate state that would interfere with
+				// later cells.
 				fx := bootstrapMatrixFixture(t, "m2-in")
 				caller := scopedClients(t, conn, roleAdmin, fx.tenantID)
 

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -659,7 +659,7 @@ func (s *Service) UpdateTenant(ctx context.Context, req *pb.UpdateTenantRequest)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: resolved.ID}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 	tenantID := resolved.ID
@@ -745,7 +745,7 @@ func (s *Service) DeleteTenant(ctx context.Context, req *pb.DeleteTenantRequest)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenant.ID}); err != nil {
+	if err := s.guard.Check(ctx, authz.ActionGlobal, authz.Resource{}); err != nil {
 		return nil, err
 	}
 

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -456,6 +456,43 @@ func TestDeleteTenant_CrossTenantRejected(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// --- Tenant admin cannot delete/rename own tenant (issue #675) ---
+
+func TestDeleteTenant_TenantAdminPermissionDenied(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	// Admin scoped to testTenantID; tries to delete their own tenant.
+	// Must get PermissionDenied — only superadmin may delete a tenant.
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID, Name: "my-tenant"}, nil)
+
+	_, err := svc.DeleteTenant(ctx, &pb.DeleteTenantRequest{Id: testTenantID})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
+func TestUpdateTenant_TenantAdminPermissionDenied(t *testing.T) {
+	store := &mockStore{}
+	svc := NewService(store, WithLogger(testLogger))
+	// Admin scoped to testTenantID; tries to rename their own tenant.
+	// Must get PermissionDenied — only superadmin may rename a tenant.
+	ctx := adminCtxWithTenants(testTenantID)
+
+	store.On("GetTenantByID", ctx, testTenantID).
+		Return(domain.Tenant{ID: testTenantID, Name: "my-tenant"}, nil)
+
+	newName := "renamed-tenant"
+	_, err := svc.UpdateTenant(ctx, &pb.UpdateTenantRequest{Id: testTenantID, Name: &newName})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	store.AssertExpectations(t)
+}
+
 // --- Empty FieldPath validation (issue #447) ---
 
 func TestLockField_EmptyFieldPath(t *testing.T) {


### PR DESCRIPTION
## Summary
- Tenant-scoped admins could delete or rename their own tenant (cascading config and audit chain loss), while only superadmins can create one — an asymmetric and dangerous privilege gap.
- `UpdateTenant` and `DeleteTenant` now require `ActionGlobal` (superadmin), matching `CreateTenant`.

## Test plan
- [x] Tenant admin gets `PermissionDenied` on delete of own tenant (`TestDeleteTenant_TenantAdminPermissionDenied`)
- [x] Tenant admin gets `PermissionDenied` on rename of own tenant (`TestUpdateTenant_TenantAdminPermissionDenied`)
- [x] Cross-tenant rejection still works (existing tests unchanged)
- [x] `make test` passes
- [x] `make lint-go` clean

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)