### PR TITLE
refactor(cli): use shared schema-YAML parse helper in docgen

### DIFF
--- a/cmd/decree/docgen.go
+++ b/cmd/decree/docgen.go
@@ -5,10 +5,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/opendecree/decree/sdk/adminclient"
 	"github.com/opendecree/decree/sdk/tools/docgen"
+	"github.com/opendecree/decree/sdk/tools/validate"
 )
 
 var docgenCmd = &cobra.Command{
@@ -126,42 +126,19 @@ func adminSchemaToDocgen(s *adminclient.Schema) docgen.Schema {
 	return ds
 }
 
-// schemaFromYAML parses a schema YAML file into a docgen.Schema.
+// schemaFromYAML parses a schema YAML file into a docgen.Schema using the
+// shared validate.ParseSchema helper (enforces spec_version:"v1").
 func schemaFromYAML(data []byte) (*docgen.Schema, error) {
-	var doc struct {
-		Name        string `yaml:"name"`
-		Description string `yaml:"description"`
-		Version     int32  `yaml:"version"`
-		Fields      map[string]struct {
-			Type        string `yaml:"type"`
-			Description string `yaml:"description"`
-			Default     string `yaml:"default"`
-			Nullable    bool   `yaml:"nullable"`
-			Deprecated  bool   `yaml:"deprecated"`
-			RedirectTo  string `yaml:"redirect_to"`
-			Constraints *struct {
-				Minimum          *float64 `yaml:"minimum"`
-				Maximum          *float64 `yaml:"maximum"`
-				ExclusiveMinimum *float64 `yaml:"exclusiveMinimum"`
-				ExclusiveMaximum *float64 `yaml:"exclusiveMaximum"`
-				MinLength        *int32   `yaml:"minLength"`
-				MaxLength        *int32   `yaml:"maxLength"`
-				Pattern          string   `yaml:"pattern"`
-				Enum             []string `yaml:"enum"`
-				JSONSchema       string   `yaml:"json_schema"`
-			} `yaml:"constraints"`
-		} `yaml:"fields"`
-	}
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	sf, err := validate.ParseSchema(data)
+	if err != nil {
 		return nil, fmt.Errorf("invalid schema YAML: %w", err)
 	}
-
 	s := &docgen.Schema{
-		Name:        doc.Name,
-		Description: doc.Description,
-		Version:     doc.Version,
+		Name:        sf.Name,
+		Description: sf.Description,
+		Version:     sf.Version,
 	}
-	for path, f := range doc.Fields {
+	for path, f := range sf.Fields {
 		df := docgen.Field{
 			Path:        path,
 			Type:        f.Type,
@@ -170,6 +147,13 @@ func schemaFromYAML(data []byte) (*docgen.Schema, error) {
 			Nullable:    f.Nullable,
 			Deprecated:  f.Deprecated,
 			RedirectTo:  f.RedirectTo,
+			Title:       f.Title,
+			Example:     f.Example,
+			Tags:        f.Tags,
+			Format:      f.Format,
+			ReadOnly:    f.ReadOnly,
+			WriteOnce:   f.WriteOnce,
+			Sensitive:   f.Sensitive,
 		}
 		if f.Constraints != nil {
 			df.Constraints = &docgen.Constraints{

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -214,7 +214,8 @@ func TestAdminSchemaToDocgen_NoConstraints(t *testing.T) {
 // --- schemaFromYAML ---
 
 func TestSchemaFromYAML(t *testing.T) {
-	yaml := `name: payments
+	yaml := `spec_version: v1
+name: payments
 description: Payment config
 version: 1
 fields:
@@ -279,15 +280,16 @@ func TestSchemaFromYAML_Invalid(t *testing.T) {
 	}
 }
 
-func TestSchemaFromYAML_Empty(t *testing.T) {
-	s, err := schemaFromYAML([]byte("name: test\n"))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestSchemaFromYAML_MissingSpecVersion(t *testing.T) {
+	_, err := schemaFromYAML([]byte("name: test\nfields:\n  x:\n    type: string\n"))
+	if err == nil {
+		t.Fatal("expected error for missing spec_version, got nil")
 	}
-	if got := s.Name; got != "test" {
-		t.Errorf("got %v, want %v", got, "test")
-	}
-	if len(s.Fields) != 0 {
-		t.Errorf("expected empty, got %v", s.Fields)
+}
+
+func TestSchemaFromYAML_NoFields(t *testing.T) {
+	_, err := schemaFromYAML([]byte("spec_version: v1\nname: test\n"))
+	if err == nil {
+		t.Fatal("expected error for missing fields, got nil")
 	}
 }

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -23,13 +23,15 @@ import (
 
 // SchemaFile is the parsed representation of a schema YAML file.
 type SchemaFile struct {
-	SpecVersion string              `yaml:"spec_version"`
-	Schema      string              `yaml:"$schema,omitempty"`
-	ID          string              `yaml:"$id,omitempty"`
-	Name        string              `yaml:"name"`
-	Description string              `yaml:"description,omitempty"`
-	Info        any                 `yaml:"info,omitempty"`
-	Fields      map[string]FieldDef `yaml:"fields"`
+	SpecVersion        string              `yaml:"spec_version"`
+	Schema             string              `yaml:"$schema,omitempty"`
+	ID                 string              `yaml:"$id,omitempty"`
+	Name               string              `yaml:"name"`
+	Description        string              `yaml:"description,omitempty"`
+	Version            int32               `yaml:"version,omitempty"`
+	VersionDescription string              `yaml:"version_description,omitempty"`
+	Info               any                 `yaml:"info,omitempty"`
+	Fields             map[string]FieldDef `yaml:"fields"`
 }
 
 // FieldDef describes a single field in the schema YAML.


### PR DESCRIPTION
## Summary

- Eliminates the third copy of the schema-YAML struct in `cmd/decree/docgen.go` by delegating to `validate.ParseSchema`, which already owns the canonical parse-and-validate path for schema YAML files.
- Adds `spec_version: v1` enforcement to the offline docgen path, which the removed local struct was silently skipping.
- Adds `Version` and `VersionDescription` to `validate.SchemaFile` so the shared struct covers the full schema-YAML contract, and maps the additional field attributes (`Title`, `Example`, `Tags`, `Format`, `ReadOnly`, `WriteOnce`, `Sensitive`) that the old copy dropped on the floor.

## Test plan

- [x] `make test` passes (all packages green, including `cmd/decree` and `sdk/tools/validate`)
- [x] `make lint-go` reports 0 issues
- [x] Updated `TestSchemaFromYAML` fixture now includes `spec_version: v1`
- [x] Replaced the permissive `TestSchemaFromYAML_Empty` with `TestSchemaFromYAML_MissingSpecVersion` and `TestSchemaFromYAML_NoFields` to assert the new validation behavior

Closes #712