### PR TITLE
fix(server): batch-fetch defaults snapshot in import DEFAULTS filter

### DIFF
--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -1478,24 +1478,32 @@ func (s *Service) filterByImportMode(ctx context.Context, tenantID string, lates
 		return values
 
 	case pb.ImportMode_IMPORT_MODE_DEFAULTS:
-		// Defaults: only include values for fields that have no current value.
+		// Defaults: only include values for fields that have no row in the
+		// current snapshot. Fetch the full snapshot once and filter in-memory
+		// to avoid N+1 (previously 2N) per-field round-trips.
+		if latestVersion == 0 {
+			return values // No existing config — include all.
+		}
+		rows, err := s.store.GetFullConfigAtVersion(ctx, GetFullConfigAtVersionParams{
+			TenantID: tenantID,
+			Version:  latestVersion,
+		})
+		if err != nil {
+			// On error, fall back to including all values (safe: worst case we
+			// overwrite defaults that are already set, which DEFAULTS mode
+			// normally prevents, but a DB error here is unexpected anyway).
+			s.logger.WarnContext(ctx, "filterByImportMode: failed to fetch snapshot for DEFAULTS filter, including all values", "error", err)
+			return values
+		}
+		existing := make(map[string]struct{}, len(rows))
+		for _, r := range rows {
+			existing[r.FieldPath] = struct{}{}
+		}
 		var filtered []configValueImport
 		for _, v := range values {
-			current := s.getCurrentValue(ctx, tenantID, v.FieldPath, latestVersion)
-			if current == "" {
-				// Check if the field truly has no value (not just empty string).
-				_, err := s.store.GetConfigValueAtVersion(ctx, GetConfigValueAtVersionParams{
-					TenantID:  tenantID,
-					FieldPath: v.FieldPath,
-					Version:   latestVersion,
-				})
-				if err != nil {
-					// Field doesn't exist — include it.
-					filtered = append(filtered, v)
-				}
-				// Field exists (even if empty) — skip.
+			if _, ok := existing[v.FieldPath]; !ok {
+				filtered = append(filtered, v)
 			}
-			// Field has a non-empty value — skip.
 		}
 		return filtered
 

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1145,6 +1145,74 @@ values:
 	store.AssertNotCalled(t, "GetFullConfigAtVersion")
 }
 
+func TestImportConfig_DefaultsMode_SnapshotFetchError_FallsBackToAll(t *testing.T) {
+	// When GetFullConfigAtVersion returns an error, filterByImportMode falls
+	// back to including all values (safe degradation) and the import proceeds.
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	yamlContent := []byte(`
+spec_version: "v1"
+values:
+  app.alpha:
+    value: "a"
+  app.beta:
+    value: "b"
+`)
+
+	store.On("GetTenantByID", ctx, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", ctx, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", ctx, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "app.alpha", FieldType: domain.FieldTypeString},
+			{Path: "app.beta", FieldType: domain.FieldTypeString},
+		}, nil)
+	store.On("GetFieldLocks", ctx, tenantID1).
+		Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 2}, nil)
+
+	// Snapshot fetch fails — should log a warning and include all values.
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
+		TenantID: tenantID1,
+		Version:  2,
+	}).Return([]GetFullConfigAtVersionRow{}, errors.New("db connection lost"))
+
+	// Both fields are included (fallback) — changeG old-value lookups follow.
+	store.On("GetConfigValueAtVersion", mock.Anything, mock.MatchedBy(func(p GetConfigValueAtVersionParams) bool {
+		return p.TenantID == tenantID1
+	})).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
+
+	newVersionID := versionID20
+	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: newVersionID, TenantID: tenantID1, Version: 3, CreatedBy: "unknown"}, nil)
+	store.On("BulkSetConfigValues", ctx, mock.MatchedBy(func(args []SetConfigValueParams) bool {
+		return len(args) == 2 // both fields written despite fetch error
+	})).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.MatchedBy(func(args []InsertAuditWriteLogParams) bool {
+		return len(args) == 2
+	})).Return(nil)
+	cache := &mockCache{}
+	pub := &mockPublisher{}
+	svc.cache = cache
+	svc.publisher = pub
+	cache.On("Invalidate", ctx, tenantID1).Return(nil)
+	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+
+	_, err := svc.ImportConfig(ctx, &pb.ImportConfigRequest{
+		TenantId:    tenantID1,
+		YamlContent: yamlContent,
+		Mode:        pb.ImportMode_IMPORT_MODE_DEFAULTS,
+	})
+
+	require.NoError(t, err)
+	// Both fields written — fallback included all values despite the fetch error.
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
+	store.AssertNumberOfCalls(t, "GetFullConfigAtVersion", 1)
+}
+
 // --- Usage Recording ---
 
 func TestGetField_RecordsUsage(t *testing.T) {

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -995,12 +995,17 @@ values:
 	store.On("GetLatestConfigVersion", ctx, tenantID1).
 		Return(domain.ConfigVersion{Version: 1}, nil)
 
-	// app.existing has a value -> should be skipped in defaults mode
-	store.On("GetConfigValueAtVersion", mock.Anything, mock.MatchedBy(func(p GetConfigValueAtVersionParams) bool {
-		return p.FieldPath == "app.existing"
-	})).Return(GetConfigValueAtVersionRow{Value: strPtr("already-set")}, nil)
+	// DEFAULTS filter: one bulk snapshot fetch instead of N per-field calls.
+	// app.existing is present in the snapshot → skipped by the filter.
+	// app.missing is absent from the snapshot → included.
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
+		TenantID: tenantID1,
+		Version:  1,
+	}).Return([]GetFullConfigAtVersionRow{
+		{FieldPath: "app.existing", Value: strPtr("already-set")},
+	}, nil)
 
