### PR TITLE
fix(configclient): route snapshot reads through retry wrapper

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -322,6 +322,140 @@ func TestAtVersion(t *testing.T) {
 	}
 }
 
+// --- Snapshot retry ---
+
+func TestSnapshot_RetriedOnRetryableError(t *testing.T) {
+	calls := 0
+	tr := &mockTransport{}
+	client := New(tr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+
+	tr.on("GetConfig", func(args ...any) bool {
+		calls++
+		r := args[0].(*GetConfigRequest)
+		return r.Version == nil
+	}, &GetConfigResponse{TenantID: "t1", Version: 7}, nil)
+
+	snap, err := client.Snapshot(ctx, "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Version() != 7 {
+		t.Errorf("got %v, want %v", snap.Version(), int32(7))
+	}
+}
+
+func TestSnapshotGet_RetriedOnRetryableError(t *testing.T) {
+	ctr := &countingReadTransport{failUntil: 2}
+	client := New(ctr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+	snap := client.AtVersion("t1", 4)
+
+	val, err := snap.Get(ctx, "feature.x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "retried-ok" {
+		t.Errorf("got %v, want retried-ok", val)
+	}
+	if ctr.calls != 3 {
+		t.Errorf("expected 3 calls (2 failures + 1 success), got %d", ctr.calls)
+	}
+}
+
+func TestSnapshotGetAll_RetriedOnRetryableError(t *testing.T) {
+	ctr := &countingReadTransport{failUntil: 2}
+	client := New(ctr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+	snap := client.AtVersion("t1", 2)
+
+	vals, err := snap.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["field"] != "retried-ok" {
+		t.Errorf("got %v, want retried-ok", vals["field"])
+	}
+	if ctr.calls != 3 {
+		t.Errorf("expected 3 calls, got %d", ctr.calls)
+	}
+}
+
+func TestSnapshotGetFields_RetriedOnRetryableError(t *testing.T) {
+	ctr := &countingReadTransport{failUntil: 2}
+	client := New(ctr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+	ctx := context.Background()
+	snap := client.AtVersion("t1", 2)
+
+	vals, err := snap.GetFields(ctx, []string{"field"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vals["field"] != "retried-ok" {
+		t.Errorf("got %v, want retried-ok", vals["field"])
+	}
+	if ctr.calls != 3 {
+		t.Errorf("expected 3 calls, got %d", ctr.calls)
+	}
+}
+
+// countingReadTransport fails the first N read calls with RetryableError and succeeds thereafter.
+type countingReadTransport struct {
+	mockTransport
+	failUntil int
+	calls     int
+}
+
+func (t *countingReadTransport) GetField(_ context.Context, _ *GetFieldRequest) (*GetFieldResponse, error) {
+	t.calls++
+	if t.calls <= t.failUntil {
+		return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+	}
+	return &GetFieldResponse{FieldPath: "feature.x", Value: StringVal("retried-ok")}, nil
+}
+
+func (t *countingReadTransport) GetConfig(_ context.Context, _ *GetConfigRequest) (*GetConfigResponse, error) {
+	t.calls++
+	if t.calls <= t.failUntil {
+		return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+	}
+	return &GetConfigResponse{
+		TenantID: "t1",
+		Version:  2,
+		Values:   []ConfigValue{{FieldPath: "field", Value: StringVal("retried-ok")}},
+	}, nil
+}
+
+func (t *countingReadTransport) GetFields(_ context.Context, _ *GetFieldsRequest) (*GetFieldsResponse, error) {
+	t.calls++
+	if t.calls <= t.failUntil {
+		return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+	}
+	return &GetFieldsResponse{
+		Values: []ConfigValue{{FieldPath: "field", Value: StringVal("retried-ok")}},
+	}, nil
+}
+
 // --- GetForUpdate + LockedValue.Set ---
 
 func TestGetForUpdate_ThenSet(t *testing.T) {

--- a/sdk/configclient/snapshot.go
+++ b/sdk/configclient/snapshot.go
@@ -17,13 +17,15 @@ type Snapshot struct {
 // All subsequent reads on the returned Snapshot use this version, ensuring consistency
 // across multiple Get calls within the same flow.
 func (c *Client) Snapshot(ctx context.Context, tenantID string) (*Snapshot, error) {
-	resp, err := c.transport.GetConfig(ctx, &GetConfigRequest{
-		TenantID: tenantID,
+	return retry(ctx, c, func(ctx context.Context) (*Snapshot, error) {
+		resp, err := c.transport.GetConfig(ctx, &GetConfigRequest{
+			TenantID: tenantID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &Snapshot{client: c, tenantID: tenantID, version: resp.Version}, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return &Snapshot{client: c, tenantID: tenantID, version: resp.Version}, nil
 }
 
 // AtVersion creates a read-only view pinned to the specified config version.
@@ -40,44 +42,50 @@ func (s *Snapshot) Version() int32 {
 // Get returns the value of a single field at the pinned version.
 // Returns [ErrNotFound] if the field has no value at this version.
 func (s *Snapshot) Get(ctx context.Context, fieldPath string) (string, error) {
-	resp, err := s.client.transport.GetField(ctx, &GetFieldRequest{
-		TenantID:  s.tenantID,
-		FieldPath: fieldPath,
-		Version:   &s.version,
+	return retry(ctx, s.client, func(ctx context.Context) (string, error) {
+		resp, err := s.client.transport.GetField(ctx, &GetFieldRequest{
+			TenantID:  s.tenantID,
+			FieldPath: fieldPath,
+			Version:   &s.version,
+		})
+		if err != nil {
+			return "", err
+		}
+		return resp.Value.String(), nil
 	})
-	if err != nil {
-		return "", err
-	}
-	return resp.Value.String(), nil
 }
 
 // GetAll returns all configuration values at the pinned version.
 func (s *Snapshot) GetAll(ctx context.Context) (map[string]string, error) {
 	v := s.version
-	resp, err := s.client.transport.GetConfig(ctx, &GetConfigRequest{
-		TenantID: s.tenantID,
-		Version:  &v,
+	return retry(ctx, s.client, func(ctx context.Context) (map[string]string, error) {
+		resp, err := s.client.transport.GetConfig(ctx, &GetConfigRequest{
+			TenantID: s.tenantID,
+			Version:  &v,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return configToMap(resp), nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return configToMap(resp), nil
 }
 
 // GetFields returns the values for the specified field paths at the pinned version.
 // Fields that have no value at this version are omitted from the result.
 func (s *Snapshot) GetFields(ctx context.Context, fieldPaths []string) (map[string]string, error) {
-	resp, err := s.client.transport.GetFields(ctx, &GetFieldsRequest{
-		TenantID:   s.tenantID,
-		FieldPaths: fieldPaths,
-		Version:    &s.version,
+	return retry(ctx, s.client, func(ctx context.Context) (map[string]string, error) {
+		resp, err := s.client.transport.GetFields(ctx, &GetFieldsRequest{
+			TenantID:   s.tenantID,
+			FieldPaths: fieldPaths,
+			Version:    &s.version,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result := make(map[string]string, len(resp.Values))
+		for _, v := range resp.Values {
+			result[v.FieldPath] = v.Value.String()
+		}
+		return result, nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	result := make(map[string]string, len(resp.Values))
-	for _, v := range resp.Values {
-		result[v.FieldPath] = v.Value.String()
-	}
-	return result, nil
 }


### PR DESCRIPTION
## Summary
- Snapshot read methods (`Snapshot.Get`, `Snapshot.GetAll`, `Snapshot.GetFields`, `Client.Snapshot`) called the transport directly, bypassing `retry()`, so `WithRetry` was silently ignored for snapshot reads.
- Wrapping all four methods in `retry()` gives snapshot reads the same retry behavior as regular reads (`Get`, `GetAll`, `GetFields`).
- Adds `countingReadTransport` test helper and four new tests asserting each snapshot method retries on retryable errors.

## Test plan
- [x] `TestSnapshotGet_RetriedOnRetryableError` — snapshot.Get retries 2 failures before succeeding
- [x] `TestSnapshotGetAll_RetriedOnRetryableError` — snapshot.GetAll retries 2 failures before succeeding
- [x] `TestSnapshotGetFields_RetriedOnRetryableError` — snapshot.GetFields retries 2 failures before succeeding
- [x] `TestSnapshot_RetriedOnRetryableError` — Client.Snapshot retries on retryable error
- [x] `make test` passes (all packages, race detector)
- [x] `make lint-go` clean

Closes #682