### PR TITLE
docs: fix non-compiling Go SDK examples and sdk.md gaps

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,6 +1,39 @@
 # SDKs
 
-Three Go SDK packages, each an independent module. Full API reference is hosted on pkg.go.dev.
+> **Alpha** — OpenDecree is under active development. SDK APIs may change between releases. The authoritative, version-pinned API for each package is on pkg.go.dev.
+
+Six Go SDK packages, each an independent module. Full API reference is hosted on pkg.go.dev.
+
+- **`configclient`** — runtime config reads and writes for application code.
+- **`adminclient`** — schema, tenant, audit, and config admin operations.
+- **`configwatcher`** — live typed configuration values with automatic subscription.
+- **`tools`** — reusable power tools (diff, docgen, validate, seed, dump).
+- **`grpctransport`** — gRPC connection management and the `Transport` the clients run on.
+- **`retry`** — the shared retry policy (exponential backoff) used by the clients.
+
+The `contrib/` directory additionally holds optional configuration-loader integrations (`envconfig`, `koanf`, `viper`).
+
+## Connecting
+
+The clients run on a `Transport`. The `grpctransport` package dials the server and wraps the connection into a client:
+
+```go
+import "github.com/opendecree/decree/sdk/grpctransport"
+
+// TLS with system roots by default; use WithInsecure() for a local plaintext server.
+conn, err := grpctransport.Dial("localhost:9090", grpctransport.WithInsecure())
+if err != nil {
+    log.Fatal(err)
+}
+defer conn.Close()
+
+client, err := grpctransport.NewConfigClient(conn)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+`grpctransport` also provides `NewAdminClient(conn, ...)` and `NewWatcher(conn, tenantID, ...)`. A single `*grpc.ClientConn` can back multiple clients; the caller owns it and must `Close` it when done.
 
 ## configclient
 
@@ -38,25 +71,46 @@ Reusable power tools for config management — importable as Go packages for int
 
 Packages: `diff` (config version diffing), `docgen` (schema → markdown), `validate` (offline YAML validation), `seed` (bootstrap from YAML), `dump` (full tenant backup). Offline tools have zero gRPC/proto dependencies.
 
+## grpctransport
+
+gRPC connection management and the gRPC implementation of the `Transport` the clients depend on.
+
+- **Install:** `go get github.com/opendecree/decree/sdk/grpctransport@latest`
+- **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport](https://pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport)
+
+`Dial(target, ...)` returns a `*grpc.ClientConn` (TLS with system roots by default; `WithInsecure()`, `WithCustomCA()`, and `WithKeepalive()` adjust it). The convenience constructors `NewConfigClient`, `NewAdminClient`, and `NewWatcher` wrap a connection into the matching client. For a custom connection — for example one with interceptors — construct the `*grpc.ClientConn` yourself and pass it to one of those constructors.
+
+## retry
+
+The shared retry policy used by the clients: exponential backoff with optional jitter, applied to transient (retryable) errors. Enable it on a client with that client's `WithRetry` option. The package also exposes `Config`, `IsRetryable`, and backoff helpers for use in custom tooling.
+
+- **Install:** `go get github.com/opendecree/decree/sdk/retry@latest`
+- **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/retry](https://pkg.go.dev/github.com/opendecree/decree/sdk/retry)
+
 ## OpenTelemetry instrumentation (Go)
 
-The Go SDKs accept a `grpc.ClientConn` that callers construct themselves. Wire an OTel interceptor at connection time:
+The Go SDKs run on a `*grpc.ClientConn` that callers can construct themselves. Wire an OTel interceptor at connection time, then hand the connection to a `grpctransport` constructor:
 
 ```go
 import (
     "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
     "google.golang.org/grpc"
-    "github.com/opendecree/decree/sdk/configclient"
+    "google.golang.org/grpc/credentials/insecure"
+
+    "github.com/opendecree/decree/sdk/grpctransport"
 )
 
 conn, err := grpc.NewClient(
     "localhost:9090",
     grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
 )
