### PR TITLE
fix(cli): enforce required flags via cobra MarkFlagRequired

### DIFF
--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -393,8 +393,8 @@ func TestSchemaCreate_MissingFile_ErrorNotOnStdout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing --file, got nil")
 	}
-	if !strings.Contains(err.Error(), "--file") {
-		t.Errorf("expected error to mention --file, got %q", err.Error())
+	if !strings.Contains(err.Error(), "file") {
+		t.Errorf("expected error to mention file, got %q", err.Error())
 	}
 	if stdout.Len() != 0 {
 		t.Errorf("expected empty stdout on flag error, got: %q", stdout.String())

--- a/cmd/decree/diff.go
+++ b/cmd/decree/diff.go
@@ -27,7 +27,7 @@ File mode (compare two local config YAML files):
 
 		var oldValues, newValues map[string]string
 
-		if oldFile != "" && newFile != "" {
+		if oldFile != "" {
 			// File mode: compare two local YAML files.
 			oldData, err := os.ReadFile(oldFile)
 			if err != nil {
@@ -39,8 +39,6 @@ File mode (compare two local config YAML files):
 			}
 			oldValues = parseConfigValues(oldData)
 			newValues = parseConfigValues(newData)
-		} else if oldFile != "" || newFile != "" {
-			return fmt.Errorf("both --old and --new are required for file mode")
 		} else {
 			// Server mode: compare two versions.
 			if len(args) != 3 {
@@ -112,4 +110,5 @@ func parseConfigValues(data []byte) map[string]string {
 func init() {
 	diffCmd.Flags().String("old", "", "old config YAML file (file mode)")
 	diffCmd.Flags().String("new", "", "new config YAML file (file mode)")
+	diffCmd.MarkFlagsRequiredTogether("old", "new")
 }

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -21,9 +21,6 @@ var schemaCreateCmd = &cobra.Command{
 	Short: "Create a new schema from a YAML file",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, _ := cmd.Flags().GetString("file")
-		if file == "" {
-			return fmt.Errorf("--file is required")
-		}
 		data, err := os.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("read file: %w", err)
@@ -228,6 +225,7 @@ var schemaImportCmd = &cobra.Command{
 
 func init() {
 	schemaCreateCmd.Flags().StringP("file", "f", "", "YAML file with schema definition")
+	_ = schemaCreateCmd.MarkFlagRequired("file")
 	schemaGetCmd.Flags().Int32("version", 0, "specific version (default: latest)")
 	schemaExportCmd.Flags().Int32("version", 0, "specific version (default: latest)")
 	schemaImportCmd.Flags().Bool("publish", false, "auto-publish the imported version")

--- a/cmd/decree/tenant.go
+++ b/cmd/decree/tenant.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -20,9 +19,6 @@ var tenantCreateCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		schemaID, _ := cmd.Flags().GetString("schema")
 		version, _ := cmd.Flags().GetInt32("schema-version")
-		if name == "" || schemaID == "" || version == 0 {
-			return fmt.Errorf("--name, --schema, and --schema-version are required")
-		}
 		conn, err := dialServer()
 		if err != nil {
 			return err
@@ -122,8 +118,11 @@ var tenantDeleteCmd = &cobra.Command{
 
 func init() {
 	tenantCreateCmd.Flags().String("name", "", "tenant name (slug)")
+	_ = tenantCreateCmd.MarkFlagRequired("name")
 	tenantCreateCmd.Flags().String("schema", "", "schema ID")
+	_ = tenantCreateCmd.MarkFlagRequired("schema")
 	tenantCreateCmd.Flags().Int32("schema-version", 0, "published schema version")
+	_ = tenantCreateCmd.MarkFlagRequired("schema-version")
 	tenantListCmd.Flags().String("schema", "", "filter by schema ID")
 
 	tenantCmd.AddCommand(tenantCreateCmd)

--- a/cmd/decree/validate_cmd.go
+++ b/cmd/decree/validate_cmd.go
@@ -16,10 +16,6 @@ var validateCmd = &cobra.Command{
 		schemaFile, _ := cmd.Flags().GetString("schema")
 		configFile, _ := cmd.Flags().GetString("config")
 
-		if schemaFile == "" || configFile == "" {
-			return fmt.Errorf("both --schema and --config are required")
-		}
-
 		schemaData, err := os.ReadFile(schemaFile)
 		if err != nil {
 			return fmt.Errorf("read schema: %w", err)
@@ -54,6 +50,8 @@ var validateCmd = &cobra.Command{
 
 func init() {
 	validateCmd.Flags().String("schema", "", "schema YAML file")
+	_ = validateCmd.MarkFlagRequired("schema")
 	validateCmd.Flags().String("config", "", "config YAML file")
+	_ = validateCmd.MarkFlagRequired("config")
 	validateCmd.Flags().Bool("strict", false, "reject unknown fields not in schema")
 }


### PR DESCRIPTION
## Summary

- Manual empty-string / zero-value checks scattered across four CLI commands were replaced with cobra's flag-requirement API, giving consistent error messages and shell-completion awareness.
- Uses `MarkFlagRequired` for individually required flags (`schema create --file`, `tenant create --name/--schema/--schema-version`, `validate --schema/--config`) and `MarkFlagsRequiredTogether` for the `diff --old/--new` pair.

## Test plan

- [x] `make test` passes — all existing tests green, including `TestValidateCmd_MissingFlagsReturnsError` (still matches "required") and `TestSchemaCreate_MissingFile_ErrorNotOnStdout` (updated assertion to match cobra's message).
- [x] `make lint-go` passes — 0 issues, no format drift.
- [x] Unused `fmt` import removed from `tenant.go`.

Closes #711