### PR TITLE
chore(sdk): add issue refs to TODOs in convert.go and docgen.go

### DIFF
--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -78,7 +78,7 @@ func typedValueToProto(tv *configclient.TypedValue) *pb.TypedValue {
 // TODO: pb.ConfigValue.Description is dropped here and the post-write
 // ConfigVersion returned by SetField/SetFields is discarded into empty DTOs.
 // Notify configclient owners if Description or post-write version info is
-// ever needed by callers.
+// ever needed by callers. (tracked: #851)
 func configValueFromProto(cv *pb.ConfigValue) configclient.ConfigValue {
 	return configclient.ConfigValue{
 		FieldPath: cv.GetFieldPath(),

--- a/sdk/tools/docgen/docgen.go
+++ b/sdk/tools/docgen/docgen.go
@@ -347,7 +347,7 @@ func yesNo(v bool) string {
 // formatFloat formats a float64 for display, omitting the decimal point when
 // the value is a whole number.
 // TODO: this is byte-identical to validate.formatFloat; if a shared internal
-// package is added to sdk/tools, hoist both copies there.
+// package is added to sdk/tools, hoist both copies there. (#852)
 func formatFloat(f float64) string {
 	if f == float64(int64(f)) {
 		return fmt.Sprintf("%d", int64(f))


### PR DESCRIPTION
## Summary

- Two TODO comments lacked the required `#issue` reference per repo convention.
- Created tracking issues #851 (Description/ConfigVersion data loss in grpctransport) and #852 (formatFloat duplication in sdk/tools) to capture the underlying work.
- Updated both TODOs to reference their respective tracking issues.

## Test plan

- [ ] `make build` passes in `sdk/grpctransport` and `sdk/tools` modules
- [ ] TODOs in convert.go and docgen.go now reference tracking issue numbers

Closes #822