### PR TITLE
fix(server): include sensitive/readOnly/writeOnce in schema checksum

### DIFF
--- a/internal/schema/convert.go
+++ b/internal/schema/convert.go
@@ -136,7 +136,7 @@ func computeChecksum(fields []*pb.SchemaField) string {
 
 	h := sha256.New()
 	for _, f := range sorted {
-		_, _ = fmt.Fprintf(h, "%s:%s:%v:%v", f.Path, f.Type.String(), f.Nullable, f.Deprecated)
+		_, _ = fmt.Fprintf(h, "%s:%s:%v:%v:%v:%v:%v", f.Path, f.Type.String(), f.Nullable, f.Deprecated, f.Sensitive, f.ReadOnly, f.WriteOnce)
 		if f.Constraints != nil {
 			data, _ := json.Marshal(f.Constraints)
 			h.Write(data)

--- a/internal/schema/convert_test.go
+++ b/internal/schema/convert_test.go
@@ -93,6 +93,36 @@ func TestFieldToProto_EnrichmentAttributes_RoundTrip(t *testing.T) {
 	assert.True(t, got.Sensitive, "sensitive should survive round-trip")
 }
 
+func TestComputeChecksum_SensitiveFlipChangesChecksum(t *testing.T) {
+	base := []*pb.SchemaField{
+		{Path: "a.secret", Type: pb.FieldType_FIELD_TYPE_STRING, Sensitive: false},
+	}
+	sensitive := []*pb.SchemaField{
+		{Path: "a.secret", Type: pb.FieldType_FIELD_TYPE_STRING, Sensitive: true},
+	}
+	assert.NotEqual(t, computeChecksum(base), computeChecksum(sensitive), "flipping sensitive must change checksum")
+}
+
+func TestComputeChecksum_ReadOnlyFlipChangesChecksum(t *testing.T) {
+	base := []*pb.SchemaField{
+		{Path: "a.field", Type: pb.FieldType_FIELD_TYPE_STRING, ReadOnly: false},
+	}
+	readOnly := []*pb.SchemaField{
+		{Path: "a.field", Type: pb.FieldType_FIELD_TYPE_STRING, ReadOnly: true},
+	}
+	assert.NotEqual(t, computeChecksum(base), computeChecksum(readOnly), "flipping read_only must change checksum")
+}
+
+func TestComputeChecksum_WriteOnceFlipChangesChecksum(t *testing.T) {
+	base := []*pb.SchemaField{
+		{Path: "a.field", Type: pb.FieldType_FIELD_TYPE_STRING, WriteOnce: false},
+	}
+	writeOnce := []*pb.SchemaField{
+		{Path: "a.field", Type: pb.FieldType_FIELD_TYPE_STRING, WriteOnce: true},
+	}
+	assert.NotEqual(t, computeChecksum(base), computeChecksum(writeOnce), "flipping write_once must change checksum")
+}
+
 func TestPtrString(t *testing.T) {
 	assert.Nil(t, ptrString(""))
 	s := ptrString("hello")


### PR DESCRIPTION
## Summary
- Security-relevant flags (Sensitive, ReadOnly, WriteOnce) were omitted from computeChecksum, making it impossible to detect schema changes that only alter these flags.
- Extend the hash format string to include all three flags so that any mutation to access-control or sensitivity metadata is reflected in the checksum.

## Test plan
- [x] Flipping sensitive on a field produces a different checksum
- [x] Flipping read_only on a field produces a different checksum
- [x] Flipping write_once on a field produces a different checksum
- [x] make test passes
- [x] make lint-go passes (0 issues)

Closes #679