### PR TITLE
docs: use consistent server binary name across install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ const enabled = await client.get(tenantId, "payments.enabled", Boolean);
 ### Try it instantly (no Docker needed)
 
 ```bash
+# go install names the server binary "server" after its directory; the canonical
+# name is decree-server, matching the release archives and Docker image.
 go install github.com/opendecree/decree/cmd/server@latest
+mv "$(go env GOPATH)/bin/server" "$(go env GOPATH)/bin/decree-server"
 go install github.com/opendecree/decree/cmd/decree@latest
 
 # Start with in-memory storage — zero dependencies

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,14 +15,14 @@ ARG COMMIT=unknown
 COPY . .
 RUN CGO_ENABLED=0 go build \
     -ldflags "-s -w -X github.com/opendecree/decree/internal/version.Version=${VERSION} -X github.com/opendecree/decree/internal/version.Commit=${COMMIT}" \
-    -o /bin/decree ./cmd/server
+    -o /bin/decree-server ./cmd/server
 
 # Runtime stage
 # gcr.io/distroless/static-debian12:nonroot
 FROM gcr.io/distroless/static-debian12@sha256:9c346e4be81b5ca7ff31a0d89eaeade58b0f95cfd3baed1f36083ddb47ca3160
 
-COPY --from=builder /bin/decree /bin/decree
+COPY --from=builder /bin/decree-server /bin/decree-server
 
 USER nonroot:nonroot
 
-ENTRYPOINT ["/bin/decree"]
+ENTRYPOINT ["/bin/decree-server"]

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -7,7 +7,10 @@ OpenDecree is a single Go binary with two external dependencies: PostgreSQL and 
 Run with in-memory storage — zero external dependencies:
 
 ```bash
+# go install names the server binary "server" after its directory; the canonical
+# name is decree-server, matching the release archives and Docker image.
 go install github.com/opendecree/decree/cmd/server@latest
+mv "$(go env GOPATH)/bin/server" "$(go env GOPATH)/bin/decree-server"
 STORAGE_BACKEND=memory HTTP_PORT=8080 decree-server
 
 # Swagger UI: http://localhost:8080/docs


### PR DESCRIPTION
## Summary
- A new user's first command failed with `command not found`: `go install ./cmd/server` produces a binary named `server`, but the install docs immediately invoked `decree-server`.
- Standardizes on `decree-server` as the canonical server binary name (already used by the Makefile, GoReleaser, docker-compose, and man pages) and makes the install snippets actually produce that name.

## Changes
- `README.md` and `docs/server/deployment.md`: after `go install ./cmd/server`, rename the produced `server` binary to `decree-server` so the next command works.
- `build/Dockerfile`: the server image now builds, copies, and entrypoints `/bin/decree-server` instead of `/bin/decree` (the latter collided with the CLI binary name).

## Test plan
- `make build` produces `bin/decree-server` + `bin/decree`.
- `docker build -f build/Dockerfile` builds clean; container starts via `/bin/decree-server`.
- Repo-wide grep confirms no remaining contradictory binary invocations in docs.

Closes #875