### PR TITLE
fix(configclient): honor WithDescription on SetMany/SetManyTyped

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -1431,6 +1431,69 @@ func TestSetMany_WithValueDescriptionsAndChecksums(t *testing.T) {
 	}
 }
 
+func TestSetMany_WithDescription_honored(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	var capturedDesc string
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		capturedDesc = r.Description
+		return true
+	}, &SetFieldsResponse{}, nil)
+
+	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithDescription("via-option"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedDesc != "via-option" {
+		t.Errorf("description: got %q, want %q", capturedDesc, "via-option")
+	}
+}
+
+func TestSetManyTyped_WithDescription_honored(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	var capturedDesc string
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		capturedDesc = r.Description
+		return true
+	}, &SetFieldsResponse{}, nil)
+
+	err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{"a": IntVal(1)}, "", WithDescription("via-option"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedDesc != "via-option" {
+		t.Errorf("description: got %q, want %q", capturedDesc, "via-option")
+	}
+}
+
+func TestSetMany_positional_beats_option(t *testing.T) {
+	tr := &mockTransport{}
+	client := New(tr)
+	ctx := context.Background()
+
+	var capturedDesc string
+	tr.on("SetFields", func(args ...any) bool {
+		r := args[0].(*SetFieldsRequest)
+		capturedDesc = r.Description
+		return true
+	}, &SetFieldsResponse{}, nil)
+
+	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "positional", WithDescription("via-option"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedDesc != "positional" {
+		t.Errorf("description: got %q, want %q", capturedDesc, "positional")
+	}
+}
+
 func TestLockedValue_Set_WithDescription(t *testing.T) {
 	tr := &mockTransport{}
 	client := New(tr)

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -166,6 +166,10 @@ func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts .
 // to opt in to safe retry with server-side deduplication.
 func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
+	effectiveDescription := description
+	if effectiveDescription == "" {
+		effectiveDescription = wo.description
+	}
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		// Sort by FieldPath for deterministic request ordering.
 		paths := make([]string, 0, len(values))
@@ -188,7 +192,7 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
 			TenantID:       tenantID,
 			Updates:        updates,
-			Description:    description,
+			Description:    effectiveDescription,
 			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err
@@ -203,6 +207,10 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 // to opt in to safe retry with server-side deduplication.
 func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string, opts ...WriteOption) error {
 	wo := applyWriteOptions(opts)
+	effectiveDescription := description
+	if effectiveDescription == "" {
+		effectiveDescription = wo.description
+	}
 	return doWrite(ctx, c, wo, func(ctx context.Context) error {
 		// Sort by FieldPath for deterministic request ordering.
 		paths := make([]string, 0, len(values))
@@ -225,7 +233,7 @@ func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[s
 		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
 			TenantID:       tenantID,
 			Updates:        updates,
-			Description:    description,
+			Description:    effectiveDescription,
 			IdempotencyKey: wo.idempotencyKey,
 		})
 		return err


### PR DESCRIPTION
## Summary

- `SetMany` and `SetManyTyped` accepted `WithDescription(...)` as a `WriteOption` but silently discarded it, always using only the positional `description` arg.
- Now merges both: the positional arg wins when non-empty; `WithDescription` is the fallback when the positional arg is empty.
- Keeps backward compatibility — callers using only the positional arg see no change.

## Test plan

- [x] `TestSetMany_WithDescription_honored`: empty positional + `WithDescription("via-option")` → description is `"via-option"`.
- [x] `TestSetManyTyped_WithDescription_honored`: same for `SetManyTyped`.
- [x] `TestSetMany_positional_beats_option`: `"positional"` + `WithDescription("via-option")` → description is `"positional"`.
- [x] `make test` and `make lint-go` clean.

Closes #813