### PR TITLE
fix(server): use canonical string format for enum comparison

### DIFF
--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"net/url"
 	"regexp"
+	"strconv"
+	"time"
 	"unicode/utf8"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
@@ -310,19 +312,32 @@ func addNumericChecks(checks *[]checkFunc, c *pb.FieldConstraints, extract func(
 }
 
 // typedValueToString extracts a string representation for enum comparison.
+// It uses the same canonical format as storage (FormatFloat 'f' for numbers,
+// RFC3339Nano for time, Duration.String() for duration) so that stored values
+// round-trip correctly through enum validation.
 func typedValueToString(tv *pb.TypedValue) string {
 	if tv == nil {
 		return ""
 	}
 	switch v := tv.Kind.(type) {
 	case *pb.TypedValue_IntegerValue:
-		return fmt.Sprintf("%d", v.IntegerValue)
+		return strconv.FormatInt(v.IntegerValue, 10)
 	case *pb.TypedValue_NumberValue:
-		return fmt.Sprintf("%g", v.NumberValue)
+		return strconv.FormatFloat(v.NumberValue, 'f', -1, 64)
 	case *pb.TypedValue_StringValue:
 		return v.StringValue
 	case *pb.TypedValue_BoolValue:
-		return fmt.Sprintf("%t", v.BoolValue)
+		return strconv.FormatBool(v.BoolValue)
+	case *pb.TypedValue_TimeValue:
+		if v.TimeValue != nil {
+			return v.TimeValue.AsTime().Format(time.RFC3339Nano)
+		}
+		return ""
+	case *pb.TypedValue_DurationValue:
+		if v.DurationValue != nil {
+			return v.DurationValue.AsDuration().String()
+		}
+		return ""
 	case *pb.TypedValue_UrlValue:
 		return v.UrlValue
 	case *pb.TypedValue_JsonValue:

--- a/internal/validation/validator_extra_test.go
+++ b/internal/validation/validator_extra_test.go
@@ -2,8 +2,11 @@ package validation
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/internal/storage/domain"
@@ -33,7 +36,23 @@ func TestTypedValueToString(t *testing.T) {
 		{"bool", &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: true}}, "true"},
 		{"url", &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://x.io"}}, "https://x.io"},
 		{"json", &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: "[1]"}}, "[1]"},
-		{"time falls through to default", &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{}}, ""},
+		{"time nil inner", &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{}}, ""},
+		{
+			"time with value",
+			&pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC))}},
+			"2024-01-02T03:04:05Z",
+		},
+		{"duration nil inner", &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{}}, ""},
+		{
+			"duration with value",
+			&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(90 * time.Second)}},
+			"1m30s",
+		},
+		{
+			"large number uses f format not g",
+			&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 1_000_000}},
+			"1000000",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,6 +158,27 @@ func TestValidate_EnumOnInteger(t *testing.T) {
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 1}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 5}}))
+}
+
+func TestValidate_EnumOnLargeNumber(t *testing.T) {
+	// Storage writes 1000000 as "1000000" (FormatFloat 'f'), not "1e+06" (%g).
+	// Enum comparison must use the same format or valid stored values are falsely rejected.
+	v := NewFieldValidator("quota", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+		EnumValues: []string{"1000000", "2000000"},
+	})
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 1_000_000}}))
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 3_000_000}}))
+}
+
+func TestValidate_EnumOnDuration(t *testing.T) {
+	// Enum on a duration field: stored values use Duration.String() format.
+	v := NewFieldValidator("ttl", pb.FieldType_FIELD_TYPE_DURATION, false, false, &pb.FieldConstraints{
+		EnumValues: []string{"1m30s", "5m0s"},
+	})
+
+	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(90 * time.Second)}}))
+	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(10 * time.Second)}}))
 }
 
 // --- Duration constraints ---


### PR DESCRIPTION
## Summary
- Fix a false-rejection bug where enum validation for number fields diverged from storage serialization (`%g` produced `1e+06` while storage writes `1000000`).
- Add missing Time and Duration cases to `typedValueToString` so enum constraints on those field types work correctly instead of always failing.

## Test plan
- [ ] `TestValidate_EnumOnLargeNumber` — confirms `1000000.0` matches the enum value `"1000000"`, not `"1e+06"`
- [ ] `TestValidate_EnumOnDuration` — confirms duration enum comparison works end-to-end
- [ ] `TestTypedValueToString` — unit-covers all cases including new time/duration paths
- [ ] `make test` passes (all packages, race detector)
- [ ] `make lint-go` passes (0 issues)

Closes #678