### PR TITLE
refactor(sdk): extract shared retry engine into sdk/retry

### DIFF
--- a/sdk/adminclient/errors.go
+++ b/sdk/adminclient/errors.go
@@ -3,6 +3,8 @@ package adminclient
 import (
 	"errors"
 	"fmt"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 var (
@@ -45,15 +47,8 @@ func InvalidArgumentError(message string) error {
 // RetryableError wraps an error to indicate the operation may succeed on retry.
 // Transport implementations should wrap transient errors (e.g. Unavailable,
 // DeadlineExceeded, ResourceExhausted) in RetryableError.
-type RetryableError struct {
-	Err error
-}
-
-func (e *RetryableError) Error() string { return e.Err.Error() }
-func (e *RetryableError) Unwrap() error { return e.Err }
+// It is an alias for the shared [sdkretry.RetryableError] type.
+type RetryableError = sdkretry.RetryableError
 
 // IsRetryable reports whether err is marked as retryable by the transport.
-func IsRetryable(err error) bool {
-	var re *RetryableError
-	return errors.As(err, &re)
-}
+var IsRetryable = sdkretry.IsRetryable

--- a/sdk/adminclient/options.go
+++ b/sdk/adminclient/options.go
@@ -41,7 +41,7 @@ func WithServerTransport(t ServerTransport) Option {
 // By default, only errors wrapped in [RetryableError] by the transport are retried.
 func WithRetry(cfg RetryConfig) Option {
 	return func(o *clientOptions) {
-		o.retry = cfg.withDefaults()
+		o.retry = cfg.WithDefaults()
 		o.retryEnabled = true
 	}
 }

--- a/sdk/adminclient/retry.go
+++ b/sdk/adminclient/retry.go
@@ -8,63 +8,22 @@ import (
 )
 
 // RetryConfig configures automatic retry with exponential backoff.
-type RetryConfig struct {
-	// MaxAttempts is the maximum number of attempts (including the first).
-	// Default: 3.
-	MaxAttempts int
-	// InitialBackoff is the delay before the first retry.
-	// Default: 100ms.
-	InitialBackoff time.Duration
-	// MaxBackoff caps the backoff duration.
-	// Default: 5s.
-	MaxBackoff time.Duration
-	// Jitter adds randomness to backoff to avoid thundering herd.
-	// Default: false.
-	Jitter bool
-	// RetryableCheck determines if an error is retryable.
-	// If nil, defaults to checking for [RetryableError].
-	RetryableCheck func(err error) bool
-}
-
-func (c RetryConfig) withDefaults() RetryConfig {
-	if c.MaxAttempts <= 0 {
-		c.MaxAttempts = 3
-	}
-	if c.InitialBackoff <= 0 {
-		c.InitialBackoff = 100 * time.Millisecond
-	}
-	if c.MaxBackoff <= 0 {
-		c.MaxBackoff = 5 * time.Second
-	}
-	if c.RetryableCheck == nil {
-		c.RetryableCheck = IsRetryable
-	}
-	return c
-}
+// It is an alias for the shared [sdkretry.Config] type.
+type RetryConfig = sdkretry.Config
 
 // retry executes fn with retries if retry is enabled. Otherwise calls fn once.
 // Only idempotent operations (reads: List*, Get*) should be wrapped with retry.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
-	return sdkretry.Run(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
+	return sdkretry.Run(ctx, c.opts.retryEnabled, c.opts.retry, fn)
 }
 
 // retryDo executes fn with retries if retry is enabled, for void operations.
 func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
-	return sdkretry.RunDo(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
+	return sdkretry.RunDo(ctx, c.opts.retryEnabled, c.opts.retry, fn)
 }
 
 // backoffDuration computes exponential backoff with optional jitter.
 // Exposed for tests.
 func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
 	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
-}
-
-func toSharedConfig(c RetryConfig) sdkretry.Config {
-	return sdkretry.Config{
-		MaxAttempts:    c.MaxAttempts,
-		InitialBackoff: c.InitialBackoff,
-		MaxBackoff:     c.MaxBackoff,
-		Jitter:         c.Jitter,
-		RetryableCheck: c.RetryableCheck,
-	}
 }

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -162,7 +162,7 @@ func TestRetry_ContextCancellationStopsRetry(t *testing.T) {
 }
 
 func TestRetryConfig_Defaults(t *testing.T) {
-	cfg := RetryConfig{}.withDefaults()
+	cfg := RetryConfig{}.WithDefaults()
 	if cfg.MaxAttempts != 3 {
 		t.Errorf("got %v, want %v", cfg.MaxAttempts, 3)
 	}
@@ -182,7 +182,7 @@ func TestRetryConfig_PreservesCustomValues(t *testing.T) {
 		MaxAttempts:    5,
 		InitialBackoff: 200 * time.Millisecond,
 		MaxBackoff:     10 * time.Second,
-	}.withDefaults()
+	}.WithDefaults()
 	if cfg.MaxAttempts != 5 {
 		t.Errorf("got %v, want %v", cfg.MaxAttempts, 5)
 	}

--- a/sdk/configclient/errors.go
+++ b/sdk/configclient/errors.go
@@ -8,6 +8,8 @@ package configclient
 import (
 	"errors"
 	"fmt"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 var (
@@ -55,15 +57,8 @@ func InvalidArgumentError(message string) error {
 // RetryableError wraps an error to indicate the operation may succeed on retry.
 // Transport implementations should wrap transient errors (e.g., network issues,
 // server overload) in RetryableError.
-type RetryableError struct {
-	Err error
-}
-
-func (e *RetryableError) Error() string { return e.Err.Error() }
-func (e *RetryableError) Unwrap() error { return e.Err }
+// It is an alias for the shared [sdkretry.RetryableError] type.
+type RetryableError = sdkretry.RetryableError
 
 // IsRetryable reports whether err is marked as retryable by the transport.
-func IsRetryable(err error) bool {
-	var re *RetryableError
-	return errors.As(err, &re)
-}
+var IsRetryable = sdkretry.IsRetryable

--- a/sdk/configclient/retry.go
+++ b/sdk/configclient/retry.go
@@ -8,71 +8,30 @@ import (
 )
 
 // RetryConfig configures automatic retry with exponential backoff.
-type RetryConfig struct {
-	// MaxAttempts is the maximum number of attempts (including the first).
-	// Default: 3.
-	MaxAttempts int
-	// InitialBackoff is the delay before the first retry.
-	// Default: 100ms.
-	InitialBackoff time.Duration
-	// MaxBackoff caps the backoff duration.
-	// Default: 5s.
-	MaxBackoff time.Duration
-	// Jitter adds randomness to backoff to avoid thundering herd.
-	// Default: false.
-	Jitter bool
-	// RetryableCheck determines if an error is retryable.
-	// If nil, defaults to checking for [RetryableError].
-	RetryableCheck func(err error) bool
-}
-
-func (c RetryConfig) withDefaults() RetryConfig {
-	if c.MaxAttempts <= 0 {
-		c.MaxAttempts = 3
-	}
-	if c.InitialBackoff <= 0 {
-		c.InitialBackoff = 100 * time.Millisecond
-	}
-	if c.MaxBackoff <= 0 {
-		c.MaxBackoff = 5 * time.Second
-	}
-	if c.RetryableCheck == nil {
-		c.RetryableCheck = IsRetryable
-	}
-	return c
-}
+// It is an alias for the shared [sdkretry.Config] type.
+type RetryConfig = sdkretry.Config
 
 // WithRetry enables automatic retry with exponential backoff for transient errors.
 // By default, only errors wrapped in [RetryableError] by the transport are retried.
 func WithRetry(cfg RetryConfig) Option {
 	return func(o *options) {
-		o.retry = cfg.withDefaults()
+		o.retry = cfg.WithDefaults()
 		o.retryEnabled = true
 	}
 }
 
 // retry executes fn with retries if retry is enabled. Otherwise calls fn once.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
-	return sdkretry.Run(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
+	return sdkretry.Run(ctx, c.opts.retryEnabled, c.opts.retry, fn)
 }
 
 // retryDo executes fn with retries if retry is enabled, for void operations.
 func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
-	return sdkretry.RunDo(ctx, c.opts.retryEnabled, toSharedConfig(c.opts.retry), fn)
+	return sdkretry.RunDo(ctx, c.opts.retryEnabled, c.opts.retry, fn)
 }
 
 // backoffDuration computes exponential backoff with optional jitter.
 // Exposed for tests.
 func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
 	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
-}
-
-func toSharedConfig(c RetryConfig) sdkretry.Config {
-	return sdkretry.Config{
-		MaxAttempts:    c.MaxAttempts,
-		InitialBackoff: c.InitialBackoff,
-		MaxBackoff:     c.MaxBackoff,
-		Jitter:         c.Jitter,
-		RetryableCheck: c.RetryableCheck,
-	}
 }

--- a/sdk/configclient/retry_test.go
+++ b/sdk/configclient/retry_test.go
@@ -135,7 +135,7 @@ func TestRetry_RespectsContextCancellation(t *testing.T) {
 }
 
 func TestRetryConfig_Defaults(t *testing.T) {
-	cfg := RetryConfig{}.withDefaults()
+	cfg := RetryConfig{}.WithDefaults()
 	if cfg.MaxAttempts != 3 {
 		t.Errorf("got %v, want %v", cfg.MaxAttempts, 3)
 	}
@@ -155,7 +155,7 @@ func TestRetryConfig_PreservesCustomValues(t *testing.T) {
 		MaxAttempts:    5,
 		InitialBackoff: 200 * time.Millisecond,
 		MaxBackoff:     10 * time.Second,
-	}.withDefaults()
+	}.WithDefaults()
 	if cfg.MaxAttempts != 5 {
 		t.Errorf("got %v, want %v", cfg.MaxAttempts, 5)
 	}

--- a/sdk/retry/retry.go
+++ b/sdk/retry/retry.go
@@ -4,23 +4,62 @@ package retry
 
 import (
 	"context"
+	"errors"
 	"math"
 	"math/rand/v2"
 	"time"
 )
 
+// RetryableError wraps an error to indicate the operation may succeed on retry.
+// Transport implementations should wrap transient errors (e.g., network issues,
+// server overload) in RetryableError.
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string { return e.Err.Error() }
+func (e *RetryableError) Unwrap() error { return e.Err }
+
+// IsRetryable reports whether err is marked as retryable by the transport.
+func IsRetryable(err error) bool {
+	var re *RetryableError
+	return errors.As(err, &re)
+}
+
 // Config holds the parameters for the retry loop.
 type Config struct {
 	// MaxAttempts is the maximum number of attempts (including the first).
+	// Default: 3.
 	MaxAttempts int
 	// InitialBackoff is the delay before the first retry.
+	// Default: 100ms.
 	InitialBackoff time.Duration
 	// MaxBackoff caps the backoff duration.
+	// Default: 5s.
 	MaxBackoff time.Duration
 	// Jitter adds randomness to the backoff to avoid thundering herd.
+	// Default: false.
 	Jitter bool
 	// RetryableCheck reports whether an error is retryable.
+	// If nil, defaults to checking for [RetryableError].
 	RetryableCheck func(err error) bool
+}
+
+// WithDefaults returns a copy of c with zero fields replaced by sensible defaults.
+func (c Config) WithDefaults() Config {
+	if c.MaxAttempts <= 0 {
+		c.MaxAttempts = 3
+	}
+	if c.InitialBackoff <= 0 {
+		c.InitialBackoff = 100 * time.Millisecond
+	}
+	if c.MaxBackoff <= 0 {
+		c.MaxBackoff = 5 * time.Second
+	}
+	if c.RetryableCheck == nil {
+		c.RetryableCheck = IsRetryable
+	}
+	return c
 }
 
 // Run executes fn with exponential-backoff retry when enabled is true.

--- a/sdk/retry/retry_test.go
+++ b/sdk/retry/retry_test.go
@@ -1,0 +1,68 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestRetryableError(t *testing.T) {
+	inner := fmt.Errorf("connection refused")
+	re := &RetryableError{Err: inner}
+
+	if re.Error() != inner.Error() {
+		t.Errorf("Error() = %q, want %q", re.Error(), inner.Error())
+	}
+	if !errors.Is(re, inner) {
+		t.Error("errors.Is should find wrapped inner error via Unwrap")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	if !IsRetryable(&RetryableError{Err: fmt.Errorf("unavailable")}) {
+		t.Error("expected RetryableError to be retryable")
+	}
+	if IsRetryable(fmt.Errorf("plain error")) {
+		t.Error("expected plain error to not be retryable")
+	}
+	if IsRetryable(nil) {
+		t.Error("expected nil to not be retryable")
+	}
+}
+
+func TestConfig_WithDefaults(t *testing.T) {
+	cfg := Config{}.WithDefaults()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %d, want 3", cfg.MaxAttempts)
+	}
+	if cfg.InitialBackoff != 100*time.Millisecond {
+		t.Errorf("InitialBackoff = %v, want 100ms", cfg.InitialBackoff)
+	}
+	if cfg.MaxBackoff != 5*time.Second {
+		t.Errorf("MaxBackoff = %v, want 5s", cfg.MaxBackoff)
+	}
+	if cfg.RetryableCheck == nil {
+		t.Fatal("RetryableCheck should not be nil")
+	}
+	if !cfg.RetryableCheck(&RetryableError{Err: fmt.Errorf("transient")}) {
+		t.Error("default RetryableCheck should accept RetryableError")
+	}
+}
+
+func TestConfig_WithDefaults_PreservesCustomValues(t *testing.T) {
+	cfg := Config{
+		MaxAttempts:    5,
+		InitialBackoff: 200 * time.Millisecond,
+		MaxBackoff:     10 * time.Second,
+	}.WithDefaults()
+	if cfg.MaxAttempts != 5 {
+		t.Errorf("MaxAttempts = %d, want 5", cfg.MaxAttempts)
+	}
+	if cfg.InitialBackoff != 200*time.Millisecond {
+		t.Errorf("InitialBackoff = %v, want 200ms", cfg.InitialBackoff)
+	}
+	if cfg.MaxBackoff != 10*time.Second {
+		t.Errorf("MaxBackoff = %v, want 10s", cfg.MaxBackoff)
+	}
+}


### PR DESCRIPTION
## Summary
- Eliminates duplicated retry machinery across configclient and adminclient by consolidating RetryableError, IsRetryable, and Config.WithDefaults into the shared sdk/retry module, which previously only held the algorithmic core.
- Both clients now use type aliases (RetryConfig = sdkretry.Config, RetryableError = sdkretry.RetryableError) so their public API is unchanged — callers see no breaking change.
- Removes the redundant toSharedConfig adapter function and the private withDefaults methods that were just copying fields into an identical struct.

## Test plan
- [x] sdk/retry: new retry_test.go covers RetryableError, IsRetryable, Config.WithDefaults
- [x] configclient tests pass with shared retry (90.8% coverage, above 87.1% threshold)
- [x] adminclient tests pass with shared retry (98.2% coverage, above 97.9% threshold)
- [x] grpctransport tests pass — still creates RetryableError via the client-package aliases
- [x] make test passes across all modules
- [x] make lint-go clean

Closes #655