### PR TITLE
feat(deploy): add Grafana dashboard template for OTel metrics

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,60 @@
+# Grafana Dashboard — OpenDecree Service Overview
+
+Pre-built Grafana 10+ dashboard for monitoring the decree server via OpenTelemetry metrics.
+
+## Importing the Dashboard
+
+1. Open Grafana → **Dashboards** → **Import**.
+2. Click **Upload dashboard JSON file** and select `dashboard.json`.
+3. When prompted, select the **Prometheus** datasource that scrapes the decree OTel exporter.
+4. Click **Import**.
+
+## Required Datasource
+
+The dashboard uses a Prometheus datasource. The decree server exposes metrics via an OTel Prometheus exporter (default port `9090`, path `/metrics`). Configure Prometheus to scrape that endpoint, then add it as a datasource in Grafana.
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: decree
+    static_configs:
+      - targets: ["decree-service:9090"]
+```
+
+## Metric Namespace and OTel-to-Prometheus Translation
+
+The decree server registers metrics under the `decree` OTel meter. The OTel Prometheus exporter applies these transformations before exposing metrics:
+
+- Dots (`.`) in metric names become underscores (`_`).
+- The meter name (`decree`) is prepended as a namespace: `decree_<metric>`.
+- Counters (OTel `Int64Counter`) get a `_total` suffix.
+
+Examples:
+
+| OTel name | Prometheus name |
+|-----------|-----------------|
+| `db.pool.acquired_connections` | `decree_db_pool_acquired_connections` |
+| `config.cache.hits` | `decree_config_cache_hits_total` |
+| `config.writes` | `decree_config_writes_total` |
+| `ratelimit.rejected` | `decree_ratelimit_rejected_total` |
+| `pubsub.dropped_total` | `decree_pubsub_dropped_total` |
+| `auth.jwks_refresh_failures_total` | `decree_auth_jwks_refresh_failures_total` |
+| `validation.json_schema_compile_timeouts_total` | `decree_validation_json_schema_compile_timeouts_total` |
+| `validation.json_schema_compiles_in_flight` | `decree_validation_json_schema_compiles_in_flight` |
+
+Standard gRPC metrics emitted by `otelgrpc` are not namespaced and use `rpc_` prefix (e.g., `rpc_server_duration_milliseconds_bucket`).
+
+## Dashboard Panels
+
+| Row | Panel | Type | What it shows |
+|-----|-------|------|---------------|
+| Database Connection Pool | DB Pool Utilization (write) | Gauge | `acquired / max` for write pool; yellow ≥ 80%, red ≥ 95% |
+| Database Connection Pool | DB Pool Utilization (read) | Gauge | Same for read pool |
+| Database Connection Pool | DB Pool Connections | Time series | Acquired, idle, total for both pools |
+| Config Operations | Config Write Rate | Stat | Writes/min (5-minute rate) |
+| Config Operations | Cache Hit Rate | Time series | `hits / (hits + misses)` |
+| Reliability | Rate Limit Rejections | Stat | Rejections/min (5-minute rate) |
+| Reliability | PubSub Drops | Stat | Drops/min (5-minute rate) |
+| Reliability | JWKS Refresh Failures | Stat | Failures in the last hour; red threshold at > 0 |
+| gRPC Latency | gRPC P99 Latency | Time series | P99 server duration by method |

--- a/deploy/grafana/dashboard.json
+++ b/deploy/grafana/dashboard.json
@@ -1,0 +1,541 @@
+{
+  "__inputs": [
+    {
+      "name": "datasource",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping the decree OTel exporter",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "id": null,
+  "uid": "opendecree-overview",
+  "title": "OpenDecree — Service Overview",
+  "description": "OTel metrics emitted by the decree server (database pool, config operations, reliability, gRPC latency)",
+  "tags": ["opendecree", "otel"],
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Database Connection Pool",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "gauge",
+      "title": "DB Pool Utilization (write)",
+      "description": "Fraction of write pool connections currently acquired",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "minVizHeight": 75,
+        "minVizWidth": 75
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.95 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "decree_db_pool_acquired_connections{pool=\"write\"} / decree_db_pool_max_connections{pool=\"write\"}",
+          "instant": true,
+          "legendFormat": "write pool utilization",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "DB Pool Utilization (read)",
+      "description": "Fraction of read pool connections currently acquired",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "minVizHeight": 75,
+        "minVizWidth": 75
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.95 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "decree_db_pool_acquired_connections{pool=\"read\"} / decree_db_pool_max_connections{pool=\"read\"}",
+          "instant": true,
+          "legendFormat": "read pool utilization",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "DB Pool Connections",
+      "description": "Acquired, idle, and total connections for write and read pools over time",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "none" },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "decree_db_pool_acquired_connections",
+          "legendFormat": "acquired ({{pool}})",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "decree_db_pool_idle_connections",
+          "legendFormat": "idle ({{pool}})",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "decree_db_pool_total_connections",
+          "legendFormat": "total ({{pool}})",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Config Operations",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Config Write Rate",
+      "description": "Config writes per minute (5-minute rate)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 10 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "displayName": "writes/min",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "mappings": [],
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(decree_config_writes_total[5m])) * 60",
+          "legendFormat": "writes/min",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Cache Hit Rate",
+      "description": "Config cache hit rate over time (hits / (hits + misses))",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 10 },
+      "options": {
+        "tooltip": { "mode": "single", "sort": "none" },
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(decree_config_cache_hits_total[5m]) / (rate(decree_config_cache_hits_total[5m]) + rate(decree_config_cache_misses_total[5m]))",
+          "legendFormat": "cache hit rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Reliability",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Rate Limit Rejections",
+      "description": "Requests rejected by the rate limiter per minute (5-minute rate)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "displayName": "rejections/min",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "mappings": [],
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(decree_ratelimit_rejected_total[5m]) * 60",
+          "legendFormat": "rejections/min",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "PubSub Drops",
+      "description": "Events dropped because a subscriber channel was full, per minute (5-minute rate)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1,
+          "displayName": "drops/min",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "mappings": [],
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(decree_pubsub_dropped_total[5m]) * 60",
+          "legendFormat": "drops/min",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "JWKS Refresh Failures",
+      "description": "JWKS background refresh failures in the last hour",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "displayName": "failures (1h)",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": [],
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "increase(decree_auth_jwks_refresh_failures_total[1h])",
+          "legendFormat": "JWKS failures",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "gRPC Latency",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "gRPC P99 Latency",
+      "description": "99th percentile gRPC server request duration by method",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (le, rpc_method) (rate(rpc_server_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p99 {{rpc_method}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "label": "Datasource",
+        "description": "Prometheus datasource",
+        "pluginId": "prometheus",
+        "refresh": 1,
+        "options": [],
+        "includeAll": false,
+        "multi": false,
+        "query": "prometheus",
+        "hide": 0,
+        "current": {}
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "links": []
+}


### PR DESCRIPTION
## Summary

- No pre-built observability dashboard existed for the decree service, requiring operators to build panels from scratch when setting up monitoring.
- Added a Grafana 10+ dashboard JSON with 9 panels across 4 rows: DB connection pool utilization (gauge + time series), config write rate and cache hit rate, reliability indicators (rate-limit rejections, pub/sub drops, JWKS failures), and gRPC P99 latency.
- Dashboard uses a `${datasource}` template variable for easy import into any Prometheus-backed Grafana instance.
- Added a README with import instructions and the OTel-to-Prometheus metric name translation table.

## Test plan

- [ ] Import `deploy/grafana/dashboard.json` into a Grafana instance — no parse errors
- [ ] All panels load correctly with a Prometheus datasource scraping the decree OTel exporter
- [ ] DB pool utilization gauge shows correct thresholds (yellow at 80%, red at 95%)

Closes #21