### PR TITLE
fix(server): start Limits from DefaultLimits to preserve ReDoS cap

### DIFF
--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/opendecree/decree/internal/schema"
 	"github.com/opendecree/decree/internal/storage"
+	"github.com/opendecree/decree/internal/validation"
 )
 
 func TestParseEnvDuration_Unset(t *testing.T) {
@@ -33,6 +35,19 @@ func TestLoadConfig_DBPoolEnvVars(t *testing.T) {
 	assert.Equal(t, time.Hour, cfg.DBMaxConnLifetime)
 	assert.Equal(t, 15*time.Minute, cfg.DBMaxConnIdleTime)
 	assert.Equal(t, 2*time.Minute, cfg.DBHealthCheckPeriod)
+}
+
+// TestDefaultLimitsRegexCapActive asserts that the regex-length ReDoS cap is
+// non-zero in the default limits for both the schema and validation packages.
+// A zero value disables the cap entirely, which is the bug fixed in #676.
+func TestDefaultLimitsRegexCapActive(t *testing.T) {
+	sl := schema.DefaultLimits()
+	assert.Greater(t, sl.RegexPatternMaxLength, 0,
+		"schema.DefaultLimits().RegexPatternMaxLength must be > 0 to guard against ReDoS")
+
+	vl := validation.DefaultLimits()
+	assert.Greater(t, vl.RegexMaxLength, 0,
+		"validation.DefaultLimits().RegexMaxLength must be > 0 to guard against ReDoS")
 }
 
 func TestPoolConfigFromServerCfg(t *testing.T) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -298,12 +298,14 @@ func run() int {
 	validationMetrics := telemetry.NewValidationMetrics(otelCfg)
 
 	// Validator factory (shared between schema + config services).
+	// Start from DefaultLimits so fields not wired to env vars (e.g.
+	// RegexMaxLength) keep their safe defaults rather than being zeroed.
+	validationLimits := validation.DefaultLimits()
+	validationLimits.CompileTimeout = cfg.SchemaCompileTimeout
+	validationLimits.MaxDepth = cfg.SchemaMaxRefDepth
+	validationLimits.MaxConcurrentCompiles = cfg.SchemaMaxConcurrentCompiles
 	validatorOpts := []validation.Option{
-		validation.WithLimits(validation.Limits{
-			CompileTimeout:        cfg.SchemaCompileTimeout,
-			MaxDepth:              cfg.SchemaMaxRefDepth,
-			MaxConcurrentCompiles: cfg.SchemaMaxConcurrentCompiles,
-		}),
+		validation.WithLimits(validationLimits),
 	}
 	if counter, ok := validationMetrics.TimeoutCounter(); ok {
 		validatorOpts = append(validatorOpts, validation.WithTimeoutCounter(counter))
@@ -348,15 +350,17 @@ func run() int {
 
 	// Register services.
 	if srv.IsServiceEnabled("schema") {
+		// Start from DefaultLimits so fields not wired to env vars (e.g.
+		// RegexPatternMaxLength) keep their safe defaults rather than being zeroed.
+		schemaLimits := schema.DefaultLimits()
+		schemaLimits.MaxFields = cfg.SchemaMaxFields
+		schemaLimits.MaxDocBytes = cfg.SchemaMaxDocBytes
+		schemaLimits.MaxRemoveFields = cfg.SchemaMaxRemoveFields
 		schemaSvc := schema.NewService(schemaStoreVal,
 			schema.WithLogger(logger),
 			schema.WithMetrics(schemaMetrics),
 			schema.WithValidators(validatorFactory),
-			schema.WithLimits(schema.Limits{
-				MaxFields:       cfg.SchemaMaxFields,
-				MaxDocBytes:     cfg.SchemaMaxDocBytes,
-				MaxRemoveFields: cfg.SchemaMaxRemoveFields,
-			}),
+			schema.WithLimits(schemaLimits),
 		)
 		pb.RegisterSchemaServiceServer(srv.GRPCServer(), schemaSvc)
 		srv.SetServiceHealthy("centralconfig.v1.SchemaService")


### PR DESCRIPTION
## Summary
- Partial `Limits` struct literals in `cmd/server/main.go` were zeroing fields not wired to env vars, including `RegexMaxLength` and `RegexPatternMaxLength`, silently disabling the 1024-byte ReDoS guard in production.
- Both `validation.Limits` and `schema.Limits` are now initialised from `DefaultLimits()` before applying env-var overrides, so any field not yet exposed via config retains its safe default.

## Test plan
- [ ] `TestDefaultLimitsRegexCapActive` asserts both `schema.DefaultLimits().RegexPatternMaxLength > 0` and `validation.DefaultLimits().RegexMaxLength > 0`
- [ ] `make test` passes (all packages, race detector on)
- [ ] `make lint-go` passes clean

Closes #676