### PR TITLE
refactor(pgconv): add Converter adapter type; accept interface in wiring

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -284,7 +284,17 @@ func run() int {
 		logger.WarnContext(ctx, "ENABLE_REFLECTION=1 set — gRPC server reflection enabled (not recommended for production)")
 	}
 
-	srvBuild := buildServerOptions(cfg, logger, extraOpts, serverTLS, rlInterceptor, preAuthInterceptor)
+	// Convert concrete rate-limiter pointers to the GRPCInterceptor interface
+	// using explicit nil guards — a nil *ratelimit.Interceptor assigned directly
+	// to an interface would produce a non-nil interface wrapping a nil pointer.
+	var rl, preAuth server.GRPCInterceptor
+	if rlInterceptor != nil {
+		rl = rlInterceptor
+	}
+	if preAuthInterceptor != nil {
+		preAuth = preAuthInterceptor
+	}
+	srvBuild := buildServerOptions(cfg, logger, extraOpts, serverTLS, rl, preAuth)
 	srv, err := server.New(cfg.GRPCPort, authInterceptor, srvBuild.Opts...)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to create server", "error", err)

--- a/cmd/server/options.go
+++ b/cmd/server/options.go
@@ -6,7 +6,6 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/opendecree/decree/internal/ratelimit"
 	"github.com/opendecree/decree/internal/server"
 )
 
