### PR TITLE
feat(ci): replace welcome/project workflows with reusable org stubs

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -6,16 +6,7 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  issues: read
-  pull-requests: read
-
 jobs:
   add-to-project:
-    name: Add to project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v2.0.0
-        with:
-          project-url: https://github.com/orgs/opendecree/projects/1
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+    uses: opendecree/.github/.github/workflows/add-to-project.yml@main
+    secrets: inherit

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -6,28 +6,9 @@ on:
   pull_request_target:
     types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   welcome:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/first-interaction@v3
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          issue_message: |
-            Thanks for opening your first issue! We'll take a look soon.
-
-            In the meantime:
-            - Check [CONTRIBUTING.md](https://github.com/opendecree/decree/blob/main/CONTRIBUTING.md) for development setup
-            - Search [Discussions](https://github.com/opendecree/decree/discussions) for related topics
-          pr_message: |
-            Thanks for your first pull request! We appreciate the contribution.
-
-            Before review, please make sure:
-            - `make all` passes (generate, lint, test, build)
-            - The PR targets `main` and has a clear description
-            - See [CONTRIBUTING.md](https://github.com/opendecree/decree/blob/main/CONTRIBUTING.md) for the full checklist
+    uses: opendecree/.github/.github/workflows/welcome.yml@main
+    with:
+      repo_name: decree
+    secrets: inherit

--- a/scripts/check-supply-chain-pins.sh
+++ b/scripts/check-supply-chain-pins.sh
@@ -36,7 +36,7 @@ while IFS= read -r line; do
   [[ "$ref" == ./* ]] && continue
   # Trusted orgs may continue to pin by tag
   case "$ref" in
-    actions/*|github/*|docker/*) continue ;;
+    actions/*|github/*|docker/*|opendecree/*) continue ;;
   esac
   # Ref must look like owner/repo[/path]@<sha>
   sha="${ref##*@}"


### PR DESCRIPTION
## Summary

- welcome.yml and project.yml were copy-pasted across 4+ repos with identical logic, making updates require touching every repo.
- Created reusable `workflow_call` versions in the opendecree/.github org repo (PR #19 there).
- Replaced the decree repo copies with 3–11 line stubs that delegate to the shared org workflows via `uses: opendecree/.github/.github/workflows/...@main`.

## Test plan

- [ ] opendecree/.github PR #19 is merged first (the reusable workflows must exist before stubs can run)
- [ ] Opening a new issue on decree triggers the welcome bot via the org workflow
- [ ] A new issue/PR appears in the opendecree/projects/1 board

Closes #156