### PR TITLE
feat(skills): harden /pr to require Closes #N body reference

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -15,10 +15,38 @@ Create a pull request for the current branch.
 3. Determine title:
    - If `$ARGUMENTS` is provided, use it as the title
    - Otherwise, derive from commits (under 70 chars, imperative mood)
-4. Create the PR:
+4. Detect issue references by running `check.sh` from the skill directory:
+
+```bash
+eval "$(bash "$(dirname "$0")/check.sh" 2>/dev/null)" || true
+```
+
+This sets `$ISSUE_REFS` (space-separated issue numbers, e.g. `"312 456"`).
+
+5. Branch on issue refs:
+
+   **If `$ISSUE_REFS` is non-empty:**
+   - Build a `Closes` block from the refs:
+     ```
+     Closes #312
+     Closes #456
+     ```
+   - Include this block at the top of the PR body (before `## Summary`).
+
+   **If `$ISSUE_REFS` is empty:**
+   - Print a warning:
+     ```
+     Warning: This PR does not reference any issue. Open anyway, or attach an issue?
+     Enter issue number to attach (or press Enter to open without one):
+     ```
+   - Read user input. If they provide a number N, set `ISSUE_REFS="N"` and include `Closes #N` in the body. If they press Enter (empty input), proceed without a `Closes` line.
+
+6. Create the PR. When refs are present, include the `Closes` block:
 
 ```
 gh pr create --title "TITLE" --body "$(cat <<'EOF'
+Closes #NNN
+
 ## Summary
 <1-3 bullet points summarizing the changes>
 
@@ -30,11 +58,13 @@ EOF
 )"
 ```
 
-5. Report the PR URL
+When no refs, omit the `Closes` line.
+
+7. Report the PR URL
 
 ## Rules
 - Do NOT assign reviewers (solo maintainer)
 - Do NOT set milestone (managed separately)
 - Title under 70 characters
 - Summary bullets focus on "why" not "what"
-- Include issue references (Closes #N) when applicable
+- Always include `Closes #N` when issue refs are found in commits

--- a/.claude/skills/pr/check.sh
+++ b/.claude/skills/pr/check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# check.sh — extract issue references from commits since main
+# Outputs: export ISSUE_REFS="123 456" (space-separated, deduplicated)
+# Exit 0 if refs found, exit 1 if none found
+
+set -euo pipefail
+
+log=$(git log --oneline main..HEAD 2>/dev/null || true)
+
+if [[ -z "$log" ]]; then
+  export ISSUE_REFS=""
+  exit 1
+fi
+
+# Match patterns (case-insensitive):
+#   #123
+#   closes #123 / close #123
+#   fixes #123 / fix #123
+#   resolves #123 / resolve #123
+#   refs #123 / ref #123
+refs=$(echo "$log" \
+  | grep -oiE '(closes?|fixes?|resolves?|refs?)[[:space:]]+#([0-9]+)|#([0-9]+)' \
+  | grep -oE '[0-9]+' \
+  | sort -nu \
+  | tr '\n' ' ' \
+  | sed 's/[[:space:]]*$//')
+
+if [[ -z "$refs" ]]; then
+  export ISSUE_REFS=""
+  exit 1
+fi
+
+export ISSUE_REFS="$refs"
+echo "export ISSUE_REFS=\"$refs\""
+exit 0


### PR DESCRIPTION
## Summary

- The `/pr` skill previously left issue linkage to developer memory; PRs were opened without `Closes #N` lines and issues were closed manually after merge.
- `check.sh` now parses `git log main..HEAD` for all ref patterns (`#NNN`, `closes/fixes/resolves/refs #NNN`, case-insensitive) and surfaces them before the PR body is built.
- When commits reference issues, `Closes #NNN` lines are prepended automatically; when none are found, the skill prompts for confirmation before proceeding.

## Test plan

- [ ] Open a PR from a branch whose commits reference `Closes #N` — verify body includes the closes line
- [ ] Open a PR from a branch with no issue refs — verify the confirmation prompt fires
- [ ] Run `check.sh` standalone on both branch types and confirm exit 0 / 1

Closes #312