### PR TITLE
fix(cli): skip --wait for offline commands

### DIFF
--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -481,6 +481,71 @@ func TestPrintStatus_WritesToStderrNotStdout(t *testing.T) {
 	}
 }
 
+// --- isOfflineInvocation (#709) ---
+
+func TestIsOfflineInvocation_AlwaysOffline(t *testing.T) {
+	offline := []string{"validate", "version", "gen-docs", "gen-man"}
+	for _, name := range offline {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: name}
+			if !isOfflineInvocation(cmd) {
+				t.Errorf("expected %q to be offline", name)
+			}
+		})
+	}
+}
+
+func TestIsOfflineInvocation_DiffFileMode(t *testing.T) {
+	cmd := &cobra.Command{Use: "diff"}
+	cmd.Flags().String("old", "", "")
+	cmd.Flags().String("new", "", "")
+
+	// Neither flag set → server mode → not offline.
+	if isOfflineInvocation(cmd) {
+		t.Error("expected diff with no flags to be online")
+	}
+
+	// Only --old set → still server mode (error case, but not offline).
+	_ = cmd.Flags().Set("old", "v1.yaml")
+	if isOfflineInvocation(cmd) {
+		t.Error("expected diff with only --old to be online")
+	}
+
+	// Both flags set → file mode → offline.
+	_ = cmd.Flags().Set("new", "v2.yaml")
+	if !isOfflineInvocation(cmd) {
+		t.Error("expected diff with --old and --new to be offline")
+	}
+}
+
+func TestIsOfflineInvocation_DocgenFileMode(t *testing.T) {
+	cmd := &cobra.Command{Use: "docgen"}
+	cmd.Flags().String("file", "", "")
+
+	// No --file → server mode → not offline.
+	if isOfflineInvocation(cmd) {
+		t.Error("expected docgen with no --file to be online")
+	}
+
+	// --file set → offline.
+	_ = cmd.Flags().Set("file", "schema.yaml")
+	if !isOfflineInvocation(cmd) {
+		t.Error("expected docgen with --file to be offline")
+	}
+}
+
+func TestIsOfflineInvocation_OnlineCommands(t *testing.T) {
+	online := []string{"schema", "tenant", "config", "watch", "lock", "audit", "seed", "dump"}
+	for _, name := range online {
+		t.Run(name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: name}
+			if isOfflineInvocation(cmd) {
+				t.Errorf("expected %q to be online", name)
+			}
+		})
+	}
+}
+
 // --- Completions ---
 
 func TestCompletionScripts(t *testing.T) {

--- a/cmd/decree/main.go
+++ b/cmd/decree/main.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		if !flagWait {
+		if !flagWait || isOfflineInvocation(cmd) {
 			return nil
 		}
 		timeout, err := time.ParseDuration(flagWaitTimeout)
@@ -62,6 +62,23 @@ var rootCmd = &cobra.Command{
 		fmt.Fprintf(cmd.ErrOrStderr(), "Server ready.\n")
 		return nil
 	},
+}
+
+// isOfflineInvocation returns true when the given command does not need a
+// server connection and therefore should not block on --wait.
+func isOfflineInvocation(cmd *cobra.Command) bool {
+	switch cmd.Name() {
+	case "validate", "version", "gen-docs", "gen-man":
+		return true
+	case "diff":
+		old, _ := cmd.Flags().GetString("old")
+		new, _ := cmd.Flags().GetString("new")
+		return old != "" && new != ""
+	case "docgen":
+		file, _ := cmd.Flags().GetString("file")
+		return file != ""
+	}
+	return false
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- `--wait` was wired as a `PersistentPreRunE` on the root command, so it fired for every command including ones that never touch the server, causing unnecessary dials and blocking.
- Adds `isOfflineInvocation` to gate the wait logic: always-offline commands (`validate`, `version`, `gen-docs`, `gen-man`) are unconditionally skipped; `diff` and `docgen` are skipped when their file-mode flags (`--old`/`--new` and `--file`) are both present.

## Test plan

- `TestIsOfflineInvocation_AlwaysOffline` — validate, version, gen-docs, gen-man return true
- `TestIsOfflineInvocation_DiffFileMode` — diff with neither / only one / both file flags
- `TestIsOfflineInvocation_DocgenFileMode` — docgen with and without `--file`
- `TestIsOfflineInvocation_OnlineCommands` — schema, tenant, config, etc. return false
- `make test` passes (all packages, race detector)
- `make lint-go` passes (0 issues)

Closes #709