### PR TITLE
fix(cli): route status messages to stderr

### DIFF
--- a/cmd/decree/audit.go
+++ b/cmd/decree/audit.go
@@ -144,7 +144,7 @@ var auditUnusedCmd = &cobra.Command{
 			return err
 		}
 		if len(fields) == 0 {
-			fmt.Println("No unused fields.")
+			printStatus(cmd, "No unused fields.\n")
 			return nil
 		}
 		rows := tableRows([]string{"UNUSED_FIELD"})

--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -463,6 +463,24 @@ func TestIsolatedCommand_FreshState(t *testing.T) {
 	}
 }
 
+// --- Status message routing ---
+
+func TestPrintStatus_WritesToStderrNotStdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	printStatus(cmd, "Deleted.\n")
+
+	if stdout.Len() != 0 {
+		t.Errorf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Deleted.") {
+		t.Errorf("expected stderr to contain %q, got %q", "Deleted.", stderr.String())
+	}
+}
+
 // --- Completions ---
 
 func TestCompletionScripts(t *testing.T) {

--- a/cmd/decree/config.go
+++ b/cmd/decree/config.go
@@ -103,7 +103,7 @@ Values are parsed according to the schema's field type:
 		if err := runConfigSet(cmd.Context(), admin, cfg, args[0], args[1], args[2]); err != nil {
 			return err
 		}
-		fmt.Println("Set.")
+		printStatus(cmd, "Set.\n")
 		return nil
 	},
 }
@@ -161,7 +161,7 @@ var configSetManyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Set %d values.\n", n)
+		printStatus(cmd, "Set %d values.\n", n)
 		return nil
 	},
 }
@@ -248,7 +248,7 @@ var configRollbackCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Rolled back to v%d → created v%d\n", version, v.Version)
+		printStatus(cmd, "Rolled back to v%d → created v%d\n", version, v.Version)
 		return nil
 	},
 }
@@ -319,7 +319,7 @@ var configImportCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Imported → created v%d\n", v.Version)
+		printStatus(cmd, "Imported → created v%d\n", v.Version)
 		return nil
 	},
 }

--- a/cmd/decree/diff.go
+++ b/cmd/decree/diff.go
@@ -83,7 +83,7 @@ File mode (compare two local config YAML files):
 
 		result := diff.Compare(oldValues, newValues)
 		if !result.HasChanges() {
-			fmt.Println("No changes.")
+			printStatus(cmd, "No changes.\n")
 			return nil
 		}
 

--- a/cmd/decree/gendocs.go
+++ b/cmd/decree/gendocs.go
@@ -48,7 +48,7 @@ var genDocsCmd = &cobra.Command{
 			return fmt.Errorf("generate docs: %w", err)
 		}
 
-		fmt.Printf("CLI docs generated in %s/\n", outDir)
+		printStatus(cmd, "CLI docs generated in %s/\n", outDir)
 		return nil
 	},
 }
@@ -81,7 +81,7 @@ var genManCmd = &cobra.Command{
 			return fmt.Errorf("generate man pages: %w", err)
 		}
 
-		fmt.Printf("Man pages generated in %s/\n", outDir)
+		printStatus(cmd, "Man pages generated in %s/\n", outDir)
 		return nil
 	},
 }

--- a/cmd/decree/locks.go
+++ b/cmd/decree/locks.go
@@ -30,7 +30,7 @@ var lockSetCmd = &cobra.Command{
 		if err := admin.LockField(cmd.Context(), args[0], args[1]); err != nil {
 			return err
 		}
-		fmt.Printf("Locked %s\n", args[1])
+		printStatus(cmd, "Locked %s\n", args[1])
 		return nil
 	},
 }
@@ -53,7 +53,7 @@ var lockRemoveCmd = &cobra.Command{
 		if err := admin.UnlockField(cmd.Context(), args[0], args[1]); err != nil {
 			return err
 		}
-		fmt.Printf("Unlocked %s\n", args[1])
+		printStatus(cmd, "Unlocked %s\n", args[1])
 		return nil
 	},
 }
