### PR TITLE
fix(server): enforce read_only and write_once field attributes

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -576,10 +576,19 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	}
 	oldValue := s.getCurrentValue(ctx, tenantID, req.FieldPath, latestVersion)
 
-	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	// Fetch sensitive + write-guard attrs in one store round-trip.
+	fieldSets, err := s.getSchemaFieldSets(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
+	// Enforce read_only / write_once schema attributes.
+	if attrs, ok := fieldSets.WriteAttrs[req.FieldPath]; ok {
+		if err := checkWriteAttributes(req.FieldPath, attrs, oldValue); err != nil {
+			return nil, err
+		}
+	}
+
+	sensitiveFields := fieldSets.Sensitive
 
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)
 	if err != nil {
@@ -742,10 +751,21 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 		})
 	}
 
-	sensitiveFieldsMulti, err := s.getSensitiveFieldSet(ctx, tenantID)
+	// Fetch sensitive + write-guard attrs in one store round-trip.
+	fieldSetsMulti, err := s.getSchemaFieldSets(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
+	// Enforce read_only / write_once schema attributes.
+	for i, update := range req.Updates {
+		if attrs, ok := fieldSetsMulti.WriteAttrs[update.FieldPath]; ok {
+			if err := checkWriteAttributes(update.FieldPath, attrs, changes[i].oldValue); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	sensitiveFieldsMulti := fieldSetsMulti.Sensitive
 
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)
 	if err != nil {
@@ -961,6 +981,24 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 		tv := stringToTypedValue(row.Value, lookupFieldType(rollbackTypes, row.FieldPath))
 		if err := s.validateField(ctx, tenantID, row.FieldPath, tv); err != nil {
 			return nil, err
+		}
+	}
+
+	// Enforce read_only / write_once schema attributes after lock/validation checks.
+	rollbackFieldSets, err := s.getSchemaFieldSets(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rollbackLatestVersion, err := s.resolveVersion(ctx, tenantID, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range targetRows {
+		if attrs, ok := rollbackFieldSets.WriteAttrs[row.FieldPath]; ok {
+			currentValue := s.getCurrentValue(ctx, tenantID, row.FieldPath, rollbackLatestVersion)
+			if err := checkWriteAttributes(row.FieldPath, attrs, currentValue); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1328,10 +1366,21 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 		desc = parsed.Description
 	}
 
-	sensitiveFields, err := s.getSensitiveFieldSet(ctx, tenantID)
+	// Fetch sensitive + write-guard attrs in one store round-trip.
+	importFieldSets, err := s.getSchemaFieldSets(ctx, tenantID)
 	if err != nil {
 		return nil, err
 	}
+	// Enforce read_only / write_once schema attributes.
+	for i, v := range values {
+		if attrs, ok := importFieldSets.WriteAttrs[v.FieldPath]; ok {
+			if err := checkWriteAttributes(v.FieldPath, attrs, changes[i].oldValue); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	sensitiveFields := importFieldSets.Sensitive
 
 	depRules, err := s.fetchDependentRequiredRules(ctx, tenantID)
 	if err != nil {
@@ -1466,8 +1515,58 @@ func (s *Service) filterByImportMode(ctx context.Context, tenantID string, lates
 	}
 }
 
-// getSensitiveFieldSet returns a set of field paths that are marked sensitive
-// for the tenant's current schema version.
+// schemaFieldSets bundles the per-field attribute sets derived from a single
+// schema-fields fetch. Both sets are built in one pass to avoid a second round-trip.
+type schemaFieldSets struct {
+	// Sensitive maps field path → true for fields marked sensitive.
+	Sensitive map[string]bool
+	// WriteAttrs maps field path → write-guard attributes for fields that have
+	// ReadOnly or WriteOnce set. Fields with neither attribute are absent.
+	WriteAttrs map[string]fieldWriteAttrs
+}
+
+// fieldWriteAttrs holds the write-guard attributes for a single schema field.
+type fieldWriteAttrs struct {
+	ReadOnly  bool
+	WriteOnce bool
+}
+
+// getSchemaFieldSets fetches the schema fields for a tenant and builds both
+// the sensitive-field set and the write-guard attribute map in one pass.
+// Returns a gRPC status error on any store failure.
+func (s *Service) getSchemaFieldSets(ctx context.Context, tenantID string) (schemaFieldSets, error) {
+	tenant, err := s.store.GetTenantByID(ctx, tenantID)
+	if err != nil {
+		return schemaFieldSets{}, status.Error(codes.NotFound, "tenant not found")
+	}
+	sv, err := s.store.GetSchemaVersion(ctx, domain.SchemaVersionKey{
+		SchemaID: tenant.SchemaID,
+		Version:  tenant.SchemaVersion,
+	})
+	if err != nil {
+		return schemaFieldSets{}, status.Error(codes.Internal, "failed to get schema version")
+	}
+	fields, err := s.store.GetSchemaFields(ctx, sv.ID)
+	if err != nil {
+		return schemaFieldSets{}, status.Error(codes.Internal, "failed to get schema fields")
+	}
+	sets := schemaFieldSets{
+		Sensitive:  make(map[string]bool, len(fields)),
+		WriteAttrs: make(map[string]fieldWriteAttrs, len(fields)),
+	}
+	for _, f := range fields {
+		if f.Sensitive {
+			sets.Sensitive[f.Path] = true
+		}
+		if f.ReadOnly || f.WriteOnce {
+			sets.WriteAttrs[f.Path] = fieldWriteAttrs{ReadOnly: f.ReadOnly, WriteOnce: f.WriteOnce}
+		}
+	}
+	return sets, nil
+}
+
+// getSensitiveFieldSetFromTenant returns only the sensitive-field set from a
+// pre-resolved tenant. Used by read paths that don't need write-guard attrs.
 func (s *Service) getSensitiveFieldSetFromTenant(ctx context.Context, tenant domain.Tenant) (map[string]bool, error) {
 	sv, err := s.store.GetSchemaVersion(ctx, domain.SchemaVersionKey{
 		SchemaID: tenant.SchemaID,
@@ -1495,6 +1594,20 @@ func (s *Service) getSensitiveFieldSet(ctx context.Context, tenantID string) (ma
 		return nil, status.Error(codes.NotFound, "tenant not found")
 	}
 	return s.getSensitiveFieldSetFromTenant(ctx, tenant)
+}
+
+// checkWriteAttributes enforces ReadOnly and WriteOnce field attributes.
+// currentValue is the field's value at the latest version ("" means unset).
+// Returns codes.FailedPrecondition when a read-only field is written and when
+// a write-once field already has a value.
+func checkWriteAttributes(fieldPath string, attrs fieldWriteAttrs, currentValue string) error {
+	if attrs.ReadOnly {
+		return status.Errorf(codes.FailedPrecondition, "field %s is read-only and cannot be modified", fieldPath)
+	}
+	if attrs.WriteOnce && currentValue != "" {
+		return status.Errorf(codes.FailedPrecondition, "field %s is write-once and already has a value", fieldPath)
+	}
+	return nil
 }
 
 // --- Helpers ---

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -564,6 +564,8 @@ func TestRollbackToVersion_Success(t *testing.T) {
 	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
 	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	// getFieldWriteAttrsMap needs schema store calls.
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
 		TenantId: tenantID1,
@@ -617,6 +619,8 @@ func TestRollbackToVersion_VersionConflictReturnsAborted(t *testing.T) {
 	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
 		Return(domain.ConfigVersion{}, ErrVersionConflict)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	// getFieldWriteAttrsMap needs schema store calls.
+	setupNoSensitiveFields(store)
 
 	_, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
 		TenantId: tenantID1,
@@ -644,6 +648,8 @@ func TestRollbackToVersion_VersionConflictRetried(t *testing.T) {
 	store.On("BulkSetConfigValues", mock.Anything, mock.Anything).Return(nil)
 	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	// getFieldWriteAttrsMap needs schema store calls.
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
 		TenantId: tenantID1,
@@ -667,6 +673,8 @@ func TestRollbackToVersion_LockedField_ReturnsFailedPrecondition(t *testing.T) {
 		Return([]GetFullConfigAtVersionRow{{FieldPath: "payments.fee", Value: strPtr("0.5")}}, nil)
 	store.On("GetFieldLocks", mock.Anything, tenantID1).
 		Return([]domain.TenantFieldLock{{TenantID: tenantID1, FieldPath: "payments.fee"}}, nil)
+	// getFieldWriteAttrsMap needs schema store calls.
+	setupNoSensitiveFields(store)
 
 	_, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{TenantId: tenantID1, Version: 2})
 	require.Error(t, err)
@@ -1554,6 +1562,8 @@ func TestRollbackToVersion_PreInvalidateFails_WriteProceeds(t *testing.T) {
 	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(errors.New("redis down")).Once()
 	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil).Once()
+	// getFieldWriteAttrsMap needs schema store calls.
+	setupNoSensitiveFields(store)
 
 	resp, err := svc.RollbackToVersion(ctx, &pb.RollbackToVersionRequest{
 		TenantId: tenantID1,
@@ -1671,4 +1681,95 @@ func TestSetField_SensitiveFields_SchemaFieldsError(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+// --- read_only / write_once enforcement ---
+
+// setupWriteAttrService creates a service with a schema that declares one
+// read-only field ("config.frozen") and one write-once field ("config.init").
+func setupWriteAttrService(t *testing.T) (*Service, *mockStore, *mockCache, *mockPublisher) {
+	t.Helper()
+	svc, store, c, pub := newTestService()
+	// Schema store calls used by getSchemaFieldSets.
+	store.On("GetTenantByID", mock.Anything, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil).Maybe()
+	store.On("GetSchemaVersion", mock.Anything, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil).Maybe()
+	store.On("GetSchemaFields", mock.Anything, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "config.frozen", FieldType: domain.FieldTypeString, ReadOnly: true},
+			{Path: "config.init", FieldType: domain.FieldTypeString, WriteOnce: true},
+		}, nil).Maybe()
+	return svc, store, c, pub
+}
+
+func TestSetField_ReadOnly_Rejected(t *testing.T) {
+	svc, store, _, _ := setupWriteAttrService(t)
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "config.frozen",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "new-value"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "read-only")
+}
+
+func TestSetField_WriteOnce_SecondWrite_Rejected(t *testing.T) {
+	// Write-once field already has a value — the second write must be rejected.
+	svc, store, _, _ := setupWriteAttrService(t)
+	ctx := superadminCtx()
+
+	existingVal := "initial-value"
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	// getCurrentValue returns the existing value for the write-once check.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{Value: &existingVal}, nil)
+
+	_, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "config.init",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "second-value"}},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "write-once")
+}
+
+func TestSetField_WriteOnce_FirstWrite_Allowed(t *testing.T) {
+	// Write-once field has no existing value — the first write must succeed.
+	svc, store, cache, pub := setupWriteAttrService(t)
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{}, domain.ErrNotFound)
+	store.On("CreateConfigVersion", mock.Anything, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, TenantID: tenantID1, Version: 1, CreatedBy: "unknown"}, nil)
+	store.On("SetConfigValue", mock.Anything, mock.AnythingOfType("config.SetConfigValueParams")).Return(nil)
+	store.On("InsertAuditWriteLog", mock.Anything, mock.AnythingOfType("config.InsertAuditWriteLogParams")).Return(nil)
+	cache.On("Invalidate", mock.Anything, tenantID1).Return(nil)
+	pub.On("Publish", mock.Anything, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+
+	resp, err := svc.SetField(ctx, &pb.SetFieldRequest{
+		TenantId:  tenantID1,
+		FieldPath: "config.init",
+		Value:     &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "first-value"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), resp.ConfigVersion.Version)
 }

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1773,3 +1773,48 @@ func TestSetField_WriteOnce_FirstWrite_Allowed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), resp.ConfigVersion.Version)
 }
+
+func TestSetFields_ReadOnly_Rejected(t *testing.T) {
+	svc, store, _, _ := setupWriteAttrService(t)
+	ctx := superadminCtx()
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+
+	_, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "config.frozen", Value: &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}}},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "read-only")
+}
+
+func TestSetFields_WriteOnce_SecondWrite_Rejected(t *testing.T) {
+	svc, store, _, _ := setupWriteAttrService(t)
+	ctx := superadminCtx()
+	existing := "initial"
+
+	store.On("GetFieldLocks", ctx, tenantID1).Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", mock.Anything, tenantID1).
+		Return(domain.ConfigVersion{Version: 1}, nil)
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.Anything).
+		Return(GetConfigValueAtVersionRow{Value: &existing}, nil)
+
+	_, err := svc.SetFields(ctx, &pb.SetFieldsRequest{
+		TenantId: tenantID1,
+		Updates: []*pb.FieldUpdate{
+			{FieldPath: "config.init", Value: &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "second"}}},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	assert.Contains(t, status.Convert(err).Message(), "write-once")
+}


### PR DESCRIPTION
## Summary
- Enforce ReadOnly attribute: reject writes with FailedPrecondition
- Enforce WriteOnce attribute: reject writes when field already has a value
- Tests: read-only write rejected, write-once second write rejected

## Test plan
- [ ] Write to read-only field returns FailedPrecondition
- [ ] Second write to write-once field rejected
- [ ] make test passes

Closes #680
🤖 Generated with [Claude Code](https://claude.com/claude-code)