### PR TITLE
fix(configclient): add WriteOptions and checksum-mismatch retry to Update

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -573,6 +573,138 @@ func TestUpdate_Success(t *testing.T) {
 	}
 }
 
+func TestUpdate_WriteOptionsForwarded(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{
+		FieldPath: "k", Value: StringVal("old"), Checksum: "chk1",
+	}, nil)
+
+	var capturedReq *SetFieldRequest
+	tr.on("SetField", func(args ...any) bool {
+		capturedReq = args[0].(*SetFieldRequest)
+		return true
+	}, &SetFieldResponse{}, nil)
+
+	err := client.Update(ctx, "t1", "k", func(current string) (string, error) {
+		return "new", nil
+	}, WithDescription("my-desc"), WithValueDescription("val-desc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("SetField was not called")
+	}
+	if capturedReq.Description != "my-desc" {
+		t.Errorf("description: got %q, want %q", capturedReq.Description, "my-desc")
+	}
+	if capturedReq.ValueDescription != "val-desc" {
+		t.Errorf("value description: got %q, want %q", capturedReq.ValueDescription, "val-desc")
+	}
+}
+
+func TestUpdate_RetryOnChecksumMismatch(t *testing.T) {
+	ctx := context.Background()
+
+	var stGets, stSets int
+	st := &sequencedTransport{
+		getField: func(_ context.Context, req *GetFieldRequest) (*GetFieldResponse, error) {
+			stGets++
+			switch stGets {
+			case 1:
+				return &GetFieldResponse{FieldPath: req.FieldPath, Value: StringVal("old"), Checksum: "chk1"}, nil
+			default:
+				return &GetFieldResponse{FieldPath: req.FieldPath, Value: StringVal("mid"), Checksum: "chk2"}, nil
+			}
+		},
+		setField: func(_ context.Context, _ *SetFieldRequest) (*SetFieldResponse, error) {
+			stSets++
+			if stSets == 1 {
+				// First attempt: concurrent writer changed the value.
+				return nil, ErrChecksumMismatch
+			}
+			return &SetFieldResponse{}, nil
+		},
+	}
+
+	client := New(st)
+	err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
+		return current + "-updated", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stGets != 2 {
+		t.Errorf("expected 2 GetField calls (1 per attempt), got %d", stGets)
+	}
+	if stSets != 2 {
+		t.Errorf("expected 2 SetField calls (1 mismatch + 1 success), got %d", stSets)
+	}
+}
+
+func TestUpdate_ChecksumMismatchExhaustsRetries(t *testing.T) {
+	ctx := context.Background()
+
+	var stGets, stSets int
+	st := &sequencedTransport{
+		getField: func(_ context.Context, req *GetFieldRequest) (*GetFieldResponse, error) {
+			stGets++
+			return &GetFieldResponse{FieldPath: req.FieldPath, Value: StringVal("v"), Checksum: "chk"}, nil
+		},
+		setField: func(_ context.Context, _ *SetFieldRequest) (*SetFieldResponse, error) {
+			stSets++
+			return nil, ErrChecksumMismatch
+		},
+	}
+
+	client := New(st)
+	err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
+		return current + "!", nil
+	})
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("got error %v, want ErrChecksumMismatch", err)
+	}
+	if stGets != updateMaxAttempts {
+		t.Errorf("expected %d GetField calls, got %d", updateMaxAttempts, stGets)
+	}
+	if stSets != updateMaxAttempts {
+		t.Errorf("expected %d SetField calls, got %d", updateMaxAttempts, stSets)
+	}
+}
+
+// sequencedTransport is a Transport implementation driven by user-supplied
+// function fields. Used to build stateful call sequences in tests.
+type sequencedTransport struct {
+	getField func(context.Context, *GetFieldRequest) (*GetFieldResponse, error)
+	setField func(context.Context, *SetFieldRequest) (*SetFieldResponse, error)
+}
+
+func (t *sequencedTransport) GetField(ctx context.Context, req *GetFieldRequest) (*GetFieldResponse, error) {
+	return t.getField(ctx, req)
+}
+
+func (t *sequencedTransport) SetField(ctx context.Context, req *SetFieldRequest) (*SetFieldResponse, error) {
+	return t.setField(ctx, req)
+}
+
+func (t *sequencedTransport) GetConfig(_ context.Context, _ *GetConfigRequest) (*GetConfigResponse, error) {
+	panic("sequencedTransport: GetConfig not implemented")
+}
+
+func (t *sequencedTransport) GetFields(_ context.Context, _ *GetFieldsRequest) (*GetFieldsResponse, error) {
+	panic("sequencedTransport: GetFields not implemented")
+}
+
+func (t *sequencedTransport) SetFields(_ context.Context, _ *SetFieldsRequest) (*SetFieldsResponse, error) {
+	panic("sequencedTransport: SetFields not implemented")
+}
+
+func (t *sequencedTransport) Subscribe(_ context.Context, _ *SubscribeRequest) (Subscription, error) {
+	panic("sequencedTransport: Subscribe not implemented")
+}
+
 // --- Typed getters ---
 
 func TestGetInt_Success(t *testing.T) {

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -674,6 +674,51 @@ func TestUpdate_ChecksumMismatchExhaustsRetries(t *testing.T) {
 	}
 }
 
+func TestUpdate_UpdateFnError(t *testing.T) {
+	fnErr := errors.New("fn failed")
+	calls := 0
+	tr := &sequencedTransport{
+		getField: func(_ context.Context, _ *GetFieldRequest) (*GetFieldResponse, error) {
+			calls++
+			return &GetFieldResponse{FieldPath: "f", Value: StringVal("v"), Checksum: "cs"}, nil
+		},
+		setField: func(_ context.Context, _ *SetFieldRequest) (*SetFieldResponse, error) {
+			t.Fatal("Set should not be called when updateFn errors")
+			return nil, nil
+		},
+	}
+	client := New(tr)
+	err := client.Update(context.Background(), "t1", "f", func(string) (string, error) {
+		return "", fnErr
+	})
+	if !errors.Is(err, fnErr) {
+		t.Errorf("expected fnErr, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 GetField call, got %d", calls)
+	}
+}
+
+func TestUpdate_GetForUpdateError(t *testing.T) {
+	getErr := errors.New("get failed")
+	tr := &sequencedTransport{
+		getField: func(_ context.Context, _ *GetFieldRequest) (*GetFieldResponse, error) {
+			return nil, getErr
+		},
+		setField: func(_ context.Context, _ *SetFieldRequest) (*SetFieldResponse, error) {
+			t.Fatal("Set should not be called when GetForUpdate errors")
+			return nil, nil
+		},
+	}
+	client := New(tr)
+	err := client.Update(context.Background(), "t1", "f", func(s string) (string, error) {
+		return s + "_new", nil
+	})
+	if !errors.Is(err, getErr) {
+		t.Errorf("expected getErr, got %v", err)
+	}
+}
+
 // sequencedTransport is a Transport implementation driven by user-supplied
 // function fields. Used to build stateful call sequences in tests.
 type sequencedTransport struct {

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -2,6 +2,7 @@ package configclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -294,22 +295,38 @@ func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOp
 	})
 }
 
+// updateMaxAttempts is the maximum number of read-modify-write attempts in Update.
+const updateMaxAttempts = 3
+
 // Update performs an atomic read-modify-write on a single field.
 // It reads the current value and checksum, calls updateFn with the current value,
 // and writes the result back with the checksum for optimistic concurrency.
+// On [ErrChecksumMismatch] (concurrent write by another caller) the entire
+// read-modify-write cycle is retried up to 3 times before returning the error.
 //
-// Returns [ErrChecksumMismatch] if the value was modified between the read and write.
+// Returns [ErrChecksumMismatch] if the value was still being concurrently modified
+// after all retry attempts.
 // Returns [ErrNotFound] if the field has no value set.
-func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateFn func(current string) (string, error)) error {
-	lv, err := c.GetForUpdate(ctx, tenantID, fieldPath)
-	if err != nil {
-		return err
+func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateFn func(current string) (string, error), opts ...WriteOption) error {
+	for attempt := range updateMaxAttempts {
+		lv, err := c.GetForUpdate(ctx, tenantID, fieldPath)
+		if err != nil {
+			return err
+		}
+		newValue, err := updateFn(lv.Value)
+		if err != nil {
+			return err
+		}
+		err = lv.Set(ctx, newValue, opts...)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrChecksumMismatch) || attempt == updateMaxAttempts-1 {
+			return err
+		}
 	}
-	newValue, err := updateFn(lv.Value)
-	if err != nil {
-		return err
-	}
-	return lv.Set(ctx, newValue)
+	// Unreachable, but satisfies the compiler.
+	return ErrChecksumMismatch
 }
 
 // --- Type-specific setters ---


### PR DESCRIPTION
## Summary

- `Update` took no `WriteOption` arguments, making it impossible to attach descriptions or idempotency keys to the underlying write.
- Without a retry loop, any concurrent write between the read and write step forced callers to handle `ErrChecksumMismatch` retry logic themselves.

## Test plan

- [x] `TestUpdate_WriteOptionsForwarded` — verifies `WithDescription` and `WithValueDescription` reach the `SetField` request
- [x] `TestUpdate_RetryOnChecksumMismatch` — verifies a single mismatch triggers a re-read and succeeds on the second attempt
- [x] `TestUpdate_ChecksumMismatchExhaustsRetries` — verifies the error is returned after `updateMaxAttempts` (3) consecutive mismatches
- [x] `make test` passes (all modules)
- [x] `make lint-go` passes (0 issues)

Closes #683