### PR TITLE
fix(cli): silence usage on errors, treat EOF as clean, fix validate exit

### DIFF
--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -286,6 +286,45 @@ func TestParseDuration_Invalid(t *testing.T) {
 	}
 }
 
+// --- SilenceUsage / SilenceErrors (#707) ---
+
+func TestRootCmd_SilenceUsage(t *testing.T) {
+	if !rootCmd.SilenceUsage {
+		t.Error("expected rootCmd.SilenceUsage = true, got false")
+	}
+}
+
+func TestRootCmd_SilenceErrors(t *testing.T) {
+	if !rootCmd.SilenceErrors {
+		t.Error("expected rootCmd.SilenceErrors = true, got false")
+	}
+}
+
+// --- validate RunE returns error instead of os.Exit (#708) ---
+
+// TestValidateCmd_MissingFlagsReturnsError verifies that validateCmd.RunE
+// returns an error (rather than calling os.Exit) when required flags are absent.
+func TestValidateCmd_MissingFlagsReturnsError(t *testing.T) {
+	rootCmd.SetArgs([]string{"validate"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing --schema / --config, got nil")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("expected error to mention %q, got %q", "required", err.Error())
+	}
+}
+
+// TestValidateCmd_InvalidSchemaFileReturnsError verifies that a missing schema
+// file returns an error from RunE instead of calling os.Exit.
+func TestValidateCmd_InvalidSchemaFileReturnsError(t *testing.T) {
+	rootCmd.SetArgs([]string{"validate", "--schema", "/nonexistent/schema.yaml", "--config", "/nonexistent/config.yaml"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing schema file, got nil")
+	}
+}
+
 // --- Completions ---
 
 func TestCompletionScripts(t *testing.T) {

--- a/cmd/decree/main.go
+++ b/cmd/decree/main.go
@@ -37,9 +37,11 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "decree",
-	Short: "OpenDecree CLI",
-	Long:  "Command-line tool for managing schemas, tenants, and configuration values in OpenDecree.",
+	Use:           "decree",
+	Short:         "OpenDecree CLI",
+	Long:          "Command-line tool for managing schemas, tenants, and configuration values in OpenDecree.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		if !flagWait {
 			return nil

--- a/cmd/decree/signal_test.go
+++ b/cmd/decree/signal_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -58,5 +59,14 @@ func TestWatchStream_OtherErrorPreserved(t *testing.T) {
 	}
 	if !errors.Is(err, rpcErr) {
 		t.Errorf("expected original error preserved, got %v", err)
+	}
+}
+
+// TestWatchStream_EOFReturnsNil verifies that io.EOF (graceful server shutdown)
+// is treated as a clean stream end and mapped to nil — exit 0.
+func TestWatchStream_EOFReturnsNil(t *testing.T) {
+	err := normalizeStreamErr(io.EOF)
+	if err != nil {
+		t.Errorf("expected nil for io.EOF, got %v", err)
 	}
 }

--- a/cmd/decree/validate_cmd.go
+++ b/cmd/decree/validate_cmd.go
@@ -48,8 +48,7 @@ var validateCmd = &cobra.Command{
 		for _, v := range result.Violations {
 			fmt.Fprintf(os.Stderr, "  %s\n", v.Error())
 		}
-		os.Exit(1)
-		return nil
+		return fmt.Errorf("validation failed with %d violation(s)", len(result.Violations))
 	},
 }
 

--- a/cmd/decree/watch.go
+++ b/cmd/decree/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"time"
 
@@ -15,11 +16,14 @@ import (
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
 )
 
-// normalizeStreamErr maps a streaming RPC error to nil when the error is caused
-// by context cancellation (Ctrl-C / SIGTERM), so the CLI exits with code 0.
-// All other errors are returned unchanged.
+// normalizeStreamErr maps a streaming RPC error to nil when the error signals a
+// clean stream end: context cancellation (Ctrl-C / SIGTERM) or io.EOF (graceful
+// server shutdown). All other errors are returned unchanged.
 func normalizeStreamErr(err error) error {
 	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	if errors.Is(err, io.EOF) {
 		return nil
 	}
 	if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {


### PR DESCRIPTION
## Summary

- CLI was printing the full usage block after every runtime error because \`SilenceUsage\` and \`SilenceErrors\` were unset — every failure confused users with irrelevant flag documentation (#707).
- Graceful server shutdown sends \`io.EOF\` on the watch stream, which was surfaced as "Error: EOF" with exit 1 instead of a clean exit 0 (#706).
- The \`validate\` command called \`os.Exit(1)\` inside \`RunE\`, bypassing deferred cleanup and cobra's error path; the \`return nil\` after it was dead code (#708).

## Test plan

- [x] \`TestRootCmd_SilenceUsage\` — asserts \`SilenceUsage = true\`
- [x] \`TestRootCmd_SilenceErrors\` — asserts \`SilenceErrors = true\`
- [x] \`TestWatchStream_EOFReturnsNil\` — \`normalizeStreamErr(io.EOF)\` returns nil
- [x] \`TestValidateCmd_MissingFlagsReturnsError\` — missing flags return error, not exit
- [x] \`TestValidateCmd_InvalidSchemaFileReturnsError\` — bad file path returns error, not exit
- [x] \`make test\` passes (88.2% coverage, threshold 86.1%)
- [x] \`make lint-go\` clean

Closes #706
Closes #707
Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)