### PR TITLE
fix(adminclient): wrap retry around per-page call, not entire accumulation loop

### DIFF
--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -43,29 +43,30 @@ func (c *Client) QueryWriteLog(ctx context.Context, filters ...AuditFilter) ([]*
 	if c.audit == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return retry(ctx, c, func(ctx context.Context) ([]*AuditEntry, error) {
-		var all []*AuditEntry
-		pageToken := ""
-		for {
+	var all []*AuditEntry
+	pageToken := ""
+	for {
+		token := pageToken
+		resp, err := retry(ctx, c, func(ctx context.Context) (*QueryWriteLogResponse, error) {
 			req := &QueryWriteLogRequest{
 				PageSize:  100,
-				PageToken: pageToken,
+				PageToken: token,
 			}
 			for _, f := range filters {
 				f(req)
 			}
-			resp, err := c.audit.QueryWriteLog(ctx, req)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, resp.Entries...)
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+			return c.audit.QueryWriteLog(ctx, req)
+		})
+		if err != nil {
+			return nil, err
 		}
-		return all, nil
-	})
+		all = append(all, resp.Entries...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
 }
 
 // AuditIterator is a streaming handle returned by [Client.QueryWriteLogIter].

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -27,22 +27,22 @@ func (c *Client) ListConfigVersions(ctx context.Context, tenantID string) ([]*Ve
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return retry(ctx, c, func(ctx context.Context) ([]*Version, error) {
-		var all []*Version
-		pageToken := ""
-		for {
-			resp, err := c.config.ListVersions(ctx, tenantID, 100, pageToken)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, resp.Versions...)
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+	var all []*Version
+	pageToken := ""
+	for {
+		resp, err := retry(ctx, c, func(ctx context.Context) (*ListVersionsResponse, error) {
+			return c.config.ListVersions(ctx, tenantID, 100, pageToken)
+		})
+		if err != nil {
+			return nil, err
 		}
-		return all, nil
-	})
+		all = append(all, resp.Versions...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
 }
 
 // GetConfigVersion retrieves metadata for a specific config version.

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -406,3 +406,208 @@ func TestRetry_GetSchema_ContextCancellation(t *testing.T) {
 		t.Errorf("got error %v, want context.Canceled", err)
 	}
 }
+
+// TestRetry_ListSchemas_PerPageRetry verifies that a retryable error on page 2
+// retries only that page and does not restart from page 1.
+func TestRetry_ListSchemas_PerPageRetry(t *testing.T) {
+	// calls tracks the pageToken passed on each invocation.
+	var tokensReceived []string
+	ms := &mockSchemaTransport{
+		listSchemasFn: func(_ context.Context, _ int32, pageToken string) (*ListSchemasResponse, error) {
+			tokensReceived = append(tokensReceived, pageToken)
+			switch pageToken {
+			case "":
+				return &ListSchemasResponse{
+					Schemas:       []*Schema{{ID: "s1"}},
+					NextPageToken: "page2",
+				}, nil
+			case "page2":
+				// Fail twice, then succeed — verifying retries stay on page 2.
+				if len(tokensReceived) < 4 {
+					return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+				}
+				return &ListSchemasResponse{Schemas: []*Schema{{ID: "s2"}}}, nil
+			}
+			return nil, fmt.Errorf("unexpected token %q", pageToken)
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	schemas, err := c.ListSchemas(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(schemas) != 2 {
+		t.Errorf("got %d schemas, want 2", len(schemas))
+	}
+	// Page 1 fetched once; page 2 fetched 3 times (2 failures + 1 success).
+	if len(tokensReceived) != 4 {
+		t.Errorf("got %d calls, want 4 (1 for page1 + 3 for page2)", len(tokensReceived))
+	}
+	// The first call must be page 1, the rest must all be page 2 (no restart).
+	if tokensReceived[0] != "" {
+		t.Errorf("call 0: got token %q, want empty (page 1)", tokensReceived[0])
+	}
+	for i := 1; i < len(tokensReceived); i++ {
+		if tokensReceived[i] != "page2" {
+			t.Errorf("call %d: got token %q, want page2", i, tokensReceived[i])
+		}
+	}
+}
+
+// TestRetry_ListTenants_PerPageRetry verifies per-page retry for ListTenants.
+func TestRetry_ListTenants_PerPageRetry(t *testing.T) {
+	var tokensReceived []string
+	ms := &mockSchemaTransport{
+		listTenantsFn: func(_ context.Context, _ *string, _ int32, pageToken string) (*ListTenantsResponse, error) {
+			tokensReceived = append(tokensReceived, pageToken)
+			switch pageToken {
+			case "":
+				return &ListTenantsResponse{
+					Tenants:       []*Tenant{{ID: "t1"}},
+					NextPageToken: "page2",
+				}, nil
+			case "page2":
+				if len(tokensReceived) < 4 {
+					return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+				}
+				return &ListTenantsResponse{Tenants: []*Tenant{{ID: "t2"}}}, nil
+			}
+			return nil, fmt.Errorf("unexpected token %q", pageToken)
+		},
+	}
+	c := New(
+		WithSchemaTransport(ms),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	tenants, err := c.ListTenants(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tenants) != 2 {
+		t.Errorf("got %d tenants, want 2", len(tenants))
+	}
+	if len(tokensReceived) != 4 {
+		t.Errorf("got %d calls, want 4", len(tokensReceived))
+	}
+	if tokensReceived[0] != "" {
+		t.Errorf("call 0: got token %q, want empty", tokensReceived[0])
+	}
+	for i := 1; i < len(tokensReceived); i++ {
+		if tokensReceived[i] != "page2" {
+			t.Errorf("call %d: got token %q, want page2", i, tokensReceived[i])
+		}
+	}
+}
+
+// TestRetry_ListConfigVersions_PerPageRetry verifies per-page retry for ListConfigVersions.
+func TestRetry_ListConfigVersions_PerPageRetry(t *testing.T) {
+	var tokensReceived []string
+	mc := &mockConfigTransport{
+		listVersionsFn: func(_ context.Context, _ string, _ int32, pageToken string) (*ListVersionsResponse, error) {
+			tokensReceived = append(tokensReceived, pageToken)
+			switch pageToken {
+			case "":
+				return &ListVersionsResponse{
+					Versions:      []*Version{{Version: 2}},
+					NextPageToken: "page2",
+				}, nil
+			case "page2":
+				if len(tokensReceived) < 4 {
+					return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+				}
+				return &ListVersionsResponse{Versions: []*Version{{Version: 1}}}, nil
+			}
+			return nil, fmt.Errorf("unexpected token %q", pageToken)
+		},
+	}
+	c := New(
+		WithConfigTransport(mc),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	versions, err := c.ListConfigVersions(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("got %d versions, want 2", len(versions))
+	}
+	if len(tokensReceived) != 4 {
+		t.Errorf("got %d calls, want 4", len(tokensReceived))
+	}
+	if tokensReceived[0] != "" {
+		t.Errorf("call 0: got token %q, want empty", tokensReceived[0])
+	}
+	for i := 1; i < len(tokensReceived); i++ {
+		if tokensReceived[i] != "page2" {
+			t.Errorf("call %d: got token %q, want page2", i, tokensReceived[i])
+		}
+	}
+}
+
+// TestRetry_QueryWriteLog_PerPageRetry verifies per-page retry for QueryWriteLog.
+func TestRetry_QueryWriteLog_PerPageRetry(t *testing.T) {
+	var tokensReceived []string
+	ma := &mockAuditTransport{
+		queryWriteLogFn: func(_ context.Context, req *QueryWriteLogRequest) (*QueryWriteLogResponse, error) {
+			tokensReceived = append(tokensReceived, req.PageToken)
+			switch req.PageToken {
+			case "":
+				return &QueryWriteLogResponse{
+					Entries:       []*AuditEntry{{ID: "e1"}},
+					NextPageToken: "page2",
+				}, nil
+			case "page2":
+				if len(tokensReceived) < 4 {
+					return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+				}
+				return &QueryWriteLogResponse{Entries: []*AuditEntry{{ID: "e2"}}}, nil
+			}
+			return nil, fmt.Errorf("unexpected token %q", req.PageToken)
+		},
+	}
+	c := New(
+		WithAuditTransport(ma),
+		WithRetry(RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}),
+	)
+
+	entries, err := c.QueryWriteLog(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("got %d entries, want 2", len(entries))
+	}
+	if len(tokensReceived) != 4 {
+		t.Errorf("got %d calls, want 4", len(tokensReceived))
+	}
+	if tokensReceived[0] != "" {
+		t.Errorf("call 0: got token %q, want empty", tokensReceived[0])
+	}
+	for i := 1; i < len(tokensReceived); i++ {
+		if tokensReceived[i] != "page2" {
+			t.Errorf("call %d: got token %q, want page2", i, tokensReceived[i])
+		}
+	}
+}

--- a/sdk/adminclient/schema.go
+++ b/sdk/adminclient/schema.go
@@ -61,22 +61,22 @@ func (c *Client) ListSchemas(ctx context.Context) ([]*Schema, error) {
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return retry(ctx, c, func(ctx context.Context) ([]*Schema, error) {
-		var all []*Schema
-		pageToken := ""
-		for {
-			resp, err := c.schema.ListSchemas(ctx, 100, pageToken)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, resp.Schemas...)
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+	var all []*Schema
+	pageToken := ""
+	for {
+		resp, err := retry(ctx, c, func(ctx context.Context) (*ListSchemasResponse, error) {
+			return c.schema.ListSchemas(ctx, 100, pageToken)
+		})
+		if err != nil {
+			return nil, err
 		}
-		return all, nil
-	})
+		all = append(all, resp.Schemas...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
 }
 
 // UpdateSchema creates a new draft version by merging field changes with the latest version.

--- a/sdk/adminclient/tenant.go
+++ b/sdk/adminclient/tenant.go
@@ -56,26 +56,26 @@ func (c *Client) ListTenants(ctx context.Context, schemaID string) ([]*Tenant, e
 	if c.schema == nil {
 		return nil, ErrServiceNotConfigured
 	}
-	return retry(ctx, c, func(ctx context.Context) ([]*Tenant, error) {
-		var schemaFilter *string
-		if schemaID != "" {
-			schemaFilter = &schemaID
+	var schemaFilter *string
+	if schemaID != "" {
+		schemaFilter = &schemaID
+	}
+	var all []*Tenant
+	pageToken := ""
+	for {
+		resp, err := retry(ctx, c, func(ctx context.Context) (*ListTenantsResponse, error) {
+			return c.schema.ListTenants(ctx, schemaFilter, 100, pageToken)
+		})
+		if err != nil {
+			return nil, err
 		}
-		var all []*Tenant
-		pageToken := ""
-		for {
-			resp, err := c.schema.ListTenants(ctx, schemaFilter, 100, pageToken)
-			if err != nil {
-				return nil, err
-			}
-			all = append(all, resp.Tenants...)
-			if resp.NextPageToken == "" {
-				break
-			}
-			pageToken = resp.NextPageToken
+		all = append(all, resp.Tenants...)
+		if resp.NextPageToken == "" {
+			break
 		}
-		return all, nil
-	})
+		pageToken = resp.NextPageToken
+	}
+	return all, nil
 }
 
 // UpdateTenantName updates a tenant's name.


### PR DESCRIPTION
## Summary
- Auto-paginate loops in schema, tenant, config, and audit clients wrapped `retry()` around the entire accumulation loop, causing O(N²) re-fetches when a retryable error occurred on page N
- Moves `retry()` to wrap only the individual per-page RPC call — the loop and result accumulation are outside retry scope

## Test plan
- [ ] `TestListSchemas_PerPageRetry` — page-1 called once, page-2 retries in place without restarting from page-1
- [ ] `TestListTenants_PerPageRetry` — same pattern
- [ ] `TestListConfigVersions_PerPageRetry` — same pattern
- [ ] `TestQueryWriteLog_PerPageRetry` — same pattern
- [ ] `make test` passes with -race
- [ ] `make lint-go` clean

Closes #690