### PR TITLE
fix(configclient): document zero-value behavior for null fields in typed getters

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -648,6 +648,54 @@ func TestGetStringNullable_EmptyString(t *testing.T) {
 	}
 }
 
+func TestGetString_Null(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{FieldPath: "name", Value: nil}, nil)
+
+	val, err := client.GetString(ctx, "t1", "name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "" {
+		t.Errorf("got %q, want empty string", val)
+	}
+}
+
+func TestGetFloat_Null(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{FieldPath: "rate", Value: nil}, nil)
+
+	val, err := client.GetFloat(ctx, "t1", "rate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 0 {
+		t.Errorf("got %v, want 0", val)
+	}
+}
+
+func TestGetBool_Null(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{FieldPath: "enabled", Value: nil}, nil)
+
+	val, err := client.GetBool(ctx, "t1", "enabled")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != false {
+		t.Errorf("got %v, want false", val)
+	}
+}
+
 // --- Typed setters ---
 
 func TestSetInt_Success(t *testing.T) {

--- a/sdk/configclient/read.go
+++ b/sdk/configclient/read.go
@@ -59,7 +59,8 @@ func (c *Client) GetFields(ctx context.Context, tenantID string, fieldPaths []st
 // --- Type-specific getters ---
 
 // GetString returns the current value as a string.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns "" with a nil error if the field value is null; use [Client.GetStringNullable] to distinguish null from an empty string.
 // Returns [ErrTypeMismatch] if the field is not a string type.
 func (c *Client) GetString(ctx context.Context, tenantID, fieldPath string) (string, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)
@@ -78,7 +79,8 @@ func (c *Client) GetString(ctx context.Context, tenantID, fieldPath string) (str
 }
 
 // GetInt returns the current value as an int64.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns 0 with a nil error if the field value is null; use [Client.GetIntNullable] to distinguish null from zero.
 // Returns [ErrTypeMismatch] if the field is not an integer type.
 func (c *Client) GetInt(ctx context.Context, tenantID, fieldPath string) (int64, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)
@@ -95,7 +97,8 @@ func (c *Client) GetInt(ctx context.Context, tenantID, fieldPath string) (int64,
 }
 
 // GetFloat returns the current value as a float64.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns 0 with a nil error if the field value is null; use a nullable variant for null detection.
 // Returns [ErrTypeMismatch] if the field is not a number type.
 func (c *Client) GetFloat(ctx context.Context, tenantID, fieldPath string) (float64, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)
@@ -112,7 +115,8 @@ func (c *Client) GetFloat(ctx context.Context, tenantID, fieldPath string) (floa
 }
 
 // GetBool returns the current value as a bool.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns false with a nil error if the field value is null; use [Client.GetBoolNullable] to distinguish null from false.
 // Returns [ErrTypeMismatch] if the field is not a bool type.
 func (c *Client) GetBool(ctx context.Context, tenantID, fieldPath string) (bool, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)
@@ -129,7 +133,8 @@ func (c *Client) GetBool(ctx context.Context, tenantID, fieldPath string) (bool,
 }
 
 // GetTime returns the current value as a time.Time.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns a zero time.Time with a nil error if the field value is null; use a nullable variant for null detection.
 // Returns [ErrTypeMismatch] if the field is not a time type.
 func (c *Client) GetTime(ctx context.Context, tenantID, fieldPath string) (time.Time, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)
@@ -146,7 +151,8 @@ func (c *Client) GetTime(ctx context.Context, tenantID, fieldPath string) (time.
 }
 
 // GetDuration returns the current value as a time.Duration.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns [ErrNotFound] if the field does not exist.
+// Returns 0 with a nil error if the field value is null; use a nullable variant for null detection.
 // Returns [ErrTypeMismatch] if the field is not a duration type.
 func (c *Client) GetDuration(ctx context.Context, tenantID, fieldPath string) (time.Duration, error) {
 	tv, err := c.getTypedValue(ctx, tenantID, fieldPath)


### PR DESCRIPTION
## Summary
- Typed getters (`GetInt`, `GetFloat`, `GetBool`, `GetString`, `GetTime`, `GetDuration`) were documented to return `ErrNotFound` when a field had no value, but actually returned a zero value with `nil` error on null — making null indistinguishable from a genuine zero.
- Fix the doc comments to accurately describe both cases: field missing → `ErrNotFound`, field null → zero value with `nil` error.
- Direct null-sensitive callers to the corresponding `*Nullable` variants that return `nil` for null.

## Test plan
- [x] `TestGetString_Null` — null field returns `""`, no error
- [x] `TestGetFloat_Null` — null field returns `0`, no error
- [x] `TestGetBool_Null` — null field returns `false`, no error
- [x] `TestGetInt_Null`, `TestGetTime_Null`, `TestGetDuration_Null` — pre-existing coverage confirmed correct
- [x] `make test` passes
- [x] `make lint-go` clean

Closes #681