### PR TITLE
fix(validate): validate schema Default values against type and constraints

### DIFF
--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -156,6 +156,17 @@ func ParseSchema(data []byte) (*SchemaFile, error) {
 		if !isValidType(f.Type) {
 			return nil, fmt.Errorf("field %s: unknown type %q", path, f.Type)
 		}
+		if f.Default != "" {
+			dv, err := parseDefaultAsTyped(f.Type, f.Default)
+			if err != nil {
+				return nil, fmt.Errorf("field %s: invalid default: %w", path, err)
+			}
+			r := &Result{}
+			validateValue(r, path, dv, f)
+			if !r.IsValid() {
+				return nil, fmt.Errorf("field %s: default %q violates constraints: %s", path, f.Default, r.Error())
+			}
+		}
 	}
 	return &doc, nil
 }
@@ -422,6 +433,34 @@ func validateNumericConstraints(result *Result, path string, n float64, c *Const
 	}
 	if c.ExclusiveMaximum != nil && n >= *c.ExclusiveMaximum {
 		result.add(path, fmt.Sprintf("value %s must be less than %s", formatFloat(n), formatFloat(*c.ExclusiveMaximum)))
+	}
+}
+
+// parseDefaultAsTyped converts the string default stored in a schema field into
+// the Go value that validateValue expects for that type.
+func parseDefaultAsTyped(fieldType, s string) (any, error) {
+	switch fieldType {
+	case "integer":
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("not a valid integer: %q", s)
+		}
+		return float64(n), nil
+	case "number":
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("not a valid number: %q", s)
+		}
+		return f, nil
+	case "bool":
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("not a valid bool: %q (expected true or false)", s)
+		}
+		return b, nil
+	default:
+		// string, time, duration, url, json — all stored as strings; validateValue handles format checks.
+		return s, nil
 	}
 }
 

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -715,6 +715,139 @@ func assertViolation(t *testing.T, result *Result, field, msgSubstr string) {
 	t.Errorf("expected violation for %s containing %q, got: %s", field, msgSubstr, result.Error())
 }
 
+// --- Default value validation ---
+
+func TestParseSchema_DefaultValidation_InvalidType(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{"integer default not a number", `spec_version: "v1"
+name: test
+fields:
+  count:
+    type: integer
+    default: "notanumber"`},
+		{"bool default not bool", `spec_version: "v1"
+name: test
+fields:
+  flag:
+    type: bool
+    default: "yes"`},
+		{"number default not a number", `spec_version: "v1"
+name: test
+fields:
+  ratio:
+    type: number
+    default: "abc"`},
+		{"time default invalid format", `spec_version: "v1"
+name: test
+fields:
+  ts:
+    type: time
+    default: "not-a-time"`},
+		{"url default not absolute", `spec_version: "v1"
+name: test
+fields:
+  endpoint:
+    type: url
+    default: "relative/path"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSchema([]byte(tt.schema))
+			if err == nil {
+				t.Error("expected error for invalid default, got nil")
+			}
+		})
+	}
+}
+
+func TestParseSchema_DefaultValidation_ConstraintViolation(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{"integer default below minimum", `spec_version: "v1"
+name: test
+fields:
+  count:
+    type: integer
+    default: "3"
+    constraints:
+      minimum: 10`},
+		{"string default below minLength", `spec_version: "v1"
+name: test
+fields:
+  code:
+    type: string
+    default: "ab"
+    constraints:
+      minLength: 5`},
+		{"default not in enum", `spec_version: "v1"
+name: test
+fields:
+  color:
+    type: string
+    default: "purple"
+    constraints:
+      enum: [red, green, blue]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSchema([]byte(tt.schema))
+			if err == nil {
+				t.Error("expected error for default violating constraints, got nil")
+			}
+		})
+	}
+}
+
+func TestParseSchema_DefaultValidation_Valid(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+	}{
+		{"integer default valid", `spec_version: "v1"
+name: test
+fields:
+  count:
+    type: integer
+    default: "42"`},
+		{"bool default true", `spec_version: "v1"
+name: test
+fields:
+  flag:
+    type: bool
+    default: "true"`},
+		{"string default within constraints", `spec_version: "v1"
+name: test
+fields:
+  code:
+    type: string
+    default: "hello"
+    constraints:
+      minLength: 3
+      maxLength: 10`},
+		{"string default in enum", `spec_version: "v1"
+name: test
+fields:
+  color:
+    type: string
+    default: "red"
+    constraints:
+      enum: [red, green, blue]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSchema([]byte(tt.schema))
+			if err != nil {
+				t.Errorf("expected no error for valid default, got: %v", err)
+			}
+		})
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
## Summary
- Schema parsing accepted any `Default` string without checking it against the field's declared type or constraints, allowing broken defaults to ship to consumers undetected.
- Adds `parseDefaultAsTyped` to convert the string default to its Go type, then runs it through the existing `validateValue` path — the same type and constraint checks that apply to live config values now also apply to defaults at schema-parse time.

## Test plan
- [x] `TestParseSchema_DefaultValidation_InvalidType` — rejects defaults with wrong type (e.g., "notanumber" for integer, "yes" for bool)
- [x] `TestParseSchema_DefaultValidation_ConstraintViolation` — rejects defaults that violate constraints (minimum, minLength, enum)
- [x] `TestParseSchema_DefaultValidation_Valid` — accepts well-formed defaults with and without constraints
- [x] All existing validate tests pass (`make test`)
- [x] `make lint-go` clean

Closes #702