### PR TITLE
fix: enforce LockedValues in FieldLockGuard for value-scoped locks

### DIFF
--- a/internal/authz/fieldlock.go
+++ b/internal/authz/fieldlock.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -54,9 +55,32 @@ func (g FieldLockGuard) Check(ctx context.Context, action Action, r Resource) er
 		}
 	}
 	for _, lock := range locks {
-		if lock.FieldPath == r.FieldPath {
+		if lock.FieldPath != r.FieldPath {
+			continue
+		}
+		// A nil/empty raw LockedValues locks the whole field (every write blocked).
+		if len(lock.LockedValues) == 0 {
 			return status.Errorf(codes.FailedPrecondition, "field %s is locked", r.FieldPath)
 		}
+		// LockedValues is json.Marshal([]string): only the listed enum values are
+		// locked. Block only when the attempted value is one of them.
+		var values []string
+		if err := json.Unmarshal(lock.LockedValues, &values); err != nil {
+			// Fail closed: an unparseable lock blocks the write rather than
+			// silently allowing it.
+			return status.Errorf(codes.FailedPrecondition, "field %s is locked", r.FieldPath)
+		}
+		// A marshaled empty list ("[]") carries no values to scope on, so it also
+		// locks the whole field.
+		if len(values) == 0 {
+			return status.Errorf(codes.FailedPrecondition, "field %s is locked", r.FieldPath)
+		}
+		for _, v := range values {
+			if v == r.Value {
+				return status.Errorf(codes.FailedPrecondition, "value %q for field %s is locked", r.Value, r.FieldPath)
+			}
+		}
+		// Attempted value is not in this lock's set; keep scanning other locks.
 	}
 	return nil
 }

--- a/internal/authz/guard.go
+++ b/internal/authz/guard.go
@@ -21,6 +21,7 @@ const (
 type Resource struct {
 	TenantID  string
 	FieldPath string // non-empty only for field-level checks
+	Value     string // attempted new value, for value-scoped field locks
 }
 
 // Guard is a single authorization check.

--- a/internal/authz/guard_test.go
+++ b/internal/authz/guard_test.go
@@ -2,6 +2,7 @@ package authz_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -14,6 +15,14 @@ import (
 	"github.com/opendecree/decree/internal/authz"
 	"github.com/opendecree/decree/internal/storage/domain"
 )
+
+// lockedValues marshals an enum-value subset the way the store persists it.
+func lockedValues(t *testing.T, vals ...string) []byte {
+	t.Helper()
+	b, err := json.Marshal(vals)
+	require.NoError(t, err)
+	return b
+}
 
 // --- helpers ---
 
@@ -192,6 +201,87 @@ func TestFieldLockGuard_ContextCacheHit_LockedField(t *testing.T) {
 	require.Error(t, err)
 	// Field locks use FailedPrecondition (a precondition on the resource state),
 	// distinct from PermissionDenied (role/tenant access denial).
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// --- FieldLockGuard: value-scoped (LockedValues) ---
+
+func TestFieldLockGuard_NilLockedValues_LocksWholeField(t *testing.T) {
+	// Raw nil LockedValues is the whole-field lock; any value is blocked.
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: nil}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "anything"})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestFieldLockGuard_EmptyLockedValues_LocksWholeField(t *testing.T) {
+	// A marshaled empty list ("[]") carries no values to scope on, so it behaves
+	// like a whole-field lock: any value is blocked.
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t)}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "anything"})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestFieldLockGuard_ValueScoped_LockedValueBlocked(t *testing.T) {
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t, "red", "blue")}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "blue"})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestFieldLockGuard_ValueScoped_UnlistedValueAllowed(t *testing.T) {
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t, "red", "blue")}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "green"})
+	require.NoError(t, err)
+}
+
+func TestFieldLockGuard_ValueScoped_NullWriteAllowed(t *testing.T) {
+	// A clear/null write carries an empty Value, which matches no listed value.
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t, "red", "blue")}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: ""})
+	require.NoError(t, err)
+}
+
+func TestFieldLockGuard_ValueScoped_SuperAdminBypasses(t *testing.T) {
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t, "red")}},
+	})
+	err := g.Check(superAdminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "red"})
+	require.NoError(t, err)
+}
+
+func TestFieldLockGuard_ValueScoped_UnmarshalErrorFailsClosed(t *testing.T) {
+	// Corrupt LockedValues (not a JSON []string) must block the write, not panic.
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{{TenantID: tenant1, FieldPath: "a.b", LockedValues: []byte("not json")}},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "green"})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestFieldLockGuard_ValueScoped_OtherLockStillScanned(t *testing.T) {
+	// First lock (value-scoped) does not match the attempted value, but a second
+	// whole-field lock on the same path must still block.
+	g := authz.NewFieldLockGuard(&stubLockStore{
+		locks: []domain.TenantFieldLock{
+			{TenantID: tenant1, FieldPath: "a.b", LockedValues: lockedValues(t, "red")},
+			{TenantID: tenant1, FieldPath: "a.b"},
+		},
+	})
+	err := g.Check(adminCtx(), authz.ActionWrite, authz.Resource{TenantID: tenant1, FieldPath: "a.b", Value: "green"})
+	require.Error(t, err)
 	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -550,7 +550,11 @@ func (s *Service) SetField(ctx context.Context, req *pb.SetFieldRequest) (*pb.Se
 	if err != nil {
 		return nil, err
 	}
-	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: req.FieldPath}); err != nil {
+	// Value feeds value-scoped field locks (FieldLockGuard). For a null/clear
+	// write typedValueToString returns nil → Value is "", which never matches a
+	// lock that lists specific strings (acceptable: clearing is not setting a
+	// locked value).
+	if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: req.FieldPath, Value: derefString(typedValueToString(req.Value))}); err != nil {
 		return nil, err
 	}
 
