### PR TITLE
fix(cli): use SDK auth options in watch command

### DIFF
--- a/cmd/decree/connect.go
+++ b/cmd/decree/connect.go
@@ -48,3 +48,7 @@ func newAdminClient(conn *grpc.ClientConn) (*adminclient.Client, error) {
 func newConfigClient(conn *grpc.ClientConn) (*configclient.Client, error) {
 	return grpctransport.NewConfigClient(conn, authOptions()...)
 }
+
+func newConfigTransport(conn *grpc.ClientConn) (*grpctransport.ConfigTransport, error) {
+	return grpctransport.NewConfigTransport(conn, authOptions()...)
+}

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -7,11 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
-	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/sdk/adminclient"
+	"github.com/opendecree/decree/sdk/configclient"
 	"github.com/opendecree/decree/sdk/tools/docgen"
 )
 
@@ -20,20 +17,17 @@ import (
 func TestTypedValueDisplay(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    *pb.TypedValue
+		input    *configclient.TypedValue
 		expected string
 	}{
 		{"nil", nil, "<null>"},
-		{"string", &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}}, "hello"},
-		{"integer", &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}, "42"},
-		{"number", &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 3.14}}, "3.14"},
-		{"bool", &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: true}}, "true"},
-		{"url", &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com"}}, "https://example.com"},
-		{"json", &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"a":1}`}}, `{"a":1}`},
-		{"duration", &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(5 * time.Minute)}}, "5m0s"},
-		{"duration nil", &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{}}, ""},
-		{"time nil", &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{}}, ""},
-		{"empty kind", &pb.TypedValue{}, ""},
+		{"string", configclient.StringVal("hello"), "hello"},
+		{"integer", configclient.IntVal(42), "42"},
+		{"number", configclient.FloatVal(3.14), "3.14"},
+		{"bool", configclient.BoolVal(true), "true"},
+		{"url", configclient.URLVal("https://example.com"), "https://example.com"},
+		{"json", configclient.JSONVal(`{"a":1}`), `{"a":1}`},
+		{"duration", configclient.DurationVal(5 * time.Minute), "5m0s"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,7 +40,7 @@ func TestTypedValueDisplay(t *testing.T) {
 
 func TestTypedValueDisplay_Time(t *testing.T) {
 	ts := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
-	tv := &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(ts)}}
+	tv := configclient.TimeVal(ts)
 	if !strings.Contains(typedValueDisplay(tv), "2026-03-30") {
 		t.Errorf("expected %q to contain %q", typedValueDisplay(tv), "2026-03-30")
 	}

--- a/cmd/decree/watch.go
+++ b/cmd/decree/watch.go
@@ -5,15 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/sdk/configclient"
 )
 
 // normalizeStreamErr maps a streaming RPC error to nil when the error signals a
@@ -32,37 +30,11 @@ func normalizeStreamErr(err error) error {
 	return err
 }
 
-// typedValueDisplay returns a human-readable string for a TypedValue.
-func typedValueDisplay(tv *pb.TypedValue) string {
+func typedValueDisplay(tv *configclient.TypedValue) string {
 	if tv == nil {
 		return "<null>"
 	}
-	switch v := tv.Kind.(type) {
-	case *pb.TypedValue_StringValue:
-		return v.StringValue
-	case *pb.TypedValue_IntegerValue:
-		return fmt.Sprintf("%d", v.IntegerValue)
-	case *pb.TypedValue_NumberValue:
-		return strconv.FormatFloat(v.NumberValue, 'f', -1, 64)
-	case *pb.TypedValue_BoolValue:
-		return strconv.FormatBool(v.BoolValue)
-	case *pb.TypedValue_UrlValue:
-		return v.UrlValue
-	case *pb.TypedValue_JsonValue:
-		return v.JsonValue
-	case *pb.TypedValue_TimeValue:
-		if v.TimeValue != nil {
-			return v.TimeValue.AsTime().Format(time.RFC3339Nano)
-		}
-		return ""
-	case *pb.TypedValue_DurationValue:
-		if v.DurationValue != nil {
-			return v.DurationValue.AsDuration().String()
-		}
-		return ""
-	default:
-		return ""
-	}
+	return tv.String()
 }
 
 var watchCmd = &cobra.Command{
@@ -79,28 +51,13 @@ var watchCmd = &cobra.Command{
 		}
 		defer func() { _ = conn.Close() }()
 
-		ctx := cmd.Context()
-		// Inject auth metadata.
-		pairs := make([]string, 0, 6)
-		if flagSubject != "" {
-			pairs = append(pairs, "x-subject", flagSubject)
-		}
-		if flagRole != "" {
-			pairs = append(pairs, "x-role", flagRole)
-		}
-		if flagTenantID != "" {
-			pairs = append(pairs, "x-tenant-id", flagTenantID)
-		}
-		if flagToken != "" {
-			pairs = append(pairs, "authorization", "Bearer "+flagToken)
-		}
-		if len(pairs) > 0 {
-			ctx = metadata.AppendToOutgoingContext(ctx, pairs...)
+		transport, err := newConfigTransport(conn)
+		if err != nil {
+			return err
 		}
 
-		rpc := pb.NewConfigServiceClient(conn)
-		stream, err := rpc.Subscribe(ctx, &pb.SubscribeRequest{
-			TenantId:   tenantID,
+		sub, err := transport.Subscribe(cmd.Context(), &configclient.SubscribeRequest{
+			TenantID:   tenantID,
 			FieldPaths: fieldPaths,
 		})
 		if err != nil {
@@ -108,20 +65,13 @@ var watchCmd = &cobra.Command{
 		}
 
 		for {
-			resp, err := stream.Recv()
+			c, err := sub.Recv()
 			if err != nil {
 				return normalizeStreamErr(err)
 			}
-			c := resp.Change
 			ts := time.Now().Format("15:04:05")
-			old, new_ := "<null>", "<null>"
-			if c.OldValue != nil {
-				old = typedValueDisplay(c.OldValue)
-			}
-			if c.NewValue != nil {
-				new_ = typedValueDisplay(c.NewValue)
-			}
-			fmt.Printf("[%s] v%d %s: %q → %q (by %s)\n", ts, c.Version, c.FieldPath, old, new_, c.ChangedBy)
+			fmt.Printf("[%s] v%d %s: %q → %q (by %s)\n", ts, c.Version, c.FieldPath,
+				typedValueDisplay(c.OldValue), typedValueDisplay(c.NewValue), c.ChangedBy)
 		}
 	},
 }

--- a/sdk/configclient/transport.go
+++ b/sdk/configclient/transport.go
@@ -112,4 +112,6 @@ type ConfigChange struct {
 	FieldPath string
 	OldValue  *TypedValue
 	NewValue  *TypedValue
+	Version   int32
+	ChangedBy string
 }

--- a/sdk/grpctransport/subscription.go
+++ b/sdk/grpctransport/subscription.go
@@ -29,5 +29,7 @@ func (s *grpcSubscription) Recv() (*configclient.ConfigChange, error) {
 		FieldPath: change.GetFieldPath(),
 		OldValue:  typedValueFromProto(change.GetOldValue()),
 		NewValue:  typedValueFromProto(change.GetNewValue()),
+		Version:   change.GetVersion(),
+		ChangedBy: change.GetChangedBy(),
 	}, nil
 }


### PR DESCRIPTION
## Summary

- The `watch` command was hand-rolling gRPC metadata headers for auth (x-subject, x-role, x-tenant-id, bearer) instead of going through the shared `authOptions()` / SDK transport path, creating a second source of truth with drift risk.
- Refactored to use `newConfigTransport(conn)` (backed by `grpctransport.NewConfigTransport` + `authOptions()`), eliminating the duplicate auth logic entirely.
- Extended `configclient.ConfigChange` with `Version` and `ChangedBy` fields, and propagated them in `grpcSubscription.Recv`, so the subscription layer now surfaces the full change event through the SDK abstraction.

## Test plan

- [x] `make test` — all packages pass (including `cmd/decree`, `sdk/configclient`, `sdk/grpctransport`)
- [x] `make lint-go` — zero issues, no format drift
- [x] `TestTypedValueDisplay` updated to use `configclient.TypedValue` constructors; old proto-typed cases removed

Closes #710