### PR TITLE
docs: fix nonexistent CLI commands in concept docs

### DIFF
--- a/docs/concepts/audit-chain.md
+++ b/docs/concepts/audit-chain.md
@@ -25,9 +25,9 @@ The `chain_epoch` column controls which fields are included in the hash:
 | `0` | Structural fields only: `previous_hash`, `id`, `tenant_id`, `actor`, `action`, `object_kind`, `created_at` |
 | `1` | All of epoch 0 plus payload: `field_path`, `old_value`, `new_value`, `config_version`, `metadata` |
 
-Rows created before migration `003_audit_chain_epoch.sql` have `chain_epoch = 0`
-and retain their original hashes. All new rows use epoch 1, so payload changes
-are detectable.
+Rows written under the epoch-0 hash scheme have `chain_epoch = 0` and retain
+their original hashes. All new rows use epoch 1, so payload changes are
+detectable.
 
 ## Concurrency and linearisation
 
@@ -49,7 +49,7 @@ is always linear.
 
 ```bash
 # Via gRPC (CLI)
-decree admin verify-chain --tenant <tenant-id>
+decree audit verify --tenant <tenant-id>
 
 # Via API
 grpcurl -d '{"tenant_id":"<id>"}' <host> centralconfig.v1.AuditService/VerifyChain

--- a/docs/concepts/schema-format.md
+++ b/docs/concepts/schema-format.md
@@ -17,7 +17,7 @@ Place the modeline on line 1 of every file so editors with [yaml-language-server
 # yaml-language-server: $schema=https://schemas.opendecree.dev/schema/v0.1.0/decree-schema.json
 ```
 
-The CLI is filename-agnostic — `decree apply some-other-name.yaml` keeps working. The convention drives editor discovery only.
+The CLI is filename-agnostic — `decree schema import some-other-name.yaml` keeps working. The convention drives editor discovery only.
 
 ## Top-level shape
 

--- a/docs/concepts/subscriptions.md
+++ b/docs/concepts/subscriptions.md
@@ -36,7 +36,7 @@ The simplest way to watch for changes:
 decree watch <tenant-id>
 
 # Watch specific fields
-decree watch <tenant-id> --fields payments.fee_rate,payments.enabled
+decree watch <tenant-id> payments.fee_rate payments.enabled
 ```
 
 The CLI prints each change as it happens, showing the field path, old value, new value, who made the change, and when.

--- a/docs/concepts/tenants.md
+++ b/docs/concepts/tenants.md
@@ -60,10 +60,11 @@ This matters because schema versions can add, remove, or change fields. Pinning 
 
 ## Upgrading Schema Versions
 
-To upgrade a tenant to a newer schema version:
+To upgrade a tenant to a newer schema version, use the admin SDK (or the `UpdateTenant` gRPC RPC directly):
 
-```bash
-decree tenant update <tenant-id> --schema-version 2
+```go
+// Upgrade the tenant to schema version 2
+tenant, err := admin.UpdateTenantSchema(ctx, tenantID, 2)
 ```
 
 What happens during an upgrade:

--- a/docs/concepts/versioning.md
+++ b/docs/concepts/versioning.md
@@ -32,7 +32,7 @@ flowchart TD
     Resolve["Resolved at v3\nenabled = true ← v1\nfee_rate = 0.03 ← v3\ncurrency = USD ← v2"]
 ```
 
-When you read the full config at version 3, the server resolves it by layering all deltas — later versions override earlier ones for the same field. This resolution happens automatically -- `GetAllFields` and `GetField` always return the fully resolved config at the requested version.
+When you read the full config at version 3, the server resolves it by layering all deltas — later versions override earlier ones for the same field. This resolution happens automatically -- `GetConfig` and `GetField` always return the fully resolved config at the requested version.
 
 ## Version Descriptions
 
@@ -58,7 +58,7 @@ You can read config at any past version:
 decree config get-all <tenant-id>
 
 # Config as it was at version 2
-decree config get-all <tenant-id> --version 2
+decree config export <tenant-id> --version 2
 ```
 
 In the SDK:


### PR DESCRIPTION
## Summary
- Several concept docs showed CLI commands and flags that do not exist, so readers copying them hit `unknown command` / unknown-flag errors. Each replacement was verified against `cmd/decree/` and `--help`.

## Changes
- `schema-format.md`: `decree apply <file>` → `decree schema import <file>`.
- `audit-chain.md`: `decree admin verify-chain` → `decree audit verify --tenant <id>`; dropped the stale squashed migration filename (`003_audit_chain_epoch.sql`), reworded to the epoch-0 hash scheme.
- `versioning.md`: `config get-all --version` → `config export <tenant-id> --version N`; RPC `GetAllFields` → `GetConfig`.
- `subscriptions.md`: `decree watch <tenant-id> --fields a,b` → positional field paths (`decree watch <tenant-id> a b`).
- `tenants.md`: `decree tenant update --schema-version` (no such CLI command) → the real SDK call `admin.UpdateTenantSchema(...)`.
- `auth.md` `DECREE_TENANT` → `DECREE_TENANT_ID` was already corrected in #877.

## Test plan
- Docs-only. Verified every command against the cobra definitions in `cmd/decree/` and `<cmd> --help`, RPC names against `proto/centralconfig/v1/config_service.proto`, and migration filenames against the current migrations + squash history.

Closes #879