### PR TITLE
refactor: extract shared formatFloat into internal/format

### DIFF
--- a/sdk/tools/docgen/docgen.go
+++ b/sdk/tools/docgen/docgen.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/opendecree/decree/sdk/tools/internal/format"
 )
 
 // Schema is the input to documentation generation.
@@ -301,16 +303,16 @@ func writeConstraints(b *strings.Builder, c *Constraints) {
 	var lines []string
 
 	if c.Min != nil {
-		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Min)))
+		lines = append(lines, fmt.Sprintf("Minimum: %s", format.Float(*c.Min)))
 	}
 	if c.Max != nil {
-		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Max)))
+		lines = append(lines, fmt.Sprintf("Maximum: %s", format.Float(*c.Max)))
 	}
 	if c.ExclusiveMin != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMin)))
+		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", format.Float(*c.ExclusiveMin)))
 	}
 	if c.ExclusiveMax != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMax)))
+		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", format.Float(*c.ExclusiveMax)))
 	}
 	if c.MinLength != nil {
 		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
@@ -342,15 +344,4 @@ func yesNo(v bool) string {
 		return "yes"
 	}
 	return "no"
-}
-
-// formatFloat formats a float64 for display, omitting the decimal point when
-// the value is a whole number.
-// TODO: this is byte-identical to validate.formatFloat; if a shared internal
-// package is added to sdk/tools, hoist both copies there. (#852)
-func formatFloat(f float64) string {
-	if f == float64(int64(f)) {
-		return fmt.Sprintf("%d", int64(f))
-	}
-	return fmt.Sprintf("%g", f)
 }

--- a/sdk/tools/internal/format/format.go
+++ b/sdk/tools/internal/format/format.go
@@ -1,0 +1,13 @@
+// Package format holds small formatting helpers shared across the tools module.
+package format
+
+import "fmt"
+
+// Float formats a float64 for display, omitting the decimal point when the
+// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
+func Float(f float64) string {
+	if f == float64(int64(f)) {
+		return fmt.Sprintf("%d", int64(f))
+	}
+	return fmt.Sprintf("%g", f)
+}

--- a/sdk/tools/internal/format/format_test.go
+++ b/sdk/tools/internal/format/format_test.go
@@ -1,0 +1,23 @@
+package format
+
+import "testing"
+
+func TestFloat(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want string
+	}{
+		{42, "42"},
+		{3.14, "3.14"},
+		{0, "0"},
+		{-1, "-1"},
+		{1.0, "1"},
+		{-2.5, "-2.5"},
+		{1000000, "1000000"},
+	}
+	for _, tt := range tests {
+		if got := Float(tt.in); got != tt.want {
+			t.Errorf("Float(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opendecree/decree/sdk/tools/internal/format"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"gopkg.in/yaml.v3"
 )
@@ -498,16 +499,16 @@ func validateEnum(result *Result, path string, value any, enum []string) {
 
 func validateNumericConstraints(result *Result, path string, n float64, c *ConstraintsDef) {
 	if c.Minimum != nil && n < *c.Minimum {
-		result.add(path, fmt.Sprintf("value %s is less than minimum %s", formatFloat(n), formatFloat(*c.Minimum)))
+		result.add(path, fmt.Sprintf("value %s is less than minimum %s", format.Float(n), format.Float(*c.Minimum)))
 	}
 	if c.Maximum != nil && n > *c.Maximum {
-		result.add(path, fmt.Sprintf("value %s exceeds maximum %s", formatFloat(n), formatFloat(*c.Maximum)))
+		result.add(path, fmt.Sprintf("value %s exceeds maximum %s", format.Float(n), format.Float(*c.Maximum)))
 	}
 	if c.ExclusiveMinimum != nil && n <= *c.ExclusiveMinimum {
-		result.add(path, fmt.Sprintf("value %s must be greater than %s", formatFloat(n), formatFloat(*c.ExclusiveMinimum)))
+		result.add(path, fmt.Sprintf("value %s must be greater than %s", format.Float(n), format.Float(*c.ExclusiveMinimum)))
 	}
 	if c.ExclusiveMaximum != nil && n >= *c.ExclusiveMaximum {
-		result.add(path, fmt.Sprintf("value %s must be less than %s", formatFloat(n), formatFloat(*c.ExclusiveMaximum)))
+		result.add(path, fmt.Sprintf("value %s must be less than %s", format.Float(n), format.Float(*c.ExclusiveMaximum)))
 	}
 }
 
@@ -564,17 +565,10 @@ func stringifyForEnum(value any) string {
 	case uint64:
 		return strconv.FormatUint(v, 10)
 	case float64:
-		return formatFloat(v)
+		return format.Float(v)
 	default:
 		return fmt.Sprintf("%v", v)
 	}
-}
-
-func formatFloat(f float64) string {
-	if f == float64(int64(f)) {
-		return fmt.Sprintf("%d", int64(f))
-	}
-	return fmt.Sprintf("%g", f)
 }
 
 func sortedKeys[V any](m map[string]V) []string {

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -896,23 +896,6 @@ func TestViolation_Error_NoField(t *testing.T) {
 	}
 }
 
-func TestFormatFloat(t *testing.T) {
-	tests := []struct {
-		in   float64
-		want string
-	}{
-		{42, "42"},
-		{3.14, "3.14"},
-		{0, "0"},
-		{-1, "-1"},
-	}
-	for _, tt := range tests {
-		if got := formatFloat(tt.in); got != tt.want {
-			t.Errorf("formatFloat(%v) = %q, want %q", tt.in, got, tt.want)
-		}
-	}
-}
-
 // --- Helpers ---
 
 func assertViolation(t *testing.T, result *Result, field, msgSubstr string) {


### PR DESCRIPTION
## Summary
- `docgen.formatFloat` and `validate.formatFloat` were byte-identical copies in the same module and would inevitably drift (docgen even carried a TODO pointing here).
- Hoist the single canonical implementation into a new `sdk/tools/internal/format` package and repoint both call sites. Pure refactor — no behaviour change.

## Changes
- Add `sdk/tools/internal/format` with `format.Float(float64) string`.
- Replace the nine call sites in `validate.go` and `docgen.go`; delete both local copies and the stale TODO.
- Move the float-formatting unit test to the new package, adding cases for full (100%) branch coverage.

## Test plan
- [x] `make pre-commit` (pre-commit gate): all modules build, vet, lint, and test pass; coverage thresholds met (sdk/tools 96.4% ≥ 96.0%).
- [x] New `format` package at 100% statement coverage.
- [x] before-pr passed.

Closes #852