### PR TITLE
fix(cache): bound MemoryIdempotencyCache and negative cache with LRU

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -100,7 +100,7 @@ func run() int {
 		schemaStoreVal = memSchema
 		auditStoreVal = audit.NewMemoryStore()
 		configCache = cache.NewMemoryCache(ctx, 0)
-		idempotencyCache = cache.NewMemoryIdempotencyCache()
+		idempotencyCache = cache.NewMemoryIdempotencyCache(ctx, 0)
 		memOpts := []pubsub.MemoryOption{pubsub.WithLogger(logger)}
 		if counter, ok := pubSubMetrics.DroppedCounter(); ok {
 			memOpts = append(memOpts, pubsub.WithDroppedCounter(counter))

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -37,7 +37,7 @@ func WithSweepInterval(d time.Duration) MemoryCacheOption {
 type MemoryCache struct {
 	mu            sync.RWMutex
 	lru           *LRU[string, memoryCacheEntry]
-	negEntries    map[string]time.Time // negative-cache: key → expiry
+	negEntries    *LRU[string, time.Time] // negative-cache: key → expiry; LRU-bounded to maxEntries
 	maxEntries    int
 	sweepInterval time.Duration
 	cancel        context.CancelFunc
@@ -63,7 +63,7 @@ func NewMemoryCache(ctx context.Context, maxEntries int, opts ...MemoryCacheOpti
 	sweepCtx, cancel := context.WithCancel(ctx)
 	c := &MemoryCache{
 		lru:           NewLRU[string, memoryCacheEntry](maxEntries),
-		negEntries:    make(map[string]time.Time),
+		negEntries:    NewLRU[string, time.Time](maxEntries),
 		maxEntries:    maxEntries,
 		sweepInterval: cfg.sweepInterval,
 		cancel:        cancel,
@@ -124,25 +124,25 @@ func (c *MemoryCache) Invalidate(_ context.Context, tenantID string) error {
 			c.lru.Delete(k)
 		}
 	})
-	for k := range c.negEntries {
+	c.negEntries.Range(func(k string, _ time.Time) {
 		if strings.HasPrefix(k, prefix) {
-			delete(c.negEntries, k)
+			c.negEntries.Delete(k)
 		}
-	}
+	})
 	return nil
 }
 
 func (c *MemoryCache) SetNegative(_ context.Context, tenantID string, version int32, ttl time.Duration) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.negEntries[c.key(tenantID, version)] = time.Now().Add(ttl)
+	c.negEntries.Set(c.key(tenantID, version), time.Now().Add(ttl))
 	return nil
 }
 
 func (c *MemoryCache) GetNegative(_ context.Context, tenantID string, version int32) (bool, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	exp, ok := c.negEntries[c.key(tenantID, version)]
+	exp, ok := c.negEntries.Peek(c.key(tenantID, version))
 	if !ok || time.Now().After(exp) {
 		return false, nil
 	}
@@ -167,29 +167,6 @@ func (c *MemoryCache) evictExpired() {
 	c.lru.DeleteWhere(func(_ string, e memoryCacheEntry) bool {
 		return now.After(e.expiresAt)
 	})
-}
-
-// MemoryIdempotencyCache implements IdempotencyCache with an in-memory map.
-// Suitable for single-instance dev/test deployments; does not share state across
-// server replicas. Use RedisIdempotencyCache in production.
-type MemoryIdempotencyCache struct {
-	mu      sync.Mutex
-	entries map[string]time.Time
-}
-
-// NewMemoryIdempotencyCache creates an in-memory idempotency cache.
-func NewMemoryIdempotencyCache() *MemoryIdempotencyCache {
-	return &MemoryIdempotencyCache{entries: make(map[string]time.Time)}
-}
-
-func (c *MemoryIdempotencyCache) Claim(_ context.Context, key string, ttl time.Duration) (bool, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if exp, ok := c.entries[key]; ok && time.Now().Before(exp) {
-		return false, nil
-	}
-	c.entries[key] = time.Now().Add(ttl)
-	return true, nil
 }
 
 // sweepLoop periodically removes expired entries. Each iteration adds ±10%
@@ -217,9 +194,101 @@ func (c *MemoryCache) sweep() {
 	c.evictExpired()
 
 	now := time.Now()
-	for k, exp := range c.negEntries {
-		if now.After(exp) {
-			delete(c.negEntries, k)
+	c.negEntries.DeleteWhere(func(_ string, exp time.Time) bool {
+		return now.After(exp)
+	})
+}
+
+// MemoryIdempotencyOption configures optional MemoryIdempotencyCache settings.
+type MemoryIdempotencyOption func(*memoryIdempotencyConfig)
+
+type memoryIdempotencyConfig struct {
+	sweepInterval time.Duration
+}
+
+// WithIdempotencySweepInterval sets the base sweep interval for the idempotency cache.
+func WithIdempotencySweepInterval(d time.Duration) MemoryIdempotencyOption {
+	return func(cfg *memoryIdempotencyConfig) {
+		cfg.sweepInterval = d
+	}
+}
+
+// MemoryIdempotencyCache implements IdempotencyCache with an in-memory LRU.
+// Suitable for single-instance dev/test deployments; does not share state across
+// server replicas. Use RedisIdempotencyCache in production.
+type MemoryIdempotencyCache struct {
+	mu            sync.Mutex
+	lru           *LRU[string, time.Time]
+	maxEntries    int
+	sweepInterval time.Duration
+	cancel        context.CancelFunc
+	stopOnce      sync.Once
+}
+
+// NewMemoryIdempotencyCache creates an in-memory idempotency cache.
+// maxEntries bounds the number of live claims (0 uses default of 10000).
+// The background sweep goroutine stops when ctx is cancelled or Stop is called.
+func NewMemoryIdempotencyCache(ctx context.Context, maxEntries int, opts ...MemoryIdempotencyOption) *MemoryIdempotencyCache {
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxEntries
+	}
+	cfg := memoryIdempotencyConfig{sweepInterval: defaultSweepInterval}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	sweepCtx, cancel := context.WithCancel(ctx)
+	c := &MemoryIdempotencyCache{
+		lru:           NewLRU[string, time.Time](maxEntries),
+		maxEntries:    maxEntries,
+		sweepInterval: cfg.sweepInterval,
+		cancel:        cancel,
+	}
+	go c.sweepLoop(sweepCtx)
+	return c
+}
+
+func (c *MemoryIdempotencyCache) Claim(_ context.Context, key string, ttl time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if exp, ok := c.lru.Peek(key); ok && time.Now().Before(exp) {
+		return false, nil
+	}
+	c.lru.Set(key, time.Now().Add(ttl))
+	return true, nil
+}
+
+// Len returns the number of live claims in the cache.
+func (c *MemoryIdempotencyCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lru.Len()
+}
+
+// Stop stops the background sweep goroutine. Safe to call more than once.
+func (c *MemoryIdempotencyCache) Stop() {
+	c.stopOnce.Do(c.cancel)
+}
+
+func (c *MemoryIdempotencyCache) sweepLoop(ctx context.Context) {
+	for {
+		half := c.sweepInterval / 10
+		jitter := time.Duration(rand.Int64N(int64(2*half))) - half
+		timer := time.NewTimer(c.sweepInterval + jitter)
+		select {
+		case <-timer.C:
+			c.sweepExpired()
+		case <-ctx.Done():
+			timer.Stop()
+			return
 		}
 	}
+}
+
+func (c *MemoryIdempotencyCache) sweepExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.lru.DeleteWhere(func(_ string, exp time.Time) bool {
+		return now.After(exp)
+	})
 }

--- a/internal/cache/memory_test.go
+++ b/internal/cache/memory_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -196,14 +197,16 @@ func TestMemoryCache_WithSweepInterval_SweepsOnSchedule(t *testing.T) {
 // --- MemoryIdempotencyCache ---
 
 func TestMemoryIdempotencyCache_FirstClaimReturnsTrue(t *testing.T) {
-	c := NewMemoryIdempotencyCache()
+	c := NewMemoryIdempotencyCache(context.Background(), 0)
+	defer c.Stop()
 	first, err := c.Claim(context.Background(), "k1", time.Minute)
 	require.NoError(t, err)
 	assert.True(t, first)
 }
 
 func TestMemoryIdempotencyCache_SecondClaimReturnsFalse(t *testing.T) {
-	c := NewMemoryIdempotencyCache()
+	c := NewMemoryIdempotencyCache(context.Background(), 0)
+	defer c.Stop()
 	ctx := context.Background()
 	first, _ := c.Claim(ctx, "k1", time.Minute)
 	require.True(t, first)
@@ -213,7 +216,8 @@ func TestMemoryIdempotencyCache_SecondClaimReturnsFalse(t *testing.T) {
 }
 
 func TestMemoryIdempotencyCache_ExpiredKeyAllowsReclaim(t *testing.T) {
-	c := NewMemoryIdempotencyCache()
+	c := NewMemoryIdempotencyCache(context.Background(), 0)
+	defer c.Stop()
 	ctx := context.Background()
 	_, _ = c.Claim(ctx, "k1", time.Millisecond)
 	time.Sleep(5 * time.Millisecond)
@@ -223,12 +227,41 @@ func TestMemoryIdempotencyCache_ExpiredKeyAllowsReclaim(t *testing.T) {
 }
 
 func TestMemoryIdempotencyCache_DifferentKeysAreIndependent(t *testing.T) {
-	c := NewMemoryIdempotencyCache()
+	c := NewMemoryIdempotencyCache(context.Background(), 0)
+	defer c.Stop()
 	ctx := context.Background()
 	a, _ := c.Claim(ctx, "a", time.Minute)
 	b, _ := c.Claim(ctx, "b", time.Minute)
 	assert.True(t, a)
 	assert.True(t, b)
+}
+
+func TestMemoryIdempotencyCache_DoesNotGrowBeyondCap(t *testing.T) {
+	const cap = 5
+	c := NewMemoryIdempotencyCache(context.Background(), cap)
+	defer c.Stop()
+	ctx := context.Background()
+
+	// Claim cap+10 unique keys with long TTL; LRU eviction keeps size ≤ cap.
+	for i := range cap + 10 {
+		_, err := c.Claim(ctx, fmt.Sprintf("key-%d", i), time.Hour)
+		require.NoError(t, err)
+	}
+	assert.LessOrEqual(t, c.Len(), cap)
+}
+
+func TestMemoryIdempotencyCache_SweepRemovesExpired(t *testing.T) {
+	c := NewMemoryIdempotencyCache(context.Background(), 0,
+		WithIdempotencySweepInterval(50*time.Millisecond))
+	defer c.Stop()
+	ctx := context.Background()
+
+	_, _ = c.Claim(ctx, "short", time.Millisecond)
+	_, _ = c.Claim(ctx, "long", time.Hour)
+
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, c.Len(), "expired entry should be swept")
 }
 
 // --- Negative cache ---
@@ -317,4 +350,25 @@ func TestMemoryCache_NegativeCache_IndependentFromPositive(t *testing.T) {
 	assert.False(t, neg1)
 	pos2, _ := c.Get(ctx, "t1", 2)
 	assert.Nil(t, pos2)
+}
+
+func TestMemoryCache_NegativeCache_DoesNotGrowBeyondCap(t *testing.T) {
+	const cap = 5
+	c := NewMemoryCache(context.Background(), cap)
+	defer c.Stop()
+	ctx := context.Background()
+
+	// Spray cap+10 unique version numbers; LRU eviction keeps size ≤ cap.
+	for i := range int32(cap + 10) {
+		require.NoError(t, c.SetNegative(ctx, "t1", i, time.Hour))
+	}
+	// Verify via GetNegative: only the most-recently-set entries survive.
+	live := 0
+	for i := range int32(cap + 10) {
+		ok, _ := c.GetNegative(ctx, "t1", i)
+		if ok {
+			live++
+		}
+	}
+	assert.LessOrEqual(t, live, cap)
 }

--- a/internal/config/service_helpers_test.go
+++ b/internal/config/service_helpers_test.go
@@ -152,7 +152,7 @@ func TestWithIdempotencyCache(t *testing.T) {
 	c := &mockCache{}
 	pub := &mockPublisher{}
 	sub := &mockSubscriber{}
-	idc := cache.NewMemoryIdempotencyCache()
+	idc := cache.NewMemoryIdempotencyCache(context.Background(), 0)
 	svc := NewService(store, c, pub, sub, WithLogger(testLogger), WithIdempotencyCache(idc))
 	assert.NotNil(t, svc.idempotencyCache)
 }


### PR DESCRIPTION
## Summary

- Idempotency cache and negative cache both used unbounded maps; long-running single-instance deployments would OOM under cycling unique keys (same root cause as rate-limiter buckets hardened in #287).
- Both are now LRU-bounded and swept, matching the hardening pattern already in place for `MemoryCache`.

## Changes

**B1 — MemoryIdempotencyCache:** replaced raw `map[string]time.Time` with `*LRU[string, time.Time]`; added background sweep goroutine, `Stop()`, and `Len()`. Signature changed to `NewMemoryIdempotencyCache(ctx, maxEntries, ...opts)`.

**B2 — Negative cache:** changed `negEntries map[string]time.Time` to `*LRU[string, time.Time]` capped at `maxEntries`. Updated `Invalidate`, `SetNegative`, `GetNegative`, and `sweep` accordingly.

## Test plan

- [x] `TestMemoryIdempotencyCache_DoesNotGrowBeyondCap` — claims cap+10 unique keys, asserts `Len() ≤ cap`
- [x] `TestMemoryIdempotencyCache_SweepRemovesExpired` — verifies sweep goroutine removes expired claims
- [x] `TestMemoryCache_NegativeCache_DoesNotGrowBeyondCap` — sprays cap+10 unique versions, asserts ≤ cap live entries remain
- [x] `make test` — full suite green

Closes #806