-// conn is passed to the SDK client
-client := configclient.New(conn, ...)
+if err != nil {
+    log.Fatal(err)
+}
+client, err := grpctransport.NewConfigClient(conn)
 ```
 
-`otelgrpc.NewClientHandler()` uses the stats handler API (preferred over deprecated interceptors) and records spans for every RPC. The same pattern applies to `adminclient` and the watcher's underlying connection.
+`otelgrpc.NewClientHandler()` uses the stats handler API (preferred over the deprecated interceptors) and records spans for every RPC. The same connection works with `NewAdminClient` and `NewWatcher`.
 
 Install: `go get go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`

--- a/sdk/adminclient/README.md
+++ b/sdk/adminclient/README.md
@@ -43,11 +43,14 @@ tenants, _ := client.ListTenants(ctx, schema.ID)
 
 ## Field locks
 
-Locks prevent tenants from overriding a field beyond a set of allowed values:
+Locks prevent non-superadmin users from modifying a field. Omit the values to lock the whole field, or pass specific enum values to lock only those (a block-list — the listed values can no longer be set; an empty list locks the entire field):
 
 ```go
-// Lock app.tier to "free" — prevents runtime override above the free plan.
-_ = client.LockField(ctx, tenant.ID, "app.tier", "free")
+// Lock the entire app.tier field — non-superadmins can no longer change it.
+_ = client.LockField(ctx, tenant.ID, "app.tier")
+
+// Or lock specific enum values only — here, block setting app.tier to "enterprise".
+_ = client.LockField(ctx, tenant.ID, "app.tier", "enterprise")
 
 locks, _ := client.ListFieldLocks(ctx, tenant.ID)
 ```

--- a/sdk/tools/README.md
+++ b/sdk/tools/README.md
@@ -79,12 +79,19 @@ config:
 
 ### dump — export a tenant backup as a seed file
 
-Exports a tenant's schema, config, and (optionally) field locks to a seed-compatible YAML file. The output can be fed directly into `seed.Run` to recreate the tenant elsewhere.
+Returns a `*seed.File` with a tenant's schema, config, and — by default — field locks. Marshal it to YAML with `dump.Marshal`, or pass the `*seed.File` straight to `seed.Run` to recreate the tenant elsewhere.
 
 ```go
 import "github.com/opendecree/decree/sdk/tools/dump"
 
-data, err := dump.Run(ctx, adminClient, tenantID, dump.WithLocks())
+// Field locks are included by default; pass dump.WithoutLocks() to omit them.
+file, err := dump.Run(ctx, adminClient, tenantID)
+if err != nil {
+    log.Fatal(err)
+}
+
+// dump.Run returns a *seed.File. Marshal it to YAML, or hand it to seed.Run directly.
+data, err := dump.Marshal(file)
 if err != nil {
     log.Fatal(err)
 }


### PR DESCRIPTION
## Summary
- The Go SDK docs shipped examples that do not compile and an entry point that no longer matches the API, which blocks new users following the docs.
- This corrects every example against the real signatures and fills the gaps in `sdk.md`.

## Changes
- `docs/sdk.md`: replace `configclient.New(conn, ...)` (real signature takes a `Transport`, not a conn) with `grpctransport.Dial` + `grpctransport.NewConfigClient`. Add a **Connecting** section, **grpctransport** and **retry** package sections, an alpha banner, and correct the package count (six, not three).
- `sdk/tools/README.md`: the `dump` example used a nonexistent `dump.WithLocks()` and treated `dump.Run` as `[]byte`. Locks are on by default (opt out with `WithoutLocks()`), and `dump.Run` returns `*seed.File` — marshal it with `dump.Marshal`.
- `sdk/adminclient/README.md`: field locks are a **block-list** (the listed enum values cannot be set; an empty list locks the whole field), matching the `locks.go` godoc and the `FieldLock.LockedValues` proto contract. The README previously described them as an allow-list.

## Test plan
- [x] Verified every corrected signature against source: `grpctransport.Dial`/`NewConfigClient`, `configclient.New`, `dump.Run`/`Marshal`/`WithoutLocks`, and the `FieldLock.LockedValues` proto comment.
- [x] before-pr passed (docs-only).

> Note: the authz guard (`internal/authz/fieldlock.go`) currently enforces a lock on the whole field and does not yet filter by `LockedValues`. The docs describe the documented proto/godoc contract; I'll open a follow-up issue for the enforcement gap.

Closes #881