### PR TITLE
fix: drop squashed-migration reference from audit verify help

### DIFF
--- a/cmd/decree/audit.go
+++ b/cmd/decree/audit.go
@@ -96,7 +96,8 @@ var auditVerifyCmd = &cobra.Command{
 	Long: `Fetches all audit entries for the tenant (or the global chain if --tenant is
 omitted), recomputes each entry_hash, and reports any breaks.
 
-Requires migration 002_audit_tamper_evident to be applied.`,
+Requires the server's database schema to be up to date so that the tamper-evident
+hash columns are populated.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		conn, err := dialServer()
 		if err != nil {

--- a/docs/cli/decree_audit_verify.md
+++ b/docs/cli/decree_audit_verify.md
@@ -11,7 +11,8 @@ Verify the tamper-evident audit chain for a tenant
 Fetches all audit entries for the tenant (or the global chain if --tenant is
 omitted), recomputes each entry_hash, and reports any breaks.
 
-Requires migration 002_audit_tamper_evident to be applied.
+Requires the server's database schema to be up to date so that the tamper-evident
+hash columns are populated.
 
 ```
 decree audit verify [flags]

--- a/docs/man/decree-audit-verify.1
+++ b/docs/man/decree-audit-verify.1
@@ -14,7 +14,8 @@ Fetches all audit entries for the tenant (or the global chain if --tenant is
 omitted), recomputes each entry_hash, and reports any breaks.
 
 .PP
-Requires migration 002_audit_tamper_evident to be applied.
+Requires the server's database schema to be up to date so that the tamper-evident
+hash columns are populated.
 
 
 .SH OPTIONS

--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -199,7 +199,8 @@ func (c *Client) GetUnusedFields(ctx context.Context, tenantID string, since tim
 // authoritative head hash; VerifyChain does not attempt to detect it.
 //
 // Note: entry_hash and previous_hash fields require the server to be running
-// with migration 002_audit_tamper_evident applied.
+// with its database schema up to date so the tamper-evident hash columns are
+// populated.
 func (c *Client) VerifyChain(ctx context.Context, tenantID string) (VerifyChainResult, error) {
 	if c.audit == nil {
 		return VerifyChainResult{}, ErrServiceNotConfigured


### PR DESCRIPTION
## Summary
- The `decree audit verify` `Long` help text referenced the migration `002_audit_tamper_evident`, which no longer exists — the alpha migrations were squashed into `00001_baseline.sql` (#622). Because the CLI reference docs are generated from command help, the stale string also appeared in the generated docs.
- Reword the help to describe the requirement without naming a nonexistent migration.

## Changes
- `cmd/decree/audit.go`: replace "Requires migration 002_audit_tamper_evident to be applied." with a migration-agnostic sentence about the server schema being up to date so the tamper-evident hash columns are populated.
- `sdk/adminclient/audit.go`: same stale reference removed from the `VerifyChain` godoc.
- Regenerated `docs/cli/decree_audit_verify.md` and `docs/man/decree-audit-verify.1`.

## Test plan
- [x] `grep -rn 002_audit_tamper_evident` is empty repo-wide.
- [x] `go test ./...` passes for `cmd/decree` and `sdk/adminclient`.
- [x] before-pr passed: docs current, proto lint clean.

Closes #890