### PR TITLE
Move nullable/sensitive/constraints to functional options on NewFieldValidator

### DIFF
--- a/internal/validation/cache_race_test.go
+++ b/internal/validation/cache_race_test.go
@@ -23,7 +23,7 @@ func TestValidatorCache_ConcurrentSetGet(t *testing.T) {
 			tenantID := fmt.Sprintf("tenant-%d", g%5)
 			for i := range iterations {
 				validators := map[string]*FieldValidator{
-					fmt.Sprintf("field-%d", i): NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
+					fmt.Sprintf("field-%d", i): NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING),
 				}
 				c.Set(tenantID, validators)
 				c.Get(tenantID)
@@ -49,7 +49,7 @@ func TestValidatorCache_ConcurrentSetInvalidate(t *testing.T) {
 			tenantID := fmt.Sprintf("tenant-%d", g%3)
 			for range iterations {
 				validators := map[string]*FieldValidator{
-					"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
+					"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT),
 				}
 				c.Set(tenantID, validators)
 				c.Invalidate(tenantID)

--- a/internal/validation/factory.go
+++ b/internal/validation/factory.go
@@ -148,7 +148,17 @@ func (f *ValidatorFactory) GetValidators(ctx context.Context, tenantID string) (
 		if f.limits.RegexMaxLength > 0 && constraints.GetRegex() != "" && len(constraints.GetRegex()) > f.limits.RegexMaxLength {
 			return nil, fmt.Errorf("field %s: regex pattern exceeds maximum length of %d characters", field.Path, f.limits.RegexMaxLength)
 		}
-		validators[field.Path] = NewFieldValidator(field.Path, ft, field.Nullable, field.Sensitive, constraints, WithLimits(f.limits))
+		fieldOpts := []Option{WithLimits(f.limits)}
+		if field.Nullable {
+			fieldOpts = append(fieldOpts, WithNullable())
+		}
+		if field.Sensitive {
+			fieldOpts = append(fieldOpts, WithSensitive())
+		}
+		if constraints != nil {
+			fieldOpts = append(fieldOpts, WithConstraints(constraints))
+		}
+		validators[field.Path] = NewFieldValidator(field.Path, ft, fieldOpts...)
 	}
 
 	f.cache.Set(tenantID, validators)

--- a/internal/validation/factory_test.go
+++ b/internal/validation/factory_test.go
@@ -266,7 +266,7 @@ func TestCache_ReturnsUnderlyingCache(t *testing.T) {
 
 	// Should be able to manually set/get.
 	v := map[string]*FieldValidator{
-		"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
+		"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING),
 	}
 	c.Set("manual-tenant", v)
 

--- a/internal/validation/limits.go
+++ b/internal/validation/limits.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
 )
 
 // Limits caps JSON-Schema compilation cost. Zero values mean "no limit"
@@ -64,6 +66,9 @@ type options struct {
 	celCapCounter     metric.Int64Counter       // nil when metrics are disabled
 	celSoftErrCounter metric.Int64Counter       // nil when metrics are disabled
 	compileSem        chan struct{}             // nil when MaxConcurrentCompiles == 0
+	nullable          bool
+	sensitive         bool
+	constraints       *pb.FieldConstraints
 }
 
 // WithLimits sets the JSON-Schema compile limits. Defaults to
@@ -116,6 +121,25 @@ func WithCelCapCounter(c metric.Int64Counter) Option {
 // "validation.cel_soft_error_total". Pass nil to disable.
 func WithCelSoftErrCounter(c metric.Int64Counter) Option {
 	return func(o *options) { o.celSoftErrCounter = c }
+}
+
+// WithNullable marks the field as nullable. When set, a nil or empty
+// [pb.TypedValue] is accepted. Defaults to false (not nullable).
+func WithNullable() Option {
+	return func(o *options) { o.nullable = true }
+}
+
+// WithSensitive marks the field as sensitive. When set, error messages omit
+// the offending value to avoid leaking secrets in logs or responses.
+// Defaults to false.
+func WithSensitive() Option {
+	return func(o *options) { o.sensitive = true }
+}
+
+// WithConstraints attaches field constraints (min/max, regex, enum, JSON
+// Schema, etc.) to the validator. Defaults to nil (no constraints).
+func WithConstraints(c *pb.FieldConstraints) Option {
+	return func(o *options) { o.constraints = c }
 }
 
 func resolveOptions(opts []Option) options {

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -71,18 +71,20 @@ func (v *FieldValidator) Validate(tv *pb.TypedValue) error {
 	return nil
 }
 
-// NewFieldValidator creates a validator for a schema field. Pass
-// [WithLimits] to override the JSON-Schema compile defaults; without it,
-// [DefaultLimits] is used.
-func NewFieldValidator(fieldPath string, fieldType pb.FieldType, nullable bool, sensitive bool, constraints *pb.FieldConstraints, opts ...Option) *FieldValidator {
+// NewFieldValidator creates a validator for a schema field.
+// fieldPath and fieldType are required. All other parameters are optional:
+// use [WithNullable], [WithSensitive], [WithConstraints], and [WithLimits].
+// Without [WithLimits], [DefaultLimits] is used.
+func NewFieldValidator(fieldPath string, fieldType pb.FieldType, opts ...Option) *FieldValidator {
 	o := resolveOptions(opts)
 	v := &FieldValidator{
 		fieldPath:       fieldPath,
 		fieldType:       fieldType,
 		domainFieldType: domain.FieldTypeFromProto(fieldType),
-		nullable:        nullable,
-		sensitive:       sensitive,
+		nullable:        o.nullable,
+		sensitive:       o.sensitive,
 	}
+	constraints := o.constraints
 
 	// Number finiteness check is always applied (not constraint-dependent).
 	if fieldType == pb.FieldType_FIELD_TYPE_NUMBER {

--- a/internal/validation/validator_bench_test.go
+++ b/internal/validation/validator_bench_test.go
@@ -9,7 +9,7 @@ import (
 func ptr64(v float64) *float64 { return &v }
 
 func BenchmarkValidate_Integer_NoConstraints(b *testing.B) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -17,10 +17,10 @@ func BenchmarkValidate_Integer_NoConstraints(b *testing.B) {
 }
 
 func BenchmarkValidate_Integer_MinMax(b *testing.B) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, WithConstraints(&pb.FieldConstraints{
 		Min: ptr64(0),
 		Max: ptr64(100),
-	})
+	}))
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -29,9 +29,9 @@ func BenchmarkValidate_Integer_MinMax(b *testing.B) {
 
 func BenchmarkValidate_String_Pattern(b *testing.B) {
 	pattern := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		Regex: &pattern,
-	})
+	}))
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "user@example.com"}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -39,9 +39,9 @@ func BenchmarkValidate_String_Pattern(b *testing.B) {
 }
 
 func BenchmarkValidate_String_Enum(b *testing.B) {
-	v := NewFieldValidator("env", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("env", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"dev", "staging", "prod"},
-	})
+	}))
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "prod"}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -49,7 +49,7 @@ func BenchmarkValidate_String_Enum(b *testing.B) {
 }
 
 func BenchmarkValidate_URL(b *testing.B) {
-	v := NewFieldValidator("hook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
+	v := NewFieldValidator("hook", pb.FieldType_FIELD_TYPE_URL)
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com/webhook"}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -58,9 +58,9 @@ func BenchmarkValidate_URL(b *testing.B) {
 
 func BenchmarkValidate_JSON_Schema(b *testing.B) {
 	schema := `{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`
-	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, WithConstraints(&pb.FieldConstraints{
 		JsonSchema: &schema,
-	})
+	}))
 	tv := &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"name":"test"}`}}
 	for b.Loop() {
 		_ = v.Validate(tv)
@@ -75,15 +75,15 @@ func BenchmarkNewFieldValidator_WithConstraints(b *testing.B) {
 		Regex: &pattern,
 	}
 	for b.Loop() {
-		NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, constraints)
+		NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(constraints))
 	}
 }
 
 func BenchmarkValidatorCache_Get_Hit(b *testing.B) {
 	c := NewValidatorCache(0)
 	validators := map[string]*FieldValidator{
-		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
-		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
+		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING),
+		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT),
 	}
 	c.Set("tenant-1", validators)
 
@@ -95,8 +95,8 @@ func BenchmarkValidatorCache_Get_Hit(b *testing.B) {
 func BenchmarkValidatorCache_Get_Hit_Parallel(b *testing.B) {
 	c := NewValidatorCache(0)
 	validators := map[string]*FieldValidator{
-		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING, false, false, nil),
-		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT, false, false, nil),
+		"a": NewFieldValidator("a", pb.FieldType_FIELD_TYPE_STRING),
+		"b": NewFieldValidator("b", pb.FieldType_FIELD_TYPE_INT),
 	}
 	c.Set("tenant-1", validators)
 

--- a/internal/validation/validator_extra_test.go
+++ b/internal/validation/validator_extra_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 func TestFieldValidator_DomainFieldTypeAndSensitive(t *testing.T) {
-	v := NewFieldValidator("secret.token", pb.FieldType_FIELD_TYPE_STRING, false, true, nil)
+	v := NewFieldValidator("secret.token", pb.FieldType_FIELD_TYPE_STRING, WithSensitive())
 	assert.Equal(t, domain.FieldTypeString, v.DomainFieldType())
 	assert.True(t, v.Sensitive())
 
-	plain := NewFieldValidator("plain", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	plain := NewFieldValidator("plain", pb.FieldType_FIELD_TYPE_INT)
 	assert.Equal(t, domain.FieldTypeInteger, plain.DomainFieldType())
 	assert.False(t, plain.Sensitive())
 }

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -19,7 +19,7 @@ func ptr[T any](v T) *T { return &v }
 // --- Type checking ---
 
 func TestValidate_TypeCheck_IntegerField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 42}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}}))
@@ -27,28 +27,28 @@ func TestValidate_TypeCheck_IntegerField(t *testing.T) {
 }
 
 func TestValidate_TypeCheck_BoolField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: true}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 1}}))
 }
 
 func TestValidate_TypeCheck_StringField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: ""}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 0}}))
 }
 
 func TestValidate_TypeCheck_TimeField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_TIME, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_TIME)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.Now()}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "not-a-time"}}))
 }
 
 func TestValidate_TypeCheck_DurationField(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_DURATION, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_DURATION)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(0)}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "24h"}}))
@@ -57,27 +57,27 @@ func TestValidate_TypeCheck_DurationField(t *testing.T) {
 // --- Nullable ---
 
 func TestValidate_NullOnNonNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)
 	assert.Error(t, v.Validate(nil))
 }
 
 func TestValidate_NullOnNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, true, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, WithNullable())
 	require.NoError(t, v.Validate(nil))
 }
 
 func TestValidate_NilKindOnNonNullable(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)
 	assert.Error(t, v.Validate(&pb.TypedValue{}))
 }
 
 // --- Integer constraints ---
 
 func TestValidate_IntegerMinMax(t *testing.T) {
-	v := NewFieldValidator("retries", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("retries", pb.FieldType_FIELD_TYPE_INT, WithConstraints(&pb.FieldConstraints{
 		Min: ptr(float64(0)),
 		Max: ptr(float64(10)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 5}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 0}}))
@@ -89,10 +89,10 @@ func TestValidate_IntegerMinMax(t *testing.T) {
 // --- Number constraints ---
 
 func TestValidate_NumberMinMax(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, WithConstraints(&pb.FieldConstraints{
 		Min: ptr(float64(0)),
 		Max: ptr(float64(1)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 0.5}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: -0.1}}))
@@ -102,10 +102,10 @@ func TestValidate_NumberMinMax(t *testing.T) {
 // --- String constraints ---
 
 func TestValidate_StringMinMaxLength(t *testing.T) {
-	v := NewFieldValidator("name", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("name", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		MinLength: ptr(int32(2)),
 		MaxLength: ptr(int32(10)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "x"}}))
@@ -113,9 +113,9 @@ func TestValidate_StringMinMaxLength(t *testing.T) {
 }
 
 func TestValidate_StringPattern(t *testing.T) {
-	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("email", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		Regex: ptr(`^[^@]+@[^@]+$`),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "user@example.com"}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "not-an-email"}}))
@@ -124,9 +124,9 @@ func TestValidate_StringPattern(t *testing.T) {
 func TestValidate_InvalidRegexInDB_FailsClosed(t *testing.T) {
 	// Simulates a bad pattern written directly to the DB bypassing schema validation.
 	// The validator must fail closed: every value is rejected, not silently accepted.
-	v := NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		Regex: ptr(`[invalid`),
-	})
+	}))
 
 	// Fail closed: broken constraint rejects all values, not accepts everything.
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "any value"}})
@@ -136,27 +136,27 @@ func TestValidate_InvalidRegexInDB_FailsClosed(t *testing.T) {
 
 func TestValidate_InvalidRegex_IncrementsCounter(t *testing.T) {
 	ctr := &countingCounter{}
-	NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	NewFieldValidator("field", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		Regex: ptr(`[invalid`),
-	}, WithRegexErrorCounter(ctr))
+	}), WithRegexErrorCounter(ctr))
 	assert.Equal(t, int64(1), ctr.n.Load())
 }
 
 // --- Enum constraints ---
 
 func TestValidate_Enum(t *testing.T) {
-	v := NewFieldValidator("currency", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("currency", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"USD", "EUR", "GBP"},
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "USD"}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "ILS"}}))
 }
 
 func TestValidate_EnumOnInteger(t *testing.T) {
-	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"1", "2", "3"},
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 1}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 5}}))
@@ -165,9 +165,9 @@ func TestValidate_EnumOnInteger(t *testing.T) {
 func TestValidate_EnumOnLargeNumber(t *testing.T) {
 	// Storage writes 1000000 as "1000000" (FormatFloat 'f'), not "1e+06" (%g).
 	// Enum comparison must use the same format or valid stored values are falsely rejected.
-	v := NewFieldValidator("quota", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("quota", pb.FieldType_FIELD_TYPE_NUMBER, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"1000000", "2000000"},
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 1_000_000}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 3_000_000}}))
@@ -175,9 +175,9 @@ func TestValidate_EnumOnLargeNumber(t *testing.T) {
 
 func TestValidate_EnumOnDuration(t *testing.T) {
 	// Enum on a duration field: stored values use Duration.String() format.
-	v := NewFieldValidator("ttl", pb.FieldType_FIELD_TYPE_DURATION, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("ttl", pb.FieldType_FIELD_TYPE_DURATION, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"1m30s", "5m0s"},
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(90 * time.Second)}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(10 * time.Second)}}))
@@ -186,10 +186,10 @@ func TestValidate_EnumOnDuration(t *testing.T) {
 // --- Duration constraints ---
 
 func TestValidate_DurationMinMax(t *testing.T) {
-	v := NewFieldValidator("timeout", pb.FieldType_FIELD_TYPE_DURATION, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("timeout", pb.FieldType_FIELD_TYPE_DURATION, WithConstraints(&pb.FieldConstraints{
 		Min: ptr(float64(1)),    // 1 second
 		Max: ptr(float64(3600)), // 1 hour
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(60_000_000_000)}})) // 60s
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(500_000_000)}}))       // 0.5s
@@ -199,10 +199,10 @@ func TestValidate_DurationMinMax(t *testing.T) {
 // --- Exclusive min/max ---
 
 func TestValidate_ExclusiveMinMax(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, WithConstraints(&pb.FieldConstraints{
 		ExclusiveMin: ptr(float64(0)),
 		ExclusiveMax: ptr(float64(1)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 0.5}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: 0}}))        // not > 0
@@ -211,10 +211,10 @@ func TestValidate_ExclusiveMinMax(t *testing.T) {
 }
 
 func TestValidate_ExclusiveMinMax_Integer(t *testing.T) {
-	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("level", pb.FieldType_FIELD_TYPE_INT, WithConstraints(&pb.FieldConstraints{
 		ExclusiveMin: ptr(float64(0)),
 		ExclusiveMax: ptr(float64(10)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 5}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: 0}}))  // not > 0
@@ -225,7 +225,7 @@ func TestValidate_ExclusiveMinMax_Integer(t *testing.T) {
 // --- URL validation ---
 
 func TestValidate_URL(t *testing.T) {
-	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
+	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com/hook"}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "not-a-url"}}))
@@ -235,7 +235,7 @@ func TestValidate_URL(t *testing.T) {
 // --- URL scheme allowlist ---
 
 func TestValidate_URL_DefaultSchemeAllowlist(t *testing.T) {
-	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL, false, false, nil)
+	v := NewFieldValidator("webhook", pb.FieldType_FIELD_TYPE_URL)
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "https://example.com"}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "http://example.com"}}))
@@ -254,9 +254,9 @@ func TestValidate_URL_DefaultSchemeAllowlist(t *testing.T) {
 }
 
 func TestValidate_URL_CustomSchemeAllowlist(t *testing.T) {
-	v := NewFieldValidator("s3path", pb.FieldType_FIELD_TYPE_URL, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("s3path", pb.FieldType_FIELD_TYPE_URL, WithConstraints(&pb.FieldConstraints{
 		AllowedSchemes: []string{"s3", "gs"},
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "s3://my-bucket/key"}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "gs://my-bucket/key"}}))
@@ -264,7 +264,7 @@ func TestValidate_URL_CustomSchemeAllowlist(t *testing.T) {
 }
 
 func TestValidate_URL_SensitiveSchemeError(t *testing.T) {
-	v := NewFieldValidator("secret.url", pb.FieldType_FIELD_TYPE_URL, false, true, nil)
+	v := NewFieldValidator("secret.url", pb.FieldType_FIELD_TYPE_URL, WithSensitive())
 
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "gopher://example.com"}})
 	require.Error(t, err)
@@ -276,9 +276,9 @@ func TestValidate_URL_SensitiveSchemeError(t *testing.T) {
 
 func TestValidate_JSONSchema(t *testing.T) {
 	schema := `{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}`
-	v := NewFieldValidator("metadata", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("metadata", pb.FieldType_FIELD_TYPE_JSON, WithConstraints(&pb.FieldConstraints{
 		JsonSchema: &schema,
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"name": "test"}`}}))
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"foo": "bar"}`}})) // missing required "name"
@@ -289,9 +289,9 @@ func TestValidate_InvalidJSONSchemaInDB_FailsClosed(t *testing.T) {
 	// Simulates a malformed json_schema written directly to the DB bypassing schema validation.
 	// The validator must fail closed: every value is rejected, not silently accepted.
 	bad := `{not valid json`
-	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("meta", pb.FieldType_FIELD_TYPE_JSON, WithConstraints(&pb.FieldConstraints{
 		JsonSchema: &bad,
-	})
+	}))
 
 	// Fail closed: broken constraint rejects all values, not accepts everything.
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: `{"any": "value"}`}})
@@ -302,14 +302,14 @@ func TestValidate_InvalidJSONSchemaInDB_FailsClosed(t *testing.T) {
 // --- No constraints (type check only) ---
 
 func TestValidate_NoConstraints(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING)
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "anything"}}))
 }
 
 // --- Sensitive field error suppression ---
 
 func TestValidate_Sensitive_URL_ErrorOmitsValue(t *testing.T) {
-	v := NewFieldValidator("secret.webhook", pb.FieldType_FIELD_TYPE_URL, false, true, nil)
+	v := NewFieldValidator("secret.webhook", pb.FieldType_FIELD_TYPE_URL, WithSensitive())
 
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: "not-a-url"}})
 	require.Error(t, err)
@@ -318,9 +318,9 @@ func TestValidate_Sensitive_URL_ErrorOmitsValue(t *testing.T) {
 }
 
 func TestValidate_Sensitive_Regex_ErrorOmitsValue(t *testing.T) {
-	v := NewFieldValidator("secret.token", pb.FieldType_FIELD_TYPE_STRING, false, true, &pb.FieldConstraints{
+	v := NewFieldValidator("secret.token", pb.FieldType_FIELD_TYPE_STRING, WithSensitive(), WithConstraints(&pb.FieldConstraints{
 		Regex: ptr(`^\d{4}$`),
-	})
+	}))
 
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hunter2"}})
 	require.Error(t, err)
@@ -329,9 +329,9 @@ func TestValidate_Sensitive_Regex_ErrorOmitsValue(t *testing.T) {
 }
 
 func TestValidate_Sensitive_Enum_ErrorOmitsValue(t *testing.T) {
-	v := NewFieldValidator("secret.tier", pb.FieldType_FIELD_TYPE_STRING, false, true, &pb.FieldConstraints{
+	v := NewFieldValidator("secret.tier", pb.FieldType_FIELD_TYPE_STRING, WithSensitive(), WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"gold", "silver"},
-	})
+	}))
 
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "bronze"}})
 	require.Error(t, err)
@@ -340,9 +340,9 @@ func TestValidate_Sensitive_Enum_ErrorOmitsValue(t *testing.T) {
 }
 
 func TestValidate_NonSensitive_ErrorIncludesValue(t *testing.T) {
-	v := NewFieldValidator("public.tier", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("public.tier", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		EnumValues: []string{"gold", "silver"},
-	})
+	}))
 
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "bronze"}})
 	require.Error(t, err)
@@ -357,7 +357,7 @@ func TestValidatorCache(t *testing.T) {
 	_, ok := c.Get("t1")
 	assert.False(t, ok)
 
-	validators := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
+	validators := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING)}
 	c.Set("t1", validators)
 
 	got, ok := c.Get("t1")
@@ -372,9 +372,9 @@ func TestValidatorCache(t *testing.T) {
 func TestValidatorCache_EvictsOldestWhenFull(t *testing.T) {
 	c := NewValidatorCache(2)
 
-	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
-	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)}
-	v3 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)}
+	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING)}
+	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)}
+	v3 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_BOOL)}
 
 	c.Set("t1", v1)
 	c.Set("t2", v2)
@@ -397,14 +397,14 @@ func TestValidatorCache_EvictsOldestWhenFull(t *testing.T) {
 func TestValidatorCache_UpdateExistingDoesNotGrow(t *testing.T) {
 	c := NewValidatorCache(2)
 
-	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, false, false, nil)}
-	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, false, false, nil)}
+	v1 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING)}
+	v2 := map[string]*FieldValidator{"x": NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT)}
 
 	c.Set("t1", v1)
 	c.Set("t2", v2)
 
 	// Update t1 — should not trigger eviction.
-	v1Updated := map[string]*FieldValidator{"y": NewFieldValidator("y", pb.FieldType_FIELD_TYPE_BOOL, false, false, nil)}
+	v1Updated := map[string]*FieldValidator{"y": NewFieldValidator("y", pb.FieldType_FIELD_TYPE_BOOL)}
 	c.Set("t1", v1Updated)
 	assert.Equal(t, 2, c.Len())
 
@@ -419,10 +419,10 @@ func TestValidatorCache_UpdateExistingDoesNotGrow(t *testing.T) {
 // --- Unicode / rune-based string length ---
 
 func TestValidate_StringLength_Unicode(t *testing.T) {
-	v := NewFieldValidator("label", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("label", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		MinLength: ptr(int32(2)),
 		MaxLength: ptr(int32(3)),
-	})
+	}))
 
 	// Each emoji is 1 rune but 4 bytes — byte count would produce wrong results.
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "🎉🎉"}}))  // 2 runes, 8 bytes
@@ -440,9 +440,9 @@ func TestValidate_StringLength_Unicode(t *testing.T) {
 // --- String exactly at MaxLength boundary ---
 
 func TestValidate_StringLength_ExactBoundary(t *testing.T) {
-	v := NewFieldValidator("desc", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("desc", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		MaxLength: ptr(int32(5)),
-	})
+	}))
 
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "hello"}})) // exactly 5
 	assert.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: "helloo"}}))   // 6 — one over
@@ -452,27 +452,27 @@ func TestValidate_StringLength_ExactBoundary(t *testing.T) {
 // --- math.MaxInt64 / MaxFloat64 / very small floats ---
 
 func TestValidate_Integer_MaxInt64(t *testing.T) {
-	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT, false, false, nil)
+	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT)
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MaxInt64}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MinInt64}}))
 }
 
 func TestValidate_Integer_MaxInt64_WithMax(t *testing.T) {
-	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("count", pb.FieldType_FIELD_TYPE_INT, WithConstraints(&pb.FieldConstraints{
 		Max: ptr(float64(math.MaxInt64)),
-	})
+	}))
 	// MaxInt64 as float64 rounds up slightly, so the integer MaxInt64 satisfies the constraint.
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: math.MaxInt64}}))
 }
 
 func TestValidate_Number_MaxFloat64(t *testing.T) {
-	v := NewFieldValidator("big", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	v := NewFieldValidator("big", pb.FieldType_FIELD_TYPE_NUMBER)
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.MaxFloat64}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: -math.MaxFloat64}}))
 }
 
 func TestValidate_Number_SmallFloat(t *testing.T) {
-	v := NewFieldValidator("tiny", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	v := NewFieldValidator("tiny", pb.FieldType_FIELD_TYPE_NUMBER)
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.SmallestNonzeroFloat64}}))
 	require.NoError(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: -math.SmallestNonzeroFloat64}}))
 }
@@ -480,21 +480,21 @@ func TestValidate_Number_SmallFloat(t *testing.T) {
 // --- NaN / Inf ---
 
 func TestValidate_Number_NaN_Rejected(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER)
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.NaN()}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "finite")
 }
 
 func TestValidate_Number_PosInf_Rejected(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER)
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.Inf(1)}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "finite")
 }
 
 func TestValidate_Number_NegInf_Rejected(t *testing.T) {
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, nil)
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER)
 	err := v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.Inf(-1)}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "finite")
@@ -503,10 +503,10 @@ func TestValidate_Number_NegInf_Rejected(t *testing.T) {
 func TestValidate_Number_NaN_WithConstraints_Rejected(t *testing.T) {
 	// NaN must be rejected even when min/max constraints are present, because
 	// NaN comparisons are always false and would otherwise silently pass.
-	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("rate", pb.FieldType_FIELD_TYPE_NUMBER, WithConstraints(&pb.FieldConstraints{
 		Min: ptr(float64(0)),
 		Max: ptr(float64(1)),
-	})
+	}))
 	require.Error(t, v.Validate(&pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: math.NaN()}}))
 }
 
@@ -514,17 +514,17 @@ func TestValidate_Number_NaN_WithConstraints_Rejected(t *testing.T) {
 
 func TestValidate_NilKindOnNullable(t *testing.T) {
 	// A TypedValue with no oneof set (Kind==nil) is treated as null for nullable fields.
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, true, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_INT, WithNullable())
 	require.NoError(t, v.Validate(&pb.TypedValue{}))
 }
 
 func TestValidate_NilKindOnNullable_Number(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_NUMBER, true, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_NUMBER, WithNullable())
 	require.NoError(t, v.Validate(&pb.TypedValue{}))
 }
 
 func TestValidate_NilKindOnNullable_String(t *testing.T) {
-	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, true, false, nil)
+	v := NewFieldValidator("x", pb.FieldType_FIELD_TYPE_STRING, WithNullable())
 	require.NoError(t, v.Validate(&pb.TypedValue{}))
 }
 
@@ -534,9 +534,9 @@ func TestValidate_StringLength_LargeBoundary(t *testing.T) {
 	// Verify boundary behaviour at a doc-size-scale length (5 MiB = 5242880 bytes).
 	// All ASCII, so rune count == byte count.
 	const limit = 5 * 1024 * 1024
-	v := NewFieldValidator("blob", pb.FieldType_FIELD_TYPE_STRING, false, false, &pb.FieldConstraints{
+	v := NewFieldValidator("blob", pb.FieldType_FIELD_TYPE_STRING, WithConstraints(&pb.FieldConstraints{
 		MaxLength: ptr(int32(limit)),
-	})
+	}))
 
 	atLimit := strings.Repeat("a", limit)
 	overLimit := atLimit + "a"


### PR DESCRIPTION
## Summary

- `NewFieldValidator` had 5 positional args including two adjacent booleans (`nullable`, `sensitive`) that could be silently swapped — a classic argument-order footgun.
- Moved `nullable`, `sensitive`, and `constraints` to functional options (`WithNullable()`, `WithSensitive()`, `WithConstraints(c)`), consistent with the existing `WithLimits` pattern. Only the truly required args (`fieldPath`, `fieldType`) stay positional.
- ~70 call sites in tests now read clearly without positional `false, false, nil` noise.

## Test plan

- [x] All ~70 call sites in `internal/validation/` migrated to functional options
- [x] Production call site in `factory.go` updated with conditional opts building
- [x] `go build ./internal/validation/...` clean
- [x] `make test` passes
- [x] `make lint-go` passes (0 issues)

Closes #242