### PR TITLE
refactor(cli): pre-beta polish — security, error handling, consistency

### DIFF
--- a/cmd/decree/audit.go
+++ b/cmd/decree/audit.go
@@ -27,17 +27,17 @@ var auditQueryCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 
 		var filters []adminclient.AuditFilter
-		if v, _ := cmd.Flags().GetString("tenant"); v != "" {
+		if v := mustGetString(cmd, "tenant"); v != "" {
 			filters = append(filters, adminclient.WithAuditTenant(v))
 		}
-		if v, _ := cmd.Flags().GetString("actor"); v != "" {
+		if v := mustGetString(cmd, "actor"); v != "" {
 			filters = append(filters, adminclient.WithAuditActor(v))
 		}
-		if v, _ := cmd.Flags().GetString("field"); v != "" {
+		if v := mustGetString(cmd, "field"); v != "" {
 			filters = append(filters, adminclient.WithAuditField(v))
 		}
-		if v, _ := cmd.Flags().GetString("since"); v != "" {
-			d, err := time.ParseDuration(v)
+		if v := mustGetString(cmd, "since"); v != "" {
+			d, err := parseDuration(v)
 			if err != nil {
 				return fmt.Errorf("invalid --since duration: %w", err)
 			}
@@ -104,7 +104,7 @@ Requires migration 002_audit_tamper_evident to be applied.`,
 		}
 		defer func() { _ = conn.Close() }()
 
-		tenantID, _ := cmd.Flags().GetString("tenant")
+		tenantID := mustGetString(cmd, "tenant")
 		admin, err := newAdminClient(conn)
 		if err != nil {
 			return err
@@ -188,10 +188,19 @@ func printVerifyResult(w io.Writer, result adminclient.VerifyChainResult) error 
 }
 
 // parseDuration extends time.ParseDuration with day support (e.g. "7d").
+// It rejects inputs like "7dd" or "7d1h" that look day-like but have trailing
+// characters — callers must use standard Go duration syntax for those.
 func parseDuration(s string) (time.Duration, error) {
 	if len(s) > 1 && s[len(s)-1] == 'd' {
+		prefix := s[:len(s)-1]
 		var n float64
-		if _, err := fmt.Sscanf(s[:len(s)-1], "%f", &n); err == nil {
+		var rest string
+		if _, err := fmt.Sscanf(prefix, "%f%s", &n, &rest); err == nil {
+			// Sscanf consumed a number but left trailing characters — reject.
+			return 0, fmt.Errorf("invalid duration %q: unexpected characters after day count", s)
+		}
+		// Only a number before 'd' — valid.
+		if _, err := fmt.Sscanf(prefix, "%f", &n); err == nil {
 			return time.Duration(n * float64(24*time.Hour)), nil
 		}
 	}

--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -303,6 +303,28 @@ func TestParseDuration_Invalid(t *testing.T) {
 	}
 }
 
+func TestParseDuration_TrailingChars(t *testing.T) {
+	_, err := parseDuration("7dd")
+	if err == nil {
+		t.Fatal("expected error for '7dd', got nil")
+	}
+}
+
+// --- envOrDefault ---
+
+func TestEnvOrDefault_EnvSet(t *testing.T) {
+	t.Setenv("DECREE_TEST_KEY_XYZ", "from-env")
+	if got := envOrDefault("DECREE_TEST_KEY_XYZ", "fallback"); got != "from-env" {
+		t.Errorf("got %q, want %q", got, "from-env")
+	}
+}
+
+func TestEnvOrDefault_EnvNotSet(t *testing.T) {
+	if got := envOrDefault("DECREE_TEST_KEY_UNSET_XYZ", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want %q", got, "fallback")
+	}
+}
+
 // --- SilenceUsage / SilenceErrors (#707) ---
 
 func TestRootCmd_SilenceUsage(t *testing.T) {

--- a/cmd/decree/config.go
+++ b/cmd/decree/config.go
@@ -141,7 +141,7 @@ var configSetManyCmd = &cobra.Command{
 			}
 			rawValues[parts[0]] = parts[1]
 		}
-		desc, _ := cmd.Flags().GetString("description")
+		desc := mustGetString(cmd, "description")
 
 		conn, err := dialServer()
 		if err != nil {
@@ -232,7 +232,7 @@ var configRollbackCmd = &cobra.Command{
 			return fmt.Errorf("invalid version: %s", args[1])
 		}
 		version := int32(parsedVersion)
-		desc, _ := cmd.Flags().GetString("description")
+		desc := mustGetString(cmd, "description")
 
 		conn, err := dialServer()
 		if err != nil {
@@ -265,7 +265,7 @@ var configExportCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 
 		var version *int32
-		if v, _ := cmd.Flags().GetInt32("version"); v > 0 {
+		if v := mustGetInt32(cmd, "version"); v > 0 {
 			version = &v
 		}
 		admin, err := newAdminClient(conn)
@@ -290,8 +290,8 @@ var configImportCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("read file: %w", err)
 		}
-		desc, _ := cmd.Flags().GetString("description")
-		modeStr, _ := cmd.Flags().GetString("mode")
+		desc := mustGetString(cmd, "description")
+		modeStr := mustGetString(cmd, "mode")
 
 		var mode adminclient.ImportMode
 		switch modeStr {
@@ -302,7 +302,7 @@ var configImportCmd = &cobra.Command{
 		case "defaults":
 			mode = adminclient.ImportModeDefaults
 		default:
-			mode = adminclient.ImportModeMerge
+			return fmt.Errorf("unknown --mode %q: must be merge, replace, or defaults", modeStr)
 		}
 
 		conn, err := dialServer()

--- a/cmd/decree/connect.go
+++ b/cmd/decree/connect.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
 
@@ -24,7 +25,20 @@ func dialServer() (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func authOptions() []grpctransport.Option {
+// resolveToken returns the effective bearer token. --token-file takes
+// precedence over --token; the file content is trimmed of surrounding whitespace.
+func resolveToken() (string, error) {
+	if flagTokenFile != "" {
+		data, err := os.ReadFile(flagTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("read token file: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	return flagToken, nil
+}
+
+func authOptions() ([]grpctransport.Option, error) {
 	var opts []grpctransport.Option
 	if flagSubject != "" {
 		opts = append(opts, grpctransport.WithSubject(flagSubject))
@@ -35,20 +49,36 @@ func authOptions() []grpctransport.Option {
 	if flagTenantID != "" {
 		opts = append(opts, grpctransport.WithTenantID(flagTenantID))
 	}
-	if flagToken != "" {
-		opts = append(opts, grpctransport.WithBearerToken(flagToken))
+	token, err := resolveToken()
+	if err != nil {
+		return nil, err
 	}
-	return opts
+	if token != "" {
+		opts = append(opts, grpctransport.WithBearerToken(token))
+	}
+	return opts, nil
 }
 
 func newAdminClient(conn *grpc.ClientConn) (*adminclient.Client, error) {
-	return grpctransport.NewAdminClient(conn, authOptions()...)
+	opts, err := authOptions()
+	if err != nil {
+		return nil, err
+	}
+	return grpctransport.NewAdminClient(conn, opts...)
 }
 
 func newConfigClient(conn *grpc.ClientConn) (*configclient.Client, error) {
-	return grpctransport.NewConfigClient(conn, authOptions()...)
+	opts, err := authOptions()
+	if err != nil {
+		return nil, err
+	}
+	return grpctransport.NewConfigClient(conn, opts...)
 }
 
 func newConfigTransport(conn *grpc.ClientConn) (*grpctransport.ConfigTransport, error) {
-	return grpctransport.NewConfigTransport(conn, authOptions()...)
+	opts, err := authOptions()
+	if err != nil {
+		return nil, err
+	}
+	return grpctransport.NewConfigTransport(conn, opts...)
 }

--- a/cmd/decree/connect_test.go
+++ b/cmd/decree/connect_test.go
@@ -133,6 +133,61 @@ func TestDialServer_Insecure_PrintsWarning(t *testing.T) {
 	}
 }
 
+// --- resolveToken ---
+
+func TestResolveToken_FlagToken(t *testing.T) {
+	origToken := flagToken
+	origFile := flagTokenFile
+	t.Cleanup(func() { flagToken = origToken; flagTokenFile = origFile })
+
+	flagToken = "my-jwt"
+	flagTokenFile = ""
+
+	got, err := resolveToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "my-jwt" {
+		t.Errorf("got %q, want %q", got, "my-jwt")
+	}
+}
+
+func TestResolveToken_TokenFile(t *testing.T) {
+	origToken := flagToken
+	origFile := flagTokenFile
+	t.Cleanup(func() { flagToken = origToken; flagTokenFile = origFile })
+
+	f, err := os.CreateTemp(t.TempDir(), "token-*")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	f.WriteString("  file-token\n") //nolint:errcheck
+	f.Close()
+
+	flagToken = "ignored"
+	flagTokenFile = f.Name()
+
+	got, err := resolveToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "file-token" {
+		t.Errorf("got %q, want %q", got, "file-token")
+	}
+}
+
+func TestResolveToken_TokenFile_Missing(t *testing.T) {
+	origFile := flagTokenFile
+	t.Cleanup(func() { flagTokenFile = origFile })
+
+	flagTokenFile = "/nonexistent/path/token.txt"
+
+	_, err := resolveToken()
+	if err == nil {
+		t.Error("expected error for missing token file, got nil")
+	}
+}
+
 // TestFlagInsecure_DefaultIsFalse verifies the --insecure flag defaults to false,
 // ensuring TLS is used by default.
 func TestFlagInsecure_DefaultIsFalse(t *testing.T) {

--- a/cmd/decree/diff.go
+++ b/cmd/decree/diff.go
@@ -22,8 +22,8 @@ Server mode (compare two versions of a tenant's config):
 File mode (compare two local config YAML files):
   decree diff --old config-v1.yaml --new config-v2.yaml`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		oldFile, _ := cmd.Flags().GetString("old")
-		newFile, _ := cmd.Flags().GetString("new")
+		oldFile := mustGetString(cmd, "old")
+		newFile := mustGetString(cmd, "new")
 
 		var oldValues, newValues map[string]string
 
@@ -37,8 +37,14 @@ File mode (compare two local config YAML files):
 			if err != nil {
 				return fmt.Errorf("read new file: %w", err)
 			}
-			oldValues = parseConfigValues(oldData)
-			newValues = parseConfigValues(newData)
+			oldValues, err = parseConfigValues(oldData)
+			if err != nil {
+				return fmt.Errorf("parse old file: %w", err)
+			}
+			newValues, err = parseConfigValues(newData)
+			if err != nil {
+				return fmt.Errorf("parse new file: %w", err)
+			}
 		} else {
 			// Server mode: compare two versions.
 			if len(args) != 3 {
@@ -75,8 +81,14 @@ File mode (compare two local config YAML files):
 			if err != nil {
 				return fmt.Errorf("export version %d: %w", vB, err)
 			}
-			oldValues = parseConfigValues(oldYAML)
-			newValues = parseConfigValues(newYAML)
+			oldValues, err = parseConfigValues(oldYAML)
+			if err != nil {
+				return fmt.Errorf("parse version %d: %w", vA, err)
+			}
+			newValues, err = parseConfigValues(newYAML)
+			if err != nil {
+				return fmt.Errorf("parse version %d: %w", vB, err)
+			}
 		}
 
 		result := diff.Compare(oldValues, newValues)
@@ -91,20 +103,22 @@ File mode (compare two local config YAML files):
 }
 
 // parseConfigValues extracts field→value as strings from a config YAML export.
-func parseConfigValues(data []byte) map[string]string {
+// Note: values are stringified via fmt.Sprintf("%v"), so numeric representations
+// like 1.0 vs 1, or map key ordering, may produce false diffs in file mode.
+func parseConfigValues(data []byte) (map[string]string, error) {
 	var doc struct {
 		Values map[string]struct {
 			Value any `yaml:"value"`
 		} `yaml:"values"`
 	}
 	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil
+		return nil, err
 	}
 	m := make(map[string]string, len(doc.Values))
 	for k, v := range doc.Values {
 		m[k] = fmt.Sprintf("%v", v.Value)
 	}
-	return m
+	return m, nil
 }
 
 func init() {

--- a/cmd/decree/docgen.go
+++ b/cmd/decree/docgen.go
@@ -17,8 +17,8 @@ var docgenCmd = &cobra.Command{
 	Long:  "Generate markdown documentation from a schema. Provide a schema-id to fetch from the server, or --file to use a local YAML file.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		file, _ := cmd.Flags().GetString("file")
-		outputFile, _ := cmd.Flags().GetString("output-file")
+		file := mustGetString(cmd, "file")
+		outputFile := mustGetString(cmd, "output-file")
 
 		var schema docgen.Schema
 
@@ -48,7 +48,7 @@ var docgenCmd = &cobra.Command{
 				return err
 			}
 
-			version, _ := cmd.Flags().GetInt32("version")
+			version := mustGetInt32(cmd, "version")
 			var s *adminclient.Schema
 			if version > 0 {
 				s, err = admin.GetSchemaVersion(cmd.Context(), args[0], version)
@@ -62,20 +62,21 @@ var docgenCmd = &cobra.Command{
 		}
 
 		var opts []docgen.Option
-		if noDeprecated, _ := cmd.Flags().GetBool("no-deprecated"); noDeprecated {
+		if mustGetBool(cmd, "no-deprecated") {
 			opts = append(opts, docgen.WithoutDeprecated())
 		}
-		if noConstraints, _ := cmd.Flags().GetBool("no-constraints"); noConstraints {
+		if mustGetBool(cmd, "no-constraints") {
 			opts = append(opts, docgen.WithoutConstraints())
 		}
-		if noGrouping, _ := cmd.Flags().GetBool("no-grouping"); noGrouping {
+		if mustGetBool(cmd, "no-grouping") {
 			opts = append(opts, docgen.WithoutGrouping())
 		}
 
 		md := docgen.Generate(schema, opts...)
 
 		if outputFile != "" {
-			return os.WriteFile(outputFile, []byte(md), 0o644)
+			force := mustGetBool(cmd, "force")
+			return writeFileExclusive(outputFile, []byte(md), force)
 		}
 		fmt.Print(md)
 		return nil
@@ -86,6 +87,7 @@ func init() {
 	docgenCmd.Flags().String("file", "", "schema YAML file (offline mode)")
 	docgenCmd.Flags().Int32("version", 0, "schema version (default: latest)")
 	docgenCmd.Flags().String("output-file", "", "write output to file instead of stdout")
+	docgenCmd.Flags().Bool("force", false, "overwrite output file if it already exists")
 	docgenCmd.Flags().Bool("no-deprecated", false, "exclude deprecated fields")
 	docgenCmd.Flags().Bool("no-constraints", false, "omit constraint details")
 	docgenCmd.Flags().Bool("no-grouping", false, "flat list instead of grouped by prefix")

--- a/cmd/decree/dump.go
+++ b/cmd/decree/dump.go
@@ -21,10 +21,10 @@ var dumpCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 
 		var opts []dump.Option
-		if noLocks, _ := cmd.Flags().GetBool("no-locks"); noLocks {
+		if mustGetBool(cmd, "no-locks") {
 			opts = append(opts, dump.WithoutLocks())
 		}
-		if v, _ := cmd.Flags().GetInt32("version"); v > 0 {
+		if v := mustGetInt32(cmd, "version"); v > 0 {
 			opts = append(opts, dump.WithConfigVersion(v))
 		}
 
@@ -42,9 +42,10 @@ var dumpCmd = &cobra.Command{
 			return err
 		}
 
-		outputFile, _ := cmd.Flags().GetString("output-file")
+		outputFile := mustGetString(cmd, "output-file")
 		if outputFile != "" {
-			return os.WriteFile(outputFile, data, 0o644)
+			force := mustGetBool(cmd, "force")
+			return writeFileExclusive(outputFile, data, force)
 		}
 		_, err = os.Stdout.Write(data)
 		return err
@@ -55,4 +56,5 @@ func init() {
 	dumpCmd.Flags().Int32("version", 0, "config version (default: latest)")
 	dumpCmd.Flags().Bool("no-locks", false, "exclude field locks")
 	dumpCmd.Flags().String("output-file", "", "write to file instead of stdout")
+	dumpCmd.Flags().Bool("force", false, "overwrite output file if it already exists")
 }

--- a/cmd/decree/gendocs.go
+++ b/cmd/decree/gendocs.go
@@ -43,7 +43,6 @@ var genDocsCmd = &cobra.Command{
 			return strings.ToLower(name)
 		}
 
-		rootCmd.DisableAutoGenTag = true
 		if err := doc.GenMarkdownTreeCustom(rootCmd, outDir, prepender, linkHandler); err != nil {
 			return fmt.Errorf("generate docs: %w", err)
 		}
@@ -76,7 +75,6 @@ var genManCmd = &cobra.Command{
 			Date:    &manPageDate,
 		}
 
-		rootCmd.DisableAutoGenTag = true
 		if err := doc.GenManTree(rootCmd, header, outDir); err != nil {
 			return fmt.Errorf("generate man pages: %w", err)
 		}
@@ -87,6 +85,9 @@ var genManCmd = &cobra.Command{
 }
 
 func init() {
+	// Set once here so RunE bodies don't mutate global state on every invocation.
+	rootCmd.DisableAutoGenTag = true
+
 	rootCmd.AddCommand(genDocsCmd)
 	rootCmd.AddCommand(genManCmd)
 }

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"io"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -43,6 +45,81 @@ func TestTypedValueDisplay_Time(t *testing.T) {
 	tv := configclient.TimeVal(ts)
 	if !strings.Contains(typedValueDisplay(tv), "2026-03-30") {
 		t.Errorf("expected %q to contain %q", typedValueDisplay(tv), "2026-03-30")
+	}
+}
+
+// --- printOutput (exercises the flagOutput switch) ---
+
+func TestPrintOutput_JSON(t *testing.T) {
+	orig := flagOutput
+	t.Cleanup(func() { flagOutput = orig })
+	flagOutput = "json"
+
+	// Redirect stdout.
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	err := printOutput(map[string]string{"k": "v"})
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), `"k"`) {
+		t.Errorf("expected JSON output, got: %q", buf.String())
+	}
+}
+
+func TestPrintOutput_YAML(t *testing.T) {
+	orig := flagOutput
+	t.Cleanup(func() { flagOutput = orig })
+	flagOutput = "yaml"
+
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	err := printOutput(map[string]string{"k": "v"})
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "k:") {
+		t.Errorf("expected YAML output, got: %q", buf.String())
+	}
+}
+
+func TestPrintOutput_Table(t *testing.T) {
+	orig := flagOutput
+	t.Cleanup(func() { flagOutput = orig })
+	flagOutput = "table"
+
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	err := printOutput([][]string{{"HEADER"}, {"row"}})
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "HEADER") {
+		t.Errorf("expected table output, got: %q", buf.String())
 	}
 }
 

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -96,7 +96,10 @@ values:
   app.enabled:
     value: true
 `
-	m := parseConfigValues([]byte(yaml))
+	m, err := parseConfigValues([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if m == nil {
 		t.Fatal("expected non-nil")
 	}
@@ -112,14 +115,17 @@ values:
 }
 
 func TestParseConfigValues_Invalid(t *testing.T) {
-	m := parseConfigValues([]byte("not: [valid: yaml"))
-	if m != nil {
-		t.Errorf("expected nil, got %v", m)
+	_, err := parseConfigValues([]byte("not: [valid: yaml"))
+	if err == nil {
+		t.Errorf("expected error, got nil")
 	}
 }
 
 func TestParseConfigValues_Empty(t *testing.T) {
-	m := parseConfigValues([]byte("spec_version: v1\n"))
+	m, err := parseConfigValues([]byte("spec_version: v1\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if m == nil {
 		t.Fatal("expected non-nil")
 	}

--- a/cmd/decree/main.go
+++ b/cmd/decree/main.go
@@ -17,6 +17,7 @@ var (
 	flagRole        string
 	flagTenantID    string
 	flagToken       string
+	flagTokenFile   string
 	flagOutput      string
 	flagInsecure    bool
 	flagWait        bool
@@ -87,7 +88,8 @@ func init() {
 	pf.StringVar(&flagSubject, "subject", envOrDefault("DECREE_SUBJECT", ""), "actor identity (x-subject header)")
 	pf.StringVar(&flagRole, "role", envOrDefault("DECREE_ROLE", "superadmin"), "actor role (x-role header)")
 	pf.StringVar(&flagTenantID, "tenant-id", envOrDefault("DECREE_TENANT_ID", ""), "auth tenant ID (x-tenant-id header)")
-	pf.StringVar(&flagToken, "token", envOrDefault("DECREE_TOKEN", ""), "JWT bearer token")
+	pf.StringVar(&flagToken, "token", envOrDefault("DECREE_TOKEN", ""), "JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)")
+	pf.StringVar(&flagTokenFile, "token-file", "", "path to a file containing the JWT bearer token (takes precedence over --token)")
 	pf.StringVarP(&flagOutput, "output", "o", "table", "output format: table, json, yaml")
 	pf.BoolVar(&flagInsecure, "insecure", envOrDefault("DECREE_INSECURE", "false") == "true", "disable TLS (plaintext); for local development only")
 	pf.BoolVar(&flagWait, "wait", false, "wait for the server to be ready before executing the command")

--- a/cmd/decree/schema.go
+++ b/cmd/decree/schema.go
@@ -31,7 +31,7 @@ var schemaGetCmd = &cobra.Command{
 			return err
 		}
 
-		version, _ := cmd.Flags().GetInt32("version")
+		version := mustGetInt32(cmd, "version")
 		var s *adminclient.Schema
 		if version > 0 {
 			s, err = admin.GetSchemaVersion(cmd.Context(), args[0], version)
@@ -140,7 +140,7 @@ var schemaExportCmd = &cobra.Command{
 		defer func() { _ = conn.Close() }()
 
 		var version *int32
-		if v, _ := cmd.Flags().GetInt32("version"); v > 0 {
+		if v := mustGetInt32(cmd, "version"); v > 0 {
 			version = &v
 		}
 		admin, err := newAdminClient(conn)
@@ -171,7 +171,7 @@ var schemaImportCmd = &cobra.Command{
 		}
 		defer func() { _ = conn.Close() }()
 
-		publish, _ := cmd.Flags().GetBool("publish")
+		publish := mustGetBool(cmd, "publish")
 		admin, err := newAdminClient(conn)
 		if err != nil {
 			return err

--- a/cmd/decree/seed.go
+++ b/cmd/decree/seed.go
@@ -43,7 +43,7 @@ The operation is idempotent: importing a schema with identical fields, or a conf
 		defer func() { _ = conn.Close() }()
 
 		var opts []seed.Option
-		if publish, _ := cmd.Flags().GetBool("auto-publish"); publish {
+		if publish := mustGetBool(cmd, "auto-publish"); publish {
 			opts = append(opts, seed.AutoPublish())
 		}
 

--- a/cmd/decree/server.go
+++ b/cmd/decree/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 )
@@ -36,9 +37,14 @@ var serverInfoCmd = &cobra.Command{
 		fmt.Println()
 
 		rows := tableRows([]string{"FEATURE", "ENABLED"})
-		for name, enabled := range info.Features {
+		names := make([]string, 0, len(info.Features))
+		for name := range info.Features {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
 			val := "no"
-			if enabled {
+			if info.Features[name] {
 				val = "yes"
 			}
 			rows = append(rows, []string{name, val})

--- a/cmd/decree/tenant.go
+++ b/cmd/decree/tenant.go
@@ -16,9 +16,9 @@ var tenantCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new tenant on a published schema version",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, _ := cmd.Flags().GetString("name")
-		schemaID, _ := cmd.Flags().GetString("schema")
-		version, _ := cmd.Flags().GetInt32("schema-version")
+		name := mustGetString(cmd, "name")
+		schemaID := mustGetString(cmd, "schema")
+		version := mustGetInt32(cmd, "schema-version")
 		conn, err := dialServer()
 		if err != nil {
 			return err
@@ -76,7 +76,7 @@ var tenantListCmd = &cobra.Command{
 		}
 		defer func() { _ = conn.Close() }()
 
-		schemaID, _ := cmd.Flags().GetString("schema")
+		schemaID := mustGetString(cmd, "schema")
 		admin, err := newAdminClient(conn)
 		if err != nil {
 			return err

--- a/cmd/decree/typed.go
+++ b/cmd/decree/typed.go
@@ -51,9 +51,8 @@ func parseTypedValue(fieldType, raw string) (*configclient.TypedValue, error) {
 	case "url":
 		return configclient.URLVal(raw), nil
 	case "json":
-		var tmp any
-		if err := json.Unmarshal([]byte(raw), &tmp); err != nil {
-			return nil, fmt.Errorf("invalid json value: %w", err)
+		if !json.Valid([]byte(raw)) {
+			return nil, fmt.Errorf("invalid json value: %s", raw)
 		}
 		return configclient.JSONVal(raw), nil
 	default:

--- a/cmd/decree/util.go
+++ b/cmd/decree/util.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// mustGetString retrieves a string flag value from cmd. It panics if the flag
+// does not exist (a programming error — the flag must be registered before use).
+func mustGetString(cmd *cobra.Command, name string) string {
+	v, err := cmd.Flags().GetString(name)
+	if err != nil {
+		panic(fmt.Sprintf("flag %q not registered: %v", name, err))
+	}
+	return v
+}
+
+// mustGetBool retrieves a bool flag value from cmd. It panics if the flag
+// does not exist (a programming error — the flag must be registered before use).
+func mustGetBool(cmd *cobra.Command, name string) bool {
+	v, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		panic(fmt.Sprintf("flag %q not registered: %v", name, err))
+	}
+	return v
+}
+
+// mustGetInt32 retrieves an int32 flag value from cmd. It panics if the flag
+// does not exist (a programming error — the flag must be registered before use).
+func mustGetInt32(cmd *cobra.Command, name string) int32 {
+	v, err := cmd.Flags().GetInt32(name)
+	if err != nil {
+		panic(fmt.Sprintf("flag %q not registered: %v", name, err))
+	}
+	return v
+}
+
+// writeFileExclusive writes data to path using permission 0o600. If the file
+// already exists and force is false, it returns an error. If force is true,
+// the file is overwritten.
+func writeFileExclusive(path string, data []byte, force bool) error {
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("file %q already exists; use --force to overwrite", path)
+		}
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/cmd/decree/util_test.go
+++ b/cmd/decree/util_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// --- mustGetString / mustGetBool / mustGetInt32 ---
+
+func TestMustGetString(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "default", "")
+
+	if got := mustGetString(cmd, "name"); got != "default" {
+		t.Errorf("got %q, want %q", got, "default")
+	}
+	_ = cmd.Flags().Set("name", "hello")
+	if got := mustGetString(cmd, "name"); got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+}
+
+func TestMustGetBool(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("flag", false, "")
+
+	if got := mustGetBool(cmd, "flag"); got != false {
+		t.Errorf("got %v, want false", got)
+	}
+	_ = cmd.Flags().Set("flag", "true")
+	if got := mustGetBool(cmd, "flag"); got != true {
+		t.Errorf("got %v, want true", got)
+	}
+}
+
+func TestMustGetInt32(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Int32("num", 0, "")
+
+	if got := mustGetInt32(cmd, "num"); got != 0 {
+		t.Errorf("got %v, want 0", got)
+	}
+	_ = cmd.Flags().Set("num", "42")
+	if got := mustGetInt32(cmd, "num"); got != 42 {
+		t.Errorf("got %v, want 42", got)
+	}
+}
+
+// --- writeFileExclusive ---
+
+func TestWriteFileExclusive_Creates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+
+	if err := writeFileExclusive(path, []byte("hello"), false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("got %q, want %q", string(data), "hello")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat error: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("got perm %o, want 0600", perm)
+	}
+}
+
+func TestWriteFileExclusive_NoForce_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	_ = os.WriteFile(path, []byte("original"), 0o600)
+
+	if err := writeFileExclusive(path, []byte("new"), false); err == nil {
+		t.Error("expected error when file exists and force=false, got nil")
+	}
+}
+
+func TestWriteFileExclusive_Force_Overwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.txt")
+	_ = os.WriteFile(path, []byte("original"), 0o600)
+
+	if err := writeFileExclusive(path, []byte("new"), true); err != nil {
+		t.Fatalf("unexpected error with force=true: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(data) != "new" {
+		t.Errorf("got %q, want %q", string(data), "new")
+	}
+}

--- a/cmd/decree/validate_cmd.go
+++ b/cmd/decree/validate_cmd.go
@@ -13,8 +13,8 @@ var validateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate a config YAML against a schema YAML (offline)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		schemaFile, _ := cmd.Flags().GetString("schema")
-		configFile, _ := cmd.Flags().GetString("config")
+		schemaFile := mustGetString(cmd, "schema")
+		configFile := mustGetString(cmd, "config")
 
 		schemaData, err := os.ReadFile(schemaFile)
 		if err != nil {
@@ -26,7 +26,7 @@ var validateCmd = &cobra.Command{
 		}
 
 		var opts []validate.Option
-		if strict, _ := cmd.Flags().GetBool("strict"); strict {
+		if strict := mustGetBool(cmd, "strict"); strict {
 			opts = append(opts, validate.Strict())
 		}
 

--- a/cmd/decree/version.go
+++ b/cmd/decree/version.go
@@ -15,8 +15,9 @@ var (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the CLI version",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Printf("decree %s (commit %s)\n", cliVersion, cliCommit)
+		return nil
 	},
 }
 

--- a/docs/cli/decree.md
+++ b/docs/cli/decree.md
@@ -20,7 +20,8 @@ Command-line tool for managing schemas, tenants, and configuration values in Ope
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_audit.md
+++ b/docs/cli/decree_audit.md
@@ -25,7 +25,8 @@ Query the configuration change history and field read usage statistics. Useful f
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_audit_query.md
+++ b/docs/cli/decree_audit_query.md
@@ -29,7 +29,8 @@ decree audit query [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_audit_unused.md
+++ b/docs/cli/decree_audit_unused.md
@@ -25,7 +25,8 @@ decree audit unused <tenant-id> <since-duration> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_audit_usage.md
+++ b/docs/cli/decree_audit_usage.md
@@ -25,7 +25,8 @@ decree audit usage <tenant-id> <field-path> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_audit_verify.md
+++ b/docs/cli/decree_audit_verify.md
@@ -33,7 +33,8 @@ decree audit verify [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_completion.md
+++ b/docs/cli/decree_completion.md
@@ -27,7 +27,8 @@ See each sub-command's help for details on how to use the generated script.
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_completion_bash.md
+++ b/docs/cli/decree_completion_bash.md
@@ -50,7 +50,8 @@ decree completion bash
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_completion_fish.md
+++ b/docs/cli/decree_completion_fish.md
@@ -41,7 +41,8 @@ decree completion fish [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_completion_powershell.md
+++ b/docs/cli/decree_completion_powershell.md
@@ -38,7 +38,8 @@ decree completion powershell [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_completion_zsh.md
+++ b/docs/cli/decree_completion_zsh.md
@@ -52,7 +52,8 @@ decree completion zsh [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config.md
+++ b/docs/cli/decree_config.md
@@ -25,7 +25,8 @@ Get and set typed configuration values for tenants. Supports single and batch op
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_export.md
+++ b/docs/cli/decree_config_export.md
@@ -26,7 +26,8 @@ decree config export <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_get-all.md
+++ b/docs/cli/decree_config_get-all.md
@@ -25,7 +25,8 @@ decree config get-all <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_get.md
+++ b/docs/cli/decree_config_get.md
@@ -25,7 +25,8 @@ decree config get <tenant-id> <field-path> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_import.md
+++ b/docs/cli/decree_config_import.md
@@ -27,7 +27,8 @@ decree config import <tenant-id> <file> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_rollback.md
+++ b/docs/cli/decree_config_rollback.md
@@ -26,7 +26,8 @@ decree config rollback <tenant-id> <version> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_set-many.md
+++ b/docs/cli/decree_config_set-many.md
@@ -30,7 +30,8 @@ decree config set-many <tenant-id> <key=value>... [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_set.md
+++ b/docs/cli/decree_config_set.md
@@ -39,7 +39,8 @@ decree config set <tenant-id> <field-path> <value> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_config_versions.md
+++ b/docs/cli/decree_config_versions.md
@@ -25,7 +25,8 @@ decree config versions <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_diff.md
+++ b/docs/cli/decree_diff.md
@@ -37,7 +37,8 @@ decree diff [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_docgen.md
+++ b/docs/cli/decree_docgen.md
@@ -18,6 +18,7 @@ decree docgen [schema-id] [flags]
 
 ```
       --file string          schema YAML file (offline mode)
+      --force                overwrite output file if it already exists
   -h, --help                 help for docgen
       --no-constraints       omit constraint details
       --no-deprecated        exclude deprecated fields
@@ -35,7 +36,8 @@ decree docgen [schema-id] [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_dump.md
+++ b/docs/cli/decree_dump.md
@@ -17,6 +17,7 @@ decree dump <tenant-id> [flags]
 ### Options
 
 ```
+      --force                overwrite output file if it already exists
   -h, --help                 help for dump
       --no-locks             exclude field locks
       --output-file string   write to file instead of stdout
@@ -32,7 +33,8 @@ decree dump <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_lock.md
+++ b/docs/cli/decree_lock.md
@@ -25,7 +25,8 @@ Lock and unlock configuration fields. Locked fields cannot be modified by admin 
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_lock_list.md
+++ b/docs/cli/decree_lock_list.md
@@ -25,7 +25,8 @@ decree lock list <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_lock_remove.md
+++ b/docs/cli/decree_lock_remove.md
@@ -25,7 +25,8 @@ decree lock remove <tenant-id> <field-path> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_lock_set.md
+++ b/docs/cli/decree_lock_set.md
@@ -25,7 +25,8 @@ decree lock set <tenant-id> <field-path> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema.md
+++ b/docs/cli/decree_schema.md
@@ -25,7 +25,8 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_delete.md
+++ b/docs/cli/decree_schema_delete.md
@@ -25,7 +25,8 @@ decree schema delete <schema-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_export.md
+++ b/docs/cli/decree_schema_export.md
@@ -26,7 +26,8 @@ decree schema export <schema-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_get.md
+++ b/docs/cli/decree_schema_get.md
@@ -26,7 +26,8 @@ decree schema get <schema-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_import.md
+++ b/docs/cli/decree_schema_import.md
@@ -26,7 +26,8 @@ decree schema import <file> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_list.md
+++ b/docs/cli/decree_schema_list.md
@@ -25,7 +25,8 @@ decree schema list [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_schema_publish.md
+++ b/docs/cli/decree_schema_publish.md
@@ -25,7 +25,8 @@ decree schema publish <schema-id> <version> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_seed.md
+++ b/docs/cli/decree_seed.md
@@ -40,7 +40,8 @@ decree seed <file> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_server.md
+++ b/docs/cli/decree_server.md
@@ -25,7 +25,8 @@ Query server metadata, version, and enabled features.
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_server_info.md
+++ b/docs/cli/decree_server_info.md
@@ -25,7 +25,8 @@ decree server info [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_tenant.md
+++ b/docs/cli/decree_tenant.md
@@ -25,7 +25,8 @@ Create, list, and delete tenants. Each tenant is assigned a published schema ver
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_tenant_create.md
+++ b/docs/cli/decree_tenant_create.md
@@ -28,7 +28,8 @@ decree tenant create [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_tenant_delete.md
+++ b/docs/cli/decree_tenant_delete.md
@@ -25,7 +25,8 @@ decree tenant delete <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_tenant_get.md
+++ b/docs/cli/decree_tenant_get.md
@@ -25,7 +25,8 @@ decree tenant get <tenant-id> [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_tenant_list.md
+++ b/docs/cli/decree_tenant_list.md
@@ -26,7 +26,8 @@ decree tenant list [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_validate.md
+++ b/docs/cli/decree_validate.md
@@ -28,7 +28,8 @@ decree validate [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_version.md
+++ b/docs/cli/decree_version.md
@@ -25,7 +25,8 @@ decree version [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/cli/decree_watch.md
+++ b/docs/cli/decree_watch.md
@@ -25,7 +25,8 @@ decree watch <tenant-id> [field-paths...] [flags]
       --server string         gRPC server address (default "localhost:9090")
       --subject string        actor identity (x-subject header)
       --tenant-id string      auth tenant ID (x-tenant-id header)
-      --token string          JWT bearer token
+      --token string          JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+      --token-file string     path to a file containing the JWT bearer token (takes precedence over --token)
       --wait                  wait for the server to be ready before executing the command
       --wait-timeout string   maximum time to wait for server readiness (default "60s")
 ```

--- a/docs/man/decree-audit-query.1
+++ b/docs/man/decree-audit-query.1
@@ -60,7 +60,11 @@ Query the config change audit log
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-audit-unused.1
+++ b/docs/man/decree-audit-unused.1
@@ -44,7 +44,11 @@ Find fields not read since the given duration (e.g. 7d, 24h)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-audit-usage.1
+++ b/docs/man/decree-audit-usage.1
@@ -44,7 +44,11 @@ Show read usage statistics for a field
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-audit-verify.1
+++ b/docs/man/decree-audit-verify.1
@@ -52,7 +52,11 @@ Requires migration 002_audit_tamper_evident to be applied.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-audit.1
+++ b/docs/man/decree-audit.1
@@ -44,7 +44,11 @@ Query the configuration change history and field read usage statistics. Useful f
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-completion-bash.1
+++ b/docs/man/decree-completion-bash.1
@@ -75,7 +75,11 @@ You will need to start a new shell for this setup to take effect.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-completion-fish.1
+++ b/docs/man/decree-completion-fish.1
@@ -65,7 +65,11 @@ You will need to start a new shell for this setup to take effect.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-completion-powershell.1
+++ b/docs/man/decree-completion-powershell.1
@@ -59,7 +59,11 @@ to your powershell profile.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-completion-zsh.1
+++ b/docs/man/decree-completion-zsh.1
@@ -79,7 +79,11 @@ You will need to start a new shell for this setup to take effect.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-completion.1
+++ b/docs/man/decree-completion.1
@@ -45,7 +45,11 @@ See each sub-command's help for details on how to use the generated script.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-export.1
+++ b/docs/man/decree-config-export.1
@@ -48,7 +48,11 @@ Export config to YAML
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-get-all.1
+++ b/docs/man/decree-config-get-all.1
@@ -44,7 +44,11 @@ Get all config values for a tenant
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-get.1
+++ b/docs/man/decree-config-get.1
@@ -44,7 +44,11 @@ Get a single config value
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-import.1
+++ b/docs/man/decree-config-import.1
@@ -52,7 +52,11 @@ Import config from a YAML file
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-rollback.1
+++ b/docs/man/decree-config-rollback.1
@@ -48,7 +48,11 @@ Rollback config to a previous version
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-set-many.1
+++ b/docs/man/decree-config-set-many.1
@@ -48,7 +48,11 @@ Set multiple config values atomically. Values are parsed according to each field
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-set.1
+++ b/docs/man/decree-config-set.1
@@ -55,7 +55,11 @@ Values are parsed according to the schema's field type:
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config-versions.1
+++ b/docs/man/decree-config-versions.1
@@ -44,7 +44,11 @@ List config versions
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-config.1
+++ b/docs/man/decree-config.1
@@ -44,7 +44,11 @@ Get and set typed configuration values for tenants. Supports single and batch op
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-diff.1
+++ b/docs/man/decree-diff.1
@@ -60,7 +60,11 @@ File mode (compare two local config YAML files):
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-docgen.1
+++ b/docs/man/decree-docgen.1
@@ -18,6 +18,10 @@ Generate markdown documentation from a schema. Provide a schema-id to fetch from
 	schema YAML file (offline mode)
 
 .PP
+\fB--force\fP[=false]
+	overwrite output file if it already exists
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for docgen
 
@@ -68,7 +72,11 @@ Generate markdown documentation from a schema. Provide a schema-id to fetch from
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-dump.1
+++ b/docs/man/decree-dump.1
@@ -14,6 +14,10 @@ Dump exports a tenant's schema, configuration, and field locks as a single YAML 
 
 
 .SH OPTIONS
+\fB--force\fP[=false]
+	overwrite output file if it already exists
+
+.PP
 \fB-h\fP, \fB--help\fP[=false]
 	help for dump
 
@@ -56,7 +60,11 @@ Dump exports a tenant's schema, configuration, and field locks as a single YAML 
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-lock-list.1
+++ b/docs/man/decree-lock-list.1
@@ -44,7 +44,11 @@ List field locks for a tenant
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-lock-remove.1
+++ b/docs/man/decree-lock-remove.1
@@ -44,7 +44,11 @@ Unlock a field
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-lock-set.1
+++ b/docs/man/decree-lock-set.1
@@ -44,7 +44,11 @@ Lock a field (prevents modification by non-superadmin)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-lock.1
+++ b/docs/man/decree-lock.1
@@ -44,7 +44,11 @@ Lock and unlock configuration fields. Locked fields cannot be modified by admin 
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-delete.1
+++ b/docs/man/decree-schema-delete.1
@@ -44,7 +44,11 @@ Delete a schema and all its versions (cascades to tenants)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-export.1
+++ b/docs/man/decree-schema-export.1
@@ -48,7 +48,11 @@ Export a schema to YAML
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-get.1
+++ b/docs/man/decree-schema-get.1
@@ -48,7 +48,11 @@ Show a schema
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-import.1
+++ b/docs/man/decree-schema-import.1
@@ -48,7 +48,11 @@ Import a schema from a YAML file
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-list.1
+++ b/docs/man/decree-schema-list.1
@@ -44,7 +44,11 @@ List all schemas
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema-publish.1
+++ b/docs/man/decree-schema-publish.1
@@ -44,7 +44,11 @@ Publish a schema version (makes it immutable and assignable to tenants)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-schema.1
+++ b/docs/man/decree-schema.1
@@ -44,7 +44,11 @@ Create, list, publish, import/export, and delete configuration schemas. Schemas 
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-seed.1
+++ b/docs/man/decree-seed.1
@@ -61,7 +61,11 @@ The operation is idempotent: importing a schema with identical fields, or a conf
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-server-info.1
+++ b/docs/man/decree-server-info.1
@@ -44,7 +44,11 @@ Show server version and enabled features
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-server.1
+++ b/docs/man/decree-server.1
@@ -44,7 +44,11 @@ Query server metadata, version, and enabled features.
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-tenant-create.1
+++ b/docs/man/decree-tenant-create.1
@@ -56,7 +56,11 @@ Create a new tenant on a published schema version
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-tenant-delete.1
+++ b/docs/man/decree-tenant-delete.1
@@ -44,7 +44,11 @@ Delete a tenant and all its configuration data
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-tenant-get.1
+++ b/docs/man/decree-tenant-get.1
@@ -44,7 +44,11 @@ Show a tenant
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-tenant-list.1
+++ b/docs/man/decree-tenant-list.1
@@ -48,7 +48,11 @@ List tenants
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-tenant.1
+++ b/docs/man/decree-tenant.1
@@ -44,7 +44,11 @@ Create, list, and delete tenants. Each tenant is assigned a published schema ver
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-validate.1
+++ b/docs/man/decree-validate.1
@@ -56,7 +56,11 @@ Validate a config YAML against a schema YAML (offline)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-version.1
+++ b/docs/man/decree-version.1
@@ -44,7 +44,11 @@ Print the CLI version
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree-watch.1
+++ b/docs/man/decree-watch.1
@@ -44,7 +44,11 @@ Stream live config changes (like tail -f)
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]

--- a/docs/man/decree.1
+++ b/docs/man/decree.1
@@ -43,7 +43,11 @@ Command-line tool for managing schemas, tenants, and configuration values in Ope
 
 .PP
 \fB--token\fP=""
-	JWT bearer token
+	JWT bearer token (prefer DECREE_TOKEN env var to avoid shell history exposure)
+
+.PP
+\fB--token-file\fP=""
+	path to a file containing the JWT bearer token (takes precedence over --token)
 
 .PP
 \fB--wait\fP[=false]


### PR DESCRIPTION
## Summary
- Adds `--token-file` to avoid JWT exposure in shell history/`ps`, rejects unknown `--mode` values in `import`, and propagates YAML parse errors in `diff` file-mode — all previously silent failures that could mislead operators.
- Restricts output file writes to `0o600` and gates overwrites behind `--force`, since dump output can contain sensitive config values.
- Centralizes flag-access boilerplate into `mustGet*` helpers and `writeFileExclusive`, eliminates builtin shadowing (`new_` → `newVal`), and moves global state mutation (`DisableAutoGenTag`) into `init()`.

## Test plan
- `make test` passes for all modules (pre-existing `TestWatcher_SnapshotAndStream` flake on main is unrelated).
- `cmd/decree` CLI tests pass including updated `helpers_test.go` for `parseConfigValues` signature change.
- `make lint-go` clean.

Closes #721