### PR TITLE
fix(configclient): align Get doc and filter nil values in GetFields

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -134,6 +134,22 @@ func TestGet_NotFound(t *testing.T) {
 	}
 }
 
+func TestGet_Null(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetField", nil, &GetFieldResponse{FieldPath: "payments.fee", Value: nil}, nil)
+
+	val, err := client.Get(ctx, "t1", "payments.fee")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "" {
+		t.Errorf("got %q, want empty string for null value", val)
+	}
+}
+
 // --- GetAll ---
 
 func TestGetAll_Success(t *testing.T) {
@@ -157,6 +173,33 @@ func TestGetAll_Success(t *testing.T) {
 	want := map[string]string{"a": "1", "b": "2"}
 	if !reflect.DeepEqual(vals, want) {
 		t.Errorf("got %v, want %v", vals, want)
+	}
+}
+
+// --- GetFields ---
+
+func TestGetFields_OmitsNull(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	tr.on("GetFields", nil, &GetFieldsResponse{
+		Values: []ConfigValue{
+			{FieldPath: "a", Value: StringVal("hello")},
+			{FieldPath: "b", Value: nil},
+		},
+	}, nil)
+
+	vals, err := client.GetFields(ctx, "t1", []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{"a": "hello"}
+	if !reflect.DeepEqual(vals, want) {
+		t.Errorf("got %v, want %v", vals, want)
+	}
+	if _, ok := vals["b"]; ok {
+		t.Error("null field b must be omitted from result")
 	}
 }
 

--- a/sdk/configclient/read.go
+++ b/sdk/configclient/read.go
@@ -9,7 +9,8 @@ import (
 
 // Get returns the current value of a single configuration field as a string.
 // Any typed value is converted to its string representation.
-// Returns [ErrNotFound] if the field has no value set.
+// Returns "" if the field value is null; use [Client.GetStringNullable] to distinguish null from an empty string.
+// Returns [ErrNotFound] if the field does not exist (originates from the transport).
 func (c *Client) Get(ctx context.Context, tenantID, fieldPath string) (string, error) {
 	return retry(ctx, c, func(ctx context.Context) (string, error) {
 		resp, err := c.transport.GetField(ctx, &GetFieldRequest{
@@ -50,7 +51,9 @@ func (c *Client) GetFields(ctx context.Context, tenantID string, fieldPaths []st
 		}
 		result := make(map[string]string, len(resp.Values))
 		for _, v := range resp.Values {
-			result[v.FieldPath] = v.Value.String()
+			if v.Value != nil {
+				result[v.FieldPath] = v.Value.String()
+			}
 		}
 		return result, nil
 	})


### PR DESCRIPTION
## Summary
- `Get` doc claimed `ErrNotFound` for null values, but null fields silently return `""` — `ErrNotFound` only comes from the transport when a field doesn't exist in the schema
- `GetFields` doc claimed null-valued fields are omitted, but the code was including them as empty strings
- Fixes both: rewrites `Get` doc to reflect actual null-yields-empty behavior, and adds a nil guard in `GetFields` so null entries are genuinely omitted

## Test plan
- [ ] `TestGet_Null` asserts `Get` returns `""` for a null-valued field (not an error)
- [ ] `TestGetFields_OmitsNull` asserts null-valued fields are excluded from the result map
- [ ] `make test` passes

Closes #684