### PR TITLE
fix: make docker compose quickstart work on a fresh clone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
 
   migrate:
     image: ${TOOLS_IMAGE:-decree-tools}
+    build:
+      context: .
+      dockerfile: build/Dockerfile.tools
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,9 @@ This guide walks you through setting up OpenDecree, creating your first schema a
 git clone https://github.com/opendecree/decree.git
 cd decree
 
-# Start PostgreSQL, Redis, run migrations, and start the service
+# Start PostgreSQL, Redis, run migrations, and start the service.
+# The first run builds the server and migration images from source,
+# so it may take a few minutes; subsequent runs reuse the cached images.
 docker compose up -d --wait service
 ```
 

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -25,7 +25,9 @@ The repository includes a `docker-compose.yml` that starts the full stack:
 git clone https://github.com/opendecree/decree.git
 cd decree
 
-# Start everything: PostgreSQL, Redis, migrations, and the service
+# Start everything: PostgreSQL, Redis, migrations, and the service.
+# The first run builds the server and migration images from source
+# (a few minutes); later runs reuse the cached images.
 docker compose up -d --wait service
 ```
 

--- a/docs/server/observability.md
+++ b/docs/server/observability.md
@@ -7,7 +7,9 @@ OpenDecree integrates with OpenTelemetry for distributed tracing, metrics, and l
 Enable everything with Docker Compose:
 
 ```bash
-# Start the service with OTel Collector and Jaeger
+# Start the service with OTel Collector and Jaeger.
+# The first run builds the server and migration images from source
+# (a few minutes); later runs reuse the cached images.
 docker compose up -d --wait service otel-collector jaeger
 ```
 


### PR DESCRIPTION
## Summary
- On a fresh clone, `docker compose up -d --wait service` failed: the `migrate` service referenced `image: ${TOOLS_IMAGE:-decree-tools}` — a locally-built image (`build/Dockerfile.tools` via `make tools`) that is never published — but had no `build:` stanza, so compose could not create it.
- Adds a `build:` stanza to the `migrate` service so compose builds the tools image automatically. The quickstart now runs end-to-end with zero extra manual steps.

## Changes
- `docker-compose.yml`: the `migrate` service gains a `build:` stanza pointing at `build/Dockerfile.tools` (keeps `image:` so the built image is tagged consistently).
- `docs/getting-started.md`, `docs/server/deployment.md`, `docs/server/observability.md`: note that the first run builds images from source, later runs use the cache.

## Test plan
- `docker compose config` parses valid.
- `docker compose build migrate` succeeds.
- Simulated fresh clone: `docker compose up -d --wait service` built both images from scratch, `migrate` ran goose (`migrated database to version: 2`), `service` reached healthy, and `up --wait` exited 0. Torn down with `down -v`.

Closes #876