### PR TITLE
build: bump Go floor to 1.25.11 (stdlib vuln patch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
         # golang/govulncheck-action@v1
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
-          go-version-file: go.mod
+          go-version-input: "1.25"
           work-dir: .
 
   # Validates every checked-in *.decree.schema.yaml and *.decree.config.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,7 @@ jobs:
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
           go-version-file: go.mod
+          go-version-input: ""
           work-dir: .
 
   # Validates every checked-in *.decree.schema.yaml and *.decree.config.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
         # golang/govulncheck-action@v1
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
-          go-version-input: "1.25"
+          go-version-input: "1.25.11"
           work-dir: .
 
   # Validates every checked-in *.decree.schema.yaml and *.decree.config.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,6 @@ jobs:
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
           go-version-file: go.mod
-          go-version-input: ""
           work-dir: .
 
   # Validates every checked-in *.decree.schema.yaml and *.decree.config.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendecree/decree
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0


### PR DESCRIPTION
## Summary
- Go 1.25.7 has 10 published stdlib vulnerabilities (in net/textproto, crypto/x509, html/template, net, net/http, crypto/tls). All are fixed in go1.25.11.
- The govulncheck-action defaults `go-version-input` to `stable` (currently Go 1.26.3) and internally calls setup-go again, overriding the preceding setup-go step. Go 1.26.3 itself has 2 additional stdlib vulns fixed only in 1.26.4.
- Bumping go.mod to 1.25.11 clears the 1.25.x vuln findings. Setting `go-version-input: "1.25"` in the govulncheck step ensures analysis matches the project's Go floor instead of stable.

## Test plan
- [ ] Go vuln scan passes (no stdlib vulns reported)
- [ ] All other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)