### PR TITLE
fix(adminclient): pre-beta doc and test constant cleanup

### DIFF
--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -74,6 +74,11 @@ func (c *Client) QueryWriteLog(ctx context.Context, filters ...AuditFilter) ([]*
 // or a transport error occurs. After C is closed, read Err to check for errors.
 //
 // Memory usage is bounded to one page of entries at a time.
+//
+// Goroutine leak: the background goroutine blocks on sends to C. Callers must
+// either drain C to completion or cancel the context; otherwise the goroutine
+// leaks. Err is buffered (capacity 1) so the goroutine can always write its
+// error and exit once ctx is cancelled.
 type AuditIterator struct {
 	// C receives audit entries in server-returned order (newest first by default).
 	C chan *AuditEntry

--- a/sdk/adminclient/client_test.go
+++ b/sdk/adminclient/client_test.go
@@ -189,7 +189,7 @@ func TestCreateSchema_Success(t *testing.T) {
 		return &Schema{ID: "s1", Name: "payments", Version: 1, CreatedAt: time.Now()}, nil
 	}
 
-	s, err := client.CreateSchema(ctx, "payments", []Field{{Path: "a", Type: "STRING"}}, "test")
+	s, err := client.CreateSchema(ctx, "payments", []Field{{Path: "a", Type: FieldTypeString}}, "test")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -55,8 +55,9 @@ func (c *Client) GetConfigVersion(ctx context.Context, tenantID string, version 
 	})
 }
 
-// RollbackConfig creates a new config version with the values from a previous version.
-// The description is optional — pass an empty string to use the default.
+// RollbackConfig requests the server to create a new config version populated
+// with the values from the specified previous version.
+// The description is optional — pass an empty string to use the server default.
 func (c *Client) RollbackConfig(ctx context.Context, tenantID string, targetVersion int32, description string) (*Version, error) {
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured
@@ -95,13 +96,16 @@ type importConfigOptions struct {
 }
 
 // WithImportMode sets the import mode. Defaults to [ImportModeMerge] if not specified.
+// Note: passing the zero value (0) silently overrides the default — use an
+// explicit constant ([ImportModeMerge], [ImportModeReplace], [ImportModeDefaults]).
 func WithImportMode(mode ImportMode) ImportConfigOption {
 	return func(o *importConfigOptions) { o.mode = mode }
 }
 
-// ImportConfig applies configuration values from YAML, creating a new version.
-// The description is optional — pass an empty string to use the default.
-// Mode defaults to [ImportModeMerge] unless [WithImportMode] is passed.
+// ImportConfig sends YAML configuration to the server, which applies the values
+// and creates a new version. The description is optional — pass an empty string
+// to use the server default. Mode defaults to [ImportModeMerge] unless
+// [WithImportMode] is passed.
 func (c *Client) ImportConfig(ctx context.Context, tenantID string, yamlContent []byte, description string, opts ...ImportConfigOption) (*Version, error) {
 	if c.config == nil {
 		return nil, ErrServiceNotConfigured

--- a/sdk/adminclient/operations_test.go
+++ b/sdk/adminclient/operations_test.go
@@ -73,7 +73,7 @@ func TestUpdateSchema_Success(t *testing.T) {
 		return &Schema{ID: "s1", Version: 2, CreatedAt: time.Now()}, nil
 	}
 
-	s, err := client.UpdateSchema(context.Background(), "s1", []Field{{Path: "new", Type: "STRING"}}, []string{"old"}, "v2")
+	s, err := client.UpdateSchema(context.Background(), "s1", []Field{{Path: "new", Type: FieldTypeString}}, []string{"old"}, "v2")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/sdk/retry/retry.go
+++ b/sdk/retry/retry.go
@@ -17,7 +17,10 @@ type RetryableError struct {
 	Err error
 }
 
+// Error returns the underlying error message.
 func (e *RetryableError) Error() string { return e.Err.Error() }
+
+// Unwrap returns the wrapped error for use with [errors.As] and [errors.Is].
 func (e *RetryableError) Unwrap() error { return e.Err }
 
 // IsRetryable reports whether err is marked as retryable by the transport.


### PR DESCRIPTION
## Summary
- Document AuditIterator goroutine leak risk (Err buffered cap 1, must drain C or cancel ctx).
- Document WithImportMode(0) zero-value gotcha on ImportModeMerge default.
- Soften RollbackConfig/ImportConfig doc claims to match what the SDK actually enforces.
- Add doc comments to RetryableError.Error() and Unwrap().
- Replace bare "STRING" string literals in tests with FieldType* constants.

## Test plan
- [ ] make test passes
- [ ] make lint-go passes

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)