### PR TITLE
fix: surface ConfigValue.Description and post-write ConfigVersion in SDK

### DIFF
--- a/chaos/db_outage_test.go
+++ b/chaos/db_outage_test.go
@@ -34,7 +34,7 @@ func TestDBOutage_MidFlight(t *testing.T) {
 	t.Cleanup(cleanupTenant)
 
 	// Seed a value (warms the Redis cache so reads may survive the outage).
-	require.NoError(t, cfg.Set(ctx, tenantID, "chaos.field0", "before-outage"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "chaos.field0", "before-outage")))
 
 	// Pause postgres — simulates a network partition (no TCP RST, just freeze).
 	containerPause(t, postgresContainer())
@@ -60,7 +60,7 @@ func TestDBOutage_MidFlight(t *testing.T) {
 	eventually(t, 30*time.Second, func() bool {
 		writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer writeCancel()
-		return cfg.Set(writeCtx, tenantID, "chaos.field0", "after-outage") == nil
+		return noVer(cfg.Set(writeCtx, tenantID, "chaos.field0", "after-outage")) == nil
 	})
 }
 
@@ -105,6 +105,6 @@ func TestDBRecovery_AfterRestart(t *testing.T) {
 	eventually(t, 60*time.Second, func() bool {
 		writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer writeCancel()
-		return cfg.Set(writeCtx, tenantID, "chaos.field0", "after-db-restart") == nil
+		return noVer(cfg.Set(writeCtx, tenantID, "chaos.field0", "after-db-restart")) == nil
 	})
 }

--- a/chaos/redis_outage_test.go
+++ b/chaos/redis_outage_test.go
@@ -31,7 +31,7 @@ func TestRedisOutage_CacheFallback(t *testing.T) {
 	t.Cleanup(cleanupTenant)
 
 	// Seed a value — written to DB and cached in Redis.
-	require.NoError(t, cfg.Set(ctx, tenantID, "chaos.field0", "seeded"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "chaos.field0", "seeded")))
 
 	// Pause Redis.
 	containerPause(t, redisContainer())
@@ -47,7 +47,7 @@ func TestRedisOutage_CacheFallback(t *testing.T) {
 	// SetField must succeed (DB write; Redis cache.Set and Invalidate are warn-only).
 	writeCtx, writeCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer writeCancel()
-	require.NoError(t, cfg.Set(writeCtx, tenantID, "chaos.field0", "written-during-outage"),
+	require.NoError(t, noVer(cfg.Set(writeCtx, tenantID, "chaos.field0", "written-during-outage")),
 		"SetField must succeed while Redis is paused")
 
 	// Verify the new value is readable via DB fallback.
@@ -108,7 +108,7 @@ func TestRedisOutage_PubSubDegraded(t *testing.T) {
 	// Server must still serve non-pubsub requests (no crash).
 	writeCtx, writeCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer writeCancel()
-	require.NoError(t, cfg.Set(writeCtx, tenantID, "chaos.field0", "set-during-redis-outage"),
+	require.NoError(t, noVer(cfg.Set(writeCtx, tenantID, "chaos.field0", "set-during-redis-outage")),
 		"SetField must work while Redis is paused (publish failure is warn-only)")
 
 	// Unpause Redis.

--- a/chaos/shutdown_test.go
+++ b/chaos/shutdown_test.go
@@ -42,7 +42,7 @@ func TestGracefulShutdown_UnderLoad(t *testing.T) {
 	t.Cleanup(cleanupSchema)
 	tenantID, cleanupTenant := makeTenant(t, admin, "shutdown-tenant", schemaID)
 	t.Cleanup(cleanupTenant)
-	require.NoError(t, cfg0.Set(ctx, tenantID, "chaos.field0", "initial"))
+	require.NoError(t, noVer(cfg0.Set(ctx, tenantID, "chaos.field0", "initial")))
 
 	// Warm up all connections so goroutines are immediately in-flight on start.
 	for _, c := range conns {

--- a/chaos/version_helper_test.go
+++ b/chaos/version_helper_test.go
@@ -1,0 +1,9 @@
+//go:build chaos
+
+package chaos
+
+import "github.com/opendecree/decree/sdk/configclient"
+
+// noVer drops the *ConfigVersion returned by configclient write methods so the
+// resulting error can be asserted directly in chaos tests.
+func noVer(_ *configclient.ConfigVersion, err error) error { return err }

--- a/cmd/decree/config.go
+++ b/cmd/decree/config.go
@@ -123,7 +123,8 @@ func runConfigSet(ctx context.Context, admin *adminclient.Client, cfg *configcli
 	if err != nil {
 		return fmt.Errorf("field %s: %w", fieldPath, err)
 	}
-	return cfg.SetTyped(ctx, tenantID, fieldPath, tv)
+	_, err = cfg.SetTyped(ctx, tenantID, fieldPath, tv)
+	return err
 }
 
 var configSetManyCmd = &cobra.Command{
@@ -186,7 +187,7 @@ func runConfigSetMany(ctx context.Context, admin *adminclient.Client, cfg *confi
 		}
 		typed[path] = tv
 	}
-	if err := cfg.SetManyTyped(ctx, tenantID, typed, description); err != nil {
+	if _, err := cfg.SetManyTyped(ctx, tenantID, typed, description); err != nil {
 		return 0, err
 	}
 	return len(typed), nil

--- a/e2e/auth_helpers_test.go
+++ b/e2e/auth_helpers_test.go
@@ -165,7 +165,7 @@ func bootstrapMatrixFixture(t *testing.T, namePrefix string) *matrixFixture {
 
 	// Seed one config write so RollbackToVersion / GetVersion / ListVersions
 	// have content to act on.
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.name", "seed"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.name", "seed")))
 
 	t.Cleanup(func() {
 		_ = admin.DeleteTenant(ctx, tenant.ID)

--- a/e2e/bench_audit_test.go
+++ b/e2e/bench_audit_test.go
@@ -32,7 +32,7 @@ func benchAuditEnv(b *testing.B, name string, writes int) (*adminclient.Client, 
 	require.NoError(b, err)
 
 	for i := range writes {
-		require.NoError(b, cfg.Set(ctx, tenant.ID, "bench.string", fmt.Sprintf("val-%d", i)))
+		require.NoError(b, noVer(cfg.Set(ctx, tenant.ID, "bench.string", fmt.Sprintf("val-%d", i))))
 	}
 
 	return admin, tenant.ID, func() {

--- a/e2e/bench_test.go
+++ b/e2e/bench_test.go
@@ -37,10 +37,10 @@ func benchEnv(b *testing.B, name string) (*configclient.Client, string, func()) 
 	require.NoError(b, err)
 
 	// Seed initial values.
-	require.NoError(b, cfg.Set(ctx, tenant.ID, "bench.string", "hello"))
-	require.NoError(b, cfg.SetInt(ctx, tenant.ID, "bench.int", 42))
-	require.NoError(b, cfg.SetBool(ctx, tenant.ID, "bench.bool", true))
-	require.NoError(b, cfg.SetFloat(ctx, tenant.ID, "bench.number", 3.14))
+	require.NoError(b, noVer(cfg.Set(ctx, tenant.ID, "bench.string", "hello")))
+	require.NoError(b, noVer(cfg.SetInt(ctx, tenant.ID, "bench.int", 42)))
+	require.NoError(b, noVer(cfg.SetBool(ctx, tenant.ID, "bench.bool", true)))
+	require.NoError(b, noVer(cfg.SetFloat(ctx, tenant.ID, "bench.number", 3.14)))
 
 	cleanup := func() {
 		_ = admin.DeleteTenant(ctx, tenant.ID)
@@ -91,7 +91,7 @@ func BenchmarkSetField(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; b.Loop(); i++ {
-		_ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
+		_, _ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
 	}
 }
 
@@ -102,7 +102,7 @@ func BenchmarkSetInt(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; b.Loop(); i++ {
-		_ = cfg.SetInt(ctx, tenantID, "bench.int", int64(i))
+		_, _ = cfg.SetInt(ctx, tenantID, "bench.int", int64(i))
 	}
 }
 
@@ -143,7 +143,7 @@ func BenchmarkSetField_Parallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
-			_ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
+			_, _ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
 			i++
 		}
 	})
@@ -159,7 +159,7 @@ func BenchmarkMixed_90Read_10Write(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; b.Loop(); i++ {
 		if i%10 == 0 {
-			_ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
+			_, _ = cfg.Set(ctx, tenantID, "bench.string", fmt.Sprintf("val-%d", i))
 		} else {
 			_, _ = cfg.Get(ctx, tenantID, "bench.string")
 		}
@@ -197,7 +197,7 @@ func benchGetFields(b *testing.B, name string, fieldCount int) {
 	tenant, err := admin.CreateTenant(ctx, name+"-tenant", s.ID, 1)
 	require.NoError(b, err)
 	for i, p := range paths {
-		require.NoError(b, cfg.Set(ctx, tenant.ID, p, fmt.Sprintf("val-%d", i)))
+		require.NoError(b, noVer(cfg.Set(ctx, tenant.ID, p, fmt.Sprintf("val-%d", i))))
 	}
 
 	b.Cleanup(func() {
@@ -271,7 +271,7 @@ func BenchmarkGetForUpdate_ThenSet(b *testing.B) {
 		if err != nil {
 			continue
 		}
-		_ = lv.Set(ctx, "updated")
+		_, _ = lv.Set(ctx, "updated")
 	}
 }
 

--- a/e2e/config_test.go
+++ b/e2e/config_test.go
@@ -49,9 +49,9 @@ func TestFullFlow(t *testing.T) {
 	assert.GreaterOrEqual(t, len(tenants), 1)
 
 	// 3. Set config fields via configclient (typed setters for non-string fields).
-	require.NoError(t, cfg.SetDuration(ctx, tenant.ID, "settlement.window", 24*time.Hour))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "settlement.currency", "USD"))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "settlement.fee", "0.5%"))
+	require.NoError(t, noVer(cfg.SetDuration(ctx, tenant.ID, "settlement.window", 24*time.Hour)))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "settlement.currency", "USD")))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "settlement.fee", "0.5%")))
 
 	// 4. Read config via configclient.
 	allVals, err := cfg.GetAll(ctx, tenant.ID)
@@ -94,16 +94,16 @@ func TestFullFlow(t *testing.T) {
 	assert.Equal(t, "0.5%", lv.Value)
 
 	// Set with correct checksum → succeeds.
-	require.NoError(t, lv.Set(ctx, "0.3%"))
+	require.NoError(t, noVer(lv.Set(ctx, "0.3%")))
 
 	// Set with stale checksum → fails.
-	err = lv.Set(ctx, "0.1%")
+	_, err = lv.Set(ctx, "0.1%")
 	assert.ErrorIs(t, err, configclient.ErrChecksumMismatch)
 
 	// 8. Update convenience CAS.
-	require.NoError(t, cfg.Update(ctx, tenant.ID, "settlement.fee", func(current string) (string, error) {
+	require.NoError(t, noVer(cfg.Update(ctx, tenant.ID, "settlement.fee", func(current string) (string, error) {
 		return "0.2%", nil
-	}))
+	})))
 	updated, err := cfg.Get(ctx, tenant.ID, "settlement.fee")
 	require.NoError(t, err)
 	assert.Equal(t, "0.2%", updated)
@@ -166,11 +166,11 @@ func TestConfigExportImport(t *testing.T) {
 	require.NoError(t, err)
 
 	// 3. Set config values via typed setters.
-	require.NoError(t, cfg.SetBool(ctx, tenant.ID, "app.enabled", true))
-	require.NoError(t, cfg.SetInt(ctx, tenant.ID, "app.max_retries", 3))
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "app.fee_rate", 0.025))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.name", "MyApp"))
-	require.NoError(t, cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second))
+	require.NoError(t, noVer(cfg.SetBool(ctx, tenant.ID, "app.enabled", true)))
+	require.NoError(t, noVer(cfg.SetInt(ctx, tenant.ID, "app.max_retries", 3)))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "app.fee_rate", 0.025)))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.name", "MyApp")))
+	require.NoError(t, noVer(cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second)))
 
 	// 4. Export config via adminclient.
 	yamlContent, err := admin.ExportConfig(ctx, tenant.ID, nil)

