### PR TITLE
fix(cli): reset rootCmd args after each arg-validation test

### DIFF
--- a/cmd/decree/signal_test.go
+++ b/cmd/decree/signal_test.go
@@ -15,6 +15,7 @@ import (
 // We exercise this by executing the root command with an already-cancelled
 // context and confirming the command returns without panicking.
 func TestMain_UsesSignalContext(t *testing.T) {
+	resetRootCmd(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // simulate Ctrl-C before execution
 


### PR DESCRIPTION
## Summary
- Add `resetRootCmd(t)` to `TestMain_UsesSignalContext` in `signal_test.go` — the one remaining test that called `rootCmd.SetArgs` without a cleanup reset.
- All other arg-validation tests already used `resetRootCmd` (added in #669); this closes the last gap.

## Test plan
- [x] Run `go test ./cmd/decree/...` — all pass
- [x] Run `make lint-go` — clean

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)