### PR TITLE
ci: post synthetic codecov/patch for grpctransport-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       helm: ${{ steps.filter.outputs.helm }}
       migrations: ${{ steps.filter.outputs.migrations }}
       docs: ${{ steps.filter.outputs.docs }}
+      non_grpctransport_code: ${{ steps.filter.outputs.non_grpctransport_code }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -96,6 +97,17 @@ jobs:
               - 'internal/version/**'
               - 'Makefile'
               - 'mkdocs.yml'
+            non_grpctransport_code:
+              - '**/*.go'
+              - '!sdk/grpctransport/**'
+              - '**/go.mod'
+              - '**/go.sum'
+              - 'proto/**'
+              - 'db/**'
+              - 'build/**'
+              - 'Makefile'
+              - 'docker-compose*.yml'
+              - '.github/workflows/**'
 
   # Builds/pushes the shared decree-tools Docker image used by downstream jobs.
   # Skips the build if an image tagged with the Dockerfile hash already exists
@@ -687,12 +699,36 @@ jobs:
             -f description="No coverage change (docs-only PR)" \
             -f target_url="https://codecov.io/gh/${{ github.repository }}"
 
+  # Posts a synthetic codecov/patch:success when all code changes are within
+  # sdk/grpctransport/** (fully excluded from Codecov). The test job still runs
+  # for these PRs, but Codecov silently skips the patch webhook — leaving a
+  # required check permanently pending. Mirrors codecov-skip for docs-only PRs.
+  codecov-skip-grpctransport:
+    name: Codecov skip (grpctransport-only)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.non_grpctransport_code != 'true' && github.event_name == 'pull_request'
+    permissions:
+      statuses: write
+    timeout-minutes: 5
+    steps:
+      - name: Post codecov/patch success
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+            --method POST \
+            -f state=success \
+            -f context=codecov/patch \
+            -f description="No coverage change (grpctransport-only PR)" \
+            -f target_url="https://codecov.io/gh/${{ github.repository }}"
+
   # Aggregates all job results for branch protection. A single required check
   # that passes iff every listed job passed or was legitimately skipped.
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, bench, upgrade, codecov-skip]
+    needs: [lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, bench, upgrade, codecov-skip, codecov-skip-grpctransport]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -701,4 +737,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, bench, upgrade, codecov-skip
+          allowed-skips: lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, bench, upgrade, codecov-skip, codecov-skip-grpctransport


### PR DESCRIPTION
## Summary

- grpctransport-only PRs were permanently blocked because Codecov silently skips the patch webhook when every changed file matches its ignore rules, leaving a required `codecov/patch` check pending forever
- Adds a `non_grpctransport_code` paths-filter output that is `false` when all Go changes are within `sdk/grpctransport/**`
- New `codecov-skip-grpctransport` job posts a synthetic `codecov/patch: success` for those PRs, mirroring what `codecov-skip` already does for docs-only PRs

## Test plan

- [ ] Verify CI passes on this PR (workflow-only change)
- [ ] Confirm a grpctransport-only PR merges cleanly without manual re-run

Closes #795