@@ -727,7 +731,8 @@ func (s *Service) SetFields(ctx context.Context, req *pb.SetFieldsRequest) (*pb.
 		if update.FieldPath == "" {
 			return nil, status.Error(codes.InvalidArgument, "field_path must not be empty")
 		}
-		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: update.FieldPath}); err != nil {
+		// Value feeds value-scoped field locks; "" for null/clear writes (see SetField).
+		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: update.FieldPath, Value: derefString(typedValueToString(update.Value))}); err != nil {
 			return nil, err
 		}
 		if err := s.validateField(ctx, tenantID, update.FieldPath, update.Value); err != nil {
@@ -979,7 +984,8 @@ func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersi
 	// Guard and validate each field being restored. This prevents locked or
 	// now-invalid values from being silently reinstated via rollback.
 	for _, row := range targetRows {
-		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: row.FieldPath}); err != nil {
+		// Value feeds value-scoped field locks; "" for a null restored value (see SetField).
+		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: row.FieldPath, Value: derefString(row.Value)}); err != nil {
 			return nil, err
 		}
 		tv := stringToTypedValue(row.Value, lookupFieldType(rollbackTypes, row.FieldPath))
@@ -1315,7 +1321,8 @@ func (s *Service) ImportConfig(ctx context.Context, req *pb.ImportConfigRequest)
 		if s.limits.MaxFieldValueBytes > 0 && len(v.Value) > s.limits.MaxFieldValueBytes {
 			return nil, status.Errorf(codes.InvalidArgument, "field %q value is %d bytes, exceeds limit of %d", v.FieldPath, len(v.Value), s.limits.MaxFieldValueBytes)
 		}
-		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: v.FieldPath}); err != nil {
+		// Value feeds value-scoped field locks (the import value is already canonical string form).
+		if err := s.guard.Check(ctx, authz.ActionWrite, authz.Resource{TenantID: tenantID, FieldPath: v.FieldPath, Value: v.Value}); err != nil {
 			return nil, err
 		}
 		// Convert string value to TypedValue for validation.


### PR DESCRIPTION
## Summary
- `FieldLockGuard.Check` blocked a write whenever a lock's `FieldPath` matched, ignoring the lock's `LockedValues`. A lock created with specific enum values therefore locked the **entire** field, contradicting the documented contract (the `FieldLock.LockedValues` proto field and the `adminclient.LockField` godoc both say only the listed values are locked; an empty list locks the whole field). The SDK docs were aligned to that contract in #881 — this brings enforcement in line.

## Changes
- `internal/authz/guard.go`: add `Resource.Value` (the attempted new value) for value-scoped checks.
- `internal/authz/fieldlock.go`: when a matching lock has a non-empty `LockedValues` (`json.Marshal([]string)`), block only when the attempted value is one of the listed values; nil/empty/`"[]"` still lock the whole field. Unparseable `LockedValues` fail closed (block).
- `internal/config/service.go`: populate `Resource.Value` at the four write call sites (SetField, SetFields, RollbackToVersion, ImportConfig). Null/clear writes carry an empty value and so pass value-scoped locks but are still blocked by whole-field locks.

## Test plan
- [x] New `internal/authz` tests: whole-field lock (nil and marshaled-empty), listed value blocked, unlisted value allowed, superadmin bypass on a value-scoped lock, unmarshal-error fail-closed, and multi-lock scanning. New `Check` logic at 100% coverage.
- [x] `make pre-commit`: build, vet, lint, `go test -race`, coverage all pass (`internal` 91.3% ≥ 88.5%).
- [x] All existing e2e field locks are whole-field (unchanged behavior).

Closes #894