### PR TITLE
fix(configwatcher): return error when registering after Start

### DIFF
--- a/examples/feature-flags/main.go
+++ b/examples/feature-flags/main.go
@@ -47,8 +47,8 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("create watcher: %w", err)
 	}
-	darkMode := w.Bool("features.dark_mode", false)
-	betaAccess := w.Bool("features.beta_access", false)
+	darkMode, _ := w.Bool("features.dark_mode", false)
+	betaAccess, _ := w.Bool("features.beta_access", false)
 
 	// Start loads the current values and subscribes to live changes.
 	if err := w.Start(ctx); err != nil {

--- a/examples/feature-flags/main_test.go
+++ b/examples/feature-flags/main_test.go
@@ -41,8 +41,8 @@ func TestExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create watcher: %v", err)
 	}
-	darkMode := w.Bool("features.dark_mode", false)
-	betaAccess := w.Bool("features.beta_access", false)
+	darkMode, _ := w.Bool("features.dark_mode", false)
+	betaAccess, _ := w.Bool("features.beta_access", false)
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("start watcher: %v", err)

--- a/examples/live-config/main.go
+++ b/examples/live-config/main.go
@@ -50,10 +50,10 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("create watcher: %w", err)
 	}
-	rateLimit := w.Int("server.rate_limit", 100)
-	timeout := w.Duration("server.timeout", 30*time.Second)
-	maxConns := w.Int("server.max_connections", 50)
-	debug := w.Bool("app.debug", false)
+	rateLimit, _ := w.Int("server.rate_limit", 100)
+	timeout, _ := w.Duration("server.timeout", 30*time.Second)
+	maxConns, _ := w.Int("server.max_connections", 50)
+	debug, _ := w.Bool("app.debug", false)
 
 	if err := w.Start(ctx); err != nil {
 		return fmt.Errorf("start watcher: %w", err)

--- a/examples/live-config/main_test.go
+++ b/examples/live-config/main_test.go
@@ -42,10 +42,10 @@ func TestExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create watcher: %v", err)
 	}
-	rateLimit := w.Int("server.rate_limit", 100)
-	timeout := w.Duration("server.timeout", 30*time.Second)
-	maxConns := w.Int("server.max_connections", 50)
-	debug := w.Bool("app.debug", false)
+	rateLimit, _ := w.Int("server.rate_limit", 100)
+	timeout, _ := w.Duration("server.timeout", 30*time.Second)
+	maxConns, _ := w.Int("server.max_connections", 50)
+	debug, _ := w.Bool("app.debug", false)
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("start watcher: %v", err)

--- a/sdk/configwatcher/example_test.go
+++ b/sdk/configwatcher/example_test.go
@@ -40,8 +40,8 @@ func ExampleWatcher() {
 	w := configwatcher.New(&fakeTransport{}, "tenant-1")
 
 	// Register typed fields before calling Start.
-	maxConn := w.Int("limits.max_connections", 100)
-	debug := w.Bool("app.debug", false)
+	maxConn, _ := w.Int("limits.max_connections", 100)
+	debug, _ := w.Bool("app.debug", false)
 
 	// Before Start is called, Get returns the registered default.
 	fmt.Println(maxConn.Get())
@@ -56,7 +56,7 @@ func ExampleWatcher_Start() {
 	defer cancel()
 
 	w := configwatcher.New(&fakeTransport{}, "tenant-1")
-	timeout := w.String("jobs.timeout", "30s")
+	timeout, _ := w.String("jobs.timeout", "30s")
 
 	// Start loads a snapshot and streams live updates in the background.
 	if err := w.Start(ctx); err != nil {
@@ -71,7 +71,7 @@ func ExampleWatcher_Start() {
 
 func ExampleValue_Changes() {
 	w := configwatcher.New(&fakeTransport{}, "tenant-1")
-	maxConn := w.Int("limits.max_connections", 100)
+	maxConn, _ := w.Int("limits.max_connections", 100)
 
 	// Changes channel receives a notification on every update.
 	// Read without blocking — no update has arrived yet.
@@ -86,7 +86,7 @@ func ExampleValue_Changes() {
 
 func ExampleValue_GetWithNull() {
 	w := configwatcher.New(&fakeTransport{}, "tenant-1")
-	flag := w.Bool("feature.enabled", false)
+	flag, _ := w.Bool("feature.enabled", false)
 
 	val, ok := flag.GetWithNull()
 	fmt.Println(val, ok) // default; field not yet received from server
@@ -100,7 +100,7 @@ func ExampleWithReconnectBackoff() {
 	w := configwatcher.New(&fakeTransport{}, "tenant-1",
 		configwatcher.WithReconnectBackoff(100*time.Millisecond, 10*time.Second),
 	)
-	flag := w.Bool("feature.enabled", false)
+	flag, _ := w.Bool("feature.enabled", false)
 
 	if err := w.Start(ctx); err != nil {
 		fmt.Println("start error:", err)

--- a/sdk/configwatcher/options_test.go
+++ b/sdk/configwatcher/options_test.go
@@ -57,12 +57,30 @@ func TestWithLogger(t *testing.T) {
 func TestFieldRegistration(t *testing.T) {
 	w := New(nil, "t1")
 
-	strVal := w.String("app.name", "default")
-	intVal := w.Int("app.retries", 3)
-	floatVal := w.Float("app.rate", 0.01)
-	boolVal := w.Bool("app.enabled", false)
-	durVal := w.Duration("app.timeout", time.Second)
-	rawVal := w.Raw("app.raw", "raw-default")
+	strVal, err := w.String("app.name", "default")
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
+	intVal, err := w.Int("app.retries", 3)
+	if err != nil {
+		t.Fatalf("Int: %v", err)
+	}
+	floatVal, err := w.Float("app.rate", 0.01)
+	if err != nil {
+		t.Fatalf("Float: %v", err)
+	}
+	boolVal, err := w.Bool("app.enabled", false)
+	if err != nil {
+		t.Fatalf("Bool: %v", err)
+	}
+	durVal, err := w.Duration("app.timeout", time.Second)
+	if err != nil {
+		t.Fatalf("Duration: %v", err)
+	}
+	rawVal, err := w.Raw("app.raw", "raw-default")
+	if err != nil {
+		t.Fatalf("Raw: %v", err)
+	}
 
 	if got := strVal.Get(); got != "default" {
 		t.Errorf("got %v, want %v", got, "default")

--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -82,7 +82,7 @@ func TestWatcher_ConcurrentRegisterAndPaths(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			if g%2 == 0 {
-				registerField(w, fmt.Sprintf("field-%d", g), int64(0), parseInt)
+				_, _ = registerField(w, fmt.Sprintf("field-%d", g), int64(0), parseInt)
 			} else {
 				w.registeredPaths()
 			}
@@ -122,7 +122,7 @@ func TestWatcher_ConcurrentStartAndClose(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	_ = w.String("app.name", "default")
+	_, _ = w.String("app.name", "default")
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -169,7 +169,7 @@ func TestWatcher_DoubleStart(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	_ = w.String("app.name", "default")
+	_, _ = w.String("app.name", "default")
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("first Start: %v", err)
@@ -215,7 +215,7 @@ func TestWatcher_StartCloseConcurrent(t *testing.T) {
 			done:      make(chan struct{}),
 		}
 
-		_ = w.String("app.name", "default")
+		_, _ = w.String("app.name", "default")
 
 		// ready gates Start and Close to begin at the same instant.
 		ready := make(chan struct{})
@@ -325,7 +325,10 @@ func TestWatcher_CloseWhileStreamSends(t *testing.T) {
 		done:   make(chan struct{}),
 	}
 
-	val := w.String("key", "default")
+	val, err := w.String("key", "default")
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -11,8 +11,8 @@
 //	transport := grpctransport.NewConfigTransport(conn, grpctransport.WithSubject("myapp"))
 //	w := configwatcher.New(transport, "tenant-uuid")
 //
-//	fee := w.Float("payments.fee_rate", 0.01)
-//	enabled := w.Bool("payments.enabled", false)
+//	fee, _ := w.Float("payments.fee_rate", 0.01)
+//	enabled, _ := w.Bool("payments.enabled", false)
 //
 //	w.Start(ctx)
 //	defer w.Close()
@@ -27,6 +27,7 @@ package configwatcher
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -34,6 +35,12 @@ import (
 
 	"github.com/opendecree/decree/sdk/configclient"
 )
+
+// ErrStarted is returned by Register* methods (String, Int, Bool, etc.) when
+// the watcher has already been started. All fields must be registered before
+// calling [Watcher.Start]; a field registered after Start will never receive
+// stream updates.
+var ErrStarted = errors.New("configwatcher: cannot register field after Start")
 
 // Watcher monitors a tenant's configuration via a subscription stream.
 // Register typed field accessors before calling [Watcher.Start].
@@ -119,69 +126,72 @@ func WithSnapshotTimeout(d time.Duration) Option {
 
 // String registers a string field and returns a live [Value] handle.
 // The defaultVal is returned when the field is null or missing.
-// Must be called before [Watcher.Start].
-func (w *Watcher) String(fieldPath string, defaultVal string) *Value[string] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) String(fieldPath string, defaultVal string) (*Value[string], error) {
 	return registerField(w, fieldPath, defaultVal, parseString)
 }
 
 // Int registers an integer field and returns a live [Value] handle.
 // Values are stored as decimal strings (e.g. "42") and parsed to int64.
 // The defaultVal is returned when the field is null, missing, or unparseable.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Int(fieldPath string, defaultVal int64) *Value[int64] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Int(fieldPath string, defaultVal int64) (*Value[int64], error) {
 	return registerField(w, fieldPath, defaultVal, parseInt)
 }
 
 // Float registers a floating-point field and returns a live [Value] handle.
 // Values are stored as decimal strings (e.g. "3.14") and parsed to float64.
 // The defaultVal is returned when the field is null, missing, or unparseable.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Float(fieldPath string, defaultVal float64) *Value[float64] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Float(fieldPath string, defaultVal float64) (*Value[float64], error) {
 	return registerField(w, fieldPath, defaultVal, parseFloat)
 }
 
 // Bool registers a boolean field and returns a live [Value] handle.
 // Values are stored as "true" or "false" strings.
 // The defaultVal is returned when the field is null, missing, or unparseable.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Bool(fieldPath string, defaultVal bool) *Value[bool] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Bool(fieldPath string, defaultVal bool) (*Value[bool], error) {
 	return registerField(w, fieldPath, defaultVal, parseBool)
 }
 
 // Duration registers a duration field and returns a live [Value] handle.
 // Values are stored as Go-style duration strings (e.g. "24h", "500ms").
 // The defaultVal is returned when the field is null, missing, or unparseable.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Duration(fieldPath string, defaultVal time.Duration) *Value[time.Duration] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Duration(fieldPath string, defaultVal time.Duration) (*Value[time.Duration], error) {
 	return registerField(w, fieldPath, defaultVal, parseDuration)
 }
 
 // Time registers a timestamp field and returns a live [Value] handle.
 // Values are stored as RFC3339Nano strings and parsed to time.Time.
 // The defaultVal is returned when the field is null, missing, or unparseable.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Time(fieldPath string, defaultVal time.Time) *Value[time.Time] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Time(fieldPath string, defaultVal time.Time) (*Value[time.Time], error) {
 	return registerField(w, fieldPath, defaultVal, parseTime)
 }
 
 // Raw registers a string field with no type conversion and returns a live [Value] handle.
 // This is equivalent to [Watcher.String] — provided for clarity of intent.
-// Must be called before [Watcher.Start].
-func (w *Watcher) Raw(fieldPath string, defaultVal string) *Value[string] {
+// Must be called before [Watcher.Start]; returns [ErrStarted] if called after.
+func (w *Watcher) Raw(fieldPath string, defaultVal string) (*Value[string], error) {
 	return registerField(w, fieldPath, defaultVal, parseString)
 }
 
-func registerField[T any](w *Watcher, fieldPath string, defaultVal T, parse func(string) (T, error)) *Value[T] {
+func registerField[T any](w *Watcher, fieldPath string, defaultVal T, parse func(string) (T, error)) (*Value[T], error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.started {
+		return nil, ErrStarted
+	}
 	v := newValue(defaultVal, parse)
 	v.fieldPath = fieldPath
 	v.logger = w.opts.logger
-	w.mu.Lock()
-	defer w.mu.Unlock()
 	w.fields[fieldPath] = &fieldEntry{
 		rawUpdate: func(value string, isSet bool) { v.update(value, isSet) },
 		closeFunc: func() { v.close() },
 	}
-	return v
+	return v, nil
 }
 
 // --- Lifecycle ---

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -197,10 +197,16 @@ func TestWatcher_SnapshotAndStream(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	fee := w.Float("payments.fee", 0.01)
-	enabled := w.Bool("payments.enabled", false)
+	fee, err := w.Float("payments.fee", 0.01)
+	if err != nil {
+		t.Fatalf("Float: %v", err)
+	}
+	enabled, err := w.Bool("payments.enabled", false)
+	if err != nil {
+		t.Fatalf("Bool: %v", err)
+	}
 
-	err := w.Start(ctx)
+	err = w.Start(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -256,12 +262,84 @@ func TestWatcher_SnapshotError(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	_ = w.String("app.name", "default")
+	_, _ = w.String("app.name", "default")
 
 	err := w.Start(context.Background())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
+}
+
+// TestWatcher_RegisterAfterStart verifies that calling a Register* method after
+// Start returns ErrStarted and that a field registered before Start is still live.
+func TestWatcher_RegisterAfterStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub := newMockSubscription(ctx)
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+		},
+		subscribeFn: func(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	w := &Watcher{
+		transport: tr,
+		tenantID:  "t1",
+		opts:      options{minBackoff: 10 * time.Millisecond, maxBackoff: 50 * time.Millisecond},
+		fields:    make(map[string]*fieldEntry),
+		done:      make(chan struct{}),
+	}
+
+	// Register a field before Start — must succeed.
+	name, err := w.String("app.name", "default")
+	if err != nil {
+		t.Fatalf("String before Start: %v", err)
+	}
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Registering after Start must return ErrStarted.
+	_, errAfter := w.String("app.other", "x")
+	if errAfter == nil {
+		t.Fatal("expected ErrStarted, got nil")
+	}
+	if errAfter != ErrStarted {
+		t.Errorf("got %v, want ErrStarted", errAfter)
+	}
+
+	// Verify all typed methods return ErrStarted after Start.
+	if _, e := w.Int("x", 0); e != ErrStarted {
+		t.Errorf("Int: got %v, want ErrStarted", e)
+	}
+	if _, e := w.Float("x", 0); e != ErrStarted {
+		t.Errorf("Float: got %v, want ErrStarted", e)
+	}
+	if _, e := w.Bool("x", false); e != ErrStarted {
+		t.Errorf("Bool: got %v, want ErrStarted", e)
+	}
+	if _, e := w.Duration("x", 0); e != ErrStarted {
+		t.Errorf("Duration: got %v, want ErrStarted", e)
+	}
+	if _, e := w.Time("x", time.Time{}); e != ErrStarted {
+		t.Errorf("Time: got %v, want ErrStarted", e)
+	}
+	if _, e := w.Raw("x", ""); e != ErrStarted {
+		t.Errorf("Raw: got %v, want ErrStarted", e)
+	}
+
+	// The pre-registered field must still be accessible.
+	if got := name.Get(); got != "default" {
+		t.Errorf("Get: got %q, want %q", got, "default")
+	}
+
+	cancel()
+	_ = w.Close()
 }
 
 func TestWatcher_NullField(t *testing.T) {
@@ -289,9 +367,12 @@ func TestWatcher_NullField(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	name := w.String("app.name", "fallback")
+	name, err := w.String("app.name", "fallback")
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
 
-	err := w.Start(ctx)
+	err = w.Start(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -361,7 +442,10 @@ func TestWatcher_TypeFlipMidStream(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	fee := w.Float("payments.fee", 0.01)
+	fee, err := w.Float("payments.fee", 0.01)
+	if err != nil {
+		t.Fatalf("Float: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -550,7 +634,10 @@ func TestWatcher_ReconnectVersionCursor(t *testing.T) {
 		done:   make(chan struct{}),
 	}
 
-	x := w.String("x", "default")
+	x, err := w.String("x", "default")
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -689,7 +776,10 @@ func TestWatcher_TimeField(t *testing.T) {
 	}
 
 	w := New(tr, "t1")
-	scheduled := w.Time("deploy.scheduled_at", time.Time{})
+	scheduled, err := w.Time("deploy.scheduled_at", time.Time{})
+	if err != nil {
+		t.Fatalf("Time: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -825,7 +915,10 @@ func TestValue_DroppedCount_ViaWatcher(t *testing.T) {
 	}
 
 	w := New(tr, "t1", WithLogger(logger))
-	fee := w.Int("payments.fee", 0)
+	fee, err := w.Int("payments.fee", 0)
+	if err != nil {
+		t.Fatalf("Int: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -1013,7 +1106,10 @@ func TestWatcher_ReconnectNoSpuriousChanges(t *testing.T) {
 		done:   make(chan struct{}),
 	}
 
-	name := w.String("app.name", "default")
+	name, err := w.String("app.name", "default")
+	if err != nil {
+		t.Fatalf("String: %v", err)
+	}
 
 	if err := w.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)


### PR DESCRIPTION
## Summary
- Return error from Register* methods when called after Start
- Enforces the register-before-Start contract documented in the API
- Test: post-Start registration returns error

## Test plan
- [ ] Register after Start returns error
- [ ] Register before Start works normally
- [ ] make test passes

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)