### PR TITLE
fix(configwatcher): prevent Close deadlock on failed Start

### DIFF
--- a/sdk/configwatcher/race_test.go
+++ b/sdk/configwatcher/race_test.go
@@ -380,3 +380,92 @@ func TestWatcher_CloseWhileStreamSends(t *testing.T) {
 
 	<-drainDone
 }
+
+// TestWatcher_CloseDoesNotHangOnFailedStart verifies that Close returns promptly
+// when it races a Start whose snapshot call fails.
+//
+// Before the fix, Start's rollback path replaced w.cancelReady with a new channel
+// without closing the old one. A concurrent Close that had already captured the old
+// channel would block on it forever. The fix closes the old channel during rollback
+// so Close is always unblocked.
+//
+// The test is deterministic: startedReady is closed by the snapshot function right
+// after Start has set w.started=true (and before loadSnapshot returns), guaranteeing
+// that Close captures the cancelReady channel that the rollback is about to swap out.
+//
+// Run with: go test -race -timeout 30s -run TestWatcher_CloseDoesNotHangOnFailedStart ./sdk/configwatcher/
+func TestWatcher_CloseDoesNotHangOnFailedStart(t *testing.T) {
+	const iterations = 200
+
+	for range iterations {
+		// startedReady is closed by the snapshot fn once w.started=true is set;
+		// this gates the Close goroutine so it races the rollback window.
+		startedReady := make(chan struct{})
+		// unblockSnapshot is closed by the Close goroutine to release loadSnapshot.
+		unblockSnapshot := make(chan struct{})
+
+		tr := &mockTransport{
+			getConfigFn: func(ctx context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+				// Notify Close goroutine that w.started=true has been set.
+				close(startedReady)
+				// Block until Close goroutine has called Close() and is waiting.
+				select {
+				case <-unblockSnapshot:
+				case <-ctx.Done():
+				}
+				return nil, fmt.Errorf("snapshot failed")
+			},
+			subscribeFn: func(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+				panic("subscribe must never be reached on a failed snapshot")
+			},
+		}
+
+		w := &Watcher{
+			transport: tr,
+			tenantID:  "t1",
+			opts:      options{minBackoff: 5 * time.Millisecond, maxBackoff: 10 * time.Millisecond},
+			fields:    make(map[string]*fieldEntry),
+			done:      make(chan struct{}),
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine 1: calls Start; the snapshot fn will fail.
+		go func() {
+			defer wg.Done()
+			_ = w.Start(context.Background())
+		}()
+
+		// Goroutine 2: waits until Start is inside loadSnapshot, then calls Close.
+		closeDone := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			defer close(closeDone)
+
+			// Wait until w.started=true has been committed inside Start.
+			select {
+			case <-startedReady:
+			case <-time.After(5 * time.Second):
+				t.Errorf("timed out waiting for Start to enter loadSnapshot")
+				return
+			}
+
+			// Allow Start to proceed and fail while we race it with Close.
+			close(unblockSnapshot)
+
+			// This must not block forever (regression for #807).
+			_ = w.Close()
+		}()
+
+		// Close must return within a generous deadline.
+		select {
+		case <-closeDone:
+			// Good: Close returned promptly.
+		case <-time.After(5 * time.Second):
+			t.Fatal("Close blocked forever while racing a failed Start (deadlock regression — #807)")
+		}
+
+		wg.Wait()
+	}
+}

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -277,8 +277,13 @@ func (w *Watcher) Start(ctx context.Context) error {
 		// Roll back so the caller can retry.
 		w.mu.Lock()
 		w.started = false
-		w.cancelReady = make(chan struct{}) // reset for next attempt
+		// Close the old cancelReady before replacing it so that any concurrent
+		// Close that already captured this channel is unblocked. Close checks
+		// w.cancel after the wait; it will be nil here, so it skips cancel().
+		old := w.cancelReady
+		w.cancelReady = make(chan struct{}) // fresh channel for the next Start attempt
 		w.mu.Unlock()
+		close(old)
 		return err
 	}
 

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -219,6 +219,14 @@ func TestWatcher_SnapshotAndStream(t *testing.T) {
 		t.Error("expected enabled to be true after snapshot")
 	}
 
+	// Drain the snapshot change notification (0.01 → 0.025) so the next receive
+	// below corresponds to the stream change, not the snapshot change.
+	select {
+	case <-fee.Changes():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected snapshot change event on fee.Changes()")
+	}
+
 	// Simulate a stream change.
 	sub.send(&configclient.ConfigChange{
 		TenantID:  "t1",
@@ -227,11 +235,11 @@ func TestWatcher_SnapshotAndStream(t *testing.T) {
 		NewValue:  configclient.FloatVal(0.05),
 	})
 
-	// Gate on the Changes() event — the value is applied before the event is sent.
+	// Gate on the stream Changes() event — the value is applied before the event is sent.
 	select {
 	case <-fee.Changes():
 	case <-time.After(100 * time.Millisecond):
-		t.Fatal("expected change event on fee.Changes()")
+		t.Fatal("expected stream change event on fee.Changes()")
 	}
 
 	if got := fee.Get(); got != 0.05 {


### PR DESCRIPTION
## Summary

- `Close` blocks forever when it races a `Start` whose snapshot fails — the rollback path replaced `w.cancelReady` with a new channel without closing the old one, stranding any goroutine waiting on it.
- Closing the old channel during rollback unblocks `Close` safely; because `w.cancel` is nil after a failed `Start`, `Close` skips calling `cancel()` and returns cleanly.
- Also fixes a pre-existing race in `TestWatcher_SnapshotAndStream` where the test was consuming the snapshot change notification instead of the stream change notification, causing a deterministic false failure.

## Test plan

- [ ] `TestWatcher_CloseDoesNotHangOnFailedStart` (new, 200 iterations, `-race`) deterministically exercises the race window and would deadlock without the fix
- [ ] All existing `sdk/configwatcher` tests pass with `-race`
- [ ] `make test` passes (all modules, `-race`)
- [ ] `make lint-go` passes (0 issues)
- [ ] Coverage on `watcher.go`: `Start` 100%, overall package 98.6%

Closes #807