### PR TITLE
feat(ci): dispatch SDK stub regen on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,3 +461,39 @@ jobs:
           path: |
             bench-e2e.txt
             bench-e2e-stats.txt
+
+  # Fires repository_dispatch events to decree-python, decree-typescript,
+  # and demos so they can regenerate proto stubs and open PRs automatically.
+  dispatch-sdk-regen:
+    name: Dispatch SDK stub regen
+    needs: [binaries, release-notes]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch to decree-python
+        # peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@0e0cf047c08f936c436da4399814cdb4880c8cbf
+        with:
+          token: ${{ secrets.PROJECT_TOKEN }}
+          repository: opendecree/decree-python
+          event-type: decree-released
+          client-payload: '{"version": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'
+
+      - name: Dispatch to decree-typescript
+        # peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@0e0cf047c08f936c436da4399814cdb4880c8cbf
+        with:
+          token: ${{ secrets.PROJECT_TOKEN }}
+          repository: opendecree/decree-typescript
+          event-type: decree-released
+          client-payload: '{"version": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'
+
+      - name: Dispatch to demos
+        # peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@0e0cf047c08f936c436da4399814cdb4880c8cbf
+        with:
+          token: ${{ secrets.PROJECT_TOKEN }}
+          repository: opendecree/demos
+          event-type: decree-released
+          client-payload: '{"version": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Summary

- Proto stub regeneration in Python and TypeScript SDK repos was a manual step in `/release-sdks` after each decree release; missed steps caused version drift.
- Added a `dispatch-sdk-regen` job to `release.yml` that fires `decree-released` repository_dispatch events to `opendecree/decree-python`, `opendecree/decree-typescript`, and `opendecree/demos` immediately after binaries and release notes are published.
- Corresponding `regen-stubs.yml` workflows in decree-python (PR #123) and decree-typescript (PR #115) receive the event, regenerate stubs, run tests, and open a labeled PR automatically.

## Test plan

- [ ] Push a test tag — verify dispatch events appear in decree-python/decree-typescript Actions tabs
- [ ] Verify `regen-stubs/<version>` PR is opened with `dependencies,ci` labels
- [ ] Verify tests pass in the regen PR

Closes #157