@@ -28,8 +27,8 @@ func buildServerOptions(
 	logger *slog.Logger,
 	extraGRPCOpts []grpc.ServerOption,
 	serverTLS *server.TLSConfig,
-	rl *ratelimit.Interceptor,
-	preAuth *ratelimit.Interceptor,
+	rl server.GRPCInterceptor,
+	preAuth server.GRPCInterceptor,
 ) serverOptionsBuild {
 	out := serverOptionsBuild{
 		Opts: []server.Option{

--- a/internal/storage/pgconv/adapter.go
+++ b/internal/storage/pgconv/adapter.go
@@ -1,0 +1,45 @@
+package pgconv
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// Converter is a named adapter type that groups the pgconv conversion helpers
+// as methods. It is zero-value ready and carries no state; use it where a
+// struct dependency is more convenient than calling the package-level
+// functions directly (e.g. to inject a test double or satisfy an interface).
+//
+// All methods delegate to the corresponding package-level function so
+// behaviour is identical.
+type Converter struct{}
+
+func (Converter) StringToUUID(s string) (pgtype.UUID, error) { return StringToUUID(s) }
+func (Converter) MustUUID(s string) pgtype.UUID              { return MustUUID(s) }
+func (Converter) UUIDToString(id pgtype.UUID) string         { return UUIDToString(id) }
+
+func (Converter) TimeToTimestamptz(t time.Time) pgtype.Timestamptz {
+	return TimeToTimestamptz(t)
+}
+
+func (Converter) OptionalTimeToTimestamptz(t *time.Time) pgtype.Timestamptz {
+	return OptionalTimeToTimestamptz(t)
+}
+
+func (Converter) TimestamptzToTime(ts pgtype.Timestamptz) time.Time {
+	return TimestamptzToTime(ts)
+}
+
+func (Converter) TimestamptzToOptionalTime(ts pgtype.Timestamptz) *time.Time {
+	return TimestamptzToOptionalTime(ts)
+}
+
+func (Converter) WrapNotFound(err error) error        { return WrapNotFound(err) }
+func (Converter) WrapUniqueViolation(err error) error { return WrapUniqueViolation(err) }
+func (Converter) WrapFKViolation(err error) error     { return WrapFKViolation(err) }
+
+func (Converter) FieldTypeToDB(ft domain.FieldType) string  { return FieldTypeToDB(ft) }
+func (Converter) FieldTypeFromDB(s string) domain.FieldType { return FieldTypeFromDB(s) }

--- a/internal/storage/pgconv/adapter_test.go
+++ b/internal/storage/pgconv/adapter_test.go
@@ -1,0 +1,88 @@
+package pgconv
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// TestConverter verifies that Converter delegates correctly to the package-level
+// functions. One call per method is sufficient — correctness of the underlying
+// functions is already covered by convert_test.go.
+func TestConverter(t *testing.T) {
+	c := Converter{}
+	uuid := "11111111-1111-1111-1111-111111111111"
+
+	t.Run("StringToUUID valid", func(t *testing.T) {
+		id, err := c.StringToUUID(uuid)
+		require.NoError(t, err)
+		assert.True(t, id.Valid)
+	})
+
+	t.Run("MustUUID", func(t *testing.T) {
+		id := c.MustUUID(uuid)
+		assert.True(t, id.Valid)
+	})
+
+	t.Run("UUIDToString round-trip", func(t *testing.T) {
+		id, _ := c.StringToUUID(uuid)
+		assert.Equal(t, uuid, c.UUIDToString(id))
+	})
+
+	t.Run("TimeToTimestamptz round-trip", func(t *testing.T) {
+		now := time.Now().Truncate(time.Microsecond).UTC()
+		ts := c.TimeToTimestamptz(now)
+		assert.True(t, ts.Valid)
+		assert.Equal(t, now, c.TimestamptzToTime(ts))
+	})
+
+	t.Run("OptionalTimeToTimestamptz nil", func(t *testing.T) {
+		ts := c.OptionalTimeToTimestamptz(nil)
+		assert.False(t, ts.Valid)
+	})
+
+	t.Run("OptionalTimeToTimestamptz non-nil", func(t *testing.T) {
+		now := time.Now().Truncate(time.Microsecond).UTC()
+		ts := c.OptionalTimeToTimestamptz(&now)
+		assert.True(t, ts.Valid)
+		got := c.TimestamptzToOptionalTime(ts)
+		require.NotNil(t, got)
+		assert.Equal(t, now, *got)
+	})
+
+	t.Run("TimestamptzToOptionalTime invalid", func(t *testing.T) {
+		got := c.TimestamptzToOptionalTime(pgtype.Timestamptz{})
+		assert.Nil(t, got)
+	})
+
+	t.Run("WrapNotFound passthrough", func(t *testing.T) {
+		base := errors.New("base")
+		err := c.WrapNotFound(base)
+		assert.Same(t, base, err)
+	})
+
+	t.Run("WrapUniqueViolation passthrough", func(t *testing.T) {
+		base := errors.New("base")
+		err := c.WrapUniqueViolation(base)
+		assert.Same(t, base, err)
+	})
+
+	t.Run("WrapFKViolation passthrough", func(t *testing.T) {
+		base := errors.New("base")
+		err := c.WrapFKViolation(base)
+		assert.Same(t, base, err)
+	})
+
+	t.Run("FieldTypeToDB round-trip", func(t *testing.T) {
+		ft := domain.FieldTypeString
+		s := c.FieldTypeToDB(ft)
+		assert.NotEmpty(t, s)
+		assert.Equal(t, ft, c.FieldTypeFromDB(s))
+	})
+}


### PR DESCRIPTION
## Summary

- `pgconv` lacked an explicit named adapter type, unlike the `SchemaStoreAdapter` pattern in `internal/validation`; adds `Converter` struct that delegates to all package-level functions
- `buildServerOptions` in `cmd/server` accepted `*ratelimit.Interceptor` concrete pointers where the existing `server.GRPCInterceptor` interface is the correct abstraction
- Adds nil guards at the call site to prevent the nil-interface-wrapping-nil-pointer footgun

## Test plan

- [x] `make test` passes (pre-existing `TestWatcher_SnapshotAndStream` failure in `sdk/configwatcher` is unrelated and also fails on `main`)
- [x] `make lint` passes with 0 issues
- [x] No behavior change — `Converter` delegates to package-level functions

Closes #244