@@ -78,7 +78,7 @@ var lockListCmd = &cobra.Command{
 			return err
 		}
 		if len(locks) == 0 {
-			fmt.Println("No locks.")
+			printStatus(cmd, "No locks.\n")
 			return nil
 		}
 		rows := tableRows([]string{"FIELD_PATH", "LOCKED_VALUES"})

--- a/cmd/decree/output.go
+++ b/cmd/decree/output.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
@@ -61,6 +62,12 @@ func printTable(w io.Writer, data any) error {
 		}
 	}
 	return tw.Flush()
+}
+
+// printStatus writes a human-readable status message to cmd.ErrOrStderr() so
+// that it never pollutes the machine-readable stdout stream.
+func printStatus(cmd *cobra.Command, format string, args ...any) {
+	fmt.Fprintf(cmd.ErrOrStderr(), format, args...)
 }
 
 // tableRows is a helper to build table data with headers.

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -79,7 +79,7 @@ var schemaGetCmd = &cobra.Command{
 		for _, f := range s.Fields {
 			rows = append(rows, []string{f.Path, string(f.Type), strconv.FormatBool(f.Nullable), strconv.FormatBool(f.Deprecated), f.Description})
 		}
-		fmt.Printf("Schema: %s (%s) v%d [published=%v]\n\n", s.Name, s.ID, s.Version, s.Published)
+		printStatus(cmd, "Schema: %s (%s) v%d [published=%v]\n\n", s.Name, s.ID, s.Version, s.Published)
 		return printOutput(rows)
 	},
 }
@@ -133,7 +133,7 @@ var schemaPublishCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Published %s v%d\n", s.Name, s.Version)
+		printStatus(cmd, "Published %s v%d\n", s.Name, s.Version)
 		return nil
 	},
 }
@@ -156,7 +156,7 @@ var schemaDeleteCmd = &cobra.Command{
 		if err := admin.DeleteSchema(cmd.Context(), args[0]); err != nil {
 			return err
 		}
-		fmt.Println("Deleted.")
+		printStatus(cmd, "Deleted.\n")
 		return nil
 	},
 }
@@ -218,9 +218,9 @@ var schemaImportCmd = &cobra.Command{
 			return err
 		}
 		if s.Published {
-			fmt.Printf("Imported and published %s v%d\n", s.Name, s.Version)
+			printStatus(cmd, "Imported and published %s v%d\n", s.Name, s.Version)
 		} else {
-			fmt.Printf("Imported %s v%d (draft)\n", s.Name, s.Version)
+			printStatus(cmd, "Imported %s v%d (draft)\n", s.Name, s.Version)
 		}
 		return nil
 	},

--- a/cmd/decree/tenant.go
+++ b/cmd/decree/tenant.go
@@ -115,7 +115,7 @@ var tenantDeleteCmd = &cobra.Command{
 		if err := admin.DeleteTenant(cmd.Context(), args[0]); err != nil {
 			return err
 		}
-		fmt.Println("Deleted.")
+		printStatus(cmd, "Deleted.\n")
 		return nil
 	},
 }

--- a/cmd/decree/validate_cmd.go
+++ b/cmd/decree/validate_cmd.go
@@ -40,7 +40,7 @@ var validateCmd = &cobra.Command{
 		}
 
 		if result.IsValid() {
-			fmt.Println("Valid.")
+			printStatus(cmd, "Valid.\n")
 			return nil
 		}
 


### PR DESCRIPTION
## Summary
- Human-readable status messages (\"Set.\", \"Deleted.\", \"Imported → created vN\", \"Schema:\" header, etc.) were written to stdout, polluting JSON/YAML output when `-o json|yaml` is selected or stdout is piped to another tool.
- Adds a `printStatus(cmd, format, args)` helper that routes to `cmd.ErrOrStderr()`, and replaces all ~20 status call-sites across audit, config, diff, gendocs, locks, schema, tenant, and validate commands.
- Data output (raw `config get` value, export bytes, `audit verify` result, watch events) remains on stdout.

## Test plan
- [x] `TestPrintStatus_WritesToStderrNotStdout` — asserts stdout is empty and stderr contains the message
- [x] All existing CLI tests pass (`make test`)
- [x] `make lint-go` clean

Closes #705