### PR TITLE
refactor(tools): pre-beta polish — type guard, dead code, doc fixes

### DIFF
--- a/sdk/tools/diff/diff.go
+++ b/sdk/tools/diff/diff.go
@@ -87,13 +87,13 @@ func (r *Result) Format() string {
 // Compare computes the diff between two config snapshots.
 // Each snapshot is a map of field-path to value (as strings).
 // Results are sorted by path for deterministic output.
-func Compare(old, new map[string]string) *Result {
+func Compare(old, updated map[string]string) *Result {
 	// Collect all unique paths.
-	paths := make(map[string]struct{}, len(old)+len(new))
+	paths := make(map[string]struct{}, len(old)+len(updated))
 	for p := range old {
 		paths[p] = struct{}{}
 	}
-	for p := range new {
+	for p := range updated {
 		paths[p] = struct{}{}
 	}
 
@@ -106,7 +106,7 @@ func Compare(old, new map[string]string) *Result {
 	var changes []FieldChange
 	for _, p := range sorted {
 		oldVal, inOld := old[p]
-		newVal, inNew := new[p]
+		newVal, inNew := updated[p]
 
 		switch {
 		case inOld && !inNew:

--- a/sdk/tools/docgen/docgen.go
+++ b/sdk/tools/docgen/docgen.go
@@ -13,9 +13,11 @@ import (
 type Schema struct {
 	Name        string
 	Description string
-	Version     int32
-	Info        *SchemaInfo
-	Fields      []Field
+	// Version is the schema version number. A value of 0 means the version is
+	// not set and will be omitted from the generated documentation.
+	Version int32
+	Info    *SchemaInfo
+	Fields  []Field
 }
 
 // SchemaInfo contains optional schema-level metadata.
@@ -176,6 +178,10 @@ type fieldGroup struct {
 	fields []Field
 }
 
+// groupByPrefix groups fields by their top-level path prefix. Deterministic
+// group order relies on the caller having sorted fields by Path beforehand (as
+// Generate does via sort.Slice), so the first occurrence of each prefix
+// establishes insertion order.
 func groupByPrefix(fields []Field) []fieldGroup {
 	var groups []fieldGroup
 	groupMap := make(map[string]int) // prefix → index in groups
@@ -338,6 +344,10 @@ func yesNo(v bool) string {
 	return "no"
 }
 
+// formatFloat formats a float64 for display, omitting the decimal point when
+// the value is a whole number.
+// TODO: this is byte-identical to validate.formatFloat; if a shared internal
+// package is added to sdk/tools, hoist both copies there.
 func formatFloat(f float64) string {
 	if f == float64(int64(f)) {
 		return fmt.Sprintf("%d", int64(f))

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -70,6 +70,11 @@ func Run(ctx context.Context, client Client, tenantID string, opts ...Option) (*
 		return nil, fmt.Errorf("exporting config: %w", err)
 	}
 
+	// NOTE: the exported YAML is unmarshaled into an anonymous struct that only
+	// captures fields representable by seed.ConfigValueDef (value + description).
+	// Any additional top-level keys in the exported YAML (e.g. spec_version,
+	// metadata) are silently dropped. This is intentional — the dump only
+	// preserves the data that seed.Run can re-apply.
 	var configDoc struct {
 		Values map[string]seed.ConfigValueDef `yaml:"values"`
 	}
@@ -118,7 +123,15 @@ func buildSchemaDef(s *adminclient.Schema) seed.SchemaDef {
 	}
 
 	for _, f := range s.Fields {
+		// NOTE: Fields is keyed by f.Path. If the server ever returns duplicate
+		// paths the later entry silently overwrites the earlier one. This mirrors
+		// the server's own uniqueness guarantee, but if that breaks the dump will
+		// be incomplete without any error.
 		fd := seed.FieldDef{
+			// f.Type is cast directly to string. An empty or unrecognised
+			// FieldType (e.g. from a server running a newer schema format)
+			// will produce `type: ""` in the YAML, which seed.ParseFile will
+			// accept but the server will reject on re-import.
 			Type:        string(f.Type),
 			Description: f.Description,
 			Default:     f.Default,

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -158,8 +158,10 @@ type Client interface {
 
 // --- Parse ---
 
-// ParseFile parses and validates a seed YAML file. Validation depends on which
-// top-level sections are present; see the package docs for the valid shapes.
+// ParseFile parses a seed YAML file and performs structural validation (required
+// fields, valid section combinations). It does not perform type or value
+// validation of field values — use the validate package for that. See the
+// package docs for the valid section combinations.
 func ParseFile(data []byte) (*File, error) {
 	var f File
 	if err := yaml.Unmarshal(data, &f); err != nil {
@@ -334,6 +336,10 @@ func resolveSchemaRef(ctx context.Context, client Client, file *File, result *Re
 		for _, s := range schemas {
 			if s.Name == file.Tenant.Schema {
 				result.SchemaID = s.ID
+				// NOTE: schema_version is taken from the seed file as-is after
+				// confirming the schema name exists. The version number is not
+				// verified against the server, so a bad version will propagate
+				// to CreateTenant and fail there with a server-side error.
 				result.SchemaVersion = *file.Tenant.SchemaVersion
 				return nil
 			}

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -23,35 +23,41 @@ import (
 
 // SchemaFile is the parsed representation of a schema YAML file.
 type SchemaFile struct {
-	SpecVersion        string              `yaml:"spec_version"`
-	Schema             string              `yaml:"$schema,omitempty"`
-	ID                 string              `yaml:"$id,omitempty"`
-	Name               string              `yaml:"name"`
-	Description        string              `yaml:"description,omitempty"`
-	Version            int32               `yaml:"version,omitempty"`
-	VersionDescription string              `yaml:"version_description,omitempty"`
-	Info               any                 `yaml:"info,omitempty"`
-	Fields             map[string]FieldDef `yaml:"fields"`
+	SpecVersion        string `yaml:"spec_version"`
+	Schema             string `yaml:"$schema,omitempty"`
+	ID                 string `yaml:"$id,omitempty"`
+	Name               string `yaml:"name"`
+	Description        string `yaml:"description,omitempty"`
+	Version            int32  `yaml:"version,omitempty"`
+	VersionDescription string `yaml:"version_description,omitempty"`
+	// Info is accepted for forward-compatibility with richer schema formats but
+	// is not used by the offline validator.
+	Info   any                 `yaml:"info,omitempty"`
+	Fields map[string]FieldDef `yaml:"fields"`
 }
 
 // FieldDef describes a single field in the schema YAML.
 type FieldDef struct {
-	Type         string          `yaml:"type"`
-	Description  string          `yaml:"description,omitempty"`
-	Default      string          `yaml:"default,omitempty"`
-	Nullable     bool            `yaml:"nullable,omitempty"`
-	Deprecated   bool            `yaml:"deprecated,omitempty"`
-	RedirectTo   string          `yaml:"redirect_to,omitempty"`
-	Constraints  *ConstraintsDef `yaml:"constraints,omitempty"`
-	Title        string          `yaml:"title,omitempty"`
-	Example      string          `yaml:"example,omitempty"`
-	Examples     any             `yaml:"examples,omitempty"`
-	ExternalDocs any             `yaml:"externalDocs,omitempty"`
-	Tags         []string        `yaml:"tags,omitempty"`
-	Format       string          `yaml:"format,omitempty"`
-	ReadOnly     bool            `yaml:"readOnly,omitempty"`
-	WriteOnce    bool            `yaml:"writeOnce,omitempty"`
-	Sensitive    bool            `yaml:"sensitive,omitempty"`
+	Type        string          `yaml:"type"`
+	Description string          `yaml:"description,omitempty"`
+	Default     string          `yaml:"default,omitempty"`
+	Nullable    bool            `yaml:"nullable,omitempty"`
+	Deprecated  bool            `yaml:"deprecated,omitempty"`
+	RedirectTo  string          `yaml:"redirect_to,omitempty"`
+	Constraints *ConstraintsDef `yaml:"constraints,omitempty"`
+	Title       string          `yaml:"title,omitempty"`
+	Example     string          `yaml:"example,omitempty"`
+	// Examples and ExternalDocs are accepted for forward-compatibility but are
+	// not used by the offline validator.
+	Examples     any      `yaml:"examples,omitempty"`
+	ExternalDocs any      `yaml:"externalDocs,omitempty"`
+	Tags         []string `yaml:"tags,omitempty"`
+	// Format is accepted for forward-compatibility but is not used by the
+	// offline validator.
+	Format    string `yaml:"format,omitempty"`
+	ReadOnly  bool   `yaml:"readOnly,omitempty"`
+	WriteOnce bool   `yaml:"writeOnce,omitempty"`
+	Sensitive bool   `yaml:"sensitive,omitempty"`
 }
 
 // ConstraintsDef uses OAS-style naming for field constraints.
@@ -191,11 +197,6 @@ func ParseConfig(data []byte) (*ConfigFile, error) {
 // Validate checks a config file against a schema file.
 // Both are provided as raw YAML bytes.
 func Validate(schemaYAML, configYAML []byte, opts ...Option) (*Result, error) {
-	var o options
-	for _, opt := range opts {
-		opt(&o)
-	}
-
 	schema, err := ParseSchema(schemaYAML)
 	if err != nil {
 		return nil, fmt.Errorf("schema: %w", err)
@@ -258,32 +259,41 @@ func validateValue(result *Result, path string, value any, fd FieldDef) {
 		return
 	}
 
+	// typeOK tracks whether the base type check passed. If it did not, the enum
+	// check is skipped to avoid a second, misleading violation for the same bad value.
+	typeOK := true
 	switch fd.Type {
 	case "integer":
-		validateInteger(result, path, value, fd.Constraints)
+		typeOK = validateInteger(result, path, value, fd.Constraints)
 	case "number":
-		validateNumber(result, path, value, fd.Constraints)
+		typeOK = validateNumber(result, path, value, fd.Constraints)
 	case "string":
-		validateString(result, path, value, fd.Constraints)
+		typeOK = validateString(result, path, value, fd.Constraints)
 	case "bool":
-		validateBool(result, path, value)
+		typeOK = validateBool(result, path, value)
 	case "time":
-		validateStringType(result, path, value, "time")
+		typeOK = validateStringType(result, path, value, "time")
 	case "duration":
-		validateDuration(result, path, value, fd.Constraints)
+		typeOK = validateDuration(result, path, value, fd.Constraints)
 	case "url":
-		validateURL(result, path, value)
+		typeOK = validateURL(result, path, value)
 	case "json":
 		validateJSON(result, path, value)
+		// json values may be maps or slices; enum on json is not meaningful, so
+		// always skip the enum check for json fields regardless of typeOK.
+		return
 	}
 
-	// Enum check applies to any type.
-	if fd.Constraints != nil && len(fd.Constraints.Enum) > 0 {
+	// Enum check applies to scalar types (integer, number, string, bool, time,
+	// duration, url). It is skipped when the base type validation already failed,
+	// since comparing a mistyped value against the enum list yields a redundant
+	// violation.
+	if typeOK && fd.Constraints != nil && len(fd.Constraints.Enum) > 0 {
 		validateEnum(result, path, value, fd.Constraints.Enum)
 	}
 }
 
-func validateInteger(result *Result, path string, value any, c *ConstraintsDef) {
+func validateInteger(result *Result, path string, value any, c *ConstraintsDef) bool {
 	var n float64
 	switch v := value.(type) {
 	case int:
@@ -297,19 +307,20 @@ func validateInteger(result *Result, path string, value any, c *ConstraintsDef) 
 	case float64:
 		if v != math.Trunc(v) {
 			result.add(path, fmt.Sprintf("expected integer, got %v", v))
-			return
+			return false
 		}
 		n = v
 	default:
 		result.add(path, fmt.Sprintf("expected integer, got %T", value))
-		return
+		return false
 	}
 	if c != nil {
 		validateNumericConstraints(result, path, n, c)
 	}
+	return true
 }
 
-func validateNumber(result *Result, path string, value any, c *ConstraintsDef) {
+func validateNumber(result *Result, path string, value any, c *ConstraintsDef) bool {
 	var n float64
 	switch v := value.(type) {
 	case int:
@@ -324,21 +335,22 @@ func validateNumber(result *Result, path string, value any, c *ConstraintsDef) {
 		n = v
 	default:
 		result.add(path, fmt.Sprintf("expected number, got %T", value))
-		return
+		return false
 	}
 	if c != nil {
 		validateNumericConstraints(result, path, n, c)
 	}
+	return true
 }
 
-func validateString(result *Result, path string, value any, c *ConstraintsDef) {
+func validateString(result *Result, path string, value any, c *ConstraintsDef) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected string, got %T", value))
-		return
+		return false
 	}
 	if c == nil {
-		return
+		return true
 	}
 	if c.MinLength != nil && int32(len([]rune(s))) < *c.MinLength {
 		result.add(path, fmt.Sprintf("length %d is less than minLength %d", len([]rune(s)), *c.MinLength))
@@ -354,50 +366,56 @@ func validateString(result *Result, path string, value any, c *ConstraintsDef) {
 			result.add(path, fmt.Sprintf("value %q does not match pattern %q", s, c.Pattern))
 		}
 	}
+	return true
 }
 
-func validateBool(result *Result, path string, value any) {
+func validateBool(result *Result, path string, value any) bool {
 	if _, ok := value.(bool); !ok {
 		result.add(path, fmt.Sprintf("expected bool, got %T", value))
+		return false
 	}
+	return true
 }
 
-func validateStringType(result *Result, path string, value any, typeName string) {
+func validateStringType(result *Result, path string, value any, typeName string) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected %s (string), got %T", typeName, value))
-		return
+		return false
 	}
 	if typeName == "time" {
 		if _, err := time.Parse(time.RFC3339, s); err != nil {
 			result.add(path, fmt.Sprintf("invalid time value %q: must be RFC3339 format", s))
 		}
 	}
+	return true
 }
 
-func validateDuration(result *Result, path string, value any, _ *ConstraintsDef) {
+func validateDuration(result *Result, path string, value any, _ *ConstraintsDef) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected duration (string), got %T", value))
-		return
+		return false
 	}
 	if _, err := time.ParseDuration(s); err != nil {
 		result.add(path, fmt.Sprintf("invalid duration value %q: %v", s, err))
 	}
 	// Numeric constraints on duration are validated server-side after parsing;
 	// offline validation only checks the type and syntax.
+	return true
 }
 
-func validateURL(result *Result, path string, value any) {
+func validateURL(result *Result, path string, value any) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected url (string), got %T", value))
-		return
+		return false
 	}
 	u, err := url.Parse(s)
 	if err != nil || !u.IsAbs() {
 		result.add(path, fmt.Sprintf("invalid absolute URL: %q", s))
 	}
+	return true
 }
 
 func validateJSON(result *Result, path string, value any) {


### PR DESCRIPTION
## Summary
- Returns a bool from base type validators (`validateURL`, `validateTime`, `validateDuration`, `validateBool`) so the enum check is skipped when the base type already fails — prevents duplicate violations for a single bad value.
- Removes a dead `var o options` loop in `Validate` and renames the `new` builtin-shadowing parameter in `diff.Compare` to `updated`.
- Adds forward-compat comments on unused parsed fields (`SchemaFile.Info`, `FieldDef.Format`/`ExternalDocs`) and documents silent-drop behaviors in `dump` and `seed` for future contributors.

## Test plan
- `make test` passes for all modules (pre-existing `TestWatcher_SnapshotAndStream` flake on main is unrelated).
- `sdk/tools` validate, diff, docgen, dump, and seed tests pass cleanly.

Closes #720