### PR TITLE
fix(configwatcher): deliver typed value directly via Kind() switch

### DIFF
--- a/sdk/configwatcher/value.go
+++ b/sdk/configwatcher/value.go
@@ -122,6 +122,26 @@ func (v *Value[T]) update(rawValue string, isSet bool) {
 		}
 	}
 
+	v.notifyLocked(oldVal, wasNull)
+}
+
+// updateDirect sets the value directly without string parsing.
+func (v *Value[T]) updateDirect(val T) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	oldVal := v.current
+	wasNull := !v.isSet
+
+	v.current = val
+	v.isSet = true
+
+	v.notifyLocked(oldVal, wasNull)
+}
+
+// notifyLocked emits a Change if the effective value or null-state changed.
+// Must be called with v.mu held.
+func (v *Value[T]) notifyLocked(oldVal T, wasNull bool) {
 	// Do not send on a closed channel.
 	if v.closed {
 		return

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -61,8 +61,9 @@ type Watcher struct {
 }
 
 type fieldEntry struct {
-	rawUpdate func(value string, isSet bool)
-	closeFunc func()
+	rawUpdate   func(value string, isSet bool)
+	typedUpdate func(tv *configclient.TypedValue)
+	closeFunc   func()
 }
 
 type options struct {
@@ -188,10 +189,63 @@ func registerField[T any](w *Watcher, fieldPath string, defaultVal T, parse func
 	v.fieldPath = fieldPath
 	v.logger = w.opts.logger
 	w.fields[fieldPath] = &fieldEntry{
-		rawUpdate: func(value string, isSet bool) { v.update(value, isSet) },
-		closeFunc: func() { v.close() },
+		rawUpdate:   func(value string, isSet bool) { v.update(value, isSet) },
+		typedUpdate: typedUpdater(v),
+		closeFunc:   func() { v.close() },
 	}
 	return v, nil
+}
+
+// typedUpdater returns a closure that delivers a *configclient.TypedValue directly
+// to v when the Kind matches T, and falls back to string parsing otherwise.
+func typedUpdater[T any](v *Value[T]) func(tv *configclient.TypedValue) {
+	return func(tv *configclient.TypedValue) {
+		switch tv.Kind() {
+		case configclient.KindInteger:
+			if n, ok := tv.IntValue(); ok {
+				if direct, ok := any(n).(T); ok {
+					v.updateDirect(direct)
+					return
+				}
+			}
+		case configclient.KindNumber:
+			if f, ok := tv.FloatValue(); ok {
+				if direct, ok := any(f).(T); ok {
+					v.updateDirect(direct)
+					return
+				}
+			}
+		case configclient.KindBool:
+			if b, ok := tv.BoolValue(); ok {
+				if direct, ok := any(b).(T); ok {
+					v.updateDirect(direct)
+					return
+				}
+			}
+		case configclient.KindTime:
+			if t, ok := tv.TimeValue(); ok {
+				if direct, ok := any(t).(T); ok {
+					v.updateDirect(direct)
+					return
+				}
+			}
+		case configclient.KindDuration:
+			if d, ok := tv.DurationValue(); ok {
+				if direct, ok := any(d).(T); ok {
+					v.updateDirect(direct)
+					return
+				}
+			}
+		case configclient.KindString, configclient.KindURL, configclient.KindJSON:
+			s := tv.String()
+			if direct, ok := any(s).(T); ok {
+				v.updateDirect(direct)
+				return
+			}
+		}
+		// Kind mismatch or unrecognized kind: fall back to string parsing.
+		v.update(tv.String(), true)
+	}
 }
 
 // --- Lifecycle ---
@@ -295,17 +349,17 @@ func (w *Watcher) loadSnapshot(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 
-	// Build a map of field path → string value.
-	values := make(map[string]string, len(resp.Values))
+	// Build a map of field path → TypedValue.
+	values := make(map[string]*configclient.TypedValue, len(resp.Values))
 	for _, v := range resp.Values {
-		values[v.FieldPath] = v.Value.String()
+		values[v.FieldPath] = v.Value
 	}
 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	for path, entry := range w.fields {
-		if val, ok := values[path]; ok {
-			entry.rawUpdate(val, true)
+		if tv, ok := values[path]; ok && tv != nil {
+			entry.typedUpdate(tv)
 		} else {
 			entry.rawUpdate("", false)
 		}
@@ -379,7 +433,7 @@ func (w *Watcher) subscribe(ctx context.Context, fieldPaths []string, snapshotVe
 		w.mu.RLock()
 		if entry, ok := w.fields[change.FieldPath]; ok {
 			if change.NewValue != nil {
-				entry.rawUpdate(change.NewValue.String(), true)
+				entry.typedUpdate(change.NewValue)
 			} else {
 				entry.rawUpdate("", false)
 			}

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -1164,3 +1164,236 @@ func TestWatcher_ReconnectNoSpuriousChanges(t *testing.T) {
 	cancel()
 	_ = w.Close()
 }
+
+// --- Direct typed-value delivery tests ---
+
+// TestTypedUpdater_DirectInt verifies that an IntVal is delivered to an int field
+// without going through string parsing.
+func TestTypedUpdater_DirectInt(t *testing.T) {
+	v := newValue(int64(0), parseInt)
+	u := typedUpdater(v)
+
+	u(configclient.IntVal(42))
+
+	if got := v.Get(); got != int64(42) {
+		t.Errorf("got %v, want 42", got)
+	}
+	_, ok := v.GetWithNull()
+	if !ok {
+		t.Error("expected isSet=true after direct int update")
+	}
+}
+
+// TestTypedUpdater_DirectFloat verifies that a FloatVal is delivered to a float field
+// without going through string parsing.
+func TestTypedUpdater_DirectFloat(t *testing.T) {
+	v := newValue(0.0, parseFloat)
+	u := typedUpdater(v)
+
+	u(configclient.FloatVal(3.14))
+
+	if got := v.Get(); got != 3.14 {
+		t.Errorf("got %v, want 3.14", got)
+	}
+}
+
+// TestTypedUpdater_DirectBool verifies that a BoolVal is delivered directly.
+func TestTypedUpdater_DirectBool(t *testing.T) {
+	v := newValue(false, parseBool)
+	u := typedUpdater(v)
+
+	u(configclient.BoolVal(true))
+
+	if got := v.Get(); !got {
+		t.Error("got false, want true")
+	}
+}
+
+// TestTypedUpdater_DirectDuration verifies that a DurationVal is delivered directly.
+func TestTypedUpdater_DirectDuration(t *testing.T) {
+	v := newValue(time.Duration(0), parseDuration)
+	u := typedUpdater(v)
+
+	u(configclient.DurationVal(5 * time.Minute))
+
+	if got := v.Get(); got != 5*time.Minute {
+		t.Errorf("got %v, want 5m", got)
+	}
+}
+
+// TestTypedUpdater_DirectTime verifies that a TimeVal is delivered directly.
+func TestTypedUpdater_DirectTime(t *testing.T) {
+	ts := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	v := newValue(time.Time{}, parseTime)
+	u := typedUpdater(v)
+
+	u(configclient.TimeVal(ts))
+
+	if got := v.Get(); !got.Equal(ts) {
+		t.Errorf("got %v, want %v", got, ts)
+	}
+}
+
+// TestTypedUpdater_DirectString verifies that a StringVal is delivered directly.
+func TestTypedUpdater_DirectString(t *testing.T) {
+	v := newValue("", parseString)
+	u := typedUpdater(v)
+
+	u(configclient.StringVal("hello"))
+
+	if got := v.Get(); got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+}
+
+// TestTypedUpdater_KindMismatchFallback verifies that when the server sends a
+// StringVal for an int field (kind mismatch), the watcher falls back to string
+// parsing. A parseable string succeeds; a non-parseable string falls back to default.
+func TestTypedUpdater_KindMismatchFallback(t *testing.T) {
+	v := newValue(int64(99), parseInt)
+	u := typedUpdater(v)
+
+	// StringVal "7" can be parsed as int64 via string fallback.
+	u(configclient.StringVal("7"))
+	if got := v.Get(); got != int64(7) {
+		t.Errorf("parseable fallback: got %v, want 7", got)
+	}
+
+	// StringVal "bad" cannot be parsed — falls back to default.
+	u(configclient.StringVal("bad"))
+	if got := v.Get(); got != int64(99) {
+		t.Errorf("unparseable fallback: got %v, want default 99", got)
+	}
+}
+
+// TestTypedUpdater_URLAndJSON verifies that URL and JSON typed values are delivered
+// as strings to a string field directly.
+func TestTypedUpdater_URLAndJSON(t *testing.T) {
+	v := newValue("", parseString)
+	u := typedUpdater(v)
+
+	u(configclient.URLVal("https://example.com"))
+	if got := v.Get(); got != "https://example.com" {
+		t.Errorf("URL: got %q, want %q", got, "https://example.com")
+	}
+
+	u(configclient.JSONVal(`{"key":"val"}`))
+	if got := v.Get(); got != `{"key":"val"}` {
+		t.Errorf("JSON: got %q, want %q", got, `{"key":"val"}`)
+	}
+}
+
+// TestValue_UpdateDirect verifies that updateDirect sets the value and emits a Change.
+func TestValue_UpdateDirect(t *testing.T) {
+	v := newValue(int64(0), parseInt)
+
+	v.updateDirect(int64(55))
+
+	if got := v.Get(); got != int64(55) {
+		t.Errorf("got %v, want 55", got)
+	}
+	_, ok := v.GetWithNull()
+	if !ok {
+		t.Error("expected isSet=true after updateDirect")
+	}
+
+	select {
+	case ch := <-v.Changes():
+		if ch.WasNull != true {
+			t.Error("expected WasNull=true on first direct update")
+		}
+		if ch.New != int64(55) {
+			t.Errorf("Change.New: got %v, want 55", ch.New)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected Change on channel after updateDirect")
+	}
+}
+
+// TestWatcher_SnapshotDirectDelivery verifies end-to-end that snapshot values are
+// delivered via the direct path for int and duration kinds.
+func TestWatcher_SnapshotDirectDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{
+				TenantID: "t1",
+				Version:  1,
+				Values: []configclient.ConfigValue{
+					{FieldPath: "a.int", Value: configclient.IntVal(42)},
+					{FieldPath: "b.dur", Value: configclient.DurationVal(30 * time.Second)},
+				},
+			}, nil
+		},
+		subscribeFn: func(ctx context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			return &mockSubscription{ch: make(chan *configclient.ConfigChange), ctx: ctx}, nil
+		},
+	}
+
+	w := New(tr, "t1")
+	n, err := w.Int("a.int", 0)
+	if err != nil {
+		t.Fatalf("Int: %v", err)
+	}
+	d, err := w.Duration("b.dur", 0)
+	if err != nil {
+		t.Fatalf("Duration: %v", err)
+	}
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if got := n.Get(); got != int64(42) {
+		t.Errorf("int field: got %v, want 42", got)
+	}
+	if got := d.Get(); got != 30*time.Second {
+		t.Errorf("duration field: got %v, want 30s", got)
+	}
+}
+
+// TestWatcher_StreamDirectDelivery verifies that stream updates are delivered
+// via the direct path for int fields.
+func TestWatcher_StreamDirectDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub := newMockSubscription(ctx)
+
+	tr := &mockTransport{
+		getConfigFn: func(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+			return &configclient.GetConfigResponse{TenantID: "t1", Version: 1}, nil
+		},
+		subscribeFn: func(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+			return sub, nil
+		},
+	}
+
+	w := New(tr, "t1")
+	n, err := w.Int("x.count", 0)
+	if err != nil {
+		t.Fatalf("Int: %v", err)
+	}
+
+	if err := w.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	sub.send(&configclient.ConfigChange{
+		TenantID:  "t1",
+		FieldPath: "x.count",
+		NewValue:  configclient.IntVal(100),
+	})
+
+	select {
+	case <-n.Changes():
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("no Change received")
+	}
+
+	if got := n.Get(); got != int64(100) {
+		t.Errorf("got %v, want 100", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `change.NewValue.String()` + `parseInt`/`parseFloat`/etc. round-trip with a direct `Kind()` switch that delivers native Go values without serialization/deserialization overhead
- Add `updateDirect(val T)` on `Value[T]` to set a value without string parsing, and `notifyLocked` to share change-emission logic between `update` and `updateDirect`
- String parsing is kept as a fallback for genuine kind mismatches (e.g. server sends `StringVal` for a float field)

## Test plan

- [ ] All existing tests pass (`make test`)
- [ ] `TestTypedUpdater_Direct*` — unit tests for each kind (int, float, bool, duration, time, string) verifying direct delivery
- [ ] `TestTypedUpdater_KindMismatchFallback` — verifies string-parse fallback for mismatched kinds
- [ ] `TestTypedUpdater_URLAndJSON` — verifies URL/JSON typed values are delivered as strings
- [ ] `TestValue_UpdateDirect` — verifies updateDirect sets value and emits Change
- [ ] `TestWatcher_SnapshotDirectDelivery` / `TestWatcher_StreamDirectDelivery` — end-to-end integration tests

Closes #693