### PR TITLE
refactor(grpctransport): remove dead applyAuth

### DIFF
--- a/sdk/grpctransport/applyauth_test.go
+++ b/sdk/grpctransport/applyauth_test.go
@@ -14,10 +14,8 @@ import (
 )
 
 func TestApplyAuth_BearerToken_ReturnsPerRPCCredentials(t *testing.T) {
-	_, callOpts, err := applyAuth(context.Background(), authConfig{bearerToken: "mytoken"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{bearerToken: "mytoken"})
+	_, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 1 {
 		t.Fatalf("expected 1 call option, got %d", len(callOpts))
 	}
@@ -47,10 +45,8 @@ func TestApplyAuth_BearerToken_PerRPCCredentials_SetsHeader(t *testing.T) {
 func TestApplyAuth_BearerToken_NoOutgoingMetadata(t *testing.T) {
 	// Bearer path must NOT touch outgoing context metadata (no clobbering).
 	ctx := context.Background()
-	retCtx, _, err := applyAuth(ctx, authConfig{bearerToken: "tok"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{bearerToken: "tok"})
+	retCtx, _ := applier.apply(ctx)
 	if _, ok := metadata.FromOutgoingContext(retCtx); ok {
 		t.Error("bearer token path must not set outgoing context metadata")
 	}
@@ -59,15 +55,13 @@ func TestApplyAuth_BearerToken_NoOutgoingMetadata(t *testing.T) {
 func TestApplyAuth_BearerToken_NoMetadataHeaders(t *testing.T) {
 	// With a bearer token, x-subject/x-role/x-tenant-id must NOT appear in
 	// outgoing metadata (they go via PerRPCCredentials, not context headers).
-	retCtx, _, err := applyAuth(context.Background(), authConfig{
+	applier := newAuthApplier(authConfig{
 		bearerToken: "tok",
 		subject:     "alice",
 		role:        "admin",
 		tenantID:    "acme",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	retCtx, _ := applier.apply(context.Background())
 	md, ok := metadata.FromOutgoingContext(retCtx)
 	if !ok {
 		return // no metadata is correct
@@ -89,17 +83,15 @@ func TestApplyAuth_TokenSource_ReturnsPerRPCCredentials(t *testing.T) {
 		called = true
 		return "dynamic-tok", nil
 	}
-	_, callOpts, err := applyAuth(context.Background(), authConfig{tokenSource: src})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{tokenSource: src})
+	_, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 1 {
 		t.Fatalf("expected 1 call option, got %d", len(callOpts))
 	}
 	_ = callOpts[0]
-	// Token source is called lazily by gRPC on each RPC, not at applyAuth time.
+	// Token source is called lazily by gRPC on each RPC, not at apply time.
 	if called {
-		t.Error("token source must not be called at applyAuth time")
+		t.Error("token source must not be called at apply time")
 	}
 }
 
@@ -151,13 +143,11 @@ func TestTokenSourceCreds_EmptyToken(t *testing.T) {
 
 func TestApplyAuth_TokenSource_TakesPrecedenceOverBearerToken(t *testing.T) {
 	// Both tokenSource and bearerToken set: tokenSource wins (it's checked first).
-	_, callOpts, err := applyAuth(context.Background(), authConfig{
+	applier := newAuthApplier(authConfig{
 		tokenSource: func(context.Context) (string, error) { return "source-tok", nil },
 		bearerToken: "static-tok",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	_, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 1 {
 		t.Fatalf("expected 1 call option, got %d", len(callOpts))
 	}
@@ -172,14 +162,12 @@ func TestApplyAuth_TokenSource_TakesPrecedenceOverBearerToken(t *testing.T) {
 }
 
 func TestApplyAuth_MetadataHeaders_AllFields(t *testing.T) {
-	ctx, callOpts, err := applyAuth(context.Background(), authConfig{
+	applier := newAuthApplier(authConfig{
 		subject:  "alice",
 		role:     "admin",
 		tenantID: "acme",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	ctx, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 0 {
 		t.Errorf("metadata-header path must return no call options, got %d", len(callOpts))
 	}
@@ -200,10 +188,8 @@ func TestApplyAuth_MetadataHeaders_AllFields(t *testing.T) {
 }
 
 func TestApplyAuth_MetadataHeaders_OnlyRoleSet(t *testing.T) {
-	ctx, callOpts, err := applyAuth(context.Background(), authConfig{role: "viewer"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{role: "viewer"})
+	ctx, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 0 {
 		t.Errorf("metadata-header path must return no call options, got %d", len(callOpts))
 	}
@@ -226,10 +212,8 @@ func TestApplyAuth_MetadataHeaders_PreservesCallerMetadata(t *testing.T) {
 	// AppendToOutgoingContext must not clobber pre-existing caller metadata.
 	base := metadata.Pairs("x-existing", "keep-me")
 	ctx := metadata.NewOutgoingContext(context.Background(), base)
-	ctx, _, err := applyAuth(ctx, authConfig{role: "admin"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{role: "admin"})
+	ctx, _ = applier.apply(ctx)
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		t.Fatal("no outgoing metadata")
@@ -250,14 +234,12 @@ func TestApplyAuth_MetadataHeaders_PreservesMultipleCallerKeys(t *testing.T) {
 		"x-baggage", "k=v",
 	)
 	ctx := metadata.NewOutgoingContext(context.Background(), base)
-	ctx, _, err := applyAuth(ctx, authConfig{
+	applier := newAuthApplier(authConfig{
 		subject:  "alice",
 		role:     "admin",
 		tenantID: "acme",
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	ctx, _ = applier.apply(ctx)
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		t.Fatal("no outgoing metadata")
@@ -282,10 +264,8 @@ func TestApplyAuth_MetadataHeaders_PreservesMultipleCallerKeys(t *testing.T) {
 }
 
 func TestApplyAuth_EmptyConfig_SetsNoHeaders(t *testing.T) {
-	ctx, callOpts, err := applyAuth(context.Background(), authConfig{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	applier := newAuthApplier(authConfig{})
+	ctx, callOpts := applier.apply(context.Background())
 	if len(callOpts) != 0 {
 		t.Errorf("empty config must return no call options, got %d", len(callOpts))
 	}

--- a/sdk/grpctransport/auth.go
+++ b/sdk/grpctransport/auth.go
@@ -142,44 +142,6 @@ func (t tokenSourceCreds) GetRequestMetadata(ctx context.Context, _ ...string) (
 
 func (t tokenSourceCreds) RequireTransportSecurity() bool { return true }
 
-// applyAuth injects authentication metadata into the outgoing gRPC context
-// and returns any per-RPC call options required.
-//
-// For bearer-token and token-source auth, it returns a
-// [grpc.PerRPCCredentials] call option backed by a
-// [credentials.PerRPCCredentials] implementation whose
-// RequireTransportSecurity method returns true — gRPC will refuse to send
-// the credential if the connection is not TLS-protected.
-//
-// For metadata-header auth (x-subject / x-role / x-tenant-id), headers are
-// appended to the existing outgoing metadata so the caller's metadata is
-// preserved.
-func applyAuth(ctx context.Context, auth authConfig) (context.Context, []grpc.CallOption, error) {
-	switch {
-	case auth.tokenSource != nil:
-		creds := tokenSourceCreds{source: auth.tokenSource}
-		return ctx, []grpc.CallOption{grpc.PerRPCCredentials(creds)}, nil
-	case auth.bearerToken != "":
-		creds := bearerToken{token: auth.bearerToken}
-		return ctx, []grpc.CallOption{grpc.PerRPCCredentials(creds)}, nil
-	default:
-		pairs := make([]string, 0, 6)
-		if auth.subject != "" {
-			pairs = append(pairs, "x-subject", auth.subject)
-		}
-		if auth.role != "" {
-			pairs = append(pairs, "x-role", auth.role)
-		}
-		if auth.tenantID != "" {
-			pairs = append(pairs, "x-tenant-id", auth.tenantID)
-		}
-		if len(pairs) > 0 {
-			ctx = metadata.AppendToOutgoingContext(ctx, pairs...)
-		}
-		return ctx, nil, nil
-	}
-}
-
 // authApplier holds pre-computed auth state so that per-RPC credential
 // objects and metadata key-value pairs are built once at construction time
 // rather than on every method call.


### PR DESCRIPTION
## Summary

- `applyAuth` was referenced only in tests; all production paths used `authApplier.apply`. The two implementations had already diverged in slice initialization, making silent drift a real risk.
- Removed `applyAuth` entirely and migrated 10 tests in `applyauth_test.go` to exercise `newAuthApplier` + `apply` directly — the same behavior, through the live code path.

## Test plan

- [x] All 10 migrated tests pass with the same assertions as before.
- [x] No behavior changes — only the dead function is removed.
- [x] `make test` and `make lint-go` clean.

Closes #821