-	// app.missing has no value -> should be included
+	// changeG old-value lookup: only app.missing survives the filter.
 	store.On("GetConfigValueAtVersion", mock.Anything, mock.MatchedBy(func(p GetConfigValueAtVersionParams) bool {
 		return p.FieldPath == "app.missing"
 	})).Return(GetConfigValueAtVersionRow{}, domain.ErrNotFound)
@@ -1028,8 +1033,116 @@ values:
 	})
 
 	require.NoError(t, err)
-	// Only app.missing should be set
+	// Only app.missing should be set — app.existing was already in the snapshot.
 	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
+	// Verify exactly one bulk snapshot fetch was made (no N+1).
+	store.AssertNumberOfCalls(t, "GetFullConfigAtVersion", 1)
+}
+
+func TestImportConfig_DefaultsMode_AllExistingReturnsAlreadyExists(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	yamlContent := []byte(`
+spec_version: "v1"
+values:
+  app.foo:
+    value: "from-yaml"
+  app.bar:
+    value: "from-yaml"
+`)
+
+	store.On("GetTenantByID", ctx, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", ctx, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", ctx, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "app.foo", FieldType: domain.FieldTypeString},
+			{Path: "app.bar", FieldType: domain.FieldTypeString},
+		}, nil)
+	store.On("GetFieldLocks", ctx, tenantID1).
+		Return([]domain.TenantFieldLock{}, nil)
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{Version: 3}, nil)
+
+	// Both fields exist in the snapshot — nothing should be written.
+	store.On("GetFullConfigAtVersion", mock.Anything, GetFullConfigAtVersionParams{
+		TenantID: tenantID1,
+		Version:  3,
+	}).Return([]GetFullConfigAtVersionRow{
+		{FieldPath: "app.foo", Value: strPtr("existing-foo")},
+		{FieldPath: "app.bar", Value: strPtr("existing-bar")},
+	}, nil)
+
+	_, err := svc.ImportConfig(ctx, &pb.ImportConfigRequest{
+		TenantId:    tenantID1,
+		YamlContent: yamlContent,
+		Mode:        pb.ImportMode_IMPORT_MODE_DEFAULTS,
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err), "all fields exist → AlreadyExists")
+	store.AssertNumberOfCalls(t, "GetFullConfigAtVersion", 1)
+	store.AssertNotCalled(t, "CreateConfigVersion")
+}
+
+func TestImportConfig_DefaultsMode_NoExistingConfig_IncludesAll(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := superadminCtx()
+
+	yamlContent := []byte(`
+spec_version: "v1"
+values:
+  app.alpha:
+    value: "a"
+  app.beta:
+    value: "b"
+`)
+
+	store.On("GetTenantByID", ctx, tenantID1).
+		Return(domain.Tenant{SchemaID: schemaID10, SchemaVersion: 1}, nil)
+	store.On("GetSchemaVersion", ctx, domain.SchemaVersionKey{SchemaID: schemaID10, Version: 1}).
+		Return(domain.SchemaVersion{ID: schemaVersionID}, nil)
+	store.On("GetSchemaFields", ctx, schemaVersionID).
+		Return([]domain.SchemaField{
+			{Path: "app.alpha", FieldType: domain.FieldTypeString},
+			{Path: "app.beta", FieldType: domain.FieldTypeString},
+		}, nil)
+	store.On("GetFieldLocks", ctx, tenantID1).
+		Return([]domain.TenantFieldLock{}, nil)
+	// Version 0 means no existing config.
+	store.On("GetLatestConfigVersion", ctx, tenantID1).
+		Return(domain.ConfigVersion{}, domain.ErrNotFound)
+
+	// No snapshot fetch should occur when latestVersion == 0.
+	newVersionID := versionID20
+	store.On("CreateConfigVersion", ctx, mock.AnythingOfType("config.CreateConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: newVersionID, TenantID: tenantID1, Version: 1, CreatedBy: "unknown"}, nil)
+	store.On("BulkSetConfigValues", ctx, mock.MatchedBy(func(args []SetConfigValueParams) bool {
+		return len(args) == 2
+	})).Return(nil)
+	store.On("BulkInsertAuditWriteLog", ctx, mock.MatchedBy(func(args []InsertAuditWriteLogParams) bool {
+		return len(args) == 2
+	})).Return(nil)
+	cache := &mockCache{}
+	pub := &mockPublisher{}
+	svc.cache = cache
+	svc.publisher = pub
+	cache.On("Invalidate", ctx, tenantID1).Return(nil)
+	pub.On("Publish", ctx, mock.AnythingOfType("pubsub.ConfigChangeEvent")).Return(nil)
+
+	_, err := svc.ImportConfig(ctx, &pb.ImportConfigRequest{
+		TenantId:    tenantID1,
+		YamlContent: yamlContent,
+		Mode:        pb.ImportMode_IMPORT_MODE_DEFAULTS,
+	})
+
+	require.NoError(t, err)
+	// All fields included (no existing config).
+	store.AssertCalled(t, "BulkSetConfigValues", ctx, mock.Anything)
+	// No bulk snapshot fetch — latestVersion was 0.
+	store.AssertNotCalled(t, "GetFullConfigAtVersion")
 }
 
 // --- Usage Recording ---


### PR DESCRIPTION
## Summary

- The DEFAULTS import filter was doing 2N database round-trips: one `GetConfigValueAtVersion` per field to read the current value, then a second call per field when the value was empty to distinguish "no row" from "empty string".
- This fix replaces those per-field calls with a single `GetFullConfigAtVersion` bulk snapshot fetch, then filters in memory by checking set membership — reducing round-trips from O(N) to O(1).
- When `latestVersion == 0` (no existing config), the bulk fetch is skipped entirely and all values are included directly.

## Test plan

- Updated `TestImportConfig_DefaultsMode_SkipsExistingValues` to mock `GetFullConfigAtVersion` instead of per-field `GetConfigValueAtVersion` calls; asserts exactly one snapshot fetch is made.
- Added `TestImportConfig_DefaultsMode_AllExistingReturnsAlreadyExists`: all fields present in snapshot → `AlreadyExists` returned, no version created, one snapshot fetch.
- Added `TestImportConfig_DefaultsMode_NoExistingConfig_IncludesAll`: version 0 fast-path → all fields included, `GetFullConfigAtVersion` never called.
- All three pass; full `make test` green (pre-existing `TestWatcher_SnapshotAndStream` timing failure in `sdk/configwatcher` is unrelated to this change).

Closes #674