--- a/e2e/jwt_fixture_test.go
+++ b/e2e/jwt_fixture_test.go
@@ -229,7 +229,7 @@ func bootstrapJWTMatrixFixture(t *testing.T, issuer *jwtIssuer, conn *grpc.Clien
 		t.Fatalf("bootstrapJWTMatrixFixture CreateTenant: %v", err)
 	}
 
-	if err := cfg.Set(ctx, tenant.ID, "app.name", "seed"); err != nil {
+	if _, err := cfg.Set(ctx, tenant.ID, "app.name", "seed"); err != nil {
 		t.Fatalf("bootstrapJWTMatrixFixture seed config: %v", err)
 	}
 

--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -242,16 +242,16 @@ func allRPCs() []rpcSpec {
 			name:   "SetField",
 			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
-				return c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("m1-%s", randSuffix()))
+				return noVer(c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("m1-%s", randSuffix())))
 			},
 		},
 		{
 			name:   "SetFields",
 			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
-				return c.cfg.SetMany(ctx, fx.tenantID, map[string]string{
+				return noVer(c.cfg.SetMany(ctx, fx.tenantID, map[string]string{
 					"app.name": fmt.Sprintf("m1-many-%s", randSuffix()),
-				}, "matrix")
+				}, "matrix"))
 			},
 		},
 		{
@@ -278,7 +278,7 @@ func allRPCs() []rpcSpec {
 				// the fixture seeds version 1. For user, the Set call is also
 				// denied but the error is discarded — RollbackConfig is the
 				// RPC under test.
-				_ = c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("rb-%s", randSuffix()))
+				_, _ = c.cfg.Set(ctx, fx.tenantID, "app.name", fmt.Sprintf("rb-%s", randSuffix()))
 				_, err := c.admin.RollbackConfig(ctx, fx.tenantID, 1, "matrix rollback")
 				return err
 			},

--- a/e2e/security_test.go
+++ b/e2e/security_test.go
@@ -121,7 +121,7 @@ func TestSecurity_SensitiveFieldRedacted(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Write the secret.
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "auth.token", secretValue))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "auth.token", secretValue)))
 
 	// --- Subscribe event must not carry plaintext ---
 	event, err := stream.Recv()
@@ -242,7 +242,7 @@ func TestSecurity_SchemaLimitsEnforced(t *testing.T) {
 		valCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 		cfg := newConfigClient(conn)
-		_ = cfg.Set(valCtx, tenant.ID, "data.payload", `{"ok":true}`)
+		_, _ = cfg.Set(valCtx, tenant.ID, "data.payload", `{"ok":true}`)
 		require.NoError(t, valCtx.Err(), "server must not hang on pathological JSON Schema compile")
 	})
 }
@@ -275,9 +275,9 @@ func TestSecurity_AuditChainIntegrity(t *testing.T) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-subject", "e2e-security-audit", "x-role", "superadmin")
 
 	// Lay down several config writes to build up a multi-entry chain.
-	require.NoError(t, cfg.Set(ctx, fixture.tenantID, "app.name", "alpha"))
-	require.NoError(t, cfg.Set(ctx, fixture.tenantID, "app.name", "beta"))
-	require.NoError(t, cfg.Set(ctx, fixture.tenantID, "app.name", "gamma"))
+	require.NoError(t, noVer(cfg.Set(ctx, fixture.tenantID, "app.name", "alpha")))
+	require.NoError(t, noVer(cfg.Set(ctx, fixture.tenantID, "app.name", "beta")))
+	require.NoError(t, noVer(cfg.Set(ctx, fixture.tenantID, "app.name", "gamma")))
 
 	resp, err := auditSvc.VerifyChain(ctx, &pb.VerifyChainRequest{TenantId: fixture.tenantID})
 	require.NoError(t, err)

--- a/e2e/stream_test.go
+++ b/e2e/stream_test.go
@@ -52,7 +52,7 @@ func TestConfigSubscription(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Write via configclient SDK.
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "notify.enabled", "true"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "notify.enabled", "true")))
 
 	// Read from raw stream.
 	change, err := stream.Recv()

--- a/e2e/tenant_access_matrix_test.go
+++ b/e2e/tenant_access_matrix_test.go
@@ -46,15 +46,15 @@ func writeRPCs() []writeRPCSpec {
 		{
 			name: "SetField",
 			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
-				return c.cfg.Set(ctx, tenantID, "app.name", fmt.Sprintf("m2-%s", randSuffix()))
+				return noVer(c.cfg.Set(ctx, tenantID, "app.name", fmt.Sprintf("m2-%s", randSuffix())))
 			},
 		},
 		{
 			name: "SetFields",
 			invoke: func(ctx context.Context, _ *testing.T, c *clients, tenantID, _ string) error {
-				return c.cfg.SetMany(ctx, tenantID, map[string]string{
+				return noVer(c.cfg.SetMany(ctx, tenantID, map[string]string{
 					"app.name": fmt.Sprintf("m2-many-%s", randSuffix()),
-				}, "matrix2")
+				}, "matrix2"))
 			},
 		},
 		{

--- a/e2e/tenant_test.go
+++ b/e2e/tenant_test.go
@@ -94,7 +94,7 @@ func TestUpdateTenantSchemaVersion(t *testing.T) {
 		_ = admin.DeleteTenant(ctx, tenant.ID)
 		_ = admin.DeleteSchema(ctx, s.ID)
 	})
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.value", "v1"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.value", "v1")))
 
 	// Upgrade to v2.
 	updated, err := admin.UpdateTenantSchema(ctx, tenant.ID, 2)
@@ -103,10 +103,10 @@ func TestUpdateTenantSchemaVersion(t *testing.T) {
 
 	// Validator cache must reflect v2: setting v1's `app.value` now fails;
 	// setting v2's `app.count` succeeds.
-	err = cfg.Set(ctx, tenant.ID, "app.value", "still-v1")
+	_, err = cfg.Set(ctx, tenant.ID, "app.value", "still-v1")
 	require.Error(t, err, "setting dropped field on upgraded tenant must fail")
 
-	require.NoError(t, cfg.SetInt(ctx, tenant.ID, "app.count", 7))
+	require.NoError(t, noVer(cfg.SetInt(ctx, tenant.ID, "app.count", 7)))
 	count, err := cfg.GetInt(ctx, tenant.ID, "app.count")
 	require.NoError(t, err)
 	assert.Equal(t, int64(7), count)

--- a/e2e/type_matrix_test.go
+++ b/e2e/type_matrix_test.go
@@ -187,7 +187,7 @@ func bootstrapTypeMatrix(t *testing.T) (*matrixFixture, map[string]*configclient
 		for _, nullable := range []bool{false, true} {
 			path := fieldPath(tc, nullable)
 			sample := tc.sample()
-			require.NoError(t, cfg.SetTyped(ctx, tenant.ID, path, sample),
+			require.NoError(t, noVer(cfg.SetTyped(ctx, tenant.ID, path, sample)),
 				"seeding %s", path)
 			seeds[path] = sample
 		}
@@ -219,14 +219,14 @@ func TestTypeMatrix(t *testing.T) {
 						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 						defer cancel()
 						sample := tc.sample()
-						require.NoError(t, cfg.SetTyped(ctx, fx.tenantID, path, sample))
+						require.NoError(t, noVer(cfg.SetTyped(ctx, fx.tenantID, path, sample)))
 						seeds[path] = sample // refresh seed for downstream ops
 					})
 
 					t.Run("set_null", func(t *testing.T) {
 						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 						defer cancel()
-						err := cfg.SetNull(ctx, fx.tenantID, path)
+						_, err := cfg.SetNull(ctx, fx.tenantID, path)
 						if nullable {
 							assert.NoError(t, err, "nullable field must accept null")
 						} else {
@@ -234,7 +234,7 @@ func TestTypeMatrix(t *testing.T) {
 						}
 						// Restore a non-null seed so subsequent ops have content.
 						sample := tc.sample()
-						require.NoError(t, cfg.SetTyped(ctx, fx.tenantID, path, sample))
+						require.NoError(t, noVer(cfg.SetTyped(ctx, fx.tenantID, path, sample)))
 						seeds[path] = sample
 					})
 

--- a/e2e/typed_test.go
+++ b/e2e/typed_test.go
@@ -37,11 +37,11 @@ func TestTypedValuesAndNull(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Set values with typed setters.
-	require.NoError(t, cfg.SetInt(ctx, tenant.ID, "app.retries", 5))
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.025))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.name", "MyApp"))
-	require.NoError(t, cfg.SetBool(ctx, tenant.ID, "app.enabled", true))
-	require.NoError(t, cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second))
+	require.NoError(t, noVer(cfg.SetInt(ctx, tenant.ID, "app.retries", 5)))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.025)))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.name", "MyApp")))
+	require.NoError(t, noVer(cfg.SetBool(ctx, tenant.ID, "app.enabled", true)))
+	require.NoError(t, noVer(cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second)))
 
 	// 3. Read with typed getters.
 	retries, err := cfg.GetInt(ctx, tenant.ID, "app.retries")
