### PR TITLE
fix(grpctransport): preserve retry-after by making ResourceExhausted non-retryable

### DIFF
--- a/sdk/adminclient/errors.go
+++ b/sdk/adminclient/errors.go
@@ -21,6 +21,13 @@ var (
 	// role or tenant access to perform an administrative operation.
 	ErrPermissionDenied = errors.New("permission denied")
 
+	// ErrRateLimited is returned when the server has exhausted a rate limit
+	// for the caller. Unlike transient errors, the server may attach a
+	// RetryInfo detail with a backoff hint; callers should honor that hint
+	// rather than retrying immediately. This error is intentionally NOT
+	// wrapped as RetryableError so automatic retry loops do not fire.
+	ErrRateLimited = errors.New("rate limited")
+
 	// ErrInvalidArgument is returned when the server rejects a request due to
 	// invalid input (e.g. a malformed regex constraint in a schema import).
 	ErrInvalidArgument = errors.New("invalid argument")

--- a/sdk/configclient/errors.go
+++ b/sdk/configclient/errors.go
@@ -31,6 +31,13 @@ var (
 	// ErrAlreadyExists is returned when attempting to create a resource that already exists.
 	ErrAlreadyExists = errors.New("already exists")
 
+	// ErrRateLimited is returned when the server has exhausted a rate limit
+	// for the caller. Unlike transient errors, the server may attach a
+	// RetryInfo detail with a backoff hint; callers should honor that hint
+	// rather than retrying immediately. This error is intentionally NOT
+	// wrapped as RetryableError so automatic retry loops do not fire.
+	ErrRateLimited = errors.New("rate limited")
+
 	// ErrTypeMismatch is returned when a typed getter is called on a field
 	// whose value type doesn't match (e.g. GetInt on a string field).
 	ErrTypeMismatch = errors.New("value type mismatch")

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -30,7 +30,13 @@ func mapConfigError(err error) error {
 		return configclient.ErrAlreadyExists
 	case codes.InvalidArgument:
 		return configclient.InvalidArgumentError(st.Message())
-	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+	case codes.ResourceExhausted:
+		// ResourceExhausted signals a rate limit. The server attaches a RetryInfo
+		// detail with a hard backoff hint; wrapping as RetryableError would discard
+		// that hint and cause retry loops to hammer the limiter. Return ErrRateLimited
+		// (non-retryable) so callers can inspect the hint and back off correctly.
+		return configclient.ErrRateLimited
+	case codes.Unavailable, codes.DeadlineExceeded:
 		return &configclient.RetryableError{Err: err}
 	default:
 		return err
@@ -57,7 +63,13 @@ func mapAdminError(err error) error {
 		return adminclient.ErrPermissionDenied
 	case codes.InvalidArgument:
 		return adminclient.InvalidArgumentError(st.Message())
-	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+	case codes.ResourceExhausted:
+		// ResourceExhausted signals a rate limit. The server attaches a RetryInfo
+		// detail with a hard backoff hint; wrapping as RetryableError would discard
+		// that hint and cause retry loops to hammer the limiter. Return ErrRateLimited
+		// (non-retryable) so callers can inspect the hint and back off correctly.
+		return adminclient.ErrRateLimited
+	case codes.Unavailable, codes.DeadlineExceeded:
 		return &adminclient.RetryableError{Err: err}
 	default:
 		return err

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -1,6 +1,8 @@
 package grpctransport
 
 import (
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -33,9 +35,10 @@ func mapConfigError(err error) error {
 	case codes.ResourceExhausted:
 		// ResourceExhausted signals a rate limit. The server attaches a RetryInfo
 		// detail with a hard backoff hint; wrapping as RetryableError would discard
-		// that hint and cause retry loops to hammer the limiter. Return ErrRateLimited
-		// (non-retryable) so callers can inspect the hint and back off correctly.
-		return configclient.ErrRateLimited
+		// that hint and cause retry loops to hammer the limiter. Wrap both the
+		// original gRPC error (so status.Code still returns ResourceExhausted) and
+		// ErrRateLimited (so callers can errors.Is check the sentinel).
+		return fmt.Errorf("%w: %w", err, configclient.ErrRateLimited)
 	case codes.Unavailable, codes.DeadlineExceeded:
 		return &configclient.RetryableError{Err: err}
 	default:
@@ -64,11 +67,10 @@ func mapAdminError(err error) error {
 	case codes.InvalidArgument:
 		return adminclient.InvalidArgumentError(st.Message())
 	case codes.ResourceExhausted:
-		// ResourceExhausted signals a rate limit. The server attaches a RetryInfo
-		// detail with a hard backoff hint; wrapping as RetryableError would discard
-		// that hint and cause retry loops to hammer the limiter. Return ErrRateLimited
-		// (non-retryable) so callers can inspect the hint and back off correctly.
-		return adminclient.ErrRateLimited
+		// ResourceExhausted signals a rate limit. Wrap both the original gRPC error
+		// (so status.Code still returns ResourceExhausted) and ErrRateLimited (so
+		// callers can errors.Is check the sentinel).
+		return fmt.Errorf("%w: %w", err, adminclient.ErrRateLimited)
 	case codes.Unavailable, codes.DeadlineExceeded:
 		return &adminclient.RetryableError{Err: err}
 	default:

--- a/sdk/grpctransport/errors_test.go
+++ b/sdk/grpctransport/errors_test.go
@@ -107,11 +107,14 @@ func TestMapConfigError_DeadlineExceeded_IsRetryable(t *testing.T) {
 	}
 }
 
-func TestMapConfigError_ResourceExhausted_IsRetryable(t *testing.T) {
+func TestMapConfigError_ResourceExhausted_IsRateLimited_NotRetryable(t *testing.T) {
 	err := mapConfigError(status.Error(codes.ResourceExhausted, "rate limit"))
+	if !errors.Is(err, configclient.ErrRateLimited) {
+		t.Errorf("got %v, want ErrRateLimited", err)
+	}
 	var re *configclient.RetryableError
-	if !errors.As(err, &re) {
-		t.Errorf("got %v, want *RetryableError", err)
+	if errors.As(err, &re) {
+		t.Error("ResourceExhausted must NOT be wrapped as RetryableError")
 	}
 }
 
@@ -182,11 +185,14 @@ func TestMapAdminError_DeadlineExceeded_IsRetryable(t *testing.T) {
 	}
 }
 
-func TestMapAdminError_ResourceExhausted_IsRetryable(t *testing.T) {
+func TestMapAdminError_ResourceExhausted_IsRateLimited_NotRetryable(t *testing.T) {
 	err := mapAdminError(status.Error(codes.ResourceExhausted, "rate limit"))
+	if !errors.Is(err, adminclient.ErrRateLimited) {
+		t.Errorf("got %v, want ErrRateLimited", err)
+	}
 	var re *adminclient.RetryableError
-	if !errors.As(err, &re) {
-		t.Errorf("got %v, want *RetryableError", err)
+	if errors.As(err, &re) {
+		t.Error("ResourceExhausted must NOT be wrapped as RetryableError")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Map `ResourceExhausted` to `ErrRateLimited` (non-retryable) instead of `RetryableError` in both `mapConfigError` and `mapAdminError`
- Prevents retry loops from hammering the rate limiter without honoring the server's `RetryInfo` backoff hint
- Add `ErrRateLimited` sentinel to both `adminclient` and `configclient` packages so callers can `errors.Is` check

## Test plan
- [x] `ResourceExhausted` maps to `ErrRateLimited`, not `RetryableError` (asserted in both config and admin error tests)
- [x] Callers can `errors.Is(err, configclient.ErrRateLimited)` / `adminclient.ErrRateLimited`
- [x] `make test` passes
- [x] `make lint-go` passes

Closes #697
🤖 Generated with [Claude Code](https://claude.com/claude-code)