### PR TITLE
Formalize RunInTx rollback contract on memory stores

### DIFF
--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -106,8 +106,13 @@ type InsertAuditWriteLogParams struct {
 // Implementations must return [domain.ErrNotFound] when an entity is not found.
 type Store interface {
 	// RunInTx executes fn within a database transaction.
-	// The Store passed to fn is bound to the transaction.
-	// If fn returns nil the transaction is committed; otherwise it is rolled back.
+	// The Store passed to fn is bound to that transaction; all reads and writes
+	// inside fn observe the same isolated view. If fn returns a non-nil error,
+	// the transaction is rolled back and that error is returned unchanged. If fn
+	// returns nil, the transaction is committed.
+	//
+	// Implementations must guarantee atomicity: either all writes from fn are
+	// visible after a successful return, or none are (on error).
 	RunInTx(ctx context.Context, fn func(Store) error) error
 
 	// Config versions.

--- a/internal/config/store_memory.go
+++ b/internal/config/store_memory.go
@@ -51,8 +51,74 @@ func (s *MemoryStore) nextID() string {
 }
 
 func (s *MemoryStore) RunInTx(_ context.Context, fn func(Store) error) error {
-	// Serialized execution — the mutex is already held for writes.
-	return fn(s)
+	// Clone current state into a temporary store.
+	s.mu.Lock()
+	tmp := s.clone()
+	s.mu.Unlock()
+
+	if err := fn(tmp); err != nil {
+		return err // discard tmp — rollback
+	}
+
+	// Commit: atomically swap tmp's state into s.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mergeFrom(tmp)
+	return nil
+}
+
+// clone returns a shallow copy of s with all map fields deep-copied.
+// Caller must hold s.mu before calling.
+func (s *MemoryStore) clone() *MemoryStore {
+	tmp := &MemoryStore{
+		configVersions: make(map[string]domain.ConfigVersion, len(s.configVersions)),
+		configValues:   make(map[string][]domain.ConfigValue, len(s.configValues)),
+		tenants:        make(map[string]domain.Tenant, len(s.tenants)),
+		schemaVersions: make(map[string]domain.SchemaVersion, len(s.schemaVersions)),
+		schemaFields:   make(map[string][]domain.SchemaField, len(s.schemaFields)),
+		fieldLocks:     make(map[string][]domain.TenantFieldLock, len(s.fieldLocks)),
+		auditLog:       make([]auditEntry, len(s.auditLog)),
+	}
+	for k, v := range s.configVersions {
+		tmp.configVersions[k] = v
+	}
+	for k, vs := range s.configValues {
+		cp := make([]domain.ConfigValue, len(vs))
+		copy(cp, vs)
+		tmp.configValues[k] = cp
+	}
+	for k, v := range s.tenants {
+		tmp.tenants[k] = v
+	}
+	for k, v := range s.schemaVersions {
+		tmp.schemaVersions[k] = v
+	}
+	for k, fs := range s.schemaFields {
+		cp := make([]domain.SchemaField, len(fs))
+		copy(cp, fs)
+		tmp.schemaFields[k] = cp
+	}
+	for k, ls := range s.fieldLocks {
+		cp := make([]domain.TenantFieldLock, len(ls))
+		copy(cp, ls)
+		tmp.fieldLocks[k] = cp
+	}
+	copy(tmp.auditLog, s.auditLog)
+	return tmp
+}
+
+// mergeFrom copies all state from src into s.
+// Caller must hold s.mu before calling.
+func (s *MemoryStore) mergeFrom(src *MemoryStore) {
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	s.configVersions = src.configVersions
+	s.configValues = src.configValues
+	s.tenants = src.tenants
+	s.schemaVersions = src.schemaVersions
+	s.schemaFields = src.schemaFields
+	s.fieldLocks = src.fieldLocks
+	s.auditLog = src.auditLog
 }
 
 // --- Config versions ---

--- a/internal/config/store_memory_test.go
+++ b/internal/config/store_memory_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -238,6 +239,24 @@ func TestMemoryStore_RunInTx(t *testing.T) {
 	v, err := s.GetLatestConfigVersion(ctx, "t1")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), v.Version)
+}
+
+func TestMemoryStore_RunInTx_Rollback(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	sentinel := errors.New("force rollback")
+	err := s.RunInTx(ctx, func(tx Store) error {
+		_, _ = tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
+			TenantID: "t1", Version: 1, CreatedBy: "admin",
+		})
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	// Version must not be visible after rollback.
+	_, err = s.GetLatestConfigVersion(ctx, "t1")
+	require.ErrorIs(t, err, domain.ErrNotFound)
 }
 
 func TestMemoryStore_BulkSetConfigValues(t *testing.T) {

--- a/internal/config/store_memory_test.go
+++ b/internal/config/store_memory_test.go
@@ -311,6 +311,58 @@ func TestMemoryStore_BulkSetConfigValues(t *testing.T) {
 	assert.Len(t, valuesAfterNoop, 2)
 }
 
+func TestMemoryStore_RunInTx_ClonesAllFields(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	// Pre-populate every map field so all for-loop bodies in clone() execute.
+
+	// configVersions
+	cv, err := s.CreateConfigVersion(ctx, CreateConfigVersionParams{
+		TenantID: "t1", Version: 1, CreatedBy: "admin",
+	})
+	require.NoError(t, err)
+
+	// configValues
+	val := "hello"
+	require.NoError(t, s.SetConfigValue(ctx, SetConfigValueParams{
+		ConfigVersionID: cv.ID, FieldPath: "app.name", Value: &val,
+	}))
+
+	// tenants
+	s.SetTenant(domain.Tenant{ID: "t1", Name: "acme"})
+
+	// schemaVersions
+	s.SetSchemaVersion(domain.SchemaVersion{ID: "sv1", SchemaID: "s1", Version: 1})
+
+	// schemaFields
+	s.SetSchemaFields("sv1", []domain.SchemaField{{Path: "x", FieldType: "string"}})
+
+	// fieldLocks (written directly since GetFieldLocks has no setter — use auditLog via Insert)
+	s.mu.Lock()
+	s.fieldLocks["t1"] = []domain.TenantFieldLock{{TenantID: "t1", FieldPath: "db.host"}}
+	s.mu.Unlock()
+
+	// auditLog
+	require.NoError(t, s.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+		TenantID: "t1", Actor: "admin", Action: "set_field",
+	}))
+
+	// RunInTx should clone all non-empty maps and commit.
+	err = s.RunInTx(ctx, func(tx Store) error {
+		_, err := tx.CreateConfigVersion(ctx, CreateConfigVersionParams{
+			TenantID: "t1", Version: 2, CreatedBy: "admin",
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	// Version 2 must be committed.
+	v, err := s.GetLatestConfigVersion(ctx, "t1")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), v.Version)
+}
+
 func TestMemoryStore_BulkInsertAuditWriteLog(t *testing.T) {
 	s := NewMemoryStore()
 	ctx := context.Background()

--- a/internal/schema/store.go
+++ b/internal/schema/store.go
@@ -146,8 +146,13 @@ type InsertAuditWriteLogParams struct {
 // Implementations must return [domain.ErrNotFound] when an entity is not found.
 type Store interface {
 	// RunInTx executes fn within a database transaction.
-	// The Store passed to fn is bound to the transaction.
-	// If fn returns nil the transaction is committed; otherwise it is rolled back.
+	// The Store passed to fn is bound to that transaction; all reads and writes
+	// inside fn observe the same isolated view. If fn returns a non-nil error,
+	// the transaction is rolled back and that error is returned unchanged. If fn
+	// returns nil, the transaction is committed.
+	//
+	// Implementations must guarantee atomicity: either all writes from fn are
+	// visible after a successful return, or none are (on error).
 	RunInTx(ctx context.Context, fn func(Store) error) error
 
 	// InsertAuditWriteLog writes an admin audit entry transactionally.

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -38,7 +38,67 @@ func NewMemoryStore() *MemoryStore {
 }
 
 func (m *MemoryStore) RunInTx(_ context.Context, fn func(Store) error) error {
-	return fn(m)
+	// Clone current state into a temporary store.
+	m.mu.Lock()
+	tmp := m.clone()
+	m.mu.Unlock()
+
+	if err := fn(tmp); err != nil {
+		return err // discard tmp — rollback
+	}
+
+	// Commit: atomically swap tmp's state into m.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mergeFrom(tmp)
+	return nil
+}
+
+// clone returns a shallow copy of m with all map and slice fields deep-copied.
+// Caller must hold m.mu before calling.
+func (m *MemoryStore) clone() *MemoryStore {
+	tmp := &MemoryStore{
+		schemas:        make(map[string]domain.Schema, len(m.schemas)),
+		schemaVersions: make(map[string]domain.SchemaVersion, len(m.schemaVersions)),
+		schemaFields:   make(map[string][]domain.SchemaField, len(m.schemaFields)),
+		tenants:        make(map[string]domain.Tenant, len(m.tenants)),
+		fieldLocks:     make(map[string][]domain.TenantFieldLock, len(m.fieldLocks)),
+		auditLog:       make([]domain.AuditWriteLog, len(m.auditLog)),
+	}
+	for k, v := range m.schemas {
+		tmp.schemas[k] = v
+	}
+	for k, v := range m.schemaVersions {
+		tmp.schemaVersions[k] = v
+	}
+	for k, fs := range m.schemaFields {
+		cp := make([]domain.SchemaField, len(fs))
+		copy(cp, fs)
+		tmp.schemaFields[k] = cp
+	}
+	for k, v := range m.tenants {
+		tmp.tenants[k] = v
+	}
+	for k, ls := range m.fieldLocks {
+		cp := make([]domain.TenantFieldLock, len(ls))
+		copy(cp, ls)
+		tmp.fieldLocks[k] = cp
+	}
+	copy(tmp.auditLog, m.auditLog)
+	return tmp
+}
+
+// mergeFrom copies all state from src into m.
+// Caller must hold m.mu before calling.
+func (m *MemoryStore) mergeFrom(src *MemoryStore) {
+	src.mu.Lock()
+	defer src.mu.Unlock()
+	m.schemas = src.schemas
+	m.schemaVersions = src.schemaVersions
+	m.schemaFields = src.schemaFields
+	m.tenants = src.tenants
+	m.fieldLocks = src.fieldLocks
+	m.auditLog = src.auditLog
 }
 
 func (m *MemoryStore) InsertAuditWriteLog(_ context.Context, arg InsertAuditWriteLogParams) error {

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -857,5 +857,37 @@ func TestMemoryStore_ListTenantsBySchema_KeysetCursor(t *testing.T) {
 	assert.Equal(t, tA.ID, page2[0].ID)
 }
 
+func TestMemoryStore_RunInTx(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	err := store.RunInTx(ctx, func(tx Store) error {
+		_, err := tx.CreateSchema(ctx, CreateSchemaParams{Name: "tx-schema"})
+		return err
+	})
+	require.NoError(t, err)
+
+	// Schema must be visible after successful transaction.
+	got, err := store.GetSchemaByName(ctx, "tx-schema")
+	require.NoError(t, err)
+	assert.Equal(t, "tx-schema", got.Name)
+}
+
+func TestMemoryStore_RunInTx_Rollback(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	sentinel := errors.New("force rollback")
+	err := store.RunInTx(ctx, func(tx Store) error {
+		_, _ = tx.CreateSchema(ctx, CreateSchemaParams{Name: "should-not-exist"})
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	// Schema must not be visible after rollback.
+	_, err = store.GetSchemaByName(ctx, "should-not-exist")
+	require.ErrorIs(t, err, domain.ErrNotFound)
+}
+
 // Verify MemoryStore implements Store at compile time.
 var _ Store = (*MemoryStore)(nil)

--- a/internal/schema/store_memory_test.go
+++ b/internal/schema/store_memory_test.go
@@ -889,5 +889,62 @@ func TestMemoryStore_RunInTx_Rollback(t *testing.T) {
 	require.ErrorIs(t, err, domain.ErrNotFound)
 }
 
+func TestMemoryStore_RunInTx_ClonesAllFields(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryStore()
+
+	// Pre-populate every map field so all for-loop bodies in clone() execute.
+
+	// schemas
+	s, err := store.CreateSchema(ctx, CreateSchemaParams{Name: "clone-test"})
+	require.NoError(t, err)
+
+	// schemaVersions
+	sv, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+		SchemaID: s.ID, Version: 1, Checksum: "abc",
+	})
+	require.NoError(t, err)
+
+	// schemaFields
+	_, err = store.CreateSchemaField(ctx, CreateSchemaFieldParams{
+		SchemaVersionID: sv.ID, Path: "app.name", FieldType: domain.FieldTypeString,
+	})
+	require.NoError(t, err)
+
+	// tenants
+	tenant, err := store.CreateTenant(ctx, CreateTenantParams{
+		Name: "clone-tenant", SchemaID: s.ID, SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+
+	// fieldLocks
+	err = store.CreateFieldLock(ctx, CreateFieldLockParams{
+		TenantID: tenant.ID, FieldPath: "db.host", LockedValues: []byte(`["localhost"]`),
+	})
+	require.NoError(t, err)
+
+	// auditLog
+	err = store.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{
+		TenantID: tenant.ID, Actor: "admin", Action: "create_schema",
+	})
+	require.NoError(t, err)
+
+	// RunInTx should clone all non-empty maps and commit.
+	err = store.RunInTx(ctx, func(tx Store) error {
+		_, err := tx.CreateSchema(ctx, CreateSchemaParams{Name: "tx-in-clone-test"})
+		return err
+	})
+	require.NoError(t, err)
+
+	// New schema must be committed.
+	got, err := store.GetSchemaByName(ctx, "tx-in-clone-test")
+	require.NoError(t, err)
+	assert.Equal(t, "tx-in-clone-test", got.Name)
+
+	// Existing data must still be intact.
+	_, err = store.GetSchemaByName(ctx, "clone-test")
+	require.NoError(t, err)
+}
+
 // Verify MemoryStore implements Store at compile time.
 var _ Store = (*MemoryStore)(nil)


### PR DESCRIPTION
## Summary

- Memory stores silently swallowed rollbacks: `fn(s)` mutated state even when `fn` returned an error, while the PG stores correctly rolled back — a test-fidelity gap that could mask real bugs.
- Both config and schema `MemoryStore.RunInTx` now clone state before running `fn`, discard the clone on error, and atomically commit on success.
- `RunInTx` godoc in both `Store` interfaces now states the atomicity guarantee explicitly.

## Test plan

- [x] `TestMemoryStore_RunInTx_Rollback` added to `internal/config` — verifies mutations inside a failed tx are not visible afterward
- [x] `TestMemoryStore_RunInTx` + `TestMemoryStore_RunInTx_Rollback` added to `internal/schema` — commit and rollback paths both covered
- [x] Existing `TestMemoryStore_RunInTx` (config) still passes
- [x] `go build ./internal/config/... ./internal/schema/...` clean
- [x] `make test` passes for both packages

Closes #240