### PR TITLE
fix(configclient): include fieldChecksums in doWrite retry gate

### DIFF
--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -1366,6 +1366,43 @@ func (t *countingWriteTransport) SetField(_ context.Context, _ *SetFieldRequest)
 	return &SetFieldResponse{}, nil
 }
 
+// countingBatchWriteTransport is a minimal Transport that fails the first N
+// SetFields calls with a RetryableError and succeeds thereafter.
+type countingBatchWriteTransport struct {
+	mockTransport
+	failUntil int
+	calls     int
+}
+
+func (t *countingBatchWriteTransport) SetFields(_ context.Context, _ *SetFieldsRequest) (*SetFieldsResponse, error) {
+	t.calls++
+	if t.calls <= t.failUntil {
+		return nil, &RetryableError{Err: fmt.Errorf("unavailable")}
+	}
+	return &SetFieldsResponse{}, nil
+}
+
+func TestDoWrite_FieldChecksums_Retries(t *testing.T) {
+	ctx := context.Background()
+	tr := &countingBatchWriteTransport{failUntil: 2}
+	client := New(tr, WithRetry(RetryConfig{
+		MaxAttempts:    3,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		RetryableCheck: IsRetryable,
+	}))
+
+	err := client.SetMany(ctx, "t1", map[string]string{"field": "value"}, "",
+		WithFieldChecksums(map[string]string{"field": "chk-abc"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.calls != 3 {
+		t.Errorf("SetMany with WithFieldChecksums should retry: got %d calls, want 3", tr.calls)
+	}
+}
+
 // --- WriteOption tests ---
 
 func TestSet_WithDescription(t *testing.T) {

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -75,11 +75,14 @@ func WithFieldChecksums(checksums map[string]string) WriteOption {
 	return func(o *writeOptions) { o.fieldChecksums = checksums }
 }
 
-// doWrite executes a write operation. Without an idempotency key or expected
-// checksum, the call is made exactly once. With either (both make the write
-// idempotent) and retry enabled on the client, transient errors trigger retry.
+// doWrite executes a write operation. Without an idempotency key, expected
+// checksum, or field checksums, the call is made exactly once. With any of
+// those options (all make the write idempotent) and retry enabled on the
+// client, transient errors trigger retry. [WithFieldChecksums] on batch writes
+// (SetMany/SetManyTyped) also enables retry because per-field checksums make
+// the operation idempotent.
 func doWrite(ctx context.Context, c *Client, wo writeOptions, fn func(ctx context.Context) error) error {
-	if (wo.idempotencyKey != "" || wo.expectedChecksum != "") && c.opts.retryEnabled {
+	if (wo.idempotencyKey != "" || wo.expectedChecksum != "" || len(wo.fieldChecksums) > 0) && c.opts.retryEnabled {
 		return retryDo(ctx, c, fn)
 	}
 	return fn(ctx)


### PR DESCRIPTION
## Summary

- `SetMany`/`SetManyTyped` calls using `WithFieldChecksums` are idempotent (CAS per field) but the `doWrite` retry gate only checked `idempotencyKey` and `expectedChecksum`, so they never retried on transient errors even when `WithRetry` was enabled.
- Added `len(wo.fieldChecksums) > 0` to the gate condition so checksummed batch writes also benefit from retry.

## Test plan

- [x] `TestDoWrite_FieldChecksums_Retries`: transport that fails the first 2 calls, succeeds on the 3rd; `SetMany` with `WithFieldChecksums` succeeds, confirming retry is active.
- [x] `make test` and `make lint-go` clean.

Closes #814