### PR TITLE
feat(sdk): promote InvalidArgumentError to typed error with Is() support

### DIFF
--- a/sdk/configclient/CHANGELOG.md
+++ b/sdk/configclient/CHANGELOG.md
@@ -10,6 +10,13 @@ This project uses semantic versioning with an `-alpha.N` suffix during alpha; th
 ### Added
 
 - `description`, `value_description`, and `expected_checksum` fields on write operation results (#606)
+- `InvalidArgumentError` typed struct with `Is()` support; use `errors.As` to extract the `Message` field (#246)
+- `NewInvalidArgumentError(message string) *InvalidArgumentError` constructor (#246)
+
+### Changed
+
+- **BREAKING** `ErrInvalidArgument` is now `*InvalidArgumentError` instead of an `errors.New` sentinel; `errors.Is(err, ErrInvalidArgument)` still works via the `Is()` method (#246)
+- **BREAKING** The `InvalidArgumentError(message string) error` helper function is removed; replace with `NewInvalidArgumentError(message string)` (#246)
 
 ### Fixed
 

--- a/sdk/configclient/errors.go
+++ b/sdk/configclient/errors.go
@@ -7,7 +7,6 @@ package configclient
 
 import (
 	"errors"
-	"fmt"
 
 	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
@@ -44,14 +43,41 @@ var (
 	// whose value type doesn't match (e.g. GetInt on a string field).
 	ErrTypeMismatch = errors.New("value type mismatch")
 
-	// ErrInvalidArgument is returned when a value fails server-side validation
-	// (type mismatch, constraint violation, or unknown field in strict mode).
-	ErrInvalidArgument = errors.New("invalid argument")
+	// ErrInvalidArgument is the sentinel for errors.Is matching against any
+	// InvalidArgumentError, regardless of message. Use errors.As to access
+	// the structured Message field.
+	//
+	// Breaking change (alpha): previously errors.New("invalid argument");
+	// now *InvalidArgumentError. errors.Is still works via Is().
+	ErrInvalidArgument = &InvalidArgumentError{}
 )
 
-// InvalidArgumentError wraps ErrInvalidArgument with a server message.
-func InvalidArgumentError(message string) error {
-	return fmt.Errorf("%w: %s", ErrInvalidArgument, message)
+// InvalidArgumentError carries structured validation details from the server.
+// Use [NewInvalidArgumentError] to construct one, [ErrInvalidArgument] as the
+// sentinel target for errors.Is, and errors.As to extract the Message field.
+//
+// Breaking change (alpha): the package-level InvalidArgumentError() function
+// has been removed. Replace calls with NewInvalidArgumentError().
+type InvalidArgumentError struct {
+	// Message is the server-supplied validation detail (e.g. "field app.name
+	// must match ^[a-z]+$").
+	Message string
+}
+
+// Error implements the error interface.
+func (e *InvalidArgumentError) Error() string { return "invalid argument: " + e.Message }
+
+// Is reports true for any *InvalidArgumentError target, enabling
+// errors.Is(err, ErrInvalidArgument) regardless of Message value.
+func (e *InvalidArgumentError) Is(target error) bool {
+	_, ok := target.(*InvalidArgumentError)
+	return ok
+}
+
+// NewInvalidArgumentError constructs an InvalidArgumentError with the given
+// server message. This replaces the old InvalidArgumentError() helper function.
+func NewInvalidArgumentError(message string) *InvalidArgumentError {
+	return &InvalidArgumentError{Message: message}
 }
 
 // RetryableError wraps an error to indicate the operation may succeed on retry.

--- a/sdk/configclient/errors_test.go
+++ b/sdk/configclient/errors_test.go
@@ -1,0 +1,93 @@
+package configclient
+
+import (
+	"errors"
+	"testing"
+)
+
+// --- InvalidArgumentError typed error ---
+
+func TestInvalidArgumentError_Is_ErrInvalidArgument(t *testing.T) {
+	err := NewInvalidArgumentError("field must be non-empty")
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Errorf("errors.Is(NewInvalidArgumentError(...), ErrInvalidArgument) = false, want true")
+	}
+}
+
+func TestInvalidArgumentError_As_ExposesMessage(t *testing.T) {
+	err := NewInvalidArgumentError("field must be non-empty")
+	var e *InvalidArgumentError
+	if !errors.As(err, &e) {
+		t.Fatalf("errors.As returned false, want true")
+	}
+	if e.Message != "field must be non-empty" {
+		t.Errorf("e.Message = %q, want %q", e.Message, "field must be non-empty")
+	}
+}
+
+func TestInvalidArgumentError_ErrorString(t *testing.T) {
+	err := NewInvalidArgumentError("too short")
+	want := "invalid argument: too short"
+	if err.Error() != want {
+		t.Errorf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestErrInvalidArgument_EmptyMessage(t *testing.T) {
+	// ErrInvalidArgument sentinel itself has an empty Message; it still satisfies Is.
+	if ErrInvalidArgument.Message != "" {
+		t.Errorf("ErrInvalidArgument.Message = %q, want empty", ErrInvalidArgument.Message)
+	}
+	if !errors.Is(ErrInvalidArgument, ErrInvalidArgument) {
+		t.Error("errors.Is(ErrInvalidArgument, ErrInvalidArgument) = false, want true")
+	}
+}
+
+func TestInvalidArgumentError_Is_CrossMessage(t *testing.T) {
+	// Two errors with different messages should both match ErrInvalidArgument.
+	err1 := NewInvalidArgumentError("msg1")
+	err2 := NewInvalidArgumentError("msg2")
+	if !errors.Is(err1, ErrInvalidArgument) {
+		t.Errorf("err1 should match ErrInvalidArgument")
+	}
+	if !errors.Is(err2, ErrInvalidArgument) {
+		t.Errorf("err2 should match ErrInvalidArgument")
+	}
+}
+
+func TestInvalidArgumentError_NotIs_OtherErrors(t *testing.T) {
+	err := NewInvalidArgumentError("x")
+	if errors.Is(err, ErrNotFound) {
+		t.Error("InvalidArgumentError must not match ErrNotFound")
+	}
+	if errors.Is(err, ErrLocked) {
+		t.Error("InvalidArgumentError must not match ErrLocked")
+	}
+	if errors.Is(err, ErrPermissionDenied) {
+		t.Error("InvalidArgumentError must not match ErrPermissionDenied")
+	}
+}
+
+// --- Other sentinels still work as before ---
+
+func TestSentinelErrors_Is(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"ErrNotFound", ErrNotFound},
+		{"ErrLocked", ErrLocked},
+		{"ErrPermissionDenied", ErrPermissionDenied},
+		{"ErrChecksumMismatch", ErrChecksumMismatch},
+		{"ErrAlreadyExists", ErrAlreadyExists},
+		{"ErrRateLimited", ErrRateLimited},
+		{"ErrTypeMismatch", ErrTypeMismatch},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, tc.err) {
+				t.Errorf("errors.Is(%s, %s) = false, want true", tc.name, tc.name)
+			}
+		})
+	}
+}

--- a/sdk/configclient/typed_test.go
+++ b/sdk/configclient/typed_test.go
@@ -368,7 +368,7 @@ func TestSnapshot_GetFields(t *testing.T) {
 // --- Error types ---
 
 func TestInvalidArgumentError(t *testing.T) {
-	err := InvalidArgumentError("bad value")
+	err := NewInvalidArgumentError("bad value")
 	if !errors.Is(err, ErrInvalidArgument) {
 		t.Errorf("expected ErrInvalidArgument, got %v", err)
 	}

--- a/sdk/grpctransport/errors.go
+++ b/sdk/grpctransport/errors.go
@@ -31,7 +31,7 @@ func mapConfigError(err error) error {
 	case codes.AlreadyExists:
 		return configclient.ErrAlreadyExists
 	case codes.InvalidArgument:
-		return configclient.InvalidArgumentError(st.Message())
+		return configclient.NewInvalidArgumentError(st.Message())
 	case codes.ResourceExhausted:
 		// ResourceExhausted signals a rate limit. The server attaches a RetryInfo
 		// detail with a hard backoff hint; wrapping as RetryableError would discard


### PR DESCRIPTION
## Summary

- `ErrInvalidArgument` was a plain sentinel with no structured data; consumers could only check `errors.Is` but couldn't access the validation message without string parsing
- Promotes it to `*InvalidArgumentError` struct with `Is()` support — preserving sentinel-style matching while enabling `errors.As` for field extraction
- Removes the old `InvalidArgumentError(msg) error` helper function (replaced by `NewInvalidArgumentError`)

**⚠️ BREAKING CHANGE:** `ErrInvalidArgument` type changed from `error` (sentinel) to `*InvalidArgumentError`; `InvalidArgumentError(msg)` function removed. See `sdk/configclient/CHANGELOG.md`.

## Test plan

- [x] `errors.Is(NewInvalidArgumentError("x"), ErrInvalidArgument)` returns true
- [x] `errors.As` extracts correct `Message` field
- [x] All other sentinel errors unchanged
- [x] `sdk/grpctransport` call site updated; both transport error tests pass
- [x] `make lint` passes with 0 issues

Closes #246