### PR TITLE
fix(adminclient): skip ErrNotFound gaps in GetLatestPublishedSchemaVersion

### DIFF
--- a/sdk/adminclient/client_test.go
+++ b/sdk/adminclient/client_test.go
@@ -535,3 +535,35 @@ func TestGetLatestPublishedSchemaVersion_GetSchemaVersionError(t *testing.T) {
 		t.Errorf("expected transport error, got %v", err)
 	}
 }
+
+func TestGetLatestPublishedSchemaVersion_GappedVersionHistory(t *testing.T) {
+	// v5 draft, v4 deleted (ErrNotFound), v3 published — should return v3.
+	ms := &mockSchemaTransport{}
+	client := New(WithSchemaTransport(ms))
+
+	ms.listSchemasFn = func(_ context.Context, _ int32, _ string) (*ListSchemasResponse, error) {
+		return &ListSchemasResponse{
+			Schemas: []*Schema{{ID: "s1", Name: "payments", Version: 5, Published: false}},
+		}, nil
+	}
+	ms.getSchemaFn = func(_ context.Context, id string, version *int32) (*Schema, error) {
+		if id != "s1" {
+			t.Errorf("unexpected id %q", id)
+		}
+		switch *version {
+		case 4:
+			return nil, ErrNotFound
+		case 3:
+			return &Schema{ID: "s1", Version: 3, Published: true}, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	id, version, err := client.GetLatestPublishedSchemaVersion(context.Background(), "payments")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "s1" || version != 3 {
+		t.Errorf("got %s@%d, want s1@3", id, version)
+	}
+}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -2,6 +2,7 @@ package adminclient
 
 import (
 	"context"
+	"errors"
 )
 
 // CreateSchema creates a new schema with an initial draft version (v1).
@@ -177,6 +178,9 @@ func (c *Client) GetLatestPublishedSchemaVersion(ctx context.Context, name strin
 	// Latest is a draft — walk back to find the newest published version.
 	for v := match.Version - 1; v >= 1; v-- {
 		s, err := c.GetSchemaVersion(ctx, match.ID, v)
+		if errors.Is(err, ErrNotFound) {
+			continue
+		}
 		if err != nil {
 			return "", 0, err
 		}


### PR DESCRIPTION
## Summary
- An intermediate deleted/squashed version returned ErrNotFound during the backward walk, causing the search to abort instead of continuing to older published versions.
- The fix treats ErrNotFound on any intermediate version as a skip so the walk continues; non-NotFound transport errors still abort immediately.

## Test plan
- [x] New test `TestGetLatestPublishedSchemaVersion_GappedVersionHistory`: v5 draft, v4 NotFound, v3 published — asserts v3 is returned
- [x] Existing test `TestGetLatestPublishedSchemaVersion_GetSchemaVersionError` still passes (non-NotFound error aborts)
- [x] `make test` passes (all modules)
- [x] `make lint-go` clean

Closes #689