### PR TITLE
fix(server): fail closed on malformed json_schema/regex constraints

### DIFF
--- a/internal/schema/validate_constraints.go
+++ b/internal/schema/validate_constraints.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // validateFieldConstraintsBatch runs validateFieldConstraints for each field in
@@ -102,9 +103,22 @@ func validateFieldConstraints(field *pb.SchemaField, regexMaxLen int) error {
 		}
 	}
 
-	// JSON Schema: json only
+	// JSON Schema: json only; compile eagerly to reject malformed schemas at import time.
 	if c.JsonSchema != nil && ft != pb.FieldType_FIELD_TYPE_JSON {
 		return fmt.Errorf("field %s: 'json_schema' constraint is not valid for type %s (only json)", path, ft)
+	}
+	if c.JsonSchema != nil && ft == pb.FieldType_FIELD_TYPE_JSON {
+		compiler := jsonschema.NewCompiler()
+		doc, err := jsonschema.UnmarshalJSON(strings.NewReader(*c.JsonSchema))
+		if err != nil {
+			return fmt.Errorf("field %s: invalid json_schema constraint: %w", path, err)
+		}
+		if err := compiler.AddResource("schema.json", doc); err != nil {
+			return fmt.Errorf("field %s: invalid json_schema constraint: %w", path, err)
+		}
+		if _, err := compiler.Compile("schema.json"); err != nil {
+			return fmt.Errorf("field %s: invalid json_schema constraint: %w", path, err)
+		}
 	}
 
 	// enum: any type is fine — no restriction needed

--- a/internal/schema/validate_constraints_test.go
+++ b/internal/schema/validate_constraints_test.go
@@ -84,6 +84,24 @@ func TestValidateConstraints_JSONSchema(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidateConstraints_InvalidJSONSchema_Rejected(t *testing.T) {
+	badSchemas := []string{
+		`{not valid json`,
+		`{"type": "nonexistent-type-xyz"}`,
+		`{"$ref": "http://[invalid"}`,
+	}
+	for _, bad := range badSchemas {
+		t.Run(bad, func(t *testing.T) {
+			err := validateFieldConstraints(&pb.SchemaField{
+				Path: "x", Type: pb.FieldType_FIELD_TYPE_JSON,
+				Constraints: &pb.FieldConstraints{JsonSchema: &bad},
+			}, 0)
+			assert.Error(t, err, "expected error for invalid json_schema %q", bad)
+			assert.Contains(t, err.Error(), "invalid json_schema constraint")
+		})
+	}
+}
+
 func TestValidateConstraints_EnumOnAnyType(t *testing.T) {
 	// Enum is valid on any type.
 	for _, ft := range []pb.FieldType{

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -172,11 +172,16 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 		if constraints.Regex != nil {
 			re, err := regexp.Compile(*constraints.Regex)
 			if err != nil {
-				slog.Default().Error("invalid regex constraint in schema; skipping check",
+				slog.Default().Error("invalid regex constraint in schema; failing closed",
 					"field", fieldPath, "pattern", *constraints.Regex, "error", err)
 				if o.regexErrorCounter != nil {
 					o.regexErrorCounter.Add(context.Background(), 1)
 				}
+				// Fail closed: a broken constraint must not silently accept all values.
+				compileErr := fmt.Errorf("constraint cannot be enforced: invalid regex pattern: %w", err)
+				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
+					return compileErr
+				})
 			} else {
 				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 					val := tv.Kind.(*pb.TypedValue_StringValue).StringValue
@@ -202,7 +207,15 @@ func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, 
 	case pb.FieldType_FIELD_TYPE_JSON:
 		if constraints.JsonSchema != nil {
 			jv, err := newJSONSchemaValidator(*constraints.JsonSchema, o)
-			if err == nil {
+			if err != nil {
+				slog.Default().Error("invalid json_schema constraint in schema; failing closed",
+					"field", fieldPath, "error", err)
+				// Fail closed: a broken constraint must not silently accept all values.
+				compileErr := fmt.Errorf("constraint cannot be enforced: invalid json_schema: %w", err)
+				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
+					return compileErr
+				})
+			} else {
 				v.checks = append(v.checks, func(tv *pb.TypedValue) error {
 					val := tv.Kind.(*pb.TypedValue_JsonValue).JsonValue
 					return jv.validate(val)

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -121,15 +121,17 @@ func TestValidate_StringPattern(t *testing.T) {
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "not-an-email"}}))
 }
 
-func TestValidate_InvalidRegexInDB_DoesNotPanic(t *testing.T) {
+func TestValidate_InvalidRegexInDB_FailsClosed(t *testing.T) {
 	// Simulates a bad pattern written directly to the DB bypassing schema validation.
-	// The validator must skip the regex check rather than panic.
+	// The validator must fail closed: every value is rejected, not silently accepted.
 	v := NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
 		Regex: ptr(`[invalid`),
 	})
 
-	// No panic; regex check is silently skipped so every value passes.
-	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "any value"}}))
+	// Fail closed: broken constraint rejects all values, not accepts everything.
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "any value"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "constraint cannot be enforced")
 }
 
 func TestValidate_InvalidRegex_IncrementsCounter(t *testing.T) {
@@ -281,6 +283,20 @@ func TestValidate_JSONSchema(t *testing.T) {
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"name": "test"}`}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"foo": "bar"}`}})) // missing required "name"
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `not json`}}))
+}
+
+func TestValidate_InvalidJSONSchemaInDB_FailsClosed(t *testing.T) {
+	// Simulates a malformed json_schema written directly to the DB bypassing schema validation.
+	// The validator must fail closed: every value is rejected, not silently accepted.
+	bad := `{not valid json`
+	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
+		JsonSchema: &bad,
+	})
+
+	// Fail closed: broken constraint rejects all values, not accepts everything.
+	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"any": "value"}`}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "constraint cannot be enforced")
 }
 
 // --- No constraints (type check only) ---


### PR DESCRIPTION
## Summary
- Compile json_schema at schema import time and reject if invalid
- validator.go fails closed when constraint cannot compile (error, not no-op)
- Tests: malformed json_schema rejected at import; broken constraint fails closed at runtime

## Test plan
- [x] Malformed json_schema rejected at schema import (`TestValidateConstraints_InvalidJSONSchema_Rejected`)
- [x] Runtime: broken regex constraint fails closed (`TestValidate_InvalidRegexInDB_FailsClosed`)
- [x] Runtime: broken json_schema constraint fails closed (`TestValidate_InvalidJSONSchemaInDB_FailsClosed`)
- [x] make test passes
- [x] make lint-go passes

Closes #677
🤖 Generated with [Claude Code](https://claude.com/claude-code)