### PR TITLE
fix(ci): gate SDK/CLI tests and fix the configwatcher race they hid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,13 +241,21 @@ jobs:
 
       - name: SDK + CLI + tools tests
         run: |
-          cd sdk/configclient && go test ./... -count=1 -coverprofile=../../cov-configclient.out -covermode=atomic &
-          cd sdk/adminclient && go test ./... -count=1 -coverprofile=../../cov-adminclient.out -covermode=atomic &
-          cd sdk/configwatcher && go test ./... -count=1 -coverprofile=../../cov-configwatcher.out -covermode=atomic &
-          cd sdk/grpctransport && go test ./... -count=1 -coverprofile=../../cov-grpctransport.out -covermode=atomic &
-          cd sdk/tools && go test ./... -count=1 -coverprofile=../../cov-tools.out -covermode=atomic &
-          cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic &
-          wait
+          # Run each module's tests in parallel, then wait on each PID and fail
+          # if any test run did. A bare `wait` returns 0 regardless of job exit
+          # codes, which silently un-gated every module below (see #832).
+          pids=()
+          cd sdk/configclient && go test ./... -count=1 -coverprofile=../../cov-configclient.out -covermode=atomic & pids+=($!)
+          cd sdk/adminclient && go test ./... -count=1 -coverprofile=../../cov-adminclient.out -covermode=atomic & pids+=($!)
+          cd sdk/configwatcher && go test ./... -count=1 -coverprofile=../../cov-configwatcher.out -covermode=atomic & pids+=($!)
+          cd sdk/grpctransport && go test ./... -count=1 -coverprofile=../../cov-grpctransport.out -covermode=atomic & pids+=($!)
+          cd sdk/tools && go test ./... -count=1 -coverprofile=../../cov-tools.out -covermode=atomic & pids+=($!)
+          cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic & pids+=($!)
+          fail=0
+          for pid in "${pids[@]}"; do
+            wait "$pid" || fail=1
+          done
+          exit $fail
 
       - name: Coverage ratchet
         run: |

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -219,6 +219,15 @@ func TestWatcher_SnapshotAndStream(t *testing.T) {
 		t.Error("expected enabled to be true after snapshot")
 	}
 
+	// The initial snapshot emits a Change (default -> snapshot value) on each
+	// field's channel. Drain fee's so the gate below observes the stream change,
+	// not the buffered snapshot event.
+	select {
+	case <-fee.Changes():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected initial snapshot change on fee.Changes()")
+	}
+
 	// Simulate a stream change.
 	sub.send(&configclient.ConfigChange{
 		TenantID:  "t1",


### PR DESCRIPTION
## Summary
- The "SDK + CLI + tools tests" CI step backgrounded every module's `go test` and then called a bare `wait`, which returns 0 regardless of the jobs' exit codes. Six modules (`configclient`, `adminclient`, `configwatcher`, `grpctransport`, `tools`, `cmd/decree`) were therefore not gating — any regression passed CI and `main` stayed green. This collects each background PID and waits on them individually, failing the step if any test run did.
- That gap was hiding a real failure: `TestWatcher_SnapshotAndStream` gated on the initial-snapshot `Change` event (emitted by `loadSnapshot`) instead of the stream change, then read `fee.Get()` before the stream value was applied (`got 0.025, want 0.05`). It now drains the initial snapshot change before gating on the stream change, matching the idiom the other tests already use.

## Test plan
- [x] Exit-code propagation verified: a failing backgrounded job makes the step exit 1; all-pass exits 0.
- [x] `ci.yml` validated as well-formed YAML.
- [x] `TestWatcher_SnapshotAndStream` passes deterministically (`-count=5`).
- [x] Full `sdk/configwatcher` package green; `gofmt` clean.

Closes #829
Closes #832