### PR TITLE
fix(grpctransport): error on empty TokenSource token

### DIFF
--- a/sdk/grpctransport/applyauth_test.go
+++ b/sdk/grpctransport/applyauth_test.go
@@ -134,6 +134,17 @@ func TestApplyAuth_TokenSource_ErrorPropagates(t *testing.T) {
 	}
 }
 
+func TestTokenSourceCreds_EmptyToken(t *testing.T) {
+	creds := tokenSourceCreds{source: func(context.Context) (string, error) { return "", nil }}
+	_, err := creds.GetRequestMetadata(context.Background())
+	if err == nil {
+		t.Fatal("expected error when token source returns empty string, got nil")
+	}
+	if !errors.Is(err, ErrEmptyToken) {
+		t.Errorf("expected errors.Is(err, ErrEmptyToken) to be true; got: %v", err)
+	}
+}
+
 func TestApplyAuth_TokenSource_TakesPrecedenceOverBearerToken(t *testing.T) {
 	// Both tokenSource and bearerToken set: tokenSource wins (it's checked first).
 	_, callOpts, err := applyAuth(context.Background(), authConfig{

--- a/sdk/grpctransport/auth.go
+++ b/sdk/grpctransport/auth.go
@@ -59,6 +59,10 @@ func WithBearerToken(token string) Option {
 // every RPC and its return value is used as the Bearer token. Use this
 // instead of [WithBearerToken] when tokens can expire (e.g. OAuth2,
 // short-lived JWTs).
+//
+// If the token source cannot obtain a token, it must return a non-nil error.
+// Returning an empty string with a nil error is treated as an error:
+// [ErrEmptyToken] is returned and the RPC is not sent.
 func WithTokenSource(fn func(context.Context) (string, error)) Option {
 	return func(c *config) { c.auth.tokenSource = fn }
 }
@@ -87,6 +91,12 @@ func WithLogger(l *slog.Logger) Option {
 // ErrRoleRequired is returned by transport constructors when neither
 // WithRole, WithBearerToken, nor WithTokenSource is provided.
 var ErrRoleRequired = errors.New("grpctransport: WithRole is required when not using WithBearerToken or WithTokenSource")
+
+// ErrEmptyToken is returned by [tokenSourceCreds.GetRequestMetadata] when the
+// token source returns an empty string. Callers that cannot obtain a token
+// should return a non-nil error from their token source function rather than
+// returning an empty string.
+var ErrEmptyToken = errors.New("grpctransport: TokenSource returned an empty token")
 
 func buildConfig(opts []Option) (config, error) {
 	var cfg config
@@ -125,9 +135,7 @@ func (t tokenSourceCreds) GetRequestMetadata(ctx context.Context, _ ...string) (
 		return nil, err
 	}
 	if tok == "" {
-		// Skip setting the Authorization header rather than sending a malformed
-		// "Bearer " credential. The server will treat the request as unauthenticated.
-		return nil, nil
+		return nil, ErrEmptyToken
 	}
 	return map[string]string{"authorization": "Bearer " + tok}, nil
 }


### PR DESCRIPTION
## Summary

- `tokenSourceCreds.GetRequestMetadata` silently sent unauthenticated RPCs when the token source returned an empty string — a token-refresh miss became an invisible auth failure.
- Now returns `ErrEmptyToken` so callers get an explicit, actionable error.
- Updated `WithTokenSource` docs to clarify that returning `("", nil)` is treated as an error.

## Test plan

- [x] `TestTokenSourceCreds_EmptyToken`: `tokenSourceCreds` with a source returning `("", nil)` — asserts non-nil error and `errors.Is(err, ErrEmptyToken)`.
- [x] All existing tests pass (`make test`).
- [x] `make lint-go` clean.

Closes #810