### PR TITLE
fix(retry): clamp BackoffDuration to max on left-shift overflow

### DIFF
--- a/sdk/retry/retry.go
+++ b/sdk/retry/retry.go
@@ -5,6 +5,7 @@ package retry
 import (
 	"context"
 	"errors"
+	"math"
 	"math/rand/v2"
 	"time"
 )
@@ -122,15 +123,30 @@ func RunDo(ctx context.Context, enabled bool, cfg Config, fn func(ctx context.Co
 }
 
 // BackoffDuration computes exponential backoff with optional jitter.
-// The exponent is computed with an integer bit-shift; it is clamped to 62 to
-// avoid overflow before the max-duration clamp takes effect.
+//
+// The exponent is computed with an integer bit-shift. To avoid wrap-around
+// overflow (which can produce a zero or negative duration that bypasses the
+// max-duration clamp), the shift is pre-checked: if left-shifting initial by
+// shift bits would exceed math.MaxInt64, the result is clamped to max directly
+// without performing the shift.
 func BackoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
 	shift := attempt
 	if shift > 62 {
 		shift = 62
 	}
-	backoff := initial << shift
-	if backoff > max || backoff < 0 { // negative means overflow past int64 max
+
+	// Guard against left-shift overflow. When initial << shift would exceed
+	// int64 max, the Go runtime wraps the value (it can go negative or wrap to
+	// zero), which bypasses the backoff > max and backoff < 0 clamps below.
+	// Pre-check using the equivalent inequality initial > MaxInt64 >> shift.
+	var backoff time.Duration
+	if shift > 0 && initial > time.Duration(math.MaxInt64)>>shift {
+		backoff = max
+	} else {
+		backoff = initial << shift
+	}
+
+	if backoff > max || backoff < 0 {
 		backoff = max
 	}
 	if jitter && backoff > 0 {

--- a/sdk/retry/retry_test.go
+++ b/sdk/retry/retry_test.go
@@ -1,6 +1,7 @@
 package retry
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -47,6 +48,97 @@ func TestConfig_WithDefaults(t *testing.T) {
 	}
 	if !cfg.RetryableCheck(&RetryableError{Err: fmt.Errorf("transient")}) {
 		t.Error("default RetryableCheck should accept RetryableError")
+	}
+}
+
+func TestBackoffDuration_NormalProgression(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := 5 * time.Second
+
+	// attempt 0: 100ms, attempt 1: 200ms, ..., caps at 5s
+	expected := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		1600 * time.Millisecond,
+		3200 * time.Millisecond,
+		max, // 6400ms > max
+	}
+	for i, want := range expected {
+		got := BackoffDuration(i, initial, max, false)
+		if got != want {
+			t.Errorf("attempt %d: got %v, want %v", i, got, want)
+		}
+	}
+}
+
+// TestBackoffDuration_HighAttemptsClamped checks that very high attempt counts
+// (shifts 56-62 with initial=100ms) no longer wrap around to zero. Before the
+// fix, these attempts produced 0s, creating a busy-loop instead of a 5s pause.
+func TestBackoffDuration_HighAttemptsClamped(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := 5 * time.Second
+
+	for attempt := 50; attempt <= 65; attempt++ {
+		got := BackoffDuration(attempt, initial, max, false)
+		if got != max {
+			t.Errorf("attempt %d: got %v, want %v (overflow must clamp to max)", attempt, got, max)
+		}
+	}
+}
+
+// TestBackoffDuration_JitterBound checks that jitter stays within [0, backoff).
+func TestBackoffDuration_JitterBound(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := 5 * time.Second
+
+	for attempt := 0; attempt <= 10; attempt++ {
+		noJitter := BackoffDuration(attempt, initial, max, false)
+		for i := 0; i < 50; i++ {
+			got := BackoffDuration(attempt, initial, max, true)
+			if got < 0 || (noJitter > 0 && got >= noJitter) {
+				t.Errorf("attempt %d iter %d: jitter result %v out of [0, %v)", attempt, i, got, noJitter)
+			}
+		}
+	}
+}
+
+// TestBackoffDuration_HighAttemptsJitter ensures jitter at overflow attempts
+// stays within [0, max) and never returns zero due to wrap-around.
+func TestBackoffDuration_HighAttemptsJitter(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := 5 * time.Second
+
+	// With jitter the result is random in [0, max), so we cannot assert == max.
+	// What we can assert is that it is non-negative (no wrap-around to negative)
+	// and strictly less than max (jitter always reduces).
+	for attempt := 56; attempt <= 62; attempt++ {
+		for i := 0; i < 20; i++ {
+			got := BackoffDuration(attempt, initial, max, true)
+			if got < 0 {
+				t.Errorf("attempt %d: jitter produced negative duration %v", attempt, got)
+			}
+			if got >= max {
+				t.Errorf("attempt %d: jitter result %v should be < max %v", attempt, got, max)
+			}
+		}
+	}
+}
+
+// TestRun_Disabled verifies that Run calls fn exactly once when retry is off.
+func TestRun_Disabled(t *testing.T) {
+	calls := 0
+	cfg := Config{}.WithDefaults()
+	_, err := Run(context.Background(), false, cfg, func(_ context.Context) (int, error) {
+		calls++
+		return 0, fmt.Errorf("fail")
+	})
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+	if err == nil {
+		t.Error("expected error, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `BackoffDuration` used an integer left-shift to compute the exponential backoff. For `initial=100ms`, shifts 56-62 caused the int64 value to wrap around to exactly zero, bypassing both the `> max` and `< 0` clamps and producing a zero-delay busy-loop at high attempt counts.
- The fix pre-checks for overflow before performing the shift: if `initial > math.MaxInt64 >> shift`, the result would overflow, so we clamp directly to `max` without shifting.
- Tests cover the full normal progression, attempts 50-65 all clamping to `max`, jitter bounds, and jitter correctness at high attempts.

## Test plan

- [x] `TestBackoffDuration_HighAttemptsClamped`: attempts 50-65 all return `max` (5s)
- [x] `TestBackoffDuration_NormalProgression`: attempts 0-6 follow the expected doubling sequence, capping at `max`
- [x] `TestBackoffDuration_JitterBound`: jitter stays within `[0, backoff)` for all normal attempts
- [x] `TestBackoffDuration_HighAttemptsJitter`: jitter at overflow attempts stays non-negative and below `max`
- [x] `make test` passes across all modules with `-race`
- [x] `make lint-go` reports 0 issues

Closes #811