### PR TITLE
refactor(grpctransport): pre-beta polish — auth guard, nil safety, doc fixes

### DIFF
--- a/sdk/grpctransport/auth.go
+++ b/sdk/grpctransport/auth.go
@@ -1,6 +1,3 @@
-// Package grpctransport implements the configclient.Transport,
-// adminclient.SchemaTransport, adminclient.ConfigTransport, and
-// adminclient.AuditTransport interfaces using gRPC.
 package grpctransport
 
 import (
@@ -35,16 +32,19 @@ type authConfig struct {
 }
 
 // WithSubject sets the x-subject metadata header.
+// Ignored when [WithBearerToken] or [WithTokenSource] is set.
 func WithSubject(s string) Option {
 	return func(c *config) { c.auth.subject = s }
 }
 
 // WithRole sets the x-role metadata header.
+// Ignored when [WithBearerToken] or [WithTokenSource] is set.
 func WithRole(r string) Option {
 	return func(c *config) { c.auth.role = r }
 }
 
 // WithTenantID sets the x-tenant-id metadata header.
+// Ignored when [WithBearerToken] or [WithTokenSource] is set.
 func WithTenantID(id string) Option {
 	return func(c *config) { c.auth.tenantID = id }
 }
@@ -123,6 +123,11 @@ func (t tokenSourceCreds) GetRequestMetadata(ctx context.Context, _ ...string) (
 	tok, err := t.source(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if tok == "" {
+		// Skip setting the Authorization header rather than sending a malformed
+		// "Bearer " credential. The server will treat the request as unauthenticated.
+		return nil, nil
 	}
 	return map[string]string{"authorization": "Bearer " + tok}, nil
 }

--- a/sdk/grpctransport/config_transport.go
+++ b/sdk/grpctransport/config_transport.go
@@ -41,11 +41,11 @@ func (t *ConfigTransport) GetField(ctx context.Context, req *configclient.GetFie
 	if err != nil {
 		return nil, mapConfigError(err)
 	}
-	cv := resp.GetValue()
+	cv := configValueFromProto(resp.GetValue())
 	return &configclient.GetFieldResponse{
-		FieldPath: cv.GetFieldPath(),
-		Value:     typedValueFromProto(cv.GetValue()),
-		Checksum:  cv.GetChecksum(),
+		FieldPath: cv.FieldPath,
+		Value:     cv.Value,
+		Checksum:  cv.Checksum,
 	}, nil
 }
 

--- a/sdk/grpctransport/convenience.go
+++ b/sdk/grpctransport/convenience.go
@@ -3,7 +3,6 @@ package grpctransport
 import (
 	"google.golang.org/grpc"
 
-	pb "github.com/opendecree/decree/api/centralconfig/v1"
 	"github.com/opendecree/decree/sdk/adminclient"
 	"github.com/opendecree/decree/sdk/configclient"
 	"github.com/opendecree/decree/sdk/configwatcher"
@@ -21,9 +20,9 @@ func NewConfigClient(conn grpc.ClientConnInterface, opts ...Option) (*configclie
 	if err != nil {
 		return nil, err
 	}
-	transport := &ConfigTransport{
-		rpc:  pb.NewConfigServiceClient(conn),
-		auth: newAuthApplier(cfg.auth),
+	transport, err := NewConfigTransport(conn, opts...)
+	if err != nil {
+		return nil, err
 	}
 	return configclient.New(transport, cfg.clientOpts...), nil
 }
@@ -37,15 +36,23 @@ func NewConfigClient(conn grpc.ClientConnInterface, opts ...Option) (*configclie
 //	conn, _ := grpctransport.Dial("localhost:50051", grpctransport.WithInsecure())
 //	client, err := grpctransport.NewAdminClient(conn, grpctransport.WithSubject("admin"), grpctransport.WithRole("superadmin"))
 func NewAdminClient(conn grpc.ClientConnInterface, opts ...Option) (*adminclient.Client, error) {
-	cfg, err := buildConfig(opts)
+	schemaTr, err := NewSchemaTransport(conn, opts...)
+	if err != nil {
+		return nil, err
+	}
+	configTr, err := NewAdminConfigTransport(conn, opts...)
+	if err != nil {
+		return nil, err
+	}
+	auditTr, err := NewAuditTransport(conn, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return adminclient.New(
-		adminclient.WithSchemaTransport(&SchemaTransport{rpc: pb.NewSchemaServiceClient(conn), auth: newAuthApplier(cfg.auth)}),
-		adminclient.WithConfigTransport(&AdminConfigTransport{rpc: pb.NewConfigServiceClient(conn), auth: newAuthApplier(cfg.auth)}),
-		adminclient.WithAuditTransport(&AuditTransport{rpc: pb.NewAuditServiceClient(conn), auth: newAuthApplier(cfg.auth)}),
-		adminclient.WithServerTransport(&ServerTransport{rpc: pb.NewServerServiceClient(conn)}),
+		adminclient.WithSchemaTransport(schemaTr),
+		adminclient.WithConfigTransport(configTr),
+		adminclient.WithAuditTransport(auditTr),
+		adminclient.WithServerTransport(NewServerTransport(conn)),
 	), nil
 }
 
@@ -61,9 +68,9 @@ func NewWatcher(conn grpc.ClientConnInterface, tenantID string, opts ...Option) 
 	if err != nil {
 		return nil, err
 	}
-	transport := &ConfigTransport{
-		rpc:  pb.NewConfigServiceClient(conn),
-		auth: newAuthApplier(cfg.auth),
+	transport, err := NewConfigTransport(conn, opts...)
+	if err != nil {
+		return nil, err
 	}
 	return configwatcher.New(transport, tenantID, cfg.watcherOpts...), nil
 }

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -73,6 +73,12 @@ func typedValueToProto(tv *configclient.TypedValue) *pb.TypedValue {
 
 // --- ConfigValue conversion ---
 
+// configValueFromProto converts a proto ConfigValue to the SDK type.
+//
+// TODO: pb.ConfigValue.Description is dropped here and the post-write
+// ConfigVersion returned by SetField/SetFields is discarded into empty DTOs.
+// Notify configclient owners if Description or post-write version info is
+// ever needed by callers.
 func configValueFromProto(cv *pb.ConfigValue) configclient.ConfigValue {
 	return configclient.ConfigValue{
 		FieldPath: cv.GetFieldPath(),

--- a/sdk/grpctransport/convert_test.go
+++ b/sdk/grpctransport/convert_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func ptrF64(f float64) *float64 { return &f }
-func ptrI32(i int32) *int32     { return &i }
 
 // --- TypedValue round-trips ---
 
@@ -653,5 +652,4 @@ func TestSchemaFromProto_Basic(t *testing.T) {
 	}
 }
 
-// ptrF64 and ptrI32 are used in TestConstraintsRoundTrip_ExclusiveMinMax.
-var _ = ptrI32
+// ptrF64 is used in TestConstraintsRoundTrip_ExclusiveMinMax.

--- a/sdk/grpctransport/dial.go
+++ b/sdk/grpctransport/dial.go
@@ -61,6 +61,9 @@ func WithKeepalive(params keepalive.ClientParameters) DialOption {
 
 // Dial opens a gRPC connection to target with TLS and system roots by default.
 //
+// The caller owns the returned [*grpc.ClientConn] and must call Close on it
+// when done, even if the connection was also passed to a transport constructor.
+//
 // Keepalive is enabled by default (Time=30s, Timeout=10s,
 // PermitWithoutStream=true) to prevent silent connection drops on long-lived
 // watch streams. Override with [WithKeepalive].
@@ -89,6 +92,9 @@ func Dial(target string, opts ...DialOption) (*grpc.ClientConn, error) {
 	case cfg.customCA != nil:
 		creds = credentials.NewTLS(&tls.Config{RootCAs: cfg.customCA})
 	default:
+		// An empty tls.Config uses system roots, derives the SNI from the target
+		// address, and enables full certificate verification. This is the secure
+		// default for production connections.
 		creds = credentials.NewTLS(&tls.Config{})
 	}
 

--- a/sdk/grpctransport/dial_test.go
+++ b/sdk/grpctransport/dial_test.go
@@ -18,6 +18,11 @@ func TestDial_DefaultTLS(t *testing.T) {
 	conn.Close()
 }
 
+// TODO: There is no test that verifies WithInsecure yields a plaintext
+// connection vs a TLS one. grpc.NewClient is lazy — it does not dial until
+// the first RPC, so we cannot inspect transport-level security without a live
+// server. Add a round-trip integration test (e.g. using an in-process server)
+// when the e2e harness is extended to cover transport configuration.
 func TestDial_WithInsecure(t *testing.T) {
 	conn, err := grpctransport.Dial("passthrough:///localhost:9999", grpctransport.WithInsecure())
 	if err != nil {

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -27,6 +27,10 @@ func mapConfigError(err error) error {
 	case codes.FailedPrecondition:
 		return configclient.ErrLocked
 	case codes.Aborted:
+		// Aborted is dual-purpose: it fires for checksum mismatches (optimistic
+		// concurrency) AND for concurrent-write conflicts where no checksum was
+		// supplied. The server does not yet use a distinct code or status detail
+		// to distinguish the two cases, so both map to ErrChecksumMismatch.
 		return configclient.ErrChecksumMismatch
 	case codes.AlreadyExists:
 		return configclient.ErrAlreadyExists

--- a/sdk/grpctransport/server_transport.go
+++ b/sdk/grpctransport/server_transport.go
@@ -22,6 +22,9 @@ func NewServerTransport(conn grpc.ClientConnInterface) *ServerTransport {
 	return &ServerTransport{rpc: pb.NewServerServiceClient(conn)}
 }
 
+// GetServerInfo is intentionally auth-exempt: the server bypasses auth checks
+// for this endpoint so callers can retrieve version/feature information before
+// establishing credentials.
 func (t *ServerTransport) GetServerInfo(ctx context.Context) (*adminclient.ServerInfo, error) {
 	resp, err := t.rpc.GetServerInfo(ctx, &pb.GetServerInfoRequest{})
 	if err != nil {

--- a/sdk/grpctransport/subscription.go
+++ b/sdk/grpctransport/subscription.go
@@ -22,7 +22,9 @@ func (s *grpcSubscription) Recv() (*configclient.ConfigChange, error) {
 	}
 	change := resp.GetChange()
 	if change == nil {
-		return &configclient.ConfigChange{}, nil
+		// A nil proto change has no meaningful data; return nil so the watcher's
+		// nil-skip logic can engage rather than delivering an empty ConfigChange.
+		return nil, nil
 	}
 	return &configclient.ConfigChange{
 		TenantID:  change.GetTenantId(),


### PR DESCRIPTION
## Summary
- Guards against empty token from `tokenSource` sending a malformed `Bearer ` header, and nil proto subscription change producing a non-nil empty `ConfigChange{}` that bypasses watcher nil-skip logic.
- Centralizes `ConfigValue`→DTO mapping in `config_transport.go` to reuse `configValueFromProto` instead of inlining, and refactors `convenience.go` to delegate to the public `NewXTransport` constructors.
- Adds doc comments for ownership, TLS defaults, auth-exempt endpoints, and ignored-when-token-set options to close documentation gaps found in the pre-beta review.

## Test plan
- `make test` passes for all modules (pre-existing `TestWatcher_SnapshotAndStream` flake on main is unrelated).
- `sdk/grpctransport` and `sdk/configclient` tests pass cleanly.

Closes #719