@@ -70,7 +70,7 @@ func TestTypedValuesAndNull(t *testing.T) {
 	assert.Equal(t, "5", retriesStr)
 
 	// 5. Null handling — set to null and verify.
-	require.NoError(t, cfg.SetNull(ctx, tenant.ID, "app.retries"))
+	require.NoError(t, noVer(cfg.SetNull(ctx, tenant.ID, "app.retries")))
 
 	// GetInt on null returns zero value.
 	retriesAfterNull, err := cfg.GetInt(ctx, tenant.ID, "app.retries")
@@ -83,13 +83,13 @@ func TestTypedValuesAndNull(t *testing.T) {
 	assert.Nil(t, retriesNullable)
 
 	// 6. Null vs empty string distinction.
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.name", "")) // empty string, not null
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.name", ""))) // empty string, not null
 	nameNullable, err := cfg.GetStringNullable(ctx, tenant.ID, "app.name")
 	require.NoError(t, err)
 	require.NotNil(t, nameNullable, "empty string should not be null")
 	assert.Equal(t, "", *nameNullable)
 
-	require.NoError(t, cfg.SetNull(ctx, tenant.ID, "app.name")) // now actually null
+	require.NoError(t, noVer(cfg.SetNull(ctx, tenant.ID, "app.name"))) // now actually null
 	nameNullable, err = cfg.GetStringNullable(ctx, tenant.ID, "app.name")
 	require.NoError(t, err)
 	assert.Nil(t, nameNullable, "should be null after SetNull")

--- a/e2e/upgrade_test.go
+++ b/e2e/upgrade_test.go
@@ -38,8 +38,8 @@ func TestUpgrade_Populate(t *testing.T) {
 	tenant, err := admin.CreateTenant(ctx, upgradeTenantName, s.ID, 1)
 	require.NoError(t, err)
 
-	require.NoError(t, cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "app.region", "us-east-1"))
+	require.NoError(t, noVer(cfg.SetDuration(ctx, tenant.ID, "app.timeout", 30*time.Second)))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.region", "us-east-1")))
 }
 
 // TestUpgrade_Assert verifies fixture data is intact after goose migrations,
@@ -74,7 +74,7 @@ func TestUpgrade_Assert(t *testing.T) {
 	assert.Equal(t, "us-east-1", vals["app.region"])
 
 	// Verify new writes succeed on the migrated server.
-	require.NoError(t, cfg.Set(ctx, tenantID, "app.region", "eu-west-1"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "app.region", "eu-west-1")))
 	updated, err := cfg.Get(ctx, tenantID, "app.region")
 	require.NoError(t, err)
 	assert.Equal(t, "eu-west-1", updated)

--- a/e2e/usage_test.go
+++ b/e2e/usage_test.go
@@ -32,9 +32,9 @@ func TestUsageTracking(t *testing.T) {
 	tenant, err := admin.CreateTenant(ctx, "usage-tenant-e2e", s.ID, 1)
 	require.NoError(t, err)
 
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "billing.fee", "2.5%"))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "billing.currency", "USD"))
-	require.NoError(t, cfg.Set(ctx, tenant.ID, "billing.unused", "n/a"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "billing.fee", "2.5%")))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "billing.currency", "USD")))
+	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "billing.unused", "n/a")))
 
 	// 2. Read fields — triggers usage recording.
 	_, err = cfg.Get(ctx, tenant.ID, "billing.fee")

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -56,47 +56,47 @@ func TestConstraintValidation(t *testing.T) {
 	// --- Valid values should pass ---
 
 	t.Run("valid values accepted", func(t *testing.T) {
-		require.NoError(t, cfg.SetInt(ctx, tenant.ID, "app.retries", 5))
-		require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.5))
-		require.NoError(t, cfg.Set(ctx, tenant.ID, "app.name", "MyApp"))
-		require.NoError(t, cfg.Set(ctx, tenant.ID, "app.env", "prod"))
-		require.NoError(t, cfg.SetBool(ctx, tenant.ID, "app.enabled", true))
+		require.NoError(t, noVer(cfg.SetInt(ctx, tenant.ID, "app.retries", 5)))
+		require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.5)))
+		require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.name", "MyApp")))
+		require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "app.env", "prod")))
+		require.NoError(t, noVer(cfg.SetBool(ctx, tenant.ID, "app.enabled", true)))
 	})
 
 	// --- Constraint violations should fail with informative errors ---
 
 	t.Run("integer above max", func(t *testing.T) {
-		err := cfg.SetInt(ctx, tenant.ID, "app.retries", 11)
+		_, err := cfg.SetInt(ctx, tenant.ID, "app.retries", 11)
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "maximum")
 	})
 
 	t.Run("integer below min", func(t *testing.T) {
-		err := cfg.SetInt(ctx, tenant.ID, "app.retries", -1)
+		_, err := cfg.SetInt(ctx, tenant.ID, "app.retries", -1)
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "minimum")
 	})
 
 	t.Run("number out of range", func(t *testing.T) {
-		err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 1.5)
+		_, err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 1.5)
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "maximum")
 	})
 
 	t.Run("string too short", func(t *testing.T) {
-		err := cfg.Set(ctx, tenant.ID, "app.name", "x")
+		_, err := cfg.Set(ctx, tenant.ID, "app.name", "x")
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "minimum")
 	})
 
 	t.Run("enum violation", func(t *testing.T) {
-		err := cfg.Set(ctx, tenant.ID, "app.env", "local")
+		_, err := cfg.Set(ctx, tenant.ID, "app.env", "local")
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "not in allowed")
 	})
 
 	t.Run("invalid url", func(t *testing.T) {
-		err := cfg.Set(ctx, tenant.ID, "app.webhook", "not-a-url")
+		_, err := cfg.Set(ctx, tenant.ID, "app.webhook", "not-a-url")
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "url")
 	})
@@ -104,7 +104,7 @@ func TestConstraintValidation(t *testing.T) {
 	// --- Strict mode: unknown fields rejected ---
 
 	t.Run("unknown field rejected", func(t *testing.T) {
-		err := cfg.Set(ctx, tenant.ID, "app.nonexistent", "value")
+		_, err := cfg.Set(ctx, tenant.ID, "app.nonexistent", "value")
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "not defined")
 	})
@@ -112,7 +112,7 @@ func TestConstraintValidation(t *testing.T) {
 	// --- Type mismatch ---
 
 	t.Run("wrong type rejected", func(t *testing.T) {
-		err := cfg.Set(ctx, tenant.ID, "app.retries", "not-a-number")
+		_, err := cfg.Set(ctx, tenant.ID, "app.retries", "not-a-number")
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "expected integer")
 	})
@@ -183,17 +183,17 @@ func TestExclusiveConstraints(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("value within exclusive range accepted", func(t *testing.T) {
-		require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.5))
+		require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "app.rate", 0.5)))
 	})
 
 	t.Run("value at exclusive minimum rejected", func(t *testing.T) {
-		err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 0)
+		_, err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 0)
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "greater than")
 	})
 
 	t.Run("value at exclusive maximum rejected", func(t *testing.T) {
-		err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 1)
+		_, err := cfg.SetFloat(ctx, tenant.ID, "app.rate", 1)
 		assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 		assert.Contains(t, err.Error(), "less than")
 	})

--- a/e2e/validations_test.go
+++ b/e2e/validations_test.go
@@ -65,16 +65,16 @@ func TestValidations_CrossFieldRule_RejectsAndAccepts(t *testing.T) {
 	// Stage min and max in two separate writes — order matters only because
 	// SetField evaluates each write in isolation; setting min above max
 	// produces a violation on the SECOND write whichever order we use.
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "payments.max_amount", 100))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "payments.max_amount", 100)))
 
 	// Violating write: min equals max.
-	err = cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 100)
+	_, err = cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 100)
 	require.Error(t, err, "rule must fire when min == max")
 	assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 	assert.Contains(t, err.Error(), "payments.min_amount must be less than payments.max_amount")
 
 	// Passing write: min strictly less than max.
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 10))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 10)))
 
 	// Confirm both values landed.
 	all, err := cfg.GetAll(ctx, tenant.ID)
@@ -106,12 +106,12 @@ func TestValidations_DependentRequiredAlongsideCEL(t *testing.T) {
 
 	// Pre-seed valid min/max so the CEL rule cannot fire and obscure the
 	// dependentRequired failure.
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 1))
-	require.NoError(t, cfg.SetFloat(ctx, tenant.ID, "payments.max_amount", 100))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "payments.min_amount", 1)))
+	require.NoError(t, noVer(cfg.SetFloat(ctx, tenant.ID, "payments.max_amount", 100)))
 
 	// Enabling refunds without setting the refund_window violates
 	// dependentRequired.
-	err = cfg.SetBool(ctx, tenant.ID, "payments.refunds_enabled", true)
+	_, err = cfg.SetBool(ctx, tenant.ID, "payments.refunds_enabled", true)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, configclient.ErrInvalidArgument)
 	assert.Contains(t, err.Error(), "payments.refund_window")
@@ -141,7 +141,7 @@ func TestValidations_SetFields_PostMergeStateChecked(t *testing.T) {
 	// final state satisfies min < max even though min would temporarily
 	// equal max if the writes were ordered as two separate SetField calls
 	// after a prior write at min=5.
-	err = cfg.SetManyTyped(ctx, tenant.ID, map[string]*configclient.TypedValue{
+	_, err = cfg.SetManyTyped(ctx, tenant.ID, map[string]*configclient.TypedValue{
 		"payments.min_amount": configclient.FloatVal(10),
 		"payments.max_amount": configclient.FloatVal(100),
 	}, "")

--- a/e2e/version_helper_test.go
+++ b/e2e/version_helper_test.go
@@ -1,0 +1,11 @@
+//go:build e2e
+
+package e2e
+
+import "github.com/opendecree/decree/sdk/configclient"
+
+// noVer drops the *ConfigVersion returned by configclient write methods so the
+// resulting error can be asserted directly in tests:
+//
+//	require.NoError(t, noVer(cfg.Set(ctx, tenant.ID, "k", "v")))
+func noVer(_ *configclient.ConfigVersion, err error) error { return err }

--- a/examples/multi-tenant/main.go
+++ b/examples/multi-tenant/main.go
@@ -65,16 +65,16 @@ func run() error {
 	defer admin.DeleteTenant(ctx, tenantB)
 
 	// Set different values for tenant B.
-	if err := cfg.Set(ctx, tenantB, "app.name", "Globex Corp App"); err != nil {
+	if _, err := cfg.Set(ctx, tenantB, "app.name", "Globex Corp App"); err != nil {
 		return fmt.Errorf("set app.name: %w", err)
 	}
-	if err := cfg.SetInt(ctx, tenantB, "server.rate_limit", 500); err != nil {
+	if _, err := cfg.SetInt(ctx, tenantB, "server.rate_limit", 500); err != nil {
 		return fmt.Errorf("set server.rate_limit: %w", err)
 	}
-	if err := cfg.Set(ctx, tenantB, "payments.currency", "EUR"); err != nil {
+	if _, err := cfg.Set(ctx, tenantB, "payments.currency", "EUR"); err != nil {
 		return fmt.Errorf("set payments.currency: %w", err)
 	}
-	if err := cfg.SetFloat(ctx, tenantB, "payments.fee_rate", 0.015); err != nil {
+	if _, err := cfg.SetFloat(ctx, tenantB, "payments.fee_rate", 0.015); err != nil {
 		return fmt.Errorf("set payments.fee_rate: %w", err)
 	}
 

--- a/examples/optimistic-concurrency/main.go
+++ b/examples/optimistic-concurrency/main.go
@@ -56,13 +56,17 @@ func run() error {
 	fmt.Printf("Current app.name: %q (checksum: %s)\n", locked.Value, locked.Checksum)
 
 	// Update with the checksum — succeeds only if no one else changed it.
-	if err := locked.Set(ctx, "Acme Corp App v2"); err != nil {
+	// The returned version identifies the config snapshot the write produced.
+	version, err := locked.Set(ctx, "Acme Corp App v2")
+	if err != nil {
 		return fmt.Errorf("cas set: %w", err)
 	}
-	fmt.Println("Updated to \"Acme Corp App v2\" via CAS")
+	if version != nil {
+		fmt.Printf("Updated to \"Acme Corp App v2\" via CAS (version %d)\n", version.Version)
+	}
 
 	// Try again with the stale checksum — fails with ErrChecksumMismatch.
-	err = locked.Set(ctx, "Acme Corp App v3")
+	_, err = locked.Set(ctx, "Acme Corp App v3")
 	if err != nil {
 		fmt.Printf("Stale CAS correctly rejected: %v\n", err)
 	}
@@ -76,7 +80,7 @@ func run() error {
 	// applies the function, and writes back with a checksum guard.
 	// Returns ErrChecksumMismatch if another writer modified the value
 	// between the read and write — the caller should retry if needed.
-	err = client.Update(ctx, tenantID, "app.name", func(current string) (string, error) {
+	_, err = client.Update(ctx, tenantID, "app.name", func(current string) (string, error) {
 		return current + " (updated)", nil
 	})
 	if err != nil {

--- a/sdk/configclient/client_test.go
+++ b/sdk/configclient/client_test.go
@@ -213,11 +213,14 @@ func TestSet_Success(t *testing.T) {
 	tr.on("SetField", func(args ...any) bool {
 		r := args[0].(*SetFieldRequest)
 		return r.TenantID == "t1" && r.FieldPath == "a" && r.Value != nil && r.Value.String() == "new"
-	}, &SetFieldResponse{}, nil)
+	}, &SetFieldResponse{ConfigVersion: &ConfigVersion{Version: 7, TenantID: "t1"}}, nil)
 
-	err := client.Set(ctx, "t1", "a", "new")
+	version, err := client.Set(ctx, "t1", "a", "new")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if version == nil || version.Version != 7 {
+		t.Errorf("Set version: got %+v, want version 7", version)
 	}
 }
 
@@ -228,7 +231,7 @@ func TestSet_Locked(t *testing.T) {
 
 	tr.on("SetField", nil, (*SetFieldResponse)(nil), ErrLocked)
 
-	err := client.Set(ctx, "t1", "a", "new")
+	_, err := client.Set(ctx, "t1", "a", "new")
 	if !errors.Is(err, ErrLocked) {
 		t.Errorf("got error %v, want %v", err, ErrLocked)
 	}
@@ -244,7 +247,7 @@ func TestSet_PermissionDenied(t *testing.T) {
 
 	tr.on("SetField", nil, (*SetFieldResponse)(nil), ErrPermissionDenied)
 
-	err := client.Set(ctx, "t1", "a", "new")
+	_, err := client.Set(ctx, "t1", "a", "new")
 	if !errors.Is(err, ErrPermissionDenied) {
 		t.Errorf("got error %v, want ErrPermissionDenied", err)
 	}
@@ -260,11 +263,14 @@ func TestSetMany_Success(t *testing.T) {
 	client := New(tr)
 	ctx := context.Background()
 
-	tr.on("SetFields", nil, &SetFieldsResponse{}, nil)
+	tr.on("SetFields", nil, &SetFieldsResponse{ConfigVersion: &ConfigVersion{Version: 9, TenantID: "t1"}}, nil)
 
-	err := client.SetMany(ctx, "t1", map[string]string{"a": "1", "b": "2"}, "bulk update")
+	version, err := client.SetMany(ctx, "t1", map[string]string{"a": "1", "b": "2"}, "bulk update")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if version == nil || version.Version != 9 {
+		t.Errorf("SetMany version: got %+v, want version 9", version)
 	}
 	if n := tr.called("SetFields"); n != 1 {
 		t.Errorf("expected SetFields to be called once, got %d", n)
@@ -289,7 +295,7 @@ func TestSetManyTyped_Success(t *testing.T) {
 			byPath["enabled"] != nil && byPath["enabled"].Kind() == KindBool && byPath["enabled"].MustBoolValue()
 	}, &SetFieldsResponse{}, nil)
 
-	err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{
+	_, err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{
 		"count":   IntVal(42),
 		"enabled": BoolVal(true),
 	}, "typed bulk")
@@ -637,7 +643,7 @@ func TestGetForUpdate_ThenSet(t *testing.T) {
 		return r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk123" && r.Value != nil && r.Value.String() == "new"
 	}, &SetFieldResponse{}, nil)
 
-	err = lv.Set(ctx, "new")
+	_, err = lv.Set(ctx, "new")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -659,7 +665,7 @@ func TestGetForUpdate_ChecksumMismatch(t *testing.T) {
 
 	tr.on("SetField", nil, (*SetFieldResponse)(nil), ErrChecksumMismatch)
 
-	err = lv.Set(ctx, "new")
+	_, err = lv.Set(ctx, "new")
 	if !errors.Is(err, ErrChecksumMismatch) {
 		t.Errorf("got error %v, want %v", err, ErrChecksumMismatch)
 	}
@@ -694,7 +700,7 @@ func TestLockedValue_CapturesClient(t *testing.T) {
 	}, &SetFieldResponse{}, nil)
 
 	// Set takes only ctx + new value — no client argument required.
-	if err := lv.Set(ctx, "on"); err != nil {
+	if _, err := lv.Set(ctx, "on"); err != nil {
 		t.Fatalf("Set: unexpected error: %v", err)
 	}
 
@@ -719,7 +725,7 @@ func TestUpdate_Success(t *testing.T) {
 		return r.Value != nil && r.Value.String() == "6" && r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk"
 	}, &SetFieldResponse{}, nil)
 
-	err := client.Update(ctx, "t1", "counter", func(current string) (string, error) {
+	_, err := client.Update(ctx, "t1", "counter", func(current string) (string, error) {
 		return "6", nil
 	})
 	if err != nil {
@@ -742,7 +748,7 @@ func TestUpdate_WriteOptionsForwarded(t *testing.T) {
 		return true
 	}, &SetFieldResponse{}, nil)
 
-	err := client.Update(ctx, "t1", "k", func(current string) (string, error) {
+	_, err := client.Update(ctx, "t1", "k", func(current string) (string, error) {
 		return "new", nil
 	}, WithDescription("my-desc"), WithValueDescription("val-desc"))
 	if err != nil {
@@ -784,7 +790,7 @@ func TestUpdate_RetryOnChecksumMismatch(t *testing.T) {
 	}
 
 	client := New(st)
-	err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
+	_, err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
 		return current + "-updated", nil
 	})
 	if err != nil {
@@ -814,7 +820,7 @@ func TestUpdate_ChecksumMismatchExhaustsRetries(t *testing.T) {
 	}
 
 	client := New(st)
-	err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
+	_, err := client.Update(ctx, "t1", "field", func(current string) (string, error) {
 		return current + "!", nil
 	})
 	if !errors.Is(err, ErrChecksumMismatch) {
@@ -838,7 +844,7 @@ func TestUpdate_ChecksumMismatch(t *testing.T) {
 		},
 	}
 	client := New(st)
-	err := client.Update(context.Background(), "t1", "field", func(current string) (string, error) {
+	_, err := client.Update(context.Background(), "t1", "field", func(current string) (string, error) {
 		return current + "!", nil
 	})
 	if !errors.Is(err, ErrChecksumMismatch) {
@@ -860,7 +866,7 @@ func TestUpdate_FnError(t *testing.T) {
 		},
 	}
 	client := New(tr)
-	err := client.Update(context.Background(), "t1", "f", func(string) (string, error) {
+	_, err := client.Update(context.Background(), "t1", "f", func(string) (string, error) {
 		return "", fnErr
 	})
 	if !errors.Is(err, fnErr) {
@@ -883,7 +889,7 @@ func TestUpdate_GetForUpdateError(t *testing.T) {
 		},
 	}
 	client := New(tr)
-	err := client.Update(context.Background(), "t1", "f", func(s string) (string, error) {
+	_, err := client.Update(context.Background(), "t1", "f", func(s string) (string, error) {
 		return s + "_new", nil
 	})
 	if !errors.Is(err, getErr) {
@@ -1191,7 +1197,7 @@ func TestSetInt_Success(t *testing.T) {
 		return r.Value != nil && r.Value.Kind() == KindInteger && r.Value.MustIntValue() == 42
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetInt(ctx, "t1", "retries", 42); err != nil {
+	if _, err := client.SetInt(ctx, "t1", "retries", 42); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -1206,7 +1212,7 @@ func TestSetBool_Success(t *testing.T) {
 		return r.Value != nil && r.Value.Kind() == KindBool && r.Value.MustBoolValue()
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetBool(ctx, "t1", "enabled", true); err != nil {
+	if _, err := client.SetBool(ctx, "t1", "enabled", true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -1221,7 +1227,7 @@ func TestSetFloat_Success(t *testing.T) {
 		return r.Value != nil && r.Value.Kind() == KindNumber && r.Value.MustFloatValue() == 3.14
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetFloat(ctx, "t1", "rate", 3.14); err != nil {
+	if _, err := client.SetFloat(ctx, "t1", "rate", 3.14); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -1236,7 +1242,7 @@ func TestSetNull_Success(t *testing.T) {
 		return r.Value == nil
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetNull(ctx, "t1", "retries"); err != nil {
+	if _, err := client.SetNull(ctx, "t1", "retries"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -1258,7 +1264,7 @@ func TestSet_NoRetryEvenWithRetryEnabled(t *testing.T) {
 		return true
 	}, (*SetFieldResponse)(nil), &RetryableError{Err: fmt.Errorf("unavailable")})
 
-	err := client.Set(ctx, "t1", "a", "v")
+	_, err := client.Set(ctx, "t1", "a", "v")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1282,7 +1288,7 @@ func TestSetMany_NoRetryEvenWithRetryEnabled(t *testing.T) {
 		return true
 	}, (*SetFieldsResponse)(nil), &RetryableError{Err: fmt.Errorf("unavailable")})
 
-	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "")
+	_, err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -1301,7 +1307,7 @@ func TestSet_RetriesWithIdempotencyKey(t *testing.T) {
 		RetryableCheck: IsRetryable,
 	}))
 
-	err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("key-123"))
+	_, err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("key-123"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1322,7 +1328,7 @@ func TestSet_IdempotencyKeyPassedToTransport(t *testing.T) {
 		return true
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("my-key")); err != nil {
+	if _, err := client.Set(ctx, "t1", "a", "v", WithIdempotencyKey("my-key")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotKey != "my-key" {
@@ -1342,7 +1348,7 @@ func TestSetMany_IdempotencyKeyPassedToTransport(t *testing.T) {
 		return true
 	}, &SetFieldsResponse{}, nil)
 
-	if err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithIdempotencyKey("batch-key")); err != nil {
+	if _, err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithIdempotencyKey("batch-key")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotKey != "batch-key" {
@@ -1392,7 +1398,7 @@ func TestDoWrite_FieldChecksums_Retries(t *testing.T) {
 		RetryableCheck: IsRetryable,
 	}))
 
-	err := client.SetMany(ctx, "t1", map[string]string{"field": "value"}, "",
+	_, err := client.SetMany(ctx, "t1", map[string]string{"field": "value"}, "",
 		WithFieldChecksums(map[string]string{"field": "chk-abc"}),
 	)
 	if err != nil {
@@ -1415,7 +1421,7 @@ func TestSet_WithDescription(t *testing.T) {
 		return r.Description == "why" && r.ValueDescription == "what"
 	}, &SetFieldResponse{}, nil)
 
-	err := client.Set(ctx, "t1", "a", "v", WithDescription("why"), WithValueDescription("what"))
+	_, err := client.Set(ctx, "t1", "a", "v", WithDescription("why"), WithValueDescription("what"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1431,7 +1437,7 @@ func TestSet_WithExpectedChecksum(t *testing.T) {
 		return r.ExpectedChecksum != nil && *r.ExpectedChecksum == "abc"
 	}, &SetFieldResponse{}, nil)
 
-	err := client.Set(ctx, "t1", "a", "v", WithExpectedChecksum("abc"))
+	_, err := client.Set(ctx, "t1", "a", "v", WithExpectedChecksum("abc"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1457,7 +1463,7 @@ func TestSetMany_WithValueDescriptionsAndChecksums(t *testing.T) {
 		return aOK && bOK
 	}, &SetFieldsResponse{}, nil)
 
-	err := client.SetMany(ctx, "t1",
+	_, err := client.SetMany(ctx, "t1",
 		map[string]string{"a": "1", "b": "2"},
 		"batch",
 		WithValueDescriptions(map[string]string{"a": "desc-a"}),
@@ -1480,7 +1486,7 @@ func TestSetMany_WithDescription_honored(t *testing.T) {
 		return true
 	}, &SetFieldsResponse{}, nil)
 
-	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithDescription("via-option"))
+	_, err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "", WithDescription("via-option"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1501,7 +1507,7 @@ func TestSetManyTyped_WithDescription_honored(t *testing.T) {
 		return true
 	}, &SetFieldsResponse{}, nil)
 
-	err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{"a": IntVal(1)}, "", WithDescription("via-option"))
+	_, err := client.SetManyTyped(ctx, "t1", map[string]*TypedValue{"a": IntVal(1)}, "", WithDescription("via-option"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1522,7 +1528,7 @@ func TestSetMany_positional_beats_option(t *testing.T) {
 		return true
 	}, &SetFieldsResponse{}, nil)
 
-	err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "positional", WithDescription("via-option"))
+	_, err := client.SetMany(ctx, "t1", map[string]string{"a": "1"}, "positional", WithDescription("via-option"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1551,7 +1557,7 @@ func TestLockedValue_Set_WithDescription(t *testing.T) {
 			r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk"
 	}, &SetFieldResponse{}, nil)
 
-	err = lv.Set(ctx, "new", WithDescription("my reason"), WithValueDescription("my val desc"))
+	_, err = lv.Set(ctx, "new", WithDescription("my reason"), WithValueDescription("my val desc"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1577,7 +1583,7 @@ func TestLockedValue_Set_ForwardsIdempotencyKey(t *testing.T) {
 			r.ExpectedChecksum != nil && *r.ExpectedChecksum == "chk"
 	}, &SetFieldResponse{}, nil)
 
-	err = lv.Set(ctx, "new", WithIdempotencyKey("idem-key-123"))
+	_, err = lv.Set(ctx, "new", WithIdempotencyKey("idem-key-123"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1659,7 +1665,7 @@ func TestLockedValue_Set_RejectsUnsupportedOptions(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			lv := makeLockedValue(t)
-			err := lv.Set(ctx, "new", tc.opt)
+			_, err := lv.Set(ctx, "new", tc.opt)
 			if err == nil {
 				t.Fatalf("expected ErrInvalidArgument for %s, got nil", tc.name)
 			}

--- a/sdk/configclient/example_test.go
+++ b/sdk/configclient/example_test.go
@@ -38,11 +38,11 @@ func (f *fakeTransport) GetFields(_ context.Context, req *configclient.GetFields
 }
 
 func (f *fakeTransport) SetField(_ context.Context, _ *configclient.SetFieldRequest) (*configclient.SetFieldResponse, error) {
-	return &configclient.SetFieldResponse{}, nil
+	return &configclient.SetFieldResponse{ConfigVersion: &configclient.ConfigVersion{Version: 2}}, nil
 }
 
 func (f *fakeTransport) SetFields(_ context.Context, _ *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
-	return &configclient.SetFieldsResponse{}, nil
+	return &configclient.SetFieldsResponse{ConfigVersion: &configclient.ConfigVersion{Version: 2}}, nil
 }
 
 func (f *fakeTransport) Subscribe(_ context.Context, _ *configclient.SubscribeRequest) (configclient.Subscription, error) {
@@ -66,13 +66,13 @@ func ExampleClient_Set() {
 	client := configclient.New(&fakeTransport{})
 	ctx := context.Background()
 
-	err := client.Set(ctx, "tenant-1", "app.environment", "staging")
+	version, err := client.Set(ctx, "tenant-1", "app.environment", "staging")
 	if err != nil {
 		fmt.Println("error:", err)
 		return
 	}
-	fmt.Println("ok")
-	// Output: ok
+	fmt.Println("version:", version.Version)
+	// Output: version: 2
 }
 
 func ExampleClient_GetAll() {
@@ -92,7 +92,7 @@ func ExampleClient_SetMany() {
 	client := configclient.New(&fakeTransport{})
 	ctx := context.Background()
 
-	err := client.SetMany(ctx, "tenant-1", map[string]string{
+	_, err := client.SetMany(ctx, "tenant-1", map[string]string{
 		"app.name":  "MyApp",
 		"app.debug": "false",
 	}, "bulk update")
@@ -132,7 +132,7 @@ func ExampleClient_Update() {
 	ctx := context.Background()
 
 	// Atomic read-modify-write: append a suffix to the current value.
-	err := client.Update(ctx, "tenant-1", "app.environment", func(current string) (string, error) {
+	_, err := client.Update(ctx, "tenant-1", "app.environment", func(current string) (string, error) {
 		return current + "-updated", nil
 	})
 	if err != nil {

--- a/sdk/configclient/retry.go
+++ b/sdk/configclient/retry.go
@@ -25,11 +25,6 @@ func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (
 	return sdkretry.Run(ctx, c.opts.retryEnabled, c.opts.retry, fn)
 }
 
-// retryDo executes fn with retries if retry is enabled, for void operations.
-func retryDo(ctx context.Context, c *Client, fn func(ctx context.Context) error) error {
-	return sdkretry.RunDo(ctx, c.opts.retryEnabled, c.opts.retry, fn)
-}
-
 // backoffDuration computes exponential backoff with optional jitter.
 // Exposed for tests.
 func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {

--- a/sdk/configclient/transport.go
+++ b/sdk/configclient/transport.go
@@ -1,6 +1,9 @@
 package configclient
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Transport abstracts the underlying RPC mechanism for config operations.
 // The default implementation uses gRPC (see the grpctransport package).
@@ -63,6 +66,9 @@ type ConfigValue struct {
 	FieldPath string
 	Value     *TypedValue // nil when the field is null
 	Checksum  string
+	// Description is a human-readable explanation of this specific value.
+	// Only populated when the read request asked for descriptions; empty otherwise.
+	Description string
 }
 
 // GetFieldsRequest is the input for [Transport.GetFields].
@@ -91,7 +97,11 @@ type SetFieldRequest struct {
 }
 
 // SetFieldResponse is the output of [Transport.SetField].
-type SetFieldResponse struct{}
+type SetFieldResponse struct {
+	// ConfigVersion is the version created by the write. nil if the transport
+	// did not report one.
+	ConfigVersion *ConfigVersion
+}
 
 // FieldUpdate describes a single field change within a batch write.
 type FieldUpdate struct {
@@ -110,7 +120,29 @@ type SetFieldsRequest struct {
 }
 
 // SetFieldsResponse is the output of [Transport.SetFields].
-type SetFieldsResponse struct{}
+type SetFieldsResponse struct {
+	// ConfigVersion is the version created by the batch write. nil if the
+	// transport did not report one.
+	ConfigVersion *ConfigVersion
+}
+
+// ConfigVersion describes a config version created by a write operation.
+// It is returned by the write methods (Set, SetMany, etc.) so callers can
+// use it for optimistic concurrency control or audit correlation.
+type ConfigVersion struct {
+	// ID is the server-assigned unique identifier (UUID).
+	ID string
+	// TenantID is the tenant this version belongs to (UUID).
+	TenantID string
+	// Version is the monotonically increasing version number (starts at 1).
+	Version int32
+	// Description explains what changed in this version.
+	Description string
+	// CreatedBy is the actor who created the version.
+	CreatedBy string
+	// CreatedAt is when the version was created.
+	CreatedAt time.Time
+}
 
 // SubscribeRequest is the input for [Transport.Subscribe].
 type SubscribeRequest struct {

--- a/sdk/configclient/typed_test.go
+++ b/sdk/configclient/typed_test.go
@@ -20,7 +20,7 @@ func TestSetTime_Success(t *testing.T) {
 		return r.Value != nil && r.Value.Kind() == KindTime && r.FieldPath == "x"
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetTime(ctx, "t1", "x", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
+	if _, err := client.SetTime(ctx, "t1", "x", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -35,7 +35,7 @@ func TestSetDuration_Success(t *testing.T) {
 		return r.Value != nil && r.Value.Kind() == KindDuration && r.Value.MustDurationValue() == 30*time.Second
 	}, &SetFieldResponse{}, nil)
 
-	if err := client.SetDuration(ctx, "t1", "x", 30*time.Second); err != nil {
+	if _, err := client.SetDuration(ctx, "t1", "x", 30*time.Second); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -47,7 +47,7 @@ func TestSetTyped_Success(t *testing.T) {
 
 	tr.on("SetField", nil, &SetFieldResponse{}, nil)
 
-	if err := client.SetTyped(ctx, "t1", "x", StringVal("hello")); err != nil {
+	if _, err := client.SetTyped(ctx, "t1", "x", StringVal("hello")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/sdk/configclient/write.go
+++ b/sdk/configclient/write.go
@@ -81,22 +81,51 @@ func WithFieldChecksums(checksums map[string]string) WriteOption {
 // client, transient errors trigger retry. [WithFieldChecksums] on batch writes
 // (SetMany/SetManyTyped) also enables retry because per-field checksums make
 // the operation idempotent.
-func doWrite(ctx context.Context, c *Client, wo writeOptions, fn func(ctx context.Context) error) error {
+func doWrite[T any](ctx context.Context, c *Client, wo writeOptions, fn func(ctx context.Context) (T, error)) (T, error) {
 	if (wo.idempotencyKey != "" || wo.expectedChecksum != "" || len(wo.fieldChecksums) > 0) && c.opts.retryEnabled {
-		return retryDo(ctx, c, fn)
+		return retry(ctx, c, fn)
 	}
 	return fn(ctx)
 }
 
+// setFieldVersion sends a single-field write and returns the post-write version.
+// It enforces the transport contract that a nil error must yield a non-nil
+// response, returning [ErrInvalidTransportResponse] otherwise.
+func setFieldVersion(ctx context.Context, c *Client, req *SetFieldRequest) (*ConfigVersion, error) {
+	resp, err := c.transport.SetField(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, ErrInvalidTransportResponse
+	}
+	return resp.ConfigVersion, nil
+}
+
+// setFieldsVersion sends a batch write and returns the post-write version.
+// It enforces the transport contract that a nil error must yield a non-nil
+// response, returning [ErrInvalidTransportResponse] otherwise.
+func setFieldsVersion(ctx context.Context, c *Client, req *SetFieldsRequest) (*ConfigVersion, error) {
+	resp, err := c.transport.SetFields(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, ErrInvalidTransportResponse
+	}
+	return resp.ConfigVersion, nil
+}
+
 // Set writes a single configuration value as a string.
-// Creates a new config version atomically.
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 //
 // By default, Set does not retry on transient errors. Use [WithIdempotencyKey]
 // to opt in to safe retry with server-side deduplication.
-func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opts ...WriteOption) error {
+func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
-	return doWrite(ctx, c, wo, func(ctx context.Context) error {
+	return doWrite(ctx, c, wo, func(ctx context.Context) (*ConfigVersion, error) {
 		req := &SetFieldRequest{
 			TenantID:         tenantID,
 			FieldPath:        fieldPath,
@@ -108,20 +137,20 @@ func (c *Client) Set(ctx context.Context, tenantID, fieldPath, value string, opt
 		if wo.expectedChecksum != "" {
 			req.ExpectedChecksum = &wo.expectedChecksum
 		}
-		_, err := c.transport.SetField(ctx, req)
-		return err
+		return setFieldVersion(ctx, c, req)
 	})
 }
 
 // SetTyped writes a single typed configuration value.
-// Creates a new config version atomically.
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 //
 // By default, SetTyped does not retry on transient errors. Use [WithIdempotencyKey]
 // to opt in to safe retry with server-side deduplication.
-func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue, opts ...WriteOption) error {
+func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value *TypedValue, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
-	return doWrite(ctx, c, wo, func(ctx context.Context) error {
+	return doWrite(ctx, c, wo, func(ctx context.Context) (*ConfigVersion, error) {
 		req := &SetFieldRequest{
 			TenantID:         tenantID,
 			FieldPath:        fieldPath,
@@ -133,20 +162,20 @@ func (c *Client) SetTyped(ctx context.Context, tenantID, fieldPath string, value
 		if wo.expectedChecksum != "" {
 			req.ExpectedChecksum = &wo.expectedChecksum
 		}
-		_, err := c.transport.SetField(ctx, req)
-		return err
+		return setFieldVersion(ctx, c, req)
 	})
 }
 
 // SetNull sets a configuration field to null.
-// Creates a new config version atomically.
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrLocked] if the field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 //
 // By default, SetNull does not retry on transient errors. Use [WithIdempotencyKey]
 // to opt in to safe retry with server-side deduplication.
-func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts ...WriteOption) error {
+func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
-	return doWrite(ctx, c, wo, func(ctx context.Context) error {
+	return doWrite(ctx, c, wo, func(ctx context.Context) (*ConfigVersion, error) {
 		req := &SetFieldRequest{
 			TenantID:       tenantID,
 			FieldPath:      fieldPath,
@@ -156,24 +185,25 @@ func (c *Client) SetNull(ctx context.Context, tenantID, fieldPath string, opts .
 		if wo.expectedChecksum != "" {
 			req.ExpectedChecksum = &wo.expectedChecksum
 		}
-		_, err := c.transport.SetField(ctx, req)
-		return err
+		return setFieldVersion(ctx, c, req)
 	})
 }
 
 // SetMany writes multiple configuration values atomically in a single version.
 // The description is optional — pass an empty string to omit it.
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 //
 // By default, SetMany does not retry on transient errors. Use [WithIdempotencyKey]
 // to opt in to safe retry with server-side deduplication.
-func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string, opts ...WriteOption) error {
+func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string]string, description string, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
 	effectiveDescription := description
 	if effectiveDescription == "" {
 		effectiveDescription = wo.description
 	}
-	return doWrite(ctx, c, wo, func(ctx context.Context) error {
+	return doWrite(ctx, c, wo, func(ctx context.Context) (*ConfigVersion, error) {
 		// Sort by FieldPath for deterministic request ordering.
 		paths := make([]string, 0, len(values))
 		for path := range values {
@@ -192,29 +222,30 @@ func (c *Client) SetMany(ctx context.Context, tenantID string, values map[string
 			}
 			updates = append(updates, u)
 		}
-		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
+		return setFieldsVersion(ctx, c, &SetFieldsRequest{
 			TenantID:       tenantID,
 			Updates:        updates,
 			Description:    effectiveDescription,
 			IdempotencyKey: wo.idempotencyKey,
 		})
-		return err
 	})
 }
 
 // SetManyTyped writes multiple typed configuration values atomically in a single
 // version. The description is optional — pass an empty string to omit it.
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrLocked] if any field is administratively locked; [ErrPermissionDenied] if the caller lacks access.
 //
 // By default, SetManyTyped does not retry on transient errors. Use [WithIdempotencyKey]
 // to opt in to safe retry with server-side deduplication.
-func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string, opts ...WriteOption) error {
+func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[string]*TypedValue, description string, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
 	effectiveDescription := description
 	if effectiveDescription == "" {
 		effectiveDescription = wo.description
 	}
-	return doWrite(ctx, c, wo, func(ctx context.Context) error {
+	return doWrite(ctx, c, wo, func(ctx context.Context) (*ConfigVersion, error) {
 		// Sort by FieldPath for deterministic request ordering.
 		paths := make([]string, 0, len(values))
 		for path := range values {
@@ -233,13 +264,12 @@ func (c *Client) SetManyTyped(ctx context.Context, tenantID string, values map[s
 			}
 			updates = append(updates, u)
 		}
-		_, err := c.transport.SetFields(ctx, &SetFieldsRequest{
+		return setFieldsVersion(ctx, c, &SetFieldsRequest{
 			TenantID:       tenantID,
 			Updates:        updates,
 			Description:    effectiveDescription,
 			IdempotencyKey: wo.idempotencyKey,
 		})
-		return err
 	})
 }
 
@@ -286,6 +316,8 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 
 // Set writes a new value for this field, but only if the value has not been
 // modified since the [LockedValue] was obtained via [Client.GetForUpdate].
+// Creates a new config version atomically and returns it (nil if the transport
+// does not report one).
 // Returns [ErrChecksumMismatch] if the value was changed by another writer.
 //
 // Because ExpectedChecksum makes this write idempotent, this method respects
@@ -294,20 +326,20 @@ func (c *Client) GetForUpdate(ctx context.Context, tenantID, fieldPath string) (
 // [WithExpectedChecksum], [WithValueDescriptions], and [WithFieldChecksums] are
 // not applicable to LockedValue.Set and return [ErrInvalidArgument] if supplied.
 // Use [WithIdempotencyKey], [WithDescription], and [WithValueDescription] instead.
-func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOption) error {
+func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOption) (*ConfigVersion, error) {
 	wo := applyWriteOptions(opts)
 	if wo.expectedChecksum != "" {
-		return fmt.Errorf("%w: WithExpectedChecksum is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
+		return nil, fmt.Errorf("%w: WithExpectedChecksum is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
 	}
 	if len(wo.valueDescriptions) > 0 {
-		return fmt.Errorf("%w: WithValueDescriptions is not supported on LockedValue.Set; use WithValueDescription for a single field", ErrInvalidArgument)
+		return nil, fmt.Errorf("%w: WithValueDescriptions is not supported on LockedValue.Set; use WithValueDescription for a single field", ErrInvalidArgument)
 	}
 	if len(wo.fieldChecksums) > 0 {
-		return fmt.Errorf("%w: WithFieldChecksums is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
+		return nil, fmt.Errorf("%w: WithFieldChecksums is not supported on LockedValue.Set; the checksum is managed by the lock", ErrInvalidArgument)
 	}
 	// LockedValue.Set is always safe to retry: the checksum acts as an implicit
-	// idempotency guard. Use retryDo directly to preserve that guarantee.
-	return retryDo(ctx, lv.client, func(ctx context.Context) error {
+	// idempotency guard. Use retry directly to preserve that guarantee.
+	return retry(ctx, lv.client, func(ctx context.Context) (*ConfigVersion, error) {
 		req := &SetFieldRequest{
 			TenantID:         lv.tenantID,
 			FieldPath:        lv.FieldPath,
@@ -317,8 +349,7 @@ func (lv *LockedValue) Set(ctx context.Context, newValue string, opts ...WriteOp
 			ValueDescription: wo.valueDescription,
 			IdempotencyKey:   wo.idempotencyKey,
 		}
-		_, err := lv.client.transport.SetField(ctx, req)
-		return err
+		return setFieldVersion(ctx, lv.client, req)
 	})
 }
 
@@ -328,58 +359,65 @@ const updateMaxAttempts = 3
 // Update performs an atomic read-modify-write on a single field.
 // It reads the current value and checksum, calls updateFn with the current value,
 // and writes the result back with the checksum for optimistic concurrency.
-// On [ErrChecksumMismatch] (concurrent write by another caller) the entire
-// read-modify-write cycle is retried up to 3 times before returning the error.
+// On success it returns the post-write config version (nil if the transport does
+// not report one). On [ErrChecksumMismatch] (concurrent write by another caller)
+// the entire read-modify-write cycle is retried up to 3 times before returning
+// the error.
 //
 // Returns [ErrChecksumMismatch] if the value was still being concurrently modified
 // after all retry attempts.
 // If the field exists but has a null value, updateFn receives "" (not [ErrNotFound]).
 // [ErrNotFound] is only returned when the field does not exist at all (transport error).
-func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateFn func(current string) (string, error), opts ...WriteOption) error {
+func (c *Client) Update(ctx context.Context, tenantID, fieldPath string, updateFn func(current string) (string, error), opts ...WriteOption) (*ConfigVersion, error) {
 	for attempt := range updateMaxAttempts {
 		lv, err := c.GetForUpdate(ctx, tenantID, fieldPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		newValue, err := updateFn(lv.Value)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		err = lv.Set(ctx, newValue, opts...)
+		version, err := lv.Set(ctx, newValue, opts...)
 		if err == nil {
-			return nil
+			return version, nil
 		}
 		if !errors.Is(err, ErrChecksumMismatch) || attempt == updateMaxAttempts-1 {
-			return err
+			return nil, err
 		}
 	}
 	// Unreachable, but satisfies the compiler.
-	return ErrChecksumMismatch
+	return nil, ErrChecksumMismatch
 }
 
 // --- Type-specific setters ---
 
-// SetInt writes an integer configuration value.
-func (c *Client) SetInt(ctx context.Context, tenantID, fieldPath string, value int64, opts ...WriteOption) error {
+// SetInt writes an integer configuration value and returns the post-write
+// config version (nil if the transport does not report one).
+func (c *Client) SetInt(ctx context.Context, tenantID, fieldPath string, value int64, opts ...WriteOption) (*ConfigVersion, error) {
 	return c.SetTyped(ctx, tenantID, fieldPath, IntVal(value), opts...)
 }
 
-// SetFloat writes a floating-point configuration value.
-func (c *Client) SetFloat(ctx context.Context, tenantID, fieldPath string, value float64, opts ...WriteOption) error {
+// SetFloat writes a floating-point configuration value and returns the post-write
+// config version (nil if the transport does not report one).
+func (c *Client) SetFloat(ctx context.Context, tenantID, fieldPath string, value float64, opts ...WriteOption) (*ConfigVersion, error) {
 	return c.SetTyped(ctx, tenantID, fieldPath, FloatVal(value), opts...)
 }
 
-// SetBool writes a boolean configuration value.
-func (c *Client) SetBool(ctx context.Context, tenantID, fieldPath string, value bool, opts ...WriteOption) error {
+// SetBool writes a boolean configuration value and returns the post-write
+// config version (nil if the transport does not report one).
+func (c *Client) SetBool(ctx context.Context, tenantID, fieldPath string, value bool, opts ...WriteOption) (*ConfigVersion, error) {
 	return c.SetTyped(ctx, tenantID, fieldPath, BoolVal(value), opts...)
 }
 
-// SetTime writes a timestamp configuration value.
-func (c *Client) SetTime(ctx context.Context, tenantID, fieldPath string, value time.Time, opts ...WriteOption) error {
+// SetTime writes a timestamp configuration value and returns the post-write
+// config version (nil if the transport does not report one).
+func (c *Client) SetTime(ctx context.Context, tenantID, fieldPath string, value time.Time, opts ...WriteOption) (*ConfigVersion, error) {
 	return c.SetTyped(ctx, tenantID, fieldPath, TimeVal(value), opts...)
 }
 
-// SetDuration writes a duration configuration value.
-func (c *Client) SetDuration(ctx context.Context, tenantID, fieldPath string, value time.Duration, opts ...WriteOption) error {
+// SetDuration writes a duration configuration value and returns the post-write
+// config version (nil if the transport does not report one).
+func (c *Client) SetDuration(ctx context.Context, tenantID, fieldPath string, value time.Duration, opts ...WriteOption) (*ConfigVersion, error) {
 	return c.SetTyped(ctx, tenantID, fieldPath, DurationVal(value), opts...)
 }

--- a/sdk/grpctransport/config_transport.go
+++ b/sdk/grpctransport/config_transport.go
@@ -106,11 +106,13 @@ func (t *ConfigTransport) SetField(ctx context.Context, req *configclient.SetFie
 	if req.IdempotencyKey != "" {
 		protoReq.IdempotencyKey = &req.IdempotencyKey
 	}
-	_, err := t.rpc.SetField(ctx, protoReq, callOpts...)
+	resp, err := t.rpc.SetField(ctx, protoReq, callOpts...)
 	if err != nil {
 		return nil, mapConfigError(err)
 	}
-	return &configclient.SetFieldResponse{}, nil
+	return &configclient.SetFieldResponse{
+		ConfigVersion: configVersionFromProto(resp.GetConfigVersion()),
+	}, nil
 }
 
 func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFieldsRequest) (*configclient.SetFieldsResponse, error) {
@@ -137,11 +139,13 @@ func (t *ConfigTransport) SetFields(ctx context.Context, req *configclient.SetFi
 	if req.IdempotencyKey != "" {
 		protoReq.IdempotencyKey = &req.IdempotencyKey
 	}
-	_, err := t.rpc.SetFields(ctx, protoReq, callOpts...)
+	resp, err := t.rpc.SetFields(ctx, protoReq, callOpts...)
 	if err != nil {
 		return nil, mapConfigError(err)
 	}
-	return &configclient.SetFieldsResponse{}, nil
+	return &configclient.SetFieldsResponse{
+		ConfigVersion: configVersionFromProto(resp.GetConfigVersion()),
+	}, nil
 }
 
 func (t *ConfigTransport) Subscribe(ctx context.Context, req *configclient.SubscribeRequest) (configclient.Subscription, error) {

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -74,17 +74,32 @@ func typedValueToProto(tv *configclient.TypedValue) *pb.TypedValue {
 // --- ConfigValue conversion ---
 
 // configValueFromProto converts a proto ConfigValue to the SDK type.
-//
-// TODO: pb.ConfigValue.Description is dropped here and the post-write
-// ConfigVersion returned by SetField/SetFields is discarded into empty DTOs.
-// Notify configclient owners if Description or post-write version info is
-// ever needed by callers. (tracked: #851)
 func configValueFromProto(cv *pb.ConfigValue) configclient.ConfigValue {
 	return configclient.ConfigValue{
-		FieldPath: cv.GetFieldPath(),
-		Value:     typedValueFromProto(cv.GetValue()),
-		Checksum:  cv.GetChecksum(),
+		FieldPath:   cv.GetFieldPath(),
+		Value:       typedValueFromProto(cv.GetValue()),
+		Checksum:    cv.GetChecksum(),
+		Description: cv.GetDescription(),
 	}
+}
+
+// configVersionFromProto converts a proto ConfigVersion to the SDK configclient
+// type. Returns nil when the input is nil so that absent versions stay absent.
+func configVersionFromProto(v *pb.ConfigVersion) *configclient.ConfigVersion {
+	if v == nil {
+		return nil
+	}
+	result := &configclient.ConfigVersion{
+		ID:          v.GetId(),
+		TenantID:    v.GetTenantId(),
+		Version:     v.GetVersion(),
+		Description: v.GetDescription(),
+		CreatedBy:   v.GetCreatedBy(),
+	}
+	if v.GetCreatedAt() != nil {
+		result.CreatedAt = v.GetCreatedAt().AsTime()
+	}
+	return result
 }
 
 // --- Schema/Field conversion ---

--- a/sdk/grpctransport/convert_test.go
+++ b/sdk/grpctransport/convert_test.go
@@ -14,6 +14,37 @@ import (
 
 func ptrF64(f float64) *float64 { return &f }
 
+// --- ConfigVersion conversion ---
+
+func TestConfigVersionFromProto(t *testing.T) {
+	if got := configVersionFromProto(nil); got != nil {
+		t.Fatalf("nil proto: got %v, want nil", got)
+	}
+
+	created := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	full := configVersionFromProto(&pb.ConfigVersion{
+		Id:          "ver-1",
+		TenantId:    "t1",
+		Version:     7,
+		Description: "bump fee",
+		CreatedBy:   "alice",
+		CreatedAt:   timestamppb.New(created),
+	})
+	if full == nil {
+		t.Fatal("full proto: got nil")
+	}
+	if full.ID != "ver-1" || full.TenantID != "t1" || full.Version != 7 ||
+		full.Description != "bump fee" || full.CreatedBy != "alice" || !full.CreatedAt.Equal(created) {
+		t.Errorf("full proto mapped incorrectly: %+v", full)
+	}
+
+	// A nil CreatedAt must leave the zero time, not panic.
+	noTime := configVersionFromProto(&pb.ConfigVersion{Id: "ver-2", Version: 1})
+	if noTime == nil || !noTime.CreatedAt.IsZero() {
+		t.Errorf("nil CreatedAt: got %+v, want zero CreatedAt", noTime)
+	}
+}
+
 // --- TypedValue round-trips ---
 
 func TestTypedValueRoundTrip_Integer(t *testing.T) {

--- a/stress/cache_test.go
+++ b/stress/cache_test.go
@@ -36,7 +36,7 @@ func BenchmarkManyTenants_GetAll(b *testing.B) {
 		id, cleanTenant := makeTenant(b, admin, fmt.Sprintf("stress-mt-%d", i), schemaID)
 		tenantIDs[i] = id
 		b.Cleanup(cleanTenant)
-		require.NoError(b, cfg.Set(ctx, id, "f.field_0", fmt.Sprintf("val-%d", i)))
+		require.NoError(b, noVer(cfg.Set(ctx, id, "f.field_0", fmt.Sprintf("val-%d", i))))
 	}
 
 	b.ResetTimer()
@@ -63,7 +63,7 @@ func BenchmarkManyFields_GetAll(b *testing.B) {
 	b.Cleanup(cleanTenant)
 
 	for i := 0; i < fieldCount; i++ {
-		require.NoError(b, cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i)))
+		require.NoError(b, noVer(cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i))))
 	}
 
 	b.ResetTimer()
@@ -84,11 +84,11 @@ func BenchmarkRapidInvalidation(b *testing.B) {
 	b.Cleanup(cleanSchema)
 	tenantID, cleanTenant := makeTenant(b, admin, "stress-inv-tenant", schemaID)
 	b.Cleanup(cleanTenant)
-	require.NoError(b, cfg.Set(ctx, tenantID, "f.field_0", "seed"))
+	require.NoError(b, noVer(cfg.Set(ctx, tenantID, "f.field_0", "seed")))
 
 	b.ResetTimer()
 	for i := 0; b.Loop(); i++ {
-		_ = cfg.Set(ctx, tenantID, "f.field_0", fmt.Sprintf("rapid-%d", i))
+		_, _ = cfg.Set(ctx, tenantID, "f.field_0", fmt.Sprintf("rapid-%d", i))
 	}
 }
 
@@ -116,7 +116,7 @@ func TestCacheEviction(t *testing.T) {
 		id, cleanTenant := makeTenant(t, admin, fmt.Sprintf("stress-ev-%d", i), schemaID)
 		tenantIDs[i] = id
 		defer cleanTenant()
-		require.NoError(t, cfg.Set(ctx, id, "f.field_0", fmt.Sprintf("seed-%d", i)))
+		require.NoError(t, noVer(cfg.Set(ctx, id, "f.field_0", fmt.Sprintf("seed-%d", i))))
 	}
 
 	deadline := time.Now().Add(duration)
@@ -137,7 +137,7 @@ func TestCacheEviction(t *testing.T) {
 			defer wg.Done()
 			for i := 0; time.Now().Before(deadline); i++ {
 				tid := tenantIDs[(w*100+i)%tenantCount]
-				_ = cfg.Set(ctx, tid, "f.field_0", fmt.Sprintf("write-%d-%d", w, i))
+				_, _ = cfg.Set(ctx, tid, "f.field_0", fmt.Sprintf("write-%d-%d", w, i))
 			}
 		}()
 	}

--- a/stress/connection_test.go
+++ b/stress/connection_test.go
@@ -35,7 +35,7 @@ func TestConnectionPool_ConcurrentLoad(t *testing.T) {
 	defer cleanSchema()
 	tenantID, cleanTenant := makeTenant(t, admin, "stress-pool-tenant", schemaID)
 	defer cleanTenant()
-	require.NoError(t, cfg.Set(ctx, tenantID, "f.field_0", "seed"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "f.field_0", "seed")))
 
 	var wg sync.WaitGroup
 	var errCount atomic.Int64
@@ -79,7 +79,7 @@ func TestConnectionPool_LeakDetection(t *testing.T) {
 	defer cleanSchema()
 	tenantID, cleanTenant := makeTenant(t, admin, "stress-leak-tenant", schemaID)
 	defer cleanTenant()
-	require.NoError(t, cfg.Set(ctx, tenantID, "f.field_0", "seed"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "f.field_0", "seed")))
 
 	latencies := make([]time.Duration, rounds)
 	for round := 0; round < rounds; round++ {
@@ -124,7 +124,7 @@ func BenchmarkConcurrentGetAll(b *testing.B) {
 	b.Cleanup(cleanSchema)
 	tenantID, cleanTenant := makeTenant(b, admin, "stress-concurrent-tenant", schemaID)
 	b.Cleanup(cleanTenant)
-	require.NoError(b, cfg.Set(ctx, tenantID, "f.field_0", "seed"))
+	require.NoError(b, noVer(cfg.Set(ctx, tenantID, "f.field_0", "seed")))
 
 	b.ResetTimer()
 	b.SetParallelism(goroutines)
@@ -157,7 +157,7 @@ func BenchmarkLargePayload_GetAll(b *testing.B) {
 
 	largeVal := strings.Repeat("x", valueSize)
 	for i := 0; i < fieldCount; i++ {
-		require.NoError(b, cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), largeVal))
+		require.NoError(b, noVer(cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), largeVal)))
 	}
 
 	b.ResetTimer()
@@ -212,7 +212,7 @@ func TestLargeSchema_CreateAndFetch(t *testing.T) {
 
 	// Write one value per field.
 	for i := 0; i < fieldCount; i++ {
-		require.NoError(t, cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i)))
+		require.NoError(t, noVer(cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i))))
 	}
 
 	vals, err := cfg.GetAll(ctx, tenantID)
@@ -238,7 +238,7 @@ func TestLargePayload_SetAndGet(t *testing.T) {
 	defer cleanTenant()
 
 	largeVal := strings.Repeat("abc", valueSize/3)
-	require.NoError(t, cfg.Set(ctx, tenantID, "f.field_0", largeVal))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "f.field_0", largeVal)))
 
 	got, err := cfg.Get(ctx, tenantID, "f.field_0")
 	require.NoError(t, err)

--- a/stress/memory_test.go
+++ b/stress/memory_test.go
@@ -48,7 +48,7 @@ func TestMemoryGrowth_BoundedUnderLoad(t *testing.T) {
 	tenantID, cleanTenant := makeTenant(t, admin, "stress-mg-tenant", schemaID)
 	defer cleanTenant()
 	for i := 0; i < 8; i++ {
-		require.NoError(t, cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i)))
+		require.NoError(t, noVer(cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i))))
 	}
 
 	runtime.GC()
@@ -95,7 +95,7 @@ func TestGoroutineLeak(t *testing.T) {
 	defer cleanSchema()
 	tenantID, cleanTenant := makeTenant(t, admin, "stress-gr-tenant", schemaID)
 	defer cleanTenant()
-	require.NoError(t, cfg.Set(ctx, tenantID, "f.field_0", "seed"))
+	require.NoError(t, noVer(cfg.Set(ctx, tenantID, "f.field_0", "seed")))
 
 	// Allow the stack to settle before measuring baseline.
 	time.Sleep(100 * time.Millisecond)
@@ -156,7 +156,7 @@ func TestConcurrentTenants_Isolation(t *testing.T) {
 		sentinel := fmt.Sprintf("tenant-sentinel-%d", i)
 		id, cleanTenant := makeTenant(t, admin, fmt.Sprintf("stress-iso-%d", i), schemaID)
 		defer cleanTenant()
-		require.NoError(t, cfg.Set(ctx, id, "f.field_0", sentinel))
+		require.NoError(t, noVer(cfg.Set(ctx, id, "f.field_0", sentinel)))
 		tenants[i] = tenantInfo{id: id, sentinel: sentinel}
 	}
 
@@ -180,7 +180,7 @@ func TestConcurrentTenants_Isolation(t *testing.T) {
 			for gen := 0; time.Now().Before(deadline); gen++ {
 				idx := (w*1000 + gen) % tenantCount
 				newSentinel := fmt.Sprintf("tenant-sentinel-%d-gen%d", idx, gen)
-				if err := cfg.Set(ctx, tenants[idx].id, "f.field_0", newSentinel); err == nil {
+				if _, err := cfg.Set(ctx, tenants[idx].id, "f.field_0", newSentinel); err == nil {
 					tenants[idx].sentinel = newSentinel
 				}
 			}
@@ -236,7 +236,7 @@ func BenchmarkMemoryGrowth_Sustained(b *testing.B) {
 	tenantID, cleanTenant := makeTenant(b, admin, "stress-mb-tenant", schemaID)
 	b.Cleanup(cleanTenant)
 	for i := 0; i < 8; i++ {
-		require.NoError(b, cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i)))
+		require.NoError(b, noVer(cfg.Set(ctx, tenantID, fmt.Sprintf("f.field_%d", i), fmt.Sprintf("val-%d", i))))
 	}
 
 	b.ReportAllocs()

--- a/stress/version_helper_test.go
+++ b/stress/version_helper_test.go
@@ -1,0 +1,9 @@
+//go:build stress
+
+package stress
+
+import "github.com/opendecree/decree/sdk/configclient"
+
+// noVer drops the *ConfigVersion returned by configclient write methods so the
+// resulting error can be asserted directly in stress tests.
+func noVer(_ *configclient.ConfigVersion, err error) error { return err }


### PR DESCRIPTION
## Summary
- `sdk/grpctransport/convert.go` silently dropped two pieces of server data: `pb.ConfigValue.Description` was never mapped, and the post-write `ConfigVersion` from the `SetField`/`SetFields` RPC responses was discarded into empty DTOs. Callers had no way to read a value's description or the version produced by a write.
- This plumbs both through the SDK.

## Changes
- Map `pb.ConfigValue.Description` → `configclient.ConfigValue.Description`.
- Add `configclient.ConfigVersion` (ID, TenantID, Version, Description, CreatedBy, CreatedAt) and return it from every write method, built from the RPC responses via a new `configVersionFromProto`.
- **BREAKING:** the write methods now return `(*ConfigVersion, error)` instead of `error` — `Set`, `SetTyped`, `SetNull`, the typed setters (`SetInt`/`SetFloat`/`SetBool`/`SetTime`/`SetDuration`), `SetMany`, `SetManyTyped`, `Update`, and `LockedValue.Set`. Pre-production, so no compat shim; all in-repo callers (CLI, examples, e2e) are updated. e2e adds a small `noVer()` helper to drop the version where only the error is asserted.

## Test plan
- [x] New unit test for `configVersionFromProto` (nil, full timestamp, nil timestamp) — function at 100% coverage.
- [x] Existing configclient write tests updated to assert the returned version round-trips.
- [x] `make pre-commit`: all modules build/vet/lint/test, coverage thresholds met (configclient 90.8%).
- [x] `make e2e` passes locally — the version round-trips through a real server.

Closes #851