### PR TITLE
fix(retry): clamp negative attempt to 0 in BackoffDuration

### DIFF
--- a/sdk/retry/retry.go
+++ b/sdk/retry/retry.go
@@ -134,6 +134,9 @@ func RunDo(ctx context.Context, enabled bool, cfg Config, fn func(ctx context.Co
 //
 // The base duration for attempt n is initial * 2^n, capped at max.
 //
+// Negative attempt values are treated as 0: the function returns initial (or
+// its jittered equivalent) without panicking.
+//
 // When jitter is true, the result is a uniform random value in [0, backoff)
 // — full jitter with no minimum floor. A 5 s capped backoff can therefore
 // jitter down to near-zero on any given attempt. If a guaranteed minimum wait
@@ -147,6 +150,9 @@ func RunDo(ctx context.Context, enabled bool, cfg Config, fn func(ctx context.Co
 // without performing the shift.
 func BackoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
 	shift := attempt
+	if shift < 0 {
+		shift = 0
+	}
 	if shift > 62 {
 		shift = 62
 	}

--- a/sdk/retry/retry_test.go
+++ b/sdk/retry/retry_test.go
@@ -51,6 +51,21 @@ func TestConfig_WithDefaults(t *testing.T) {
 	}
 }
 
+// TestBackoffDuration_NegativeAttempt verifies that negative attempt values do
+// not panic and are treated as attempt 0 (returning initial).
+func TestBackoffDuration_NegativeAttempt(t *testing.T) {
+	initial := 100 * time.Millisecond
+	max := time.Second
+
+	cases := []int{-1, -99}
+	for _, attempt := range cases {
+		got := BackoffDuration(attempt, initial, max, false)
+		if got != initial {
+			t.Errorf("attempt %d: got %v, want %v", attempt, got, initial)
+		}
+	}
+}
+
 func TestBackoffDuration_NormalProgression(t *testing.T) {
 	initial := 100 * time.Millisecond
 	max := 5 * time.Second
@@ -95,7 +110,7 @@ func TestBackoffDuration_JitterBound(t *testing.T) {
 
 	for attempt := 0; attempt <= 10; attempt++ {
 		noJitter := BackoffDuration(attempt, initial, max, false)
-		for i := 0; i < 50; i++ {
+		for i := range 50 {
 			got := BackoffDuration(attempt, initial, max, true)
 			if got < 0 || (noJitter > 0 && got >= noJitter) {
 				t.Errorf("attempt %d iter %d: jitter result %v out of [0, %v)", attempt, i, got, noJitter)
@@ -114,7 +129,7 @@ func TestBackoffDuration_HighAttemptsJitter(t *testing.T) {
 	// What we can assert is that it is non-negative (no wrap-around to negative)
 	// and strictly less than max (jitter always reduces).
 	for attempt := 56; attempt <= 62; attempt++ {
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			got := BackoffDuration(attempt, initial, max, true)
 			if got < 0 {
 				t.Errorf("attempt %d: jitter produced negative duration %v", attempt, got)


### PR DESCRIPTION
## Summary

- `BackoffDuration` panicked on negative `attempt` values because `initial << shift` with a negative shift is a runtime error in Go.
- Added a `shift < 0` clamp so negative attempts behave identically to attempt 0 (returning `initial` or its jittered equivalent).
- Updated the doc comment to document this behavior.

## Test plan

- [x] `TestBackoffDuration_NegativeAttempt`: covers attempts `-1` and `-99`, asserts result equals `initial` with no panic.
- [x] All existing BackoffDuration tests pass.
- [x] `make test` and `make lint-go` clean.

Closes #812