### PR TITLE
test: add Must[T] helper to testutil, migrate pagination + authcheck tests

### DIFF
--- a/internal/authcheck/authcheck_test.go
+++ b/internal/authcheck/authcheck_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/opendecree/decree/internal/testutil"
 )
 
 // allowlist contains exported method names that are intentionally exempt from
@@ -49,9 +51,7 @@ func TestAllHandlersHaveMustHaveClaims(t *testing.T) {
 		path := filepath.Join(dir, rel)
 		fset := token.NewFileSet()
 		f, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
-		}
+		f = testutil.Must(t, f, err)
 
 		for _, decl := range f.Decls {
 			fn, ok := decl.(*ast.FuncDecl)

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/opendecree/decree/internal/testutil"
 )
 
 func TestDecodePageToken_Empty(t *testing.T) {
 	offset, err := DecodePageToken("")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	offset = testutil.Must(t, offset, err)
 	if offset != 0 {
 		t.Errorf("got %d, want 0", offset)
 	}
@@ -22,9 +22,7 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 	for _, offset := range []int32{0, 1, 50, 100, 999} {
 		token := EncodePageToken(offset)
 		got, err := DecodePageToken(token)
-		if err != nil {
-			t.Fatalf("DecodePageToken(%q): %v", token, err)
-		}
+		got = testutil.Must(t, got, err)
 		if got != offset {
 			t.Errorf("round-trip offset %d: got %d", offset, got)
 		}
@@ -120,9 +118,7 @@ func TestNextPageToken(t *testing.T) {
 	// Second page token encodes correct offset
 	token := NextPageToken(50, 51, 0)
 	offset, err := DecodePageToken(token)
-	if err != nil {
-		t.Fatalf("DecodePageToken: %v", err)
-	}
+	offset = testutil.Must(t, offset, err)
 	if offset != 50 {
 		t.Errorf("got offset %d, want 50", offset)
 	}
@@ -130,9 +126,7 @@ func TestNextPageToken(t *testing.T) {
 	// Third page from offset 50
 	token = NextPageToken(50, 51, 50)
 	offset, err = DecodePageToken(token)
-	if err != nil {
-		t.Fatalf("DecodePageToken: %v", err)
-	}
+	offset = testutil.Must(t, offset, err)
 	if offset != 100 {
 		t.Errorf("got offset %d, want 100", offset)
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,19 @@
+// Package testutil provides small helpers for writing test fixtures.
+// It is only imported by *_test.go files and carries no production dependencies.
+package testutil
+
+import "testing"
+
+// Must unwraps a (value, error) pair. If err is non-nil, it calls t.Fatal
+// pointing at the caller's frame via t.Helper(), then returns the zero value
+// of T. Use it to tighten fixture setup:
+//
+//	v, err := someFunc()
+//	return testutil.Must(t, v, err)
+func Must[T any](t testing.TB, v T, err error) T {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return v
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,60 @@
+package testutil_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/opendecree/decree/internal/testutil"
+)
+
+// stubTB satisfies testing.TB for unit-testing Must without triggering
+// runtime.Goexit (which the real Fatalf calls via FailNow).
+type stubTB struct {
+	testing.TB
+	fatal  bool
+	format string
+}
+
+func (s *stubTB) Helper()                               {}
+func (s *stubTB) Fatalf(f string, _ ...any)             { s.fatal = true; s.format = f }
+func (s *stubTB) Logf(_ string, _ ...any)               {}
+func (s *stubTB) Log(_ ...any)                          {}
+func (s *stubTB) Fail()                                 { s.fatal = true }
+func (s *stubTB) FailNow()                              { s.fatal = true }
+func (s *stubTB) Failed() bool                          { return s.fatal }
+func (s *stubTB) Cleanup(_ func())                      {}
+func (s *stubTB) TempDir() string                       { return "" }
+func (s *stubTB) Setenv(_ string, _ string)             {}
+func (s *stubTB) Chdir(_ string)                        {}
+func (s *stubTB) Skipped() bool                         { return false }
+func (s *stubTB) SkipNow()                              {}
+func (s *stubTB) Skip(_ ...any)                         {}
+func (s *stubTB) Skipf(_ string, _ ...any)              {}
+func (s *stubTB) Error(_ ...any)                        { s.fatal = true }
+func (s *stubTB) Errorf(_ string, _ ...any)             { s.fatal = true }
+func (s *stubTB) Fatal(_ ...any)                        { s.fatal = true }
+func (s *stubTB) Name() string                          { return "stub" }
+func (s *stubTB) Parallel()                             {}
+func (s *stubTB) Run(_ string, _ func(*testing.T)) bool { return true }
+
+func TestMust_success(t *testing.T) {
+	got := testutil.Must(t, 42, nil)
+	if got != 42 {
+		t.Fatalf("want 42, got %d", got)
+	}
+}
+
+func TestMust_failure(t *testing.T) {
+	tb := &stubTB{}
+	testutil.Must(tb, 0, errors.New("boom"))
+	if !tb.fatal {
+		t.Fatal("expected Must to call Fatalf on error")
+	}
+}
+
+func TestMust_string(t *testing.T) {
+	got := testutil.Must(t, "hello", nil)
+	if got != "hello" {
+		t.Fatalf("want 'hello', got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Test fixtures across internal packages check `(v, err)` pairs with verbose `if err != nil { t.Fatalf }` blocks; a generic `Must[T]` helper centralizes this pattern with correct `t.Helper()` attribution
- Adds `internal/testutil.Must[T any](t testing.TB, v T, err error) T` — zero external dependencies, test-only package
- Migrates `pagination_test.go` and `authcheck_test.go` as reference examples; no production code changed

## Test plan

- [x] `make test` passes
- [x] `make lint` passes with 0 issues
- [x] No production code changed

Closes #247