### PR TITLE
fix(adminclient): wrap VerifyChain page fetch and ListFieldLocks in retry

### DIFF
--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -212,7 +212,9 @@ func (c *Client) VerifyChain(ctx context.Context, tenantID string) (VerifyChainR
 		for _, f := range filters {
 			f(req)
 		}
-		resp, err := c.audit.QueryWriteLog(ctx, req)
+		resp, err := retry(ctx, c, func(ctx context.Context) (*QueryWriteLogResponse, error) {
+			return c.audit.QueryWriteLog(ctx, req)
+		})
 		if err != nil {
 			return VerifyChainResult{}, fmt.Errorf("fetch entries: %w", err)
 		}

--- a/sdk/adminclient/locks.go
+++ b/sdk/adminclient/locks.go
@@ -27,5 +27,7 @@ func (c *Client) ListFieldLocks(ctx context.Context, tenantID string) ([]FieldLo
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return c.schema.ListFieldLocks(ctx, tenantID)
+	return retry(ctx, c, func(ctx context.Context) ([]FieldLock, error) {
+		return c.schema.ListFieldLocks(ctx, tenantID)
+	})
 }

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -258,6 +258,70 @@ func TestBackoffDuration(t *testing.T) {
 	}
 }
 
+func TestRetry_VerifyChain_RetriesOnUnavailable(t *testing.T) {
+	calls := 0
+	ma := &mockAuditTransport{
+		queryWriteLogFn: func(_ context.Context, _ *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+			calls++
+			if calls < 3 {
+				return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+			}
+			return &QueryWriteLogResponse{}, nil
+		},
+	}
+	c := New(
+		WithAuditTransport(ma),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	result, err := c.VerifyChain(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK {
+		t.Errorf("expected OK chain, got breaks: %v", result.Breaks)
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
+func TestRetry_ListFieldLocks_RetriesOnUnavailable(t *testing.T) {
+	calls := 0
+	ms := &mockSchemaTransport{
+		listFieldLocksFn: func(_ context.Context, _ string) ([]FieldLock, error) {
+			calls++
+			if calls < 3 {
+				return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+			}
+			return []FieldLock{{TenantID: "t1", FieldPath: "app.fee"}}, nil
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	locks, err := c.ListFieldLocks(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(locks) != 1 {
+		t.Errorf("got %d locks, want 1", len(locks))
+	}
+	if calls != 3 {
+		t.Errorf("got %d calls, want 3", calls)
+	}
+}
+
 func TestRetry_GetSchema_RetriesOnUnavailable(t *testing.T) {
 	calls := 0
 	ms := &mockSchemaTransport{


### PR DESCRIPTION
## Summary
- VerifyChain's pagination loop called the transport directly with no retry wrapper, leaving transient failures unretried mid-chain-walk.
- ListFieldLocks also bypassed retry entirely while every other read in the package used it consistently.
- Both calls are now wrapped in \`retry\`, matching the established pattern for all idempotent reads.

## Test plan
- [x] `TestRetry_VerifyChain_RetriesOnUnavailable` — confirms page fetch is retried on transient error before succeeding
- [x] `TestRetry_ListFieldLocks_RetriesOnUnavailable` — confirms ListFieldLocks is retried on transient error before succeeding
- [x] `make test` passes (all packages, race detector)
- [x] `make lint-go` clean
- [x] adminclient coverage 98.2% (threshold 97.9%)

Closes #688