### PR TITLE
fix(cli): remove redundant schema create subcommand

### DIFF
--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -28,7 +28,7 @@ func TestRootCommand_HasAllSubcommands(t *testing.T) {
 }
 
 func TestSchemaCommand_HasSubcommands(t *testing.T) {
-	expected := []string{"create", "get", "list", "publish", "delete", "export", "import"}
+	expected := []string{"get", "list", "publish", "delete", "export", "import"}
 	names := make([]string, 0, len(expected))
 	for _, cmd := range schemaCmd.Commands() {
 		names = append(names, cmd.Name())
@@ -377,27 +377,6 @@ func TestArgError_ReturnsNonNilError(t *testing.T) {
 	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatal("expected non-nil error for wrong arg count, got nil")
-	}
-}
-
-// TestSchemaCreate_MissingFile_ErrorNotOnStdout verifies that a RunE error
-// (missing required flag) is returned and stdout stays empty.
-func TestSchemaCreate_MissingFile_ErrorNotOnStdout(t *testing.T) {
-	resetRootCmd(t)
-	var stdout, stderr bytes.Buffer
-	rootCmd.SetOut(&stdout)
-	rootCmd.SetErr(&stderr)
-	rootCmd.SetArgs([]string{"schema", "create"}) // --file is required
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error for missing --file, got nil")
-	}
-	if !strings.Contains(err.Error(), "file") {
-		t.Errorf("expected error to mention file, got %q", err.Error())
-	}
-	if stdout.Len() != 0 {
-		t.Errorf("expected empty stdout on flag error, got: %q", stdout.String())
 	}
 }
 

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -16,36 +16,6 @@ var schemaCmd = &cobra.Command{
 	Long:  "Create, list, publish, import/export, and delete configuration schemas. Schemas define the allowed fields, types, and constraints for tenant configurations.",
 }
 
-var schemaCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a new schema from a YAML file",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		file, _ := cmd.Flags().GetString("file")
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return fmt.Errorf("read file: %w", err)
-		}
-		conn, err := dialServer()
-		if err != nil {
-			return err
-		}
-		defer func() { _ = conn.Close() }()
-
-		admin, err := newAdminClient(conn)
-		if err != nil {
-			return err
-		}
-		s, err := admin.ImportSchema(cmd.Context(), data)
-		if err != nil {
-			return err
-		}
-		return printOutput(tableRows(
-			[]string{"ID", "NAME", "VERSION", "PUBLISHED"},
-			[]string{s.ID, s.Name, strconv.Itoa(int(s.Version)), strconv.FormatBool(s.Published)},
-		))
-	},
-}
-
 var schemaGetCmd = &cobra.Command{
 	Use:   "get <schema-id>",
 	Short: "Show a schema",
@@ -224,13 +194,10 @@ var schemaImportCmd = &cobra.Command{
 }
 
 func init() {
-	schemaCreateCmd.Flags().StringP("file", "f", "", "YAML file with schema definition")
-	_ = schemaCreateCmd.MarkFlagRequired("file")
 	schemaGetCmd.Flags().Int32("version", 0, "specific version (default: latest)")
 	schemaExportCmd.Flags().Int32("version", 0, "specific version (default: latest)")
 	schemaImportCmd.Flags().Bool("publish", false, "auto-publish the imported version")
 
-	schemaCmd.AddCommand(schemaCreateCmd)
 	schemaCmd.AddCommand(schemaGetCmd)
 	schemaCmd.AddCommand(schemaListCmd)
 	schemaCmd.AddCommand(schemaPublishCmd)

--- a/docs/cli/decree_schema.md
+++ b/docs/cli/decree_schema.md
@@ -33,7 +33,6 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
 ### SEE ALSO
 
 * [decree](decree.md)	 - OpenDecree CLI
-* [decree schema create](decree_schema_create.md)	 - Create a new schema from a YAML file
 * [decree schema delete](decree_schema_delete.md)	 - Delete a schema and all its versions (cascades to tenants)
 * [decree schema export](decree_schema_export.md)	 - Export a schema to YAML
 * [decree schema get](decree_schema_get.md)	 - Show a schema

--- a/docs/man/decree-schema.1
+++ b/docs/man/decree-schema.1
@@ -56,4 +56,4 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
 
 
 .SH SEE ALSO
-\fBdecree(1)\fP, \fBdecree-schema-create(1)\fP, \fBdecree-schema-delete(1)\fP, \fBdecree-schema-export(1)\fP, \fBdecree-schema-get(1)\fP, \fBdecree-schema-import(1)\fP, \fBdecree-schema-list(1)\fP, \fBdecree-schema-publish(1)\fP
+\fBdecree(1)\fP, \fBdecree-schema-delete(1)\fP, \fBdecree-schema-export(1)\fP, \fBdecree-schema-get(1)\fP, \fBdecree-schema-import(1)\fP, \fBdecree-schema-list(1)\fP, \fBdecree-schema-publish(1)\fP


### PR DESCRIPTION
## Summary

- `schema create` was a strict subset of `schema import` — both called the same `admin.ImportSchema` API, but `create` lacked the `--publish` flag that `import` supports
- Removing it eliminates the confusion of having two commands for the same operation, with one being strictly less capable

## Test plan

- [x] `TestSchemaCommand_HasSubcommands` updated to remove `create` from expected subcommands
- [x] `TestSchemaCreate_MissingFile_ErrorNotOnStdout` removed (command no longer exists)
- [x] `make test` passes — all packages green
- [x] `make lint-go` passes — 0 issues

Closes #713