### PR TITLE
feat(sdk): add contrib/envconfig struct field adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
           cd sdk/grpctransport && go test ./... -count=1 -coverprofile=../../cov-grpctransport.out -covermode=atomic & pids+=($!)
           cd sdk/tools && go test ./... -count=1 -coverprofile=../../cov-tools.out -covermode=atomic & pids+=($!)
           cd sdk/contrib/viper && go test ./... -count=1 -coverprofile=../../cov-contrib-viper.out -covermode=atomic & pids+=($!)
+          cd sdk/contrib/envconfig && go test ./... -count=1 -coverprofile=../../cov-contrib-envconfig.out -covermode=atomic & pids+=($!)
           cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic & pids+=($!)
           fail=0
           for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
@@ -277,7 +278,7 @@ jobs:
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage.out
-          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-decree.out; do
+          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-contrib-envconfig.out cov-decree.out; do
             [ -f "$f" ] && grep -v "^mode:" "$f" >> coverage.out || true
           done
 

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,7 @@ SERVER_LDFLAGS := -X github.com/opendecree/decree/internal/version.Version=$(GIT
 CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 
 # Module list for multi-module operations.
-<<<<<<< HEAD
 SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/viper sdk/contrib/envconfig
-=======
-SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/envconfig
->>>>>>> a812a22 (chore: add contrib/envconfig to SDK_MODULES for CI coverage)
 
 .PHONY: all generate generate-proto generate-sqlc deps test lint lint-go lint-proto lint-migrations build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ SERVER_LDFLAGS := -X github.com/opendecree/decree/internal/version.Version=$(GIT
 CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 
 # Module list for multi-module operations.
-SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/viper
+<<<<<<< HEAD
+SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/viper sdk/contrib/envconfig
+=======
+SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/envconfig
+>>>>>>> a812a22 (chore: add contrib/envconfig to SDK_MODULES for CI coverage)
 
 .PHONY: all generate generate-proto generate-sqlc deps test lint lint-go lint-proto lint-migrations build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 

--- a/sdk/contrib/envconfig/README.md
+++ b/sdk/contrib/envconfig/README.md
@@ -1,0 +1,52 @@
+# envconfig
+
+> **Alpha** — API subject to change.
+
+Adapter that populates Go struct fields from OpenDecree config values using struct tags.
+
+## Install
+
+```bash
+go get github.com/opendecree/decree/sdk/contrib/envconfig
+```
+
+## Usage
+
+Tag struct fields with `decree:"<field-path>"`:
+
+```go
+type AppConfig struct {
+    Name    string        `decree:"app.name"`
+    Debug   bool          `decree:"app.debug"`
+    Count   int64         `decree:"app.count"`
+    Rate    float64       `decree:"app.rate"`
+    Timeout time.Duration `decree:"jobs.timeout"`
+}
+```
+
+Then call `Process` to populate from the remote config:
+
+```go
+var cfg AppConfig
+if err := envconfig.Process(ctx, client, tenantID, &cfg); err != nil {
+    log.Fatal(err)
+}
+fmt.Println(cfg.Name) // value from OpenDecree
+```
+
+## Supported types
+
+| Go type          | decree field type |
+|------------------|------------------|
+| `string`         | `string`         |
+| `bool`           | `bool`           |
+| `int`, `int64`   | `integer`        |
+| `float64`        | `number`         |
+| `time.Duration`  | `duration`       |
+
+Fields with no `decree` tag or tagged `decree:"-"` are skipped.
+
+## Limitations
+
+- Read-only: `Process` only reads values; writing back is not supported.
+- One call per tagged field: each field triggers one `GetField` RPC.

--- a/sdk/contrib/envconfig/envconfig.go
+++ b/sdk/contrib/envconfig/envconfig.go
@@ -1,0 +1,86 @@
+// Package envconfig populates struct fields from OpenDecree config values.
+//
+// Fields are mapped via the `decree` struct tag:
+//
+//	type AppConfig struct {
+//	    Name    string        `decree:"app.name"`
+//	    Debug   bool          `decree:"app.debug"`
+//	    Timeout time.Duration `decree:"jobs.timeout"`
+//	}
+package envconfig
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/opendecree/decree/sdk/configclient"
+)
+
+// Process reads all fields tagged with `decree:"<field-path>"` from the struct
+// pointed to by v and fetches their values from the decree config.
+func Process(ctx context.Context, client *configclient.Client, tenantID string, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() || rv.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("envconfig: v must be a non-nil pointer to a struct, got %T", v)
+	}
+	rv = rv.Elem()
+	rt := rv.Type()
+
+	for i := range rv.NumField() {
+		field := rt.Field(i)
+		tag := field.Tag.Get("decree")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		fv := rv.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+		if err := setField(ctx, client, tenantID, tag, fv); err != nil {
+			return fmt.Errorf("envconfig: field %s (decree:%q): %w", field.Name, tag, err)
+		}
+	}
+	return nil
+}
+
+var durationType = reflect.TypeOf(time.Duration(0))
+
+func setField(ctx context.Context, client *configclient.Client, tenantID, path string, fv reflect.Value) error {
+	switch {
+	case fv.Type() == durationType:
+		v, err := client.GetDuration(ctx, tenantID, path)
+		if err != nil {
+			return err
+		}
+		fv.SetInt(int64(v))
+	case fv.Kind() == reflect.String:
+		v, err := client.GetString(ctx, tenantID, path)
+		if err != nil {
+			return err
+		}
+		fv.SetString(v)
+	case fv.Kind() == reflect.Bool:
+		v, err := client.GetBool(ctx, tenantID, path)
+		if err != nil {
+			return err
+		}
+		fv.SetBool(v)
+	case fv.Kind() >= reflect.Int && fv.Kind() <= reflect.Int64:
+		v, err := client.GetInt(ctx, tenantID, path)
+		if err != nil {
+			return err
+		}
+		fv.SetInt(v)
+	case fv.Kind() == reflect.Float64 || fv.Kind() == reflect.Float32:
+		v, err := client.GetFloat(ctx, tenantID, path)
+		if err != nil {
+			return err
+		}
+		fv.SetFloat(v)
+	default:
+		return fmt.Errorf("unsupported field type %s", fv.Type())
+	}
+	return nil
+}

--- a/sdk/contrib/envconfig/envconfig_test.go
+++ b/sdk/contrib/envconfig/envconfig_test.go
@@ -1,0 +1,140 @@
+package envconfig_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/opendecree/decree/sdk/configclient"
+	envconfig "github.com/opendecree/decree/sdk/contrib/envconfig"
+)
+
+// stubTransport returns predetermined field values by path.
+type stubTransport struct {
+	values map[string]*configclient.TypedValue
+	err    error
+}
+
+func (s *stubTransport) GetField(_ context.Context, req *configclient.GetFieldRequest) (*configclient.GetFieldResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	v, ok := s.values[req.FieldPath]
+	if !ok {
+		return nil, errors.New("field not found: " + req.FieldPath)
+	}
+	return &configclient.GetFieldResponse{FieldPath: req.FieldPath, Value: v}, nil
+}
+
+func (s *stubTransport) GetConfig(_ context.Context, _ *configclient.GetConfigRequest) (*configclient.GetConfigResponse, error) {
+	return &configclient.GetConfigResponse{}, nil
+}
+
+func (s *stubTransport) GetFields(_ context.Context, req *configclient.GetFieldsRequest) (*configclient.GetFieldsResponse, error) {
+	vals := make([]configclient.ConfigValue, 0, len(req.FieldPaths))
+	for _, p := range req.FieldPaths {
+		v, ok := s.values[p]
+		if ok {
+			vals = append(vals, configclient.ConfigValue{FieldPath: p, Value: v})
+		}
+	}
+	return &configclient.GetFieldsResponse{Values: vals}, nil
+}
+
+func (s *stubTransport) SetField(_ context.Context, _ *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
+	return &configclient.SetFieldResponse{}, nil
+}
+
+func (s *stubTransport) SetFields(_ context.Context, _ *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
+	return &configclient.SetFieldsResponse{}, nil
+}
+
+func (s *stubTransport) Subscribe(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
+	return nil, nil
+}
+
+func newClient(values map[string]*configclient.TypedValue) *configclient.Client {
+	return configclient.New(&stubTransport{values: values})
+}
+
+func TestProcess_AllTypes(t *testing.T) {
+	client := newClient(map[string]*configclient.TypedValue{
+		"app.name":    configclient.StringVal("myapp"),
+		"app.debug":   configclient.BoolVal(true),
+		"app.count":   configclient.IntVal(42),
+		"app.rate":    configclient.FloatVal(1.5),
+		"app.timeout": configclient.DurationVal(5 * time.Second),
+	})
+
+	type Config struct {
+		Name    string        `decree:"app.name"`
+		Debug   bool          `decree:"app.debug"`
+		Count   int64         `decree:"app.count"`
+		Rate    float64       `decree:"app.rate"`
+		Timeout time.Duration `decree:"app.timeout"`
+	}
+
+	var cfg Config
+	if err := envconfig.Process(context.Background(), client, "t1", &cfg); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if cfg.Name != "myapp" {
+		t.Errorf("Name = %q, want %q", cfg.Name, "myapp")
+	}
+	if !cfg.Debug {
+		t.Error("Debug = false, want true")
+	}
+	if cfg.Count != 42 {
+		t.Errorf("Count = %d, want 42", cfg.Count)
+	}
+	if cfg.Rate != 1.5 {
+		t.Errorf("Rate = %f, want 1.5", cfg.Rate)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Errorf("Timeout = %v, want 5s", cfg.Timeout)
+	}
+}
+
+func TestProcess_SkipsUntagged(t *testing.T) {
+	client := newClient(map[string]*configclient.TypedValue{})
+
+	type Config struct {
+		Name       string `decree:"app.name"`
+		Untagged   string
+		Skipped    string `decree:"-"`
+		unexported string //nolint:unused
+	}
+
+	_ = client
+	// Process should not error for untagged or "-"-tagged or unexported fields
+	client2 := newClient(map[string]*configclient.TypedValue{
+		"app.name": configclient.StringVal("x"),
+	})
+	var cfg Config
+	if err := envconfig.Process(context.Background(), client2, "t1", &cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProcess_NonPointerError(t *testing.T) {
+	type Config struct{}
+	err := envconfig.Process(context.Background(), nil, "", Config{})
+	if err == nil {
+		t.Error("expected error for non-pointer, got nil")
+	}
+}
+
+func TestProcess_FieldError(t *testing.T) {
+	stub := &stubTransport{err: errors.New("transport error")}
+	client := configclient.New(stub)
+
+	type Config struct {
+		Name string `decree:"app.name"`
+	}
+	var cfg Config
+	err := envconfig.Process(context.Background(), client, "t1", &cfg)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/sdk/contrib/envconfig/go.mod
+++ b/sdk/contrib/envconfig/go.mod
@@ -1,0 +1,11 @@
+module github.com/opendecree/decree/sdk/contrib/envconfig
+
+go 1.22.0
+
+require github.com/opendecree/decree/sdk/configclient v0.1.2
+
+require github.com/opendecree/decree/sdk/retry v0.0.0 // indirect
+
+replace github.com/opendecree/decree/sdk/configclient => ../../../sdk/configclient
+
+replace github.com/opendecree/decree/sdk/retry => ../../../sdk/retry


### PR DESCRIPTION
## Summary

- There was no ergonomic way to populate Go struct fields from OpenDecree config values; callers had to write field-by-field Get* calls manually.
- Added `sdk/contrib/envconfig` — a new module that reads `decree:"<field-path>"` struct tags and fetches each field value from the configclient in one `Process` call.
- Supports `string`, `bool`, `int64`, `float64`, and `time.Duration`; untagged and `decree:"-"` fields are skipped.

## Test plan

- [ ] `go test ./...` passes in `sdk/contrib/envconfig`
- [ ] All field types populated correctly in integration test

Closes #16