### PR TITLE
fix(adminclient): guard WithImportMode(0) against overriding default

### DIFF
--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -96,10 +96,15 @@ type importConfigOptions struct {
 }
 
 // WithImportMode sets the import mode. Defaults to [ImportModeMerge] if not specified.
-// Note: passing the zero value (0) silently overrides the default — use an
-// explicit constant ([ImportModeMerge], [ImportModeReplace], [ImportModeDefaults]).
+// A zero value is ignored so callers that conditionally construct options cannot
+// accidentally clobber the default.
 func WithImportMode(mode ImportMode) ImportConfigOption {
-	return func(o *importConfigOptions) { o.mode = mode }
+	return func(o *importConfigOptions) {
+		if mode == 0 {
+			return
+		}
+		o.mode = mode
+	}
 }
 
 // ImportConfig sends YAML configuration to the server, which applies the values

--- a/sdk/adminclient/operations_test.go
+++ b/sdk/adminclient/operations_test.go
@@ -669,6 +669,24 @@ func TestImportConfig_DefaultMode(t *testing.T) {
 	}
 }
 
+func TestImportConfig_ZeroModeIsNoOp(t *testing.T) {
+	mc := &mockConfigTransport{}
+	client := New(WithConfigTransport(mc))
+
+	mc.importConfigFn = func(_ context.Context, req *ImportConfigRequest) (*Version, error) {
+		if req.Mode != ImportModeMerge {
+			t.Errorf("WithImportMode(0) changed mode to %v; want default ImportModeMerge (%v)", req.Mode, ImportModeMerge)
+		}
+		return &Version{Version: 2, CreatedAt: time.Now()}, nil
+	}
+
+	// Passing 0 must be a no-op — the default merge mode must survive.
+	_, err := client.ImportConfig(context.Background(), "t1", []byte("yaml"), "", WithImportMode(0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // --- Error propagation ---
 
 func TestTransportError_Propagated(t *testing.T) {

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -144,6 +144,7 @@ func TestRetry_ContextCancellationStopsRetry(t *testing.T) {
 		retry: RetryConfig{
 			MaxAttempts:    10,
 			InitialBackoff: time.Second,
+			MaxBackoff:     5 * time.Second,
 			RetryableCheck: IsRetryable,
 		},
 	}}


### PR DESCRIPTION
## Summary
- `WithImportMode(0)` silently overwrote the `ImportModeMerge` default with an invalid zero sentinel, which would be forwarded to the transport as-is.
- The fix makes zero a no-op in the option function, so callers that conditionally pass a mode variable cannot accidentally clobber the default.

## Test plan
- [x] `TestImportConfig_ZeroModeIsNoOp` — verifies that `WithImportMode(0)` leaves the mode at `ImportModeMerge`
- [x] Existing `TestImportConfig_DefaultMode` and `TestImportConfig_WithMode` continue to pass
- [x] `go vet ./sdk/adminclient/...` — clean
- [x] `make lint-go` — 0 issues

Closes #825