### PR TITLE
fix(tools/seed): propagate ListSchemas/ListTenants errors in resolveTenant

### DIFF
--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -368,16 +368,20 @@ func resolveTenant(ctx context.Context, client Client, file *File, result *Resul
 	// silently creating a duplicate.
 	if file.Schema.Name == "" {
 		allSchemas, err := client.ListSchemas(ctx)
-		if err == nil {
-			for _, s := range allSchemas {
-				if s.ID == result.SchemaID {
-					continue
-				}
-				others, _ := client.ListTenants(ctx, s.ID)
-				for _, t := range others {
-					if t.Name == file.Tenant.Name {
-						return fmt.Errorf("tenant %q is bound to schema %q, not %q", t.Name, s.Name, file.Tenant.Schema)
-					}
+		if err != nil {
+			return fmt.Errorf("listing schemas: %w", err)
+		}
+		for _, s := range allSchemas {
+			if s.ID == result.SchemaID {
+				continue
+			}
+			others, err := client.ListTenants(ctx, s.ID)
+			if err != nil {
+				return fmt.Errorf("listing tenants for schema %q: %w", s.Name, err)
+			}
+			for _, t := range others {
+				if t.Name == file.Tenant.Name {
+					return fmt.Errorf("tenant %q is bound to schema %q, not %q", t.Name, s.Name, file.Tenant.Schema)
 				}
 			}
 		}

--- a/sdk/tools/seed/seed_test.go
+++ b/sdk/tools/seed/seed_test.go
@@ -1033,6 +1033,52 @@ func TestRun_ConfigOnly_SchemaMismatch_ErrorMessage(t *testing.T) {
 	}
 }
 
+func TestRun_ConfigOnly_ResolveTenant_ListSchemasError(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s1", 1, nil
+		},
+		listTenantsFn: func(_ context.Context, _ string) ([]*adminclient.Tenant, error) {
+			// Tenant not found under the resolved schema — triggers cross-schema check.
+			return nil, nil
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return nil, fmt.Errorf("rpc error")
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil || !strings.Contains(err.Error(), "rpc error") {
+		t.Fatalf("expected rpc error to be propagated, got %v", err)
+	}
+}
+
+func TestRun_ConfigOnly_ResolveTenant_ListTenantsError(t *testing.T) {
+	file := configOnlyFile(nil)
+	mock := &mockClient{
+		getLatestPublishedSchemaVersionFn: func(_ context.Context, _ string) (string, int32, error) {
+			return "s_payments", 1, nil
+		},
+		listSchemasFn: func(_ context.Context) ([]*adminclient.Schema, error) {
+			return []*adminclient.Schema{
+				{ID: "s_payments", Name: "payments"},
+				{ID: "s_billing", Name: "billing"},
+			}, nil
+		},
+		listTenantsFn: func(_ context.Context, schemaID string) ([]*adminclient.Tenant, error) {
+			if schemaID == "s_payments" {
+				// Tenant not found under resolved schema — triggers cross-schema check.
+				return nil, nil
+			}
+			return nil, fmt.Errorf("db down")
+		},
+	}
+	_, err := Run(context.Background(), mock, file)
+	if err == nil || !strings.Contains(err.Error(), "db down") {
+		t.Fatalf("expected db down error to be propagated, got %v", err)
+	}
+}
+
 func TestRun_ConfigOnly_WithLocks(t *testing.T) {
 	file := configOnlyFile(nil)
 	file.Locks = []LockDef{


### PR DESCRIPTION
## Summary
- Fixes a silent error swallow in `resolveTenant`'s config-only cross-schema duplicate check: a `ListSchemas` failure was gated behind `if err == nil`, allowing a transient RPC error to skip the safety check and proceed to `CreateTenant`.
- Fixes discarded `ListTenants` errors in the same loop (`others, _ :=`), which had the same consequence for per-schema tenant lookups.

## Test plan
- [x] `TestRun_ConfigOnly_ResolveTenant_ListSchemasError` — asserts that a `ListSchemas` RPC error is returned to the caller
- [x] `TestRun_ConfigOnly_ResolveTenant_ListTenantsError` — asserts that a `ListTenants` RPC error for a non-primary schema is returned to the caller
- [x] `make test` passes (all modules)
- [x] `make lint-go` passes (0 issues)
- [x] Coverage: `sdk/tools/seed` at 97.9% (threshold 96.1%)

Closes #700