### PR TITLE
fix(configwatcher): pre-beta errorlint, dead-code, doc, and test cleanup

### DIFF
--- a/sdk/configwatcher/CHANGELOG.md
+++ b/sdk/configwatcher/CHANGELOG.md
@@ -9,7 +9,7 @@ This project uses semantic versioning with an `-alpha.N` suffix during alpha; th
 
 ### Added
 
-- `WithReconnectTimeout` bounds the `loadSnapshot` call during reconnect with an explicit timeout (#410)
+- `WithSnapshotTimeout` bounds the `loadSnapshot` call during reconnect with an explicit timeout (#410)
 - Subscribe stream-end reconnect semantics documented in package godoc
 
 ### Fixed

--- a/sdk/configwatcher/example_test.go
+++ b/sdk/configwatcher/example_test.go
@@ -62,7 +62,7 @@ func ExampleWatcher_Start() {
 	if err := w.Start(ctx); err != nil {
 		fmt.Println("start error:", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	// Get returns the current value; defaults are returned until the first snapshot.
 	fmt.Println(timeout.Get())
@@ -105,7 +105,7 @@ func ExampleWithReconnectBackoff() {
 	if err := w.Start(ctx); err != nil {
 		fmt.Println("start error:", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	fmt.Println(flag.Get())
 	// Output: false

--- a/sdk/configwatcher/value.go
+++ b/sdk/configwatcher/value.go
@@ -9,6 +9,12 @@ import (
 )
 
 // Change represents a value transition for a typed config field.
+//
+// When the [Value.Changes] channel is full and a new update arrives, the oldest
+// buffered Change is dropped so that the newest value is always delivered. This
+// means consumers that fall behind may observe a gap in the Old→New chain: the
+// Old of the next received Change may not match the New of the previously
+// received Change.
 type Change[T any] struct {
 	// Old is the previous value (or the default if WasNull is true).
 	Old T
@@ -76,6 +82,10 @@ func (v *Value[T]) DroppedCount() int64 {
 // Get returns the current value of the field. If the field is null or missing,
 // the default value provided during registration is returned.
 //
+// Get acquires a read-lock on each call. For high-frequency reads on a hot flag
+// consider caching the value locally and subscribing via [Value.Changes] instead
+// of polling Get in a tight loop.
+//
 // Get never blocks and is safe for concurrent use.
 func (v *Value[T]) Get() T {
 	v.mu.RLock()
@@ -94,7 +104,14 @@ func (v *Value[T]) GetWithNull() (val T, ok bool) {
 // Changes returns a channel that receives [Change] events whenever the field
 // value is updated via the subscription stream. The channel is buffered (capacity 16).
 //
-// The channel is closed when the [Watcher] is closed.
+// If the channel is full when a new update arrives, the oldest buffered Change
+// is evicted so the newest value is always delivered. See [Change] for how this
+// affects the Old→New chain. Use [Value.DroppedCount] to monitor how often this
+// occurs.
+//
+// The channel is closed exactly once by [Watcher.Close]. Any send that races
+// with Close is suppressed; callers must not send on the returned channel after
+// Close has been called.
 func (v *Value[T]) Changes() <-chan Change[T] {
 	return v.changesCh
 }

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -388,7 +388,7 @@ func (w *Watcher) subscriptionLoop(ctx context.Context, snapshotVersion int32) {
 			return // Context cancelled — clean shutdown.
 		}
 
-		if err == nil || err == io.EOF {
+		if err == nil || errors.Is(err, io.EOF) {
 			w.opts.logger.InfoContext(ctx, "subscription stream closed by server, reconnecting",
 				"backoff", backoff)
 		} else {
@@ -434,9 +434,6 @@ func (w *Watcher) subscribe(ctx context.Context, fieldPaths []string, snapshotVe
 		change, err := sub.Recv()
 		if err != nil {
 			return err
-		}
-		if change == nil {
-			continue
 		}
 
 		w.mu.RLock()

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -227,15 +227,13 @@ func TestWatcher_SnapshotAndStream(t *testing.T) {
 		NewValue:  configclient.FloatVal(0.05),
 	})
 
-	// Wait for change to propagate.
+	// Gate on the Changes() event — the value is applied before the event is sent.
 	select {
-	case ch := <-fee.Changes():
-		_ = ch
+	case <-fee.Changes():
 	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected change event on fee.Changes()")
 	}
 
-	// Read updated value.
-	time.Sleep(10 * time.Millisecond) // let stream update propagate
 	if got := fee.Get(); got != 0.05 {
 		t.Errorf("got %v, want %v", got, 0.05)
 	}


### PR DESCRIPTION
## Summary

- **errors.Is fix** (`watcher.go`): replace `err == io.EOF` with `errors.Is(err, io.EOF)` to correctly handle wrapped EOF errors (errorlint).
- **Dead branch removed** (`watcher.go` subscribe loop): drop the `if change == nil { continue }` branch — the production transport never returns a nil change on success.
- **Doc: `Change` and `Changes()`** (`value.go`): document the drop-oldest eviction policy and that consumers may observe gaps in the Old→New chain when the channel is full. Note DroppedCount for monitoring.
- **Doc: `Get()`** (`value.go`): document that Get acquires an RWMutex per call; suggest Changes()-based subscription for hot-flag use cases.
- **Doc: `Changes()` lifecycle** (`value.go`): document that the channel is closed exactly once by `Watcher.Close` and that sends racing with Close are suppressed.
- **CHANGELOG fix** (`CHANGELOG.md`): correct option name from `WithReconnectTimeout` to `WithSnapshotTimeout` (#410).
- **Event-driven test** (`watcher_test.go`): replace `time.Sleep(10ms)` + unconsumed-timeout select in `TestWatcher_SnapshotAndStream` with a gated `select` on `fee.Changes()` that fails the test on timeout.
- **defer error handling** (`example_test.go`): replace `defer w.Close()` with `defer func() { _ = w.Close() }()` to make the intentional error discard explicit.

## Test plan

- [x] `make test` — all 32 packages pass with `-race`
- [x] `make lint-go` — 0 issues, no fmt diff

Closes #718