### PR TITLE
feat: add DiffVersions RPC for server-side config version diffing

### DIFF
--- a/api/centralconfig/v1/config_service.pb.go
+++ b/api/centralconfig/v1/config_service.pb.go
@@ -22,6 +22,63 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// ChangeType categorizes how a field changed between two config versions.
+type ChangeType int32
+
+const (
+	// Unspecified change type. Never emitted by the server.
+	ChangeType_CHANGE_TYPE_UNSPECIFIED ChangeType = 0
+	// The field is present in to_version but absent in from_version.
+	ChangeType_CHANGE_TYPE_ADDED ChangeType = 1
+	// The field is present in from_version but absent in to_version.
+	ChangeType_CHANGE_TYPE_REMOVED ChangeType = 2
+	// The field is present in both versions with a different value.
+	ChangeType_CHANGE_TYPE_MODIFIED ChangeType = 3
+)
+
+// Enum value maps for ChangeType.
+var (
+	ChangeType_name = map[int32]string{
+		0: "CHANGE_TYPE_UNSPECIFIED",
+		1: "CHANGE_TYPE_ADDED",
+		2: "CHANGE_TYPE_REMOVED",
+		3: "CHANGE_TYPE_MODIFIED",
+	}
+	ChangeType_value = map[string]int32{
+		"CHANGE_TYPE_UNSPECIFIED": 0,
+		"CHANGE_TYPE_ADDED":       1,
+		"CHANGE_TYPE_REMOVED":     2,
+		"CHANGE_TYPE_MODIFIED":    3,
+	}
+)
+
+func (x ChangeType) Enum() *ChangeType {
+	p := new(ChangeType)
+	*p = x
+	return p
+}
+
+func (x ChangeType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ChangeType) Descriptor() protoreflect.EnumDescriptor {
+	return file_centralconfig_v1_config_service_proto_enumTypes[0].Descriptor()
+}
+
+func (ChangeType) Type() protoreflect.EnumType {
+	return &file_centralconfig_v1_config_service_proto_enumTypes[0]
+}
+
+func (x ChangeType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ChangeType.Descriptor instead.
+func (ChangeType) EnumDescriptor() ([]byte, []int) {
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{0}
+}
+
 // ImportMode controls how imported values interact with existing config.
 type ImportMode int32
 
@@ -66,11 +123,11 @@ func (x ImportMode) String() string {
 }
 
 func (ImportMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_centralconfig_v1_config_service_proto_enumTypes[0].Descriptor()
+	return file_centralconfig_v1_config_service_proto_enumTypes[1].Descriptor()
 }
 
 func (ImportMode) Type() protoreflect.EnumType {
-	return &file_centralconfig_v1_config_service_proto_enumTypes[0]
+	return &file_centralconfig_v1_config_service_proto_enumTypes[1]
 }
 
 func (x ImportMode) Number() protoreflect.EnumNumber {
@@ -79,7 +136,7 @@ func (x ImportMode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ImportMode.Descriptor instead.
 func (ImportMode) EnumDescriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{0}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{1}
 }
 
 type GetConfigRequest struct {
@@ -1100,6 +1157,188 @@ func (x *RollbackToVersionResponse) GetConfigVersion() *ConfigVersion {
 	return nil
 }
 
+type DiffVersionsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Tenant ID (UUID).
+	TenantId string `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"`
+	// The base version to diff from.
+	FromVersion int32 `protobuf:"varint,2,opt,name=from_version,json=fromVersion,proto3" json:"from_version,omitempty"`
+	// The target version to diff to.
+	ToVersion     int32 `protobuf:"varint,3,opt,name=to_version,json=toVersion,proto3" json:"to_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiffVersionsRequest) Reset() {
+	*x = DiffVersionsRequest{}
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiffVersionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiffVersionsRequest) ProtoMessage() {}
+
+func (x *DiffVersionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiffVersionsRequest.ProtoReflect.Descriptor instead.
+func (*DiffVersionsRequest) Descriptor() ([]byte, []int) {
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *DiffVersionsRequest) GetTenantId() string {
+	if x != nil {
+		return x.TenantId
+	}
+	return ""
+}
+
+func (x *DiffVersionsRequest) GetFromVersion() int32 {
+	if x != nil {
+		return x.FromVersion
+	}
+	return 0
+}
+
+func (x *DiffVersionsRequest) GetToVersion() int32 {
+	if x != nil {
+		return x.ToVersion
+	}
+	return 0
+}
+
+type DiffVersionsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The fields that differ between from_version and to_version, sorted by
+	// field path. Unchanged fields are omitted.
+	Diffs         []*FieldDiff `protobuf:"bytes,1,rep,name=diffs,proto3" json:"diffs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiffVersionsResponse) Reset() {
+	*x = DiffVersionsResponse{}
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiffVersionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiffVersionsResponse) ProtoMessage() {}
+
+func (x *DiffVersionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiffVersionsResponse.ProtoReflect.Descriptor instead.
+func (*DiffVersionsResponse) Descriptor() ([]byte, []int) {
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *DiffVersionsResponse) GetDiffs() []*FieldDiff {
+	if x != nil {
+		return x.Diffs
+	}
+	return nil
+}
+
+// FieldDiff describes a single field that differs between two config versions.
+type FieldDiff struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Dot-separated field path (e.g. "payments.fee").
+	FieldPath string `protobuf:"bytes,1,opt,name=field_path,json=fieldPath,proto3" json:"field_path,omitempty"`
+	// How the field changed.
+	ChangeType ChangeType `protobuf:"varint,2,opt,name=change_type,json=changeType,proto3,enum=centralconfig.v1.ChangeType" json:"change_type,omitempty"`
+	// The value at from_version. Empty when change_type is CHANGE_TYPE_ADDED.
+	OldValue string `protobuf:"bytes,3,opt,name=old_value,json=oldValue,proto3" json:"old_value,omitempty"`
+	// The value at to_version. Empty when change_type is CHANGE_TYPE_REMOVED.
+	NewValue      string `protobuf:"bytes,4,opt,name=new_value,json=newValue,proto3" json:"new_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FieldDiff) Reset() {
+	*x = FieldDiff{}
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FieldDiff) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FieldDiff) ProtoMessage() {}
+
+func (x *FieldDiff) ProtoReflect() protoreflect.Message {
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FieldDiff.ProtoReflect.Descriptor instead.
+func (*FieldDiff) Descriptor() ([]byte, []int) {
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *FieldDiff) GetFieldPath() string {
+	if x != nil {
+		return x.FieldPath
+	}
+	return ""
+}
+
+func (x *FieldDiff) GetChangeType() ChangeType {
+	if x != nil {
+		return x.ChangeType
+	}
+	return ChangeType_CHANGE_TYPE_UNSPECIFIED
+}
+
+func (x *FieldDiff) GetOldValue() string {
+	if x != nil {
+		return x.OldValue
+	}
+	return ""
+}
+
+func (x *FieldDiff) GetNewValue() string {
+	if x != nil {
+		return x.NewValue
+	}
+	return ""
+}
+
 type SubscribeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Tenant ID (UUID) to subscribe to.
@@ -1120,7 +1359,7 @@ type SubscribeRequest struct {
 
 func (x *SubscribeRequest) Reset() {
 	*x = SubscribeRequest{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[17]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1132,7 +1371,7 @@ func (x *SubscribeRequest) String() string {
 func (*SubscribeRequest) ProtoMessage() {}
 
 func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[17]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1145,7 +1384,7 @@ func (x *SubscribeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeRequest.ProtoReflect.Descriptor instead.
 func (*SubscribeRequest) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{17}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SubscribeRequest) GetTenantId() string {
@@ -1179,7 +1418,7 @@ type SubscribeResponse struct {
 
 func (x *SubscribeResponse) Reset() {
 	*x = SubscribeResponse{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[18]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1191,7 +1430,7 @@ func (x *SubscribeResponse) String() string {
 func (*SubscribeResponse) ProtoMessage() {}
 
 func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[18]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1204,7 +1443,7 @@ func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{18}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *SubscribeResponse) GetChange() *ConfigChange {
@@ -1230,7 +1469,7 @@ type ExportConfigRequest struct {
 
 func (x *ExportConfigRequest) Reset() {
 	*x = ExportConfigRequest{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[19]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1242,7 +1481,7 @@ func (x *ExportConfigRequest) String() string {
 func (*ExportConfigRequest) ProtoMessage() {}
 
 func (x *ExportConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[19]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1255,7 +1494,7 @@ func (x *ExportConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportConfigRequest.ProtoReflect.Descriptor instead.
 func (*ExportConfigRequest) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{19}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ExportConfigRequest) GetTenantId() string {
@@ -1289,7 +1528,7 @@ type ExportConfigResponse struct {
 
 func (x *ExportConfigResponse) Reset() {
 	*x = ExportConfigResponse{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[20]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1301,7 +1540,7 @@ func (x *ExportConfigResponse) String() string {
 func (*ExportConfigResponse) ProtoMessage() {}
 
 func (x *ExportConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[20]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1314,7 +1553,7 @@ func (x *ExportConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExportConfigResponse.ProtoReflect.Descriptor instead.
 func (*ExportConfigResponse) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{20}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ExportConfigResponse) GetYamlContent() []byte {
@@ -1340,7 +1579,7 @@ type ImportConfigRequest struct {
 
 func (x *ImportConfigRequest) Reset() {
 	*x = ImportConfigRequest{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[21]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1352,7 +1591,7 @@ func (x *ImportConfigRequest) String() string {
 func (*ImportConfigRequest) ProtoMessage() {}
 
 func (x *ImportConfigRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[21]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1365,7 +1604,7 @@ func (x *ImportConfigRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportConfigRequest.ProtoReflect.Descriptor instead.
 func (*ImportConfigRequest) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{21}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ImportConfigRequest) GetTenantId() string {
@@ -1406,7 +1645,7 @@ type ImportConfigResponse struct {
 
 func (x *ImportConfigResponse) Reset() {
 	*x = ImportConfigResponse{}
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[22]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1418,7 +1657,7 @@ func (x *ImportConfigResponse) String() string {
 func (*ImportConfigResponse) ProtoMessage() {}
 
 func (x *ImportConfigResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_centralconfig_v1_config_service_proto_msgTypes[22]
+	mi := &file_centralconfig_v1_config_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1431,7 +1670,7 @@ func (x *ImportConfigResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ImportConfigResponse.ProtoReflect.Descriptor instead.
 func (*ImportConfigResponse) Descriptor() ([]byte, []int) {
-	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{22}
+	return file_centralconfig_v1_config_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ImportConfigResponse) GetConfigVersion() *ConfigVersion {
@@ -1525,7 +1764,21 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\vdescription\x18\x03 \x01(\tH\x00R\vdescription\x88\x01\x01B\x0e\n" +
 	"\f_description\"c\n" +
 	"\x19RollbackToVersionResponse\x12F\n" +
-	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion\"\x8c\x01\n" +
+	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion\"t\n" +
+	"\x13DiffVersionsRequest\x12\x1b\n" +
+	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12!\n" +
+	"\ffrom_version\x18\x02 \x01(\x05R\vfromVersion\x12\x1d\n" +
+	"\n" +
+	"to_version\x18\x03 \x01(\x05R\ttoVersion\"I\n" +
+	"\x14DiffVersionsResponse\x121\n" +
+	"\x05diffs\x18\x01 \x03(\v2\x1b.centralconfig.v1.FieldDiffR\x05diffs\"\xa3\x01\n" +
+	"\tFieldDiff\x12\x1d\n" +
+	"\n" +
+	"field_path\x18\x01 \x01(\tR\tfieldPath\x12=\n" +
+	"\vchange_type\x18\x02 \x01(\x0e2\x1c.centralconfig.v1.ChangeTypeR\n" +
+	"changeType\x12\x1b\n" +
+	"\told_value\x18\x03 \x01(\tR\boldValue\x12\x1b\n" +
+	"\tnew_value\x18\x04 \x01(\tR\bnewValue\"\x8c\x01\n" +
 	"\x10SubscribeRequest\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x1f\n" +
 	"\vfield_paths\x18\x02 \x03(\tR\n" +
@@ -1552,11 +1805,17 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\x14ImportConfigResponse\x12F\n" +
 	"\x0econfig_version\x18\x01 \x01(\v2\x1f.centralconfig.v1.ConfigVersionR\rconfigVersion*s\n" +
 	"\n" +
+	"ChangeType\x12\x1b\n" +
+	"\x17CHANGE_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
+	"\x11CHANGE_TYPE_ADDED\x10\x01\x12\x17\n" +
+	"\x13CHANGE_TYPE_REMOVED\x10\x02\x12\x18\n" +
+	"\x14CHANGE_TYPE_MODIFIED\x10\x03*s\n" +
+	"\n" +
 	"ImportMode\x12\x1b\n" +
 	"\x17IMPORT_MODE_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11IMPORT_MODE_MERGE\x10\x01\x12\x17\n" +
 	"\x13IMPORT_MODE_REPLACE\x10\x02\x12\x18\n" +
-	"\x14IMPORT_MODE_DEFAULTS\x10\x032\xb6\f\n" +
+	"\x14IMPORT_MODE_DEFAULTS\x10\x032\xe1\r\n" +
 	"\rConfigService\x12|\n" +
 	"\tGetConfig\x12\".centralconfig.v1.GetConfigRequest\x1a#.centralconfig.v1.GetConfigResponse\"&\x82\xd3\xe4\x93\x02 \x12\x1e/v1/tenants/{tenant_id}/config\x12\x8d\x01\n" +
 	"\bGetField\x12!.centralconfig.v1.GetFieldRequest\x1a\".centralconfig.v1.GetFieldResponse\":\x82\xd3\xe4\x93\x024\x122/v1/tenants/{tenant_id}/config/fields/{field_path}\x12\x88\x01\n" +
@@ -1566,7 +1825,8 @@ const file_centralconfig_v1_config_service_proto_rawDesc = "" +
 	"\fListVersions\x12%.centralconfig.v1.ListVersionsRequest\x1a&.centralconfig.v1.ListVersionsResponse\"(\x82\xd3\xe4\x93\x02\"\x12 /v1/tenants/{tenant_id}/versions\x12\x8b\x01\n" +
 	"\n" +
 	"GetVersion\x12#.centralconfig.v1.GetVersionRequest\x1a$.centralconfig.v1.GetVersionResponse\"2\x82\xd3\xe4\x93\x02,\x12*/v1/tenants/{tenant_id}/versions/{version}\x12\xa9\x01\n" +
-	"\x11RollbackToVersion\x12*.centralconfig.v1.RollbackToVersionRequest\x1a+.centralconfig.v1.RollbackToVersionResponse\";\x82\xd3\xe4\x93\x025\"3/v1/tenants/{tenant_id}/versions/{version}:rollback\x12\x88\x01\n" +
+	"\x11RollbackToVersion\x12*.centralconfig.v1.RollbackToVersionRequest\x1a+.centralconfig.v1.RollbackToVersionResponse\";\x82\xd3\xe4\x93\x025\"3/v1/tenants/{tenant_id}/versions/{version}:rollback\x12\xa8\x01\n" +
+	"\fDiffVersions\x12%.centralconfig.v1.DiffVersionsRequest\x1a&.centralconfig.v1.DiffVersionsResponse\"I\x82\xd3\xe4\x93\x02C\x12A/v1/tenants/{tenant_id}/versions/{from_version}/diff/{to_version}\x12\x88\x01\n" +
 	"\tSubscribe\x12\".centralconfig.v1.SubscribeRequest\x1a#.centralconfig.v1.SubscribeResponse\"0\x82\xd3\xe4\x93\x02*\x12(/v1/tenants/{tenant_id}/config:subscribe0\x01\x12\x8c\x01\n" +
 	"\fExportConfig\x12%.centralconfig.v1.ExportConfigRequest\x1a&.centralconfig.v1.ExportConfigResponse\"-\x82\xd3\xe4\x93\x02'\x12%/v1/tenants/{tenant_id}/config/export\x12\x8f\x01\n" +
 	"\fImportConfig\x12%.centralconfig.v1.ImportConfigRequest\x1a&.centralconfig.v1.ImportConfigResponse\"0\x82\xd3\xe4\x93\x02*:\x01*\"%/v1/tenants/{tenant_id}/config/importB\xce\x01\n" +
@@ -1584,81 +1844,89 @@ func file_centralconfig_v1_config_service_proto_rawDescGZIP() []byte {
 	return file_centralconfig_v1_config_service_proto_rawDescData
 }
 
-var file_centralconfig_v1_config_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_centralconfig_v1_config_service_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_centralconfig_v1_config_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_centralconfig_v1_config_service_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_centralconfig_v1_config_service_proto_goTypes = []any{
-	(ImportMode)(0),                   // 0: centralconfig.v1.ImportMode
-	(*GetConfigRequest)(nil),          // 1: centralconfig.v1.GetConfigRequest
-	(*GetConfigResponse)(nil),         // 2: centralconfig.v1.GetConfigResponse
-	(*GetFieldRequest)(nil),           // 3: centralconfig.v1.GetFieldRequest
-	(*GetFieldResponse)(nil),          // 4: centralconfig.v1.GetFieldResponse
-	(*GetFieldsRequest)(nil),          // 5: centralconfig.v1.GetFieldsRequest
-	(*GetFieldsResponse)(nil),         // 6: centralconfig.v1.GetFieldsResponse
-	(*SetFieldRequest)(nil),           // 7: centralconfig.v1.SetFieldRequest
-	(*SetFieldResponse)(nil),          // 8: centralconfig.v1.SetFieldResponse
-	(*SetFieldsRequest)(nil),          // 9: centralconfig.v1.SetFieldsRequest
-	(*SetFieldsResponse)(nil),         // 10: centralconfig.v1.SetFieldsResponse
-	(*FieldUpdate)(nil),               // 11: centralconfig.v1.FieldUpdate
-	(*ListVersionsRequest)(nil),       // 12: centralconfig.v1.ListVersionsRequest
-	(*ListVersionsResponse)(nil),      // 13: centralconfig.v1.ListVersionsResponse
-	(*GetVersionRequest)(nil),         // 14: centralconfig.v1.GetVersionRequest
-	(*GetVersionResponse)(nil),        // 15: centralconfig.v1.GetVersionResponse
-	(*RollbackToVersionRequest)(nil),  // 16: centralconfig.v1.RollbackToVersionRequest
-	(*RollbackToVersionResponse)(nil), // 17: centralconfig.v1.RollbackToVersionResponse
-	(*SubscribeRequest)(nil),          // 18: centralconfig.v1.SubscribeRequest
-	(*SubscribeResponse)(nil),         // 19: centralconfig.v1.SubscribeResponse
-	(*ExportConfigRequest)(nil),       // 20: centralconfig.v1.ExportConfigRequest
-	(*ExportConfigResponse)(nil),      // 21: centralconfig.v1.ExportConfigResponse
-	(*ImportConfigRequest)(nil),       // 22: centralconfig.v1.ImportConfigRequest
-	(*ImportConfigResponse)(nil),      // 23: centralconfig.v1.ImportConfigResponse
-	(*Config)(nil),                    // 24: centralconfig.v1.Config
-	(*ConfigValue)(nil),               // 25: centralconfig.v1.ConfigValue
-	(*TypedValue)(nil),                // 26: centralconfig.v1.TypedValue
-	(*ConfigVersion)(nil),             // 27: centralconfig.v1.ConfigVersion
-	(*ConfigChange)(nil),              // 28: centralconfig.v1.ConfigChange
+	(ChangeType)(0),                   // 0: centralconfig.v1.ChangeType
+	(ImportMode)(0),                   // 1: centralconfig.v1.ImportMode
+	(*GetConfigRequest)(nil),          // 2: centralconfig.v1.GetConfigRequest
+	(*GetConfigResponse)(nil),         // 3: centralconfig.v1.GetConfigResponse
+	(*GetFieldRequest)(nil),           // 4: centralconfig.v1.GetFieldRequest
+	(*GetFieldResponse)(nil),          // 5: centralconfig.v1.GetFieldResponse
+	(*GetFieldsRequest)(nil),          // 6: centralconfig.v1.GetFieldsRequest
+	(*GetFieldsResponse)(nil),         // 7: centralconfig.v1.GetFieldsResponse
+	(*SetFieldRequest)(nil),           // 8: centralconfig.v1.SetFieldRequest
+	(*SetFieldResponse)(nil),          // 9: centralconfig.v1.SetFieldResponse
+	(*SetFieldsRequest)(nil),          // 10: centralconfig.v1.SetFieldsRequest
+	(*SetFieldsResponse)(nil),         // 11: centralconfig.v1.SetFieldsResponse
+	(*FieldUpdate)(nil),               // 12: centralconfig.v1.FieldUpdate
+	(*ListVersionsRequest)(nil),       // 13: centralconfig.v1.ListVersionsRequest
+	(*ListVersionsResponse)(nil),      // 14: centralconfig.v1.ListVersionsResponse
+	(*GetVersionRequest)(nil),         // 15: centralconfig.v1.GetVersionRequest
+	(*GetVersionResponse)(nil),        // 16: centralconfig.v1.GetVersionResponse
+	(*RollbackToVersionRequest)(nil),  // 17: centralconfig.v1.RollbackToVersionRequest
+	(*RollbackToVersionResponse)(nil), // 18: centralconfig.v1.RollbackToVersionResponse
+	(*DiffVersionsRequest)(nil),       // 19: centralconfig.v1.DiffVersionsRequest
+	(*DiffVersionsResponse)(nil),      // 20: centralconfig.v1.DiffVersionsResponse
+	(*FieldDiff)(nil),                 // 21: centralconfig.v1.FieldDiff
+	(*SubscribeRequest)(nil),          // 22: centralconfig.v1.SubscribeRequest
+	(*SubscribeResponse)(nil),         // 23: centralconfig.v1.SubscribeResponse
+	(*ExportConfigRequest)(nil),       // 24: centralconfig.v1.ExportConfigRequest
+	(*ExportConfigResponse)(nil),      // 25: centralconfig.v1.ExportConfigResponse
+	(*ImportConfigRequest)(nil),       // 26: centralconfig.v1.ImportConfigRequest
+	(*ImportConfigResponse)(nil),      // 27: centralconfig.v1.ImportConfigResponse
+	(*Config)(nil),                    // 28: centralconfig.v1.Config
+	(*ConfigValue)(nil),               // 29: centralconfig.v1.ConfigValue
+	(*TypedValue)(nil),                // 30: centralconfig.v1.TypedValue
+	(*ConfigVersion)(nil),             // 31: centralconfig.v1.ConfigVersion
+	(*ConfigChange)(nil),              // 32: centralconfig.v1.ConfigChange
 }
 var file_centralconfig_v1_config_service_proto_depIdxs = []int32{
-	24, // 0: centralconfig.v1.GetConfigResponse.config:type_name -> centralconfig.v1.Config
-	25, // 1: centralconfig.v1.GetFieldResponse.value:type_name -> centralconfig.v1.ConfigValue
-	25, // 2: centralconfig.v1.GetFieldsResponse.values:type_name -> centralconfig.v1.ConfigValue
-	26, // 3: centralconfig.v1.SetFieldRequest.value:type_name -> centralconfig.v1.TypedValue
-	27, // 4: centralconfig.v1.SetFieldResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
-	11, // 5: centralconfig.v1.SetFieldsRequest.updates:type_name -> centralconfig.v1.FieldUpdate
-	27, // 6: centralconfig.v1.SetFieldsResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
-	26, // 7: centralconfig.v1.FieldUpdate.value:type_name -> centralconfig.v1.TypedValue
-	27, // 8: centralconfig.v1.ListVersionsResponse.versions:type_name -> centralconfig.v1.ConfigVersion
-	27, // 9: centralconfig.v1.GetVersionResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
-	27, // 10: centralconfig.v1.RollbackToVersionResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
-	28, // 11: centralconfig.v1.SubscribeResponse.change:type_name -> centralconfig.v1.ConfigChange
-	0,  // 12: centralconfig.v1.ImportConfigRequest.mode:type_name -> centralconfig.v1.ImportMode
-	27, // 13: centralconfig.v1.ImportConfigResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
-	1,  // 14: centralconfig.v1.ConfigService.GetConfig:input_type -> centralconfig.v1.GetConfigRequest
-	3,  // 15: centralconfig.v1.ConfigService.GetField:input_type -> centralconfig.v1.GetFieldRequest
-	5,  // 16: centralconfig.v1.ConfigService.GetFields:input_type -> centralconfig.v1.GetFieldsRequest
-	7,  // 17: centralconfig.v1.ConfigService.SetField:input_type -> centralconfig.v1.SetFieldRequest
-	9,  // 18: centralconfig.v1.ConfigService.SetFields:input_type -> centralconfig.v1.SetFieldsRequest
-	12, // 19: centralconfig.v1.ConfigService.ListVersions:input_type -> centralconfig.v1.ListVersionsRequest
-	14, // 20: centralconfig.v1.ConfigService.GetVersion:input_type -> centralconfig.v1.GetVersionRequest
-	16, // 21: centralconfig.v1.ConfigService.RollbackToVersion:input_type -> centralconfig.v1.RollbackToVersionRequest
-	18, // 22: centralconfig.v1.ConfigService.Subscribe:input_type -> centralconfig.v1.SubscribeRequest
-	20, // 23: centralconfig.v1.ConfigService.ExportConfig:input_type -> centralconfig.v1.ExportConfigRequest
-	22, // 24: centralconfig.v1.ConfigService.ImportConfig:input_type -> centralconfig.v1.ImportConfigRequest
-	2,  // 25: centralconfig.v1.ConfigService.GetConfig:output_type -> centralconfig.v1.GetConfigResponse
-	4,  // 26: centralconfig.v1.ConfigService.GetField:output_type -> centralconfig.v1.GetFieldResponse
-	6,  // 27: centralconfig.v1.ConfigService.GetFields:output_type -> centralconfig.v1.GetFieldsResponse
-	8,  // 28: centralconfig.v1.ConfigService.SetField:output_type -> centralconfig.v1.SetFieldResponse
-	10, // 29: centralconfig.v1.ConfigService.SetFields:output_type -> centralconfig.v1.SetFieldsResponse
-	13, // 30: centralconfig.v1.ConfigService.ListVersions:output_type -> centralconfig.v1.ListVersionsResponse
-	15, // 31: centralconfig.v1.ConfigService.GetVersion:output_type -> centralconfig.v1.GetVersionResponse
-	17, // 32: centralconfig.v1.ConfigService.RollbackToVersion:output_type -> centralconfig.v1.RollbackToVersionResponse
-	19, // 33: centralconfig.v1.ConfigService.Subscribe:output_type -> centralconfig.v1.SubscribeResponse
-	21, // 34: centralconfig.v1.ConfigService.ExportConfig:output_type -> centralconfig.v1.ExportConfigResponse
-	23, // 35: centralconfig.v1.ConfigService.ImportConfig:output_type -> centralconfig.v1.ImportConfigResponse
-	25, // [25:36] is the sub-list for method output_type
-	14, // [14:25] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	28, // 0: centralconfig.v1.GetConfigResponse.config:type_name -> centralconfig.v1.Config
+	29, // 1: centralconfig.v1.GetFieldResponse.value:type_name -> centralconfig.v1.ConfigValue
+	29, // 2: centralconfig.v1.GetFieldsResponse.values:type_name -> centralconfig.v1.ConfigValue
+	30, // 3: centralconfig.v1.SetFieldRequest.value:type_name -> centralconfig.v1.TypedValue
+	31, // 4: centralconfig.v1.SetFieldResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
+	12, // 5: centralconfig.v1.SetFieldsRequest.updates:type_name -> centralconfig.v1.FieldUpdate
+	31, // 6: centralconfig.v1.SetFieldsResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
+	30, // 7: centralconfig.v1.FieldUpdate.value:type_name -> centralconfig.v1.TypedValue
+	31, // 8: centralconfig.v1.ListVersionsResponse.versions:type_name -> centralconfig.v1.ConfigVersion
+	31, // 9: centralconfig.v1.GetVersionResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
+	31, // 10: centralconfig.v1.RollbackToVersionResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
+	21, // 11: centralconfig.v1.DiffVersionsResponse.diffs:type_name -> centralconfig.v1.FieldDiff
+	0,  // 12: centralconfig.v1.FieldDiff.change_type:type_name -> centralconfig.v1.ChangeType
+	32, // 13: centralconfig.v1.SubscribeResponse.change:type_name -> centralconfig.v1.ConfigChange
+	1,  // 14: centralconfig.v1.ImportConfigRequest.mode:type_name -> centralconfig.v1.ImportMode
+	31, // 15: centralconfig.v1.ImportConfigResponse.config_version:type_name -> centralconfig.v1.ConfigVersion
+	2,  // 16: centralconfig.v1.ConfigService.GetConfig:input_type -> centralconfig.v1.GetConfigRequest
+	4,  // 17: centralconfig.v1.ConfigService.GetField:input_type -> centralconfig.v1.GetFieldRequest
+	6,  // 18: centralconfig.v1.ConfigService.GetFields:input_type -> centralconfig.v1.GetFieldsRequest
+	8,  // 19: centralconfig.v1.ConfigService.SetField:input_type -> centralconfig.v1.SetFieldRequest
+	10, // 20: centralconfig.v1.ConfigService.SetFields:input_type -> centralconfig.v1.SetFieldsRequest
+	13, // 21: centralconfig.v1.ConfigService.ListVersions:input_type -> centralconfig.v1.ListVersionsRequest
+	15, // 22: centralconfig.v1.ConfigService.GetVersion:input_type -> centralconfig.v1.GetVersionRequest
+	17, // 23: centralconfig.v1.ConfigService.RollbackToVersion:input_type -> centralconfig.v1.RollbackToVersionRequest
+	19, // 24: centralconfig.v1.ConfigService.DiffVersions:input_type -> centralconfig.v1.DiffVersionsRequest
+	22, // 25: centralconfig.v1.ConfigService.Subscribe:input_type -> centralconfig.v1.SubscribeRequest
+	24, // 26: centralconfig.v1.ConfigService.ExportConfig:input_type -> centralconfig.v1.ExportConfigRequest
+	26, // 27: centralconfig.v1.ConfigService.ImportConfig:input_type -> centralconfig.v1.ImportConfigRequest
+	3,  // 28: centralconfig.v1.ConfigService.GetConfig:output_type -> centralconfig.v1.GetConfigResponse
+	5,  // 29: centralconfig.v1.ConfigService.GetField:output_type -> centralconfig.v1.GetFieldResponse
+	7,  // 30: centralconfig.v1.ConfigService.GetFields:output_type -> centralconfig.v1.GetFieldsResponse
+	9,  // 31: centralconfig.v1.ConfigService.SetField:output_type -> centralconfig.v1.SetFieldResponse
+	11, // 32: centralconfig.v1.ConfigService.SetFields:output_type -> centralconfig.v1.SetFieldsResponse
+	14, // 33: centralconfig.v1.ConfigService.ListVersions:output_type -> centralconfig.v1.ListVersionsResponse
+	16, // 34: centralconfig.v1.ConfigService.GetVersion:output_type -> centralconfig.v1.GetVersionResponse
+	18, // 35: centralconfig.v1.ConfigService.RollbackToVersion:output_type -> centralconfig.v1.RollbackToVersionResponse
+	20, // 36: centralconfig.v1.ConfigService.DiffVersions:output_type -> centralconfig.v1.DiffVersionsResponse
+	23, // 37: centralconfig.v1.ConfigService.Subscribe:output_type -> centralconfig.v1.SubscribeResponse
+	25, // 38: centralconfig.v1.ConfigService.ExportConfig:output_type -> centralconfig.v1.ExportConfigResponse
+	27, // 39: centralconfig.v1.ConfigService.ImportConfig:output_type -> centralconfig.v1.ImportConfigResponse
+	28, // [28:40] is the sub-list for method output_type
+	16, // [16:28] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_centralconfig_v1_config_service_proto_init() }
@@ -1674,16 +1942,16 @@ func file_centralconfig_v1_config_service_proto_init() {
 	file_centralconfig_v1_config_service_proto_msgTypes[8].OneofWrappers = []any{}
 	file_centralconfig_v1_config_service_proto_msgTypes[10].OneofWrappers = []any{}
 	file_centralconfig_v1_config_service_proto_msgTypes[15].OneofWrappers = []any{}
-	file_centralconfig_v1_config_service_proto_msgTypes[17].OneofWrappers = []any{}
-	file_centralconfig_v1_config_service_proto_msgTypes[19].OneofWrappers = []any{}
-	file_centralconfig_v1_config_service_proto_msgTypes[21].OneofWrappers = []any{}
+	file_centralconfig_v1_config_service_proto_msgTypes[20].OneofWrappers = []any{}
+	file_centralconfig_v1_config_service_proto_msgTypes[22].OneofWrappers = []any{}
+	file_centralconfig_v1_config_service_proto_msgTypes[24].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_centralconfig_v1_config_service_proto_rawDesc), len(file_centralconfig_v1_config_service_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   23,
+			NumEnums:      2,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/centralconfig/v1/config_service.pb.gw.go
+++ b/api/centralconfig/v1/config_service.pb.gw.go
@@ -485,6 +485,77 @@ func local_request_ConfigService_RollbackToVersion_0(ctx context.Context, marsha
 	return msg, metadata, err
 }
 
+func request_ConfigService_DiffVersions_0(ctx context.Context, marshaler runtime.Marshaler, client ConfigServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DiffVersionsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["tenant_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tenant_id")
+	}
+	protoReq.TenantId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant_id", err)
+	}
+	val, ok = pathParams["from_version"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "from_version")
+	}
+	protoReq.FromVersion, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "from_version", err)
+	}
+	val, ok = pathParams["to_version"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "to_version")
+	}
+	protoReq.ToVersion, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "to_version", err)
+	}
+	msg, err := client.DiffVersions(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_ConfigService_DiffVersions_0(ctx context.Context, marshaler runtime.Marshaler, server ConfigServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq DiffVersionsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["tenant_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "tenant_id")
+	}
+	protoReq.TenantId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "tenant_id", err)
+	}
+	val, ok = pathParams["from_version"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "from_version")
+	}
+	protoReq.FromVersion, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "from_version", err)
+	}
+	val, ok = pathParams["to_version"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "to_version")
+	}
+	protoReq.ToVersion, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "to_version", err)
+	}
+	msg, err := server.DiffVersions(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 var filter_ConfigService_Subscribe_0 = &utilities.DoubleArray{Encoding: map[string]int{"tenant_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_ConfigService_Subscribe_0(ctx context.Context, marshaler runtime.Marshaler, client ConfigServiceClient, req *http.Request, pathParams map[string]string) (ConfigService_SubscribeClient, runtime.ServerMetadata, error) {
@@ -786,6 +857,26 @@ func RegisterConfigServiceHandlerServer(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_ConfigService_RollbackToVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ConfigService_DiffVersions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/centralconfig.v1.ConfigService/DiffVersions", runtime.WithHTTPPathPattern("/v1/tenants/{tenant_id}/versions/{from_version}/diff/{to_version}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_ConfigService_DiffVersions_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ConfigService_DiffVersions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	mux.Handle(http.MethodGet, pattern_ConfigService_Subscribe_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		err := status.Error(codes.Unimplemented, "streaming calls are not yet supported in the in-process transport")
@@ -1009,6 +1100,23 @@ func RegisterConfigServiceHandlerClient(ctx context.Context, mux *runtime.ServeM
 		}
 		forward_ConfigService_RollbackToVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_ConfigService_DiffVersions_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/centralconfig.v1.ConfigService/DiffVersions", runtime.WithHTTPPathPattern("/v1/tenants/{tenant_id}/versions/{from_version}/diff/{to_version}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_ConfigService_DiffVersions_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_ConfigService_DiffVersions_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_ConfigService_Subscribe_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1072,6 +1180,7 @@ var (
 	pattern_ConfigService_ListVersions_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "versions"}, ""))
 	pattern_ConfigService_GetVersion_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "tenants", "tenant_id", "versions", "version"}, ""))
 	pattern_ConfigService_RollbackToVersion_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"v1", "tenants", "tenant_id", "versions", "version"}, "rollback"))
+	pattern_ConfigService_DiffVersions_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5, 1, 0, 4, 1, 5, 6}, []string{"v1", "tenants", "tenant_id", "versions", "from_version", "diff", "to_version"}, ""))
 	pattern_ConfigService_Subscribe_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"v1", "tenants", "tenant_id", "config"}, "subscribe"))
 	pattern_ConfigService_ExportConfig_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 2, 4}, []string{"v1", "tenants", "tenant_id", "config", "export"}, ""))
 	pattern_ConfigService_ImportConfig_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3, 2, 4}, []string{"v1", "tenants", "tenant_id", "config", "import"}, ""))
@@ -1086,6 +1195,7 @@ var (
 	forward_ConfigService_ListVersions_0      = runtime.ForwardResponseMessage
 	forward_ConfigService_GetVersion_0        = runtime.ForwardResponseMessage
 	forward_ConfigService_RollbackToVersion_0 = runtime.ForwardResponseMessage
+	forward_ConfigService_DiffVersions_0      = runtime.ForwardResponseMessage
 	forward_ConfigService_Subscribe_0         = runtime.ForwardResponseStream
 	forward_ConfigService_ExportConfig_0      = runtime.ForwardResponseMessage
 	forward_ConfigService_ImportConfig_0      = runtime.ForwardResponseMessage

--- a/api/centralconfig/v1/config_service_grpc.pb.go
+++ b/api/centralconfig/v1/config_service_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	ConfigService_ListVersions_FullMethodName      = "/centralconfig.v1.ConfigService/ListVersions"
 	ConfigService_GetVersion_FullMethodName        = "/centralconfig.v1.ConfigService/GetVersion"
 	ConfigService_RollbackToVersion_FullMethodName = "/centralconfig.v1.ConfigService/RollbackToVersion"
+	ConfigService_DiffVersions_FullMethodName      = "/centralconfig.v1.ConfigService/DiffVersions"
 	ConfigService_Subscribe_FullMethodName         = "/centralconfig.v1.ConfigService/Subscribe"
 	ConfigService_ExportConfig_FullMethodName      = "/centralconfig.v1.ConfigService/ExportConfig"
 	ConfigService_ImportConfig_FullMethodName      = "/centralconfig.v1.ConfigService/ImportConfig"
@@ -64,6 +65,10 @@ type ConfigServiceClient interface {
 	// This does not delete intermediate versions — it creates a new version that
 	// copies the target's values.
 	RollbackToVersion(ctx context.Context, in *RollbackToVersionRequest, opts ...grpc.CallOption) (*RollbackToVersionResponse, error)
+	// DiffVersions compares the full resolved config at two versions and returns
+	// the fields that differ. Unchanged fields are omitted. Results are sorted by
+	// field path for deterministic output.
+	DiffVersions(ctx context.Context, in *DiffVersionsRequest, opts ...grpc.CallOption) (*DiffVersionsResponse, error)
 	// Subscribe opens a server-streaming connection that pushes ConfigChange events
 	// whenever the tenant's configuration is modified.
 	//
@@ -172,6 +177,16 @@ func (c *configServiceClient) RollbackToVersion(ctx context.Context, in *Rollbac
 	return out, nil
 }
 
+func (c *configServiceClient) DiffVersions(ctx context.Context, in *DiffVersionsRequest, opts ...grpc.CallOption) (*DiffVersionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DiffVersionsResponse)
+	err := c.cc.Invoke(ctx, ConfigService_DiffVersions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *configServiceClient) Subscribe(ctx context.Context, in *SubscribeRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &ConfigService_ServiceDesc.Streams[0], ConfigService_Subscribe_FullMethodName, cOpts...)
@@ -243,6 +258,10 @@ type ConfigServiceServer interface {
 	// This does not delete intermediate versions — it creates a new version that
 	// copies the target's values.
 	RollbackToVersion(context.Context, *RollbackToVersionRequest) (*RollbackToVersionResponse, error)
+	// DiffVersions compares the full resolved config at two versions and returns
+	// the fields that differ. Unchanged fields are omitted. Results are sorted by
+	// field path for deterministic output.
+	DiffVersions(context.Context, *DiffVersionsRequest) (*DiffVersionsResponse, error)
 	// Subscribe opens a server-streaming connection that pushes ConfigChange events
 	// whenever the tenant's configuration is modified.
 	//
@@ -294,6 +313,9 @@ func (UnimplementedConfigServiceServer) GetVersion(context.Context, *GetVersionR
 }
 func (UnimplementedConfigServiceServer) RollbackToVersion(context.Context, *RollbackToVersionRequest) (*RollbackToVersionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RollbackToVersion not implemented")
+}
+func (UnimplementedConfigServiceServer) DiffVersions(context.Context, *DiffVersionsRequest) (*DiffVersionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DiffVersions not implemented")
 }
 func (UnimplementedConfigServiceServer) Subscribe(*SubscribeRequest, grpc.ServerStreamingServer[SubscribeResponse]) error {
 	return status.Error(codes.Unimplemented, "method Subscribe not implemented")
@@ -469,6 +491,24 @@ func _ConfigService_RollbackToVersion_Handler(srv interface{}, ctx context.Conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ConfigService_DiffVersions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DiffVersionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConfigServiceServer).DiffVersions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ConfigService_DiffVersions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConfigServiceServer).DiffVersions(ctx, req.(*DiffVersionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ConfigService_Subscribe_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(SubscribeRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -554,6 +594,10 @@ var ConfigService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RollbackToVersion",
 			Handler:    _ConfigService_RollbackToVersion_Handler,
+		},
+		{
+			MethodName: "DiffVersions",
+			Handler:    _ConfigService_DiffVersions_Handler,
 		},
 		{
 			MethodName: "ExportConfig",

--- a/cmd/server/openapi.json
+++ b/cmd/server/openapi.json
@@ -1334,6 +1334,54 @@
         ]
       }
     },
+    "/v1/tenants/{tenantId}/versions/{fromVersion}/diff/{toVersion}": {
+      "get": {
+        "summary": "DiffVersions compares the full resolved config at two versions and returns\nthe fields that differ. Unchanged fields are omitted. Results are sorted by\nfield path for deterministic output.",
+        "operationId": "ConfigService_DiffVersions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DiffVersionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "tenantId",
+            "description": "Tenant ID (UUID).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromVersion",
+            "description": "The base version to diff from.",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "toVersion",
+            "description": "The target version to diff to.",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "ConfigService"
+        ]
+      }
+    },
     "/v1/tenants/{tenantId}/versions/{version}": {
       "get": {
         "summary": "GetVersion retrieves metadata for a specific config version.",
@@ -1690,6 +1738,17 @@
       },
       "description": "AuditEntry represents a write event recorded in the audit log.\nEvery config mutation (SetField, SetFields, RollbackToVersion) creates\none or more audit entries atomically with the config change."
     },
+    "v1ChangeType": {
+      "type": "string",
+      "enum": [
+        "CHANGE_TYPE_UNSPECIFIED",
+        "CHANGE_TYPE_ADDED",
+        "CHANGE_TYPE_REMOVED",
+        "CHANGE_TYPE_MODIFIED"
+      ],
+      "default": "CHANGE_TYPE_UNSPECIFIED",
+      "description": "ChangeType categorizes how a field changed between two config versions.\n\n - CHANGE_TYPE_UNSPECIFIED: Unspecified change type. Never emitted by the server.\n - CHANGE_TYPE_ADDED: The field is present in to_version but absent in from_version.\n - CHANGE_TYPE_REMOVED: The field is present in from_version but absent in to_version.\n - CHANGE_TYPE_MODIFIED: The field is present in both versions with a different value."
+    },
     "v1Config": {
       "type": "object",
       "properties": {
@@ -1882,6 +1941,19 @@
       },
       "description": "DependentRequiredEntry encodes one cross-field requirement: when the\ntrigger field has a non-null value, every dependent field path must also\nhave a non-null value. This is the proto wire form of JSON Schema 2020-12\ndependentRequired, which uses a `map<path, list<path>>` shape \u2014 proto\nmaps cannot hold repeated values directly, so we use a repeated list of\nentries."
     },
+    "v1DiffVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "diffs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1FieldDiff"
+          },
+          "description": "The fields that differ between from_version and to_version, sorted by\nfield path. Unchanged fields are omitted."
+        }
+      }
+    },
     "v1ExportConfigResponse": {
       "type": "object",
       "properties": {
@@ -1973,6 +2045,28 @@
         }
       },
       "description": "FieldConstraints defines validation rules for a schema field.\nWhich constraints apply depends on the field's type \u2014 see FieldType docs."
+    },
+    "v1FieldDiff": {
+      "type": "object",
+      "properties": {
+        "fieldPath": {
+          "type": "string",
+          "description": "Dot-separated field path (e.g. \"payments.fee\")."
+        },
+        "changeType": {
+          "$ref": "#/definitions/v1ChangeType",
+          "description": "How the field changed."
+        },
+        "oldValue": {
+          "type": "string",
+          "description": "The value at from_version. Empty when change_type is CHANGE_TYPE_ADDED."
+        },
+        "newValue": {
+          "type": "string",
+          "description": "The value at to_version. Empty when change_type is CHANGE_TYPE_REMOVED."
+        }
+      },
+      "description": "FieldDiff describes a single field that differs between two config versions."
     },
     "v1FieldExample": {
       "type": "object",

--- a/docs/api/api-reference.md
+++ b/docs/api/api-reference.md
@@ -44,8 +44,11 @@
     - [AuditService](#centralconfig-v1-AuditService)
   
 - [centralconfig/v1/config_service.proto](#centralconfig_v1_config_service-proto)
+    - [DiffVersionsRequest](#centralconfig-v1-DiffVersionsRequest)
+    - [DiffVersionsResponse](#centralconfig-v1-DiffVersionsResponse)
     - [ExportConfigRequest](#centralconfig-v1-ExportConfigRequest)
     - [ExportConfigResponse](#centralconfig-v1-ExportConfigResponse)
+    - [FieldDiff](#centralconfig-v1-FieldDiff)
     - [FieldUpdate](#centralconfig-v1-FieldUpdate)
     - [GetConfigRequest](#centralconfig-v1-GetConfigRequest)
     - [GetConfigResponse](#centralconfig-v1-GetConfigResponse)
@@ -68,6 +71,7 @@
     - [SubscribeRequest](#centralconfig-v1-SubscribeRequest)
     - [SubscribeResponse](#centralconfig-v1-SubscribeResponse)
   
+    - [ChangeType](#centralconfig-v1-ChangeType)
     - [ImportMode](#centralconfig-v1-ImportMode)
   
     - [ConfigService](#centralconfig-v1-ConfigService)
@@ -826,6 +830,38 @@ Usage statistics are tracked asynchronously via batched read counters.
 
 
 
+<a name="centralconfig-v1-DiffVersionsRequest"></a>
+
+### DiffVersionsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| tenant_id | [string](#string) |  | Tenant ID (UUID). |
+| from_version | [int32](#int32) |  | The base version to diff from. |
+| to_version | [int32](#int32) |  | The target version to diff to. |
+
+
+
+
+
+
+<a name="centralconfig-v1-DiffVersionsResponse"></a>
+
+### DiffVersionsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| diffs | [FieldDiff](#centralconfig-v1-FieldDiff) | repeated | The fields that differ between from_version and to_version, sorted by field path. Unchanged fields are omitted. |
+
+
+
+
+
+
 <a name="centralconfig-v1-ExportConfigRequest"></a>
 
 ### ExportConfigRequest
@@ -852,6 +888,24 @@ Usage statistics are tracked asynchronously via batched read counters.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | yaml_content | [bytes](#bytes) |  | YAML-encoded configuration values. |
+
+
+
+
+
+
+<a name="centralconfig-v1-FieldDiff"></a>
+
+### FieldDiff
+FieldDiff describes a single field that differs between two config versions.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| field_path | [string](#string) |  | Dot-separated field path (e.g. &#34;payments.fee&#34;). |
+| change_type | [ChangeType](#centralconfig-v1-ChangeType) |  | How the field changed. |
+| old_value | [string](#string) |  | The value at from_version. Empty when change_type is CHANGE_TYPE_ADDED. |
+| new_value | [string](#string) |  | The value at to_version. Empty when change_type is CHANGE_TYPE_REMOVED. |
 
 
 
@@ -1206,6 +1260,20 @@ FieldUpdate represents a single field change within a SetFields batch.
  
 
 
+<a name="centralconfig-v1-ChangeType"></a>
+
+### ChangeType
+ChangeType categorizes how a field changed between two config versions.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CHANGE_TYPE_UNSPECIFIED | 0 | Unspecified change type. Never emitted by the server. |
+| CHANGE_TYPE_ADDED | 1 | The field is present in to_version but absent in from_version. |
+| CHANGE_TYPE_REMOVED | 2 | The field is present in from_version but absent in to_version. |
+| CHANGE_TYPE_MODIFIED | 3 | The field is present in both versions with a different value. |
+
+
+
 <a name="centralconfig-v1-ImportMode"></a>
 
 ### ImportMode
@@ -1250,6 +1318,7 @@ bypasses the cache and reads directly from the database.
 | ListVersions | [ListVersionsRequest](#centralconfig-v1-ListVersionsRequest) | [ListVersionsResponse](#centralconfig-v1-ListVersionsResponse) | ListVersions returns config version history for a tenant (newest first). |
 | GetVersion | [GetVersionRequest](#centralconfig-v1-GetVersionRequest) | [GetVersionResponse](#centralconfig-v1-GetVersionResponse) | GetVersion retrieves metadata for a specific config version. |
 | RollbackToVersion | [RollbackToVersionRequest](#centralconfig-v1-RollbackToVersionRequest) | [RollbackToVersionResponse](#centralconfig-v1-RollbackToVersionResponse) | RollbackToVersion creates a new version with the same values as the target version. This does not delete intermediate versions — it creates a new version that copies the target&#39;s values. |
+| DiffVersions | [DiffVersionsRequest](#centralconfig-v1-DiffVersionsRequest) | [DiffVersionsResponse](#centralconfig-v1-DiffVersionsResponse) | DiffVersions compares the full resolved config at two versions and returns the fields that differ. Unchanged fields are omitted. Results are sorted by field path for deterministic output. |
 | Subscribe | [SubscribeRequest](#centralconfig-v1-SubscribeRequest) | [SubscribeResponse](#centralconfig-v1-SubscribeResponse) stream | Subscribe opens a server-streaming connection that pushes ConfigChange events whenever the tenant&#39;s configuration is modified.
 
 Stream lifetime: - Client disconnect: stream ends immediately. - Server closes with OK status: the server-side pub/sub backend restarted (e.g. Redis reconnect). Clients MUST reconnect with exponential backoff; an OK close does NOT indicate the subscription is permanently gone. - Server closes with error status: treat as a transient failure and reconnect with backoff.

--- a/docs/api/openapi.swagger.json
+++ b/docs/api/openapi.swagger.json
@@ -1334,6 +1334,54 @@
         ]
       }
     },
+    "/v1/tenants/{tenantId}/versions/{fromVersion}/diff/{toVersion}": {
+      "get": {
+        "summary": "DiffVersions compares the full resolved config at two versions and returns\nthe fields that differ. Unchanged fields are omitted. Results are sorted by\nfield path for deterministic output.",
+        "operationId": "ConfigService_DiffVersions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DiffVersionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "tenantId",
+            "description": "Tenant ID (UUID).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fromVersion",
+            "description": "The base version to diff from.",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "toVersion",
+            "description": "The target version to diff to.",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          }
+        ],
+        "tags": [
+          "ConfigService"
+        ]
+      }
+    },
     "/v1/tenants/{tenantId}/versions/{version}": {
       "get": {
         "summary": "GetVersion retrieves metadata for a specific config version.",
@@ -1690,6 +1738,17 @@
       },
       "description": "AuditEntry represents a write event recorded in the audit log.\nEvery config mutation (SetField, SetFields, RollbackToVersion) creates\none or more audit entries atomically with the config change."
     },
+    "v1ChangeType": {
+      "type": "string",
+      "enum": [
+        "CHANGE_TYPE_UNSPECIFIED",
+        "CHANGE_TYPE_ADDED",
+        "CHANGE_TYPE_REMOVED",
+        "CHANGE_TYPE_MODIFIED"
+      ],
+      "default": "CHANGE_TYPE_UNSPECIFIED",
+      "description": "ChangeType categorizes how a field changed between two config versions.\n\n - CHANGE_TYPE_UNSPECIFIED: Unspecified change type. Never emitted by the server.\n - CHANGE_TYPE_ADDED: The field is present in to_version but absent in from_version.\n - CHANGE_TYPE_REMOVED: The field is present in from_version but absent in to_version.\n - CHANGE_TYPE_MODIFIED: The field is present in both versions with a different value."
+    },
     "v1Config": {
       "type": "object",
       "properties": {
@@ -1882,6 +1941,19 @@
       },
       "description": "DependentRequiredEntry encodes one cross-field requirement: when the\ntrigger field has a non-null value, every dependent field path must also\nhave a non-null value. This is the proto wire form of JSON Schema 2020-12\ndependentRequired, which uses a `map<path, list<path>>` shape \u2014 proto\nmaps cannot hold repeated values directly, so we use a repeated list of\nentries."
     },
+    "v1DiffVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "diffs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1FieldDiff"
+          },
+          "description": "The fields that differ between from_version and to_version, sorted by\nfield path. Unchanged fields are omitted."
+        }
+      }
+    },
     "v1ExportConfigResponse": {
       "type": "object",
       "properties": {
@@ -1973,6 +2045,28 @@
         }
       },
       "description": "FieldConstraints defines validation rules for a schema field.\nWhich constraints apply depends on the field's type \u2014 see FieldType docs."
+    },
+    "v1FieldDiff": {
+      "type": "object",
+      "properties": {
+        "fieldPath": {
+          "type": "string",
+          "description": "Dot-separated field path (e.g. \"payments.fee\")."
+        },
+        "changeType": {
+          "$ref": "#/definitions/v1ChangeType",
+          "description": "How the field changed."
+        },
+        "oldValue": {
+          "type": "string",
+          "description": "The value at from_version. Empty when change_type is CHANGE_TYPE_ADDED."
+        },
+        "newValue": {
+          "type": "string",
+          "description": "The value at to_version. Empty when change_type is CHANGE_TYPE_REMOVED."
+        }
+      },
+      "description": "FieldDiff describes a single field that differs between two config versions."
     },
     "v1FieldExample": {
       "type": "object",

--- a/e2e/role_action_matrix_test.go
+++ b/e2e/role_action_matrix_test.go
@@ -271,6 +271,16 @@ func allRPCs() []rpcSpec {
 			},
 		},
 		{
+			name:   "DiffVersions",
+			policy: allow,
+			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {
+				// Fixture seeds version 1; diffing it against itself is a valid
+				// read (empty diff) so this exercises auth only.
+				_, err := c.admin.DiffConfigVersions(ctx, fx.tenantID, 1, 1)
+				return err
+			},
+		},
+		{
 			name:   "RollbackToVersion",
 			policy: adminOrAbove,
 			invoke: func(ctx context.Context, t *testing.T, c *clients, fx *matrixFixture) error {

--- a/internal/config/diff.go
+++ b/internal/config/diff.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"sort"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+)
+
+// diffConfigMaps computes the field-level diff between two config snapshots.
+// Each snapshot maps field path to value. A field present only in updated is
+// ADDED; present only in old is REMOVED; present in both with a different value
+// is MODIFIED. Unchanged fields are omitted. The result is sorted by field path
+// for deterministic output.
+//
+// This mirrors sdk/tools/diff.Compare but is reimplemented here because the
+// server must not import the SDK (separate module).
+func diffConfigMaps(old, updated map[string]string) []*pb.FieldDiff {
+	paths := make(map[string]struct{}, len(old)+len(updated))
+	for p := range old {
+		paths[p] = struct{}{}
+	}
+	for p := range updated {
+		paths[p] = struct{}{}
+	}
+
+	sorted := make([]string, 0, len(paths))
+	for p := range paths {
+		sorted = append(sorted, p)
+	}
+	sort.Strings(sorted)
+
+	diffs := make([]*pb.FieldDiff, 0, len(sorted))
+	for _, p := range sorted {
+		oldVal, inOld := old[p]
+		newVal, inNew := updated[p]
+
+		switch {
+		case inOld && !inNew:
+			diffs = append(diffs, &pb.FieldDiff{
+				FieldPath:  p,
+				ChangeType: pb.ChangeType_CHANGE_TYPE_REMOVED,
+				OldValue:   oldVal,
+			})
+		case !inOld && inNew:
+			diffs = append(diffs, &pb.FieldDiff{
+				FieldPath:  p,
+				ChangeType: pb.ChangeType_CHANGE_TYPE_ADDED,
+				NewValue:   newVal,
+			})
+		case oldVal != newVal:
+			diffs = append(diffs, &pb.FieldDiff{
+				FieldPath:  p,
+				ChangeType: pb.ChangeType_CHANGE_TYPE_MODIFIED,
+				OldValue:   oldVal,
+				NewValue:   newVal,
+			})
+		}
+	}
+
+	return diffs
+}

--- a/internal/config/service.go
+++ b/internal/config/service.go
@@ -942,6 +942,56 @@ func (s *Service) GetVersion(ctx context.Context, req *pb.GetVersionRequest) (*p
 	return &pb.GetVersionResponse{ConfigVersion: configVersionToProto(version)}, nil
 }
 
+// DiffVersions compares the full resolved config at from_version and to_version
+// and returns the fields that differ. Unchanged fields are omitted; results are
+// sorted by field path. Requires ActionRead.
+func (s *Service) DiffVersions(ctx context.Context, req *pb.DiffVersionsRequest) (*pb.DiffVersionsResponse, error) {
+	if err := auth.MustHaveClaims(ctx); err != nil {
+		return nil, err
+	}
+	tenantID, err := s.resolveTenantWithAccess(ctx, req.TenantId, authz.ActionRead)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate that both versions exist before loading snapshots, so a missing
+	// version yields NotFound rather than an empty diff.
+	if _, err := s.store.GetConfigVersion(ctx, GetConfigVersionParams{TenantID: tenantID, Version: req.FromVersion}); err != nil {
+		return nil, errToStatus(err, "from version not found", "failed to get from version")
+	}
+	if _, err := s.store.GetConfigVersion(ctx, GetConfigVersionParams{TenantID: tenantID, Version: req.ToVersion}); err != nil {
+		return nil, errToStatus(err, "to version not found", "failed to get to version")
+	}
+
+	fromMap, err := s.configMapAtVersion(ctx, tenantID, req.FromVersion)
+	if err != nil {
+		return nil, err
+	}
+	toMap, err := s.configMapAtVersion(ctx, tenantID, req.ToVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pb.DiffVersionsResponse{Diffs: diffConfigMaps(fromMap, toMap)}, nil
+}
+
+// configMapAtVersion loads the full resolved config at the given version and
+// returns it as a field-path -> value map. A null value is represented as "".
+func (s *Service) configMapAtVersion(ctx context.Context, tenantID string, version int32) (map[string]string, error) {
+	rows, err := s.store.GetFullConfigAtVersion(ctx, GetFullConfigAtVersionParams{
+		TenantID: tenantID,
+		Version:  version,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get config at version")
+	}
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		out[row.FieldPath] = derefString(row.Value)
+	}
+	return out, nil
+}
+
 func (s *Service) RollbackToVersion(ctx context.Context, req *pb.RollbackToVersionRequest) (*pb.RollbackToVersionResponse, error) {
 	if err := auth.MustHaveClaims(ctx); err != nil {
 		return nil, err

--- a/internal/config/service_extended_test.go
+++ b/internal/config/service_extended_test.go
@@ -571,6 +571,128 @@ func TestGetVersion_NotFound(t *testing.T) {
 	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
+// --- DiffVersions ---
+
+// setupDiffVersionExist stubs GetConfigVersion so both from/to versions resolve.
+func setupDiffVersionExist(store *mockStore, ctx context.Context) {
+	store.On("GetConfigVersion", ctx, mock.AnythingOfType("config.GetConfigVersionParams")).
+		Return(domain.ConfigVersion{ID: versionID2, Version: 1}, nil)
+}
+
+func TestDiffVersions_AddedRemovedModifiedUnchanged(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	setupDiffVersionExist(store, ctx)
+	// from(v1): keep, drop, change present.
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 1}).
+		Return([]GetFullConfigAtVersionRow{
+			{FieldPath: "keep", Value: strPtr("same")},
+			{FieldPath: "drop", Value: strPtr("gone")},
+			{FieldPath: "change", Value: strPtr("old")},
+		}, nil)
+	// to(v2): keep unchanged, change modified, add new.
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 2}).
+		Return([]GetFullConfigAtVersionRow{
+			{FieldPath: "keep", Value: strPtr("same")},
+			{FieldPath: "change", Value: strPtr("new")},
+			{FieldPath: "add", Value: strPtr("fresh")},
+		}, nil)
+
+	resp, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 1, ToVersion: 2})
+	require.NoError(t, err)
+	require.Len(t, resp.Diffs, 3)
+
+	// Sorted by field path: add, change, drop.
+	assert.Equal(t, "add", resp.Diffs[0].FieldPath)
+	assert.Equal(t, pb.ChangeType_CHANGE_TYPE_ADDED, resp.Diffs[0].ChangeType)
+	assert.Empty(t, resp.Diffs[0].OldValue)
+	assert.Equal(t, "fresh", resp.Diffs[0].NewValue)
+
+	assert.Equal(t, "change", resp.Diffs[1].FieldPath)
+	assert.Equal(t, pb.ChangeType_CHANGE_TYPE_MODIFIED, resp.Diffs[1].ChangeType)
+	assert.Equal(t, "old", resp.Diffs[1].OldValue)
+	assert.Equal(t, "new", resp.Diffs[1].NewValue)
+
+	assert.Equal(t, "drop", resp.Diffs[2].FieldPath)
+	assert.Equal(t, pb.ChangeType_CHANGE_TYPE_REMOVED, resp.Diffs[2].ChangeType)
+	assert.Equal(t, "gone", resp.Diffs[2].OldValue)
+	assert.Empty(t, resp.Diffs[2].NewValue)
+}
+
+func TestDiffVersions_Identical_EmptyDiff(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	setupDiffVersionExist(store, ctx)
+	rows := []GetFullConfigAtVersionRow{{FieldPath: "a", Value: strPtr("1")}}
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 3}).
+		Return(rows, nil)
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 4}).
+		Return(rows, nil)
+
+	resp, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 3, ToVersion: 4})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Diffs)
+}
+
+func TestDiffVersions_FromVersionNotFound(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	store.On("GetConfigVersion", ctx, GetConfigVersionParams{TenantID: tenantID1, Version: 99}).
+		Return(domain.ConfigVersion{}, domain.ErrNotFound)
+
+	_, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 99, ToVersion: 1})
+	assert.Equal(t, codes.NotFound, status.Code(err))
+	store.AssertNotCalled(t, "GetFullConfigAtVersion")
+}
+
+func TestDiffVersions_ToVersionNotFound(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	store.On("GetConfigVersion", ctx, GetConfigVersionParams{TenantID: tenantID1, Version: 1}).
+		Return(domain.ConfigVersion{ID: versionID2, Version: 1}, nil)
+	store.On("GetConfigVersion", ctx, GetConfigVersionParams{TenantID: tenantID1, Version: 99}).
+		Return(domain.ConfigVersion{}, domain.ErrNotFound)
+
+	_, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 1, ToVersion: 99})
+	assert.Equal(t, codes.NotFound, status.Code(err))
+	store.AssertNotCalled(t, "GetFullConfigAtVersion")
+}
+
+func TestDiffVersions_NullValueTreatedAsPresent(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	setupDiffVersionExist(store, ctx)
+	// from has a null-valued field; to drops it entirely → REMOVED.
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 5}).
+		Return([]GetFullConfigAtVersionRow{{FieldPath: "n", Value: nil}}, nil)
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 6}).
+		Return([]GetFullConfigAtVersionRow{}, nil)
+
+	resp, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 5, ToVersion: 6})
+	require.NoError(t, err)
+	require.Len(t, resp.Diffs, 1)
+	assert.Equal(t, "n", resp.Diffs[0].FieldPath)
+	assert.Equal(t, pb.ChangeType_CHANGE_TYPE_REMOVED, resp.Diffs[0].ChangeType)
+	assert.Empty(t, resp.Diffs[0].OldValue)
+}
+
+func TestDiffVersions_StoreError_ReturnsInternal(t *testing.T) {
+	svc, store, _, _ := newTestService()
+	ctx := auth.WithoutAuth(context.Background())
+
+	setupDiffVersionExist(store, ctx)
+	store.On("GetFullConfigAtVersion", ctx, GetFullConfigAtVersionParams{TenantID: tenantID1, Version: 7}).
+		Return([]GetFullConfigAtVersionRow(nil), errors.New("db down"))
+
+	_, err := svc.DiffVersions(ctx, &pb.DiffVersionsRequest{TenantId: tenantID1, FromVersion: 7, ToVersion: 8})
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
 // --- convert.go: typedValueToString coverage ---
 
 func TestTypedValueToString_AllTypes(t *testing.T) {

--- a/internal/config/service_test.go
+++ b/internal/config/service_test.go
@@ -1646,6 +1646,9 @@ func TestConfigService_RequiresAuth(t *testing.T) {
 	_, err = svc.GetVersion(ctx, &pb.GetVersionRequest{})
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 
+	_, err = svc.DiffVersions(ctx, &pb.DiffVersionsRequest{})
+	assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
 	_, err = svc.ExportConfig(ctx, &pb.ExportConfigRequest{})
 	assert.Equal(t, codes.Unauthenticated, status.Code(err))
 

--- a/proto/centralconfig/v1/config_service.proto
+++ b/proto/centralconfig/v1/config_service.proto
@@ -80,6 +80,14 @@ service ConfigService {
       post: "/v1/tenants/{tenant_id}/versions/{version}:rollback"
     };
   }
+  // DiffVersions compares the full resolved config at two versions and returns
+  // the fields that differ. Unchanged fields are omitted. Results are sorted by
+  // field path for deterministic output.
+  rpc DiffVersions(DiffVersionsRequest) returns (DiffVersionsResponse) {
+    option (google.api.http) = {
+      get: "/v1/tenants/{tenant_id}/versions/{from_version}/diff/{to_version}"
+    };
+  }
 
   // Real-time subscriptions via server-streaming.
 
@@ -305,6 +313,50 @@ message RollbackToVersionRequest {
 message RollbackToVersionResponse {
   // The newly created config version containing the rolled-back values.
   ConfigVersion config_version = 1;
+}
+
+message DiffVersionsRequest {
+  // Tenant ID (UUID).
+  string tenant_id = 1;
+
+  // The base version to diff from.
+  int32 from_version = 2;
+
+  // The target version to diff to.
+  int32 to_version = 3;
+}
+
+message DiffVersionsResponse {
+  // The fields that differ between from_version and to_version, sorted by
+  // field path. Unchanged fields are omitted.
+  repeated FieldDiff diffs = 1;
+}
+
+// ChangeType categorizes how a field changed between two config versions.
+enum ChangeType {
+  // Unspecified change type. Never emitted by the server.
+  CHANGE_TYPE_UNSPECIFIED = 0;
+  // The field is present in to_version but absent in from_version.
+  CHANGE_TYPE_ADDED = 1;
+  // The field is present in from_version but absent in to_version.
+  CHANGE_TYPE_REMOVED = 2;
+  // The field is present in both versions with a different value.
+  CHANGE_TYPE_MODIFIED = 3;
+}
+
+// FieldDiff describes a single field that differs between two config versions.
+message FieldDiff {
+  // Dot-separated field path (e.g. "payments.fee").
+  string field_path = 1;
+
+  // How the field changed.
+  ChangeType change_type = 2;
+
+  // The value at from_version. Empty when change_type is CHANGE_TYPE_ADDED.
+  string old_value = 3;
+
+  // The value at to_version. Empty when change_type is CHANGE_TYPE_REMOVED.
+  string new_value = 4;
 }
 
 // --- Subscription ---

--- a/sdk/adminclient/client_test.go
+++ b/sdk/adminclient/client_test.go
@@ -99,6 +99,7 @@ type mockConfigTransport struct {
 	listVersionsFn func(ctx context.Context, tenantID string, pageSize int32, pageToken string) (*ListVersionsResponse, error)
 	getVersionFn   func(ctx context.Context, tenantID string, version int32) (*Version, error)
 	rollbackFn     func(ctx context.Context, tenantID string, version int32, description string) (*Version, error)
+	diffVersionsFn func(ctx context.Context, tenantID string, fromVersion, toVersion int32) ([]FieldDiff, error)
 	exportConfigFn func(ctx context.Context, tenantID string, version *int32) ([]byte, error)
 	importConfigFn func(ctx context.Context, req *ImportConfigRequest) (*Version, error)
 }
@@ -113,6 +114,10 @@ func (m *mockConfigTransport) GetVersion(ctx context.Context, tenantID string, v
 
 func (m *mockConfigTransport) RollbackToVersion(ctx context.Context, tenantID string, version int32, description string) (*Version, error) {
 	return m.rollbackFn(ctx, tenantID, version, description)
+}
+
+func (m *mockConfigTransport) DiffVersions(ctx context.Context, tenantID string, fromVersion, toVersion int32) ([]FieldDiff, error) {
+	return m.diffVersionsFn(ctx, tenantID, fromVersion, toVersion)
 }
 
 func (m *mockConfigTransport) ExportConfig(ctx context.Context, tenantID string, version *int32) ([]byte, error) {
@@ -306,6 +311,46 @@ func TestRollbackConfig_Success(t *testing.T) {
 	}
 	if got := v.Version; got != int32(5) {
 		t.Errorf("got Version %v, want %v", got, int32(5))
+	}
+}
+
+func TestDiffConfigVersions_Success(t *testing.T) {
+	mc := &mockConfigTransport{}
+	client := New(WithConfigTransport(mc))
+	ctx := context.Background()
+
+	var gotFrom, gotTo int32
+	mc.diffVersionsFn = func(_ context.Context, _ string, fromVersion, toVersion int32) ([]FieldDiff, error) {
+		gotFrom, gotTo = fromVersion, toVersion
+		return []FieldDiff{
+			{FieldPath: "a", ChangeType: ChangeTypeAdded, NewValue: "1"},
+			{FieldPath: "b", ChangeType: ChangeTypeModified, OldValue: "2", NewValue: "3"},
+		}, nil
+	}
+
+	diffs, err := client.DiffConfigVersions(ctx, "t1", 1, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotFrom != 1 || gotTo != 4 {
+		t.Errorf("transport got from=%d to=%d, want from=1 to=4", gotFrom, gotTo)
+	}
+	if len(diffs) != 2 {
+		t.Fatalf("got %d diffs, want 2", len(diffs))
+	}
+	if diffs[0].ChangeType != ChangeTypeAdded || diffs[0].NewValue != "1" {
+		t.Errorf("diff[0] = %+v, want added/1", diffs[0])
+	}
+	if diffs[1].ChangeType != ChangeTypeModified || diffs[1].OldValue != "2" || diffs[1].NewValue != "3" {
+		t.Errorf("diff[1] = %+v, want modified/2/3", diffs[1])
+	}
+}
+
+func TestDiffConfigVersions_NotConfigured(t *testing.T) {
+	client := New()
+	_, err := client.DiffConfigVersions(context.Background(), "t1", 1, 2)
+	if !errors.Is(err, ErrServiceNotConfigured) {
+		t.Errorf("got %v, want ErrServiceNotConfigured", err)
 	}
 }
 

--- a/sdk/adminclient/config.go
+++ b/sdk/adminclient/config.go
@@ -55,6 +55,19 @@ func (c *Client) GetConfigVersion(ctx context.Context, tenantID string, version 
 	})
 }
 
+// DiffConfigVersions compares the full resolved config at two versions and
+// returns the fields that differ. Unchanged fields are omitted; the result is
+// sorted by field path. A field with a null value at a version is treated as
+// present with an empty-string value.
+func (c *Client) DiffConfigVersions(ctx context.Context, tenantID string, fromVersion, toVersion int32) ([]FieldDiff, error) {
+	if c.config == nil {
+		return nil, ErrServiceNotConfigured
+	}
+	return retry(ctx, c, func(ctx context.Context) ([]FieldDiff, error) {
+		return c.config.DiffVersions(ctx, tenantID, fromVersion, toVersion)
+	})
+}
+
 // RollbackConfig requests the server to create a new config version populated
 // with the values from the specified previous version.
 // The description is optional — pass an empty string to use the server default.

--- a/sdk/adminclient/example_test.go
+++ b/sdk/adminclient/example_test.go
@@ -154,6 +154,12 @@ func (f *fakeConfigTransport) RollbackToVersion(_ context.Context, _ string, tar
 	return &adminclient.Version{Version: targetVersion + 1}, nil
 }
 
+func (f *fakeConfigTransport) DiffVersions(_ context.Context, _ string, _, _ int32) ([]adminclient.FieldDiff, error) {
+	return []adminclient.FieldDiff{
+		{FieldPath: "payments.fee", ChangeType: adminclient.ChangeTypeModified, OldValue: "0.5", NewValue: "0.75"},
+	}, nil
+}
+
 func (f *fakeConfigTransport) ExportConfig(_ context.Context, _ string, _ *int32) ([]byte, error) {
 	return []byte("fields: []"), nil
 }
@@ -261,6 +267,22 @@ func ExampleClient_RollbackConfig() {
 	}
 	fmt.Println(v.Version > 0)
 	// Output: true
+}
+
+func ExampleClient_DiffConfigVersions() {
+	client := newFullClient()
+	ctx := context.Background()
+
+	// Compare the config at version 1 against version 2.
+	diffs, err := client.DiffConfigVersions(ctx, "tenant-1", 1, 2)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	for _, d := range diffs {
+		fmt.Printf("%s %s: %s -> %s\n", d.ChangeType, d.FieldPath, d.OldValue, d.NewValue)
+	}
+	// Output: modified payments.fee: 0.5 -> 0.75
 }
 
 func ExampleClient_ImportConfig() {

--- a/sdk/adminclient/transport.go
+++ b/sdk/adminclient/transport.go
@@ -32,6 +32,7 @@ type ConfigTransport interface {
 	ListVersions(ctx context.Context, tenantID string, pageSize int32, pageToken string) (*ListVersionsResponse, error)
 	GetVersion(ctx context.Context, tenantID string, version int32) (*Version, error)
 	RollbackToVersion(ctx context.Context, tenantID string, version int32, description string) (*Version, error)
+	DiffVersions(ctx context.Context, tenantID string, fromVersion, toVersion int32) ([]FieldDiff, error)
 	ExportConfig(ctx context.Context, tenantID string, version *int32) ([]byte, error)
 	ImportConfig(ctx context.Context, req *ImportConfigRequest) (*Version, error)
 }

--- a/sdk/adminclient/types.go
+++ b/sdk/adminclient/types.go
@@ -172,3 +172,48 @@ type Version struct {
 	CreatedBy   string
 	CreatedAt   time.Time
 }
+
+// ChangeType categorizes how a field changed between two config versions.
+type ChangeType int32
+
+const (
+	// ChangeTypeUnspecified is the zero value; never returned by the server.
+	ChangeTypeUnspecified ChangeType = 0
+	// ChangeTypeAdded means the field is present in the target version but
+	// absent in the base version.
+	ChangeTypeAdded ChangeType = 1
+	// ChangeTypeRemoved means the field is present in the base version but
+	// absent in the target version.
+	ChangeTypeRemoved ChangeType = 2
+	// ChangeTypeModified means the field is present in both versions with a
+	// different value.
+	ChangeTypeModified ChangeType = 3
+)
+
+// String returns a human-readable name for the change type.
+func (c ChangeType) String() string {
+	switch c {
+	case ChangeTypeAdded:
+		return "added"
+	case ChangeTypeRemoved:
+		return "removed"
+	case ChangeTypeModified:
+		return "modified"
+	default:
+		return "unspecified"
+	}
+}
+
+// FieldDiff describes a single field that differs between two config versions.
+type FieldDiff struct {
+	// FieldPath is the dot-separated field path (e.g. "payments.fee").
+	FieldPath string
+	// ChangeType is how the field changed.
+	ChangeType ChangeType
+	// OldValue is the value at the base version. Empty when ChangeType is
+	// ChangeTypeAdded.
+	OldValue string
+	// NewValue is the value at the target version. Empty when ChangeType is
+	// ChangeTypeRemoved.
+	NewValue string
+}

--- a/sdk/adminclient/types_test.go
+++ b/sdk/adminclient/types_test.go
@@ -287,3 +287,48 @@ func TestImportMode_Constants(t *testing.T) {
 		t.Errorf("got ImportModeDefaults %v, want 3", ImportModeDefaults)
 	}
 }
+
+func TestChangeType_Constants(t *testing.T) {
+	if ChangeTypeUnspecified != 0 {
+		t.Errorf("got ChangeTypeUnspecified %v, want 0", ChangeTypeUnspecified)
+	}
+	if ChangeTypeAdded != 1 {
+		t.Errorf("got ChangeTypeAdded %v, want 1", ChangeTypeAdded)
+	}
+	if ChangeTypeRemoved != 2 {
+		t.Errorf("got ChangeTypeRemoved %v, want 2", ChangeTypeRemoved)
+	}
+	if ChangeTypeModified != 3 {
+		t.Errorf("got ChangeTypeModified %v, want 3", ChangeTypeModified)
+	}
+}
+
+func TestChangeType_String(t *testing.T) {
+	tests := []struct {
+		ct   ChangeType
+		want string
+	}{
+		{ChangeTypeAdded, "added"},
+		{ChangeTypeRemoved, "removed"},
+		{ChangeTypeModified, "modified"},
+		{ChangeTypeUnspecified, "unspecified"},
+		{ChangeType(99), "unspecified"},
+	}
+	for _, tc := range tests {
+		if got := tc.ct.String(); got != tc.want {
+			t.Errorf("ChangeType(%d).String() = %q, want %q", tc.ct, got, tc.want)
+		}
+	}
+}
+
+func TestFieldDiff_Fields(t *testing.T) {
+	d := FieldDiff{
+		FieldPath:  "payments.fee",
+		ChangeType: ChangeTypeModified,
+		OldValue:   "0.5",
+		NewValue:   "0.75",
+	}
+	if d.FieldPath != "payments.fee" || d.ChangeType != ChangeTypeModified || d.OldValue != "0.5" || d.NewValue != "0.75" {
+		t.Errorf("FieldDiff fields not assigned correctly: %+v", d)
+	}
+}

--- a/sdk/grpctransport/config_admin_transport.go
+++ b/sdk/grpctransport/config_admin_transport.go
@@ -79,6 +79,23 @@ func (t *AdminConfigTransport) RollbackToVersion(ctx context.Context, tenantID s
 	return versionFromProto(resp.GetConfigVersion()), nil
 }
 
+func (t *AdminConfigTransport) DiffVersions(ctx context.Context, tenantID string, fromVersion, toVersion int32) ([]adminclient.FieldDiff, error) {
+	ctx, callOpts := t.auth.apply(ctx)
+	resp, err := t.rpc.DiffVersions(ctx, &pb.DiffVersionsRequest{
+		TenantId:    tenantID,
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+	}, callOpts...)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	diffs := make([]adminclient.FieldDiff, len(resp.GetDiffs()))
+	for i, d := range resp.GetDiffs() {
+		diffs[i] = fieldDiffFromProto(d)
+	}
+	return diffs, nil
+}
+
 func (t *AdminConfigTransport) ExportConfig(ctx context.Context, tenantID string, version *int32) ([]byte, error) {
 	ctx, callOpts := t.auth.apply(ctx)
 	resp, err := t.rpc.ExportConfig(ctx, &pb.ExportConfigRequest{

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -432,6 +432,28 @@ func versionFromProto(v *pb.ConfigVersion) *adminclient.Version {
 	return result
 }
 
+func fieldDiffFromProto(d *pb.FieldDiff) adminclient.FieldDiff {
+	return adminclient.FieldDiff{
+		FieldPath:  d.GetFieldPath(),
+		ChangeType: changeTypeFromProto(d.GetChangeType()),
+		OldValue:   d.GetOldValue(),
+		NewValue:   d.GetNewValue(),
+	}
+}
+
+func changeTypeFromProto(ct pb.ChangeType) adminclient.ChangeType {
+	switch ct {
+	case pb.ChangeType_CHANGE_TYPE_ADDED:
+		return adminclient.ChangeTypeAdded
+	case pb.ChangeType_CHANGE_TYPE_REMOVED:
+		return adminclient.ChangeTypeRemoved
+	case pb.ChangeType_CHANGE_TYPE_MODIFIED:
+		return adminclient.ChangeTypeModified
+	default:
+		return adminclient.ChangeTypeUnspecified
+	}
+}
+
 // --- Helpers ---
 
 func timeToProto(t *time.Time) *timestamppb.Timestamp {

--- a/sdk/grpctransport/transport_test.go
+++ b/sdk/grpctransport/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -196,6 +197,18 @@ func (s *stubConfigService) RollbackToVersion(ctx context.Context, _ *pb.Rollbac
 		return nil, s.err
 	}
 	return &pb.RollbackToVersionResponse{ConfigVersion: &pb.ConfigVersion{TenantId: "t1", Version: 2}}, nil
+}
+
+func (s *stubConfigService) DiffVersions(ctx context.Context, _ *pb.DiffVersionsRequest) (*pb.DiffVersionsResponse, error) {
+	s.lastMD = incomingMD(ctx)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &pb.DiffVersionsResponse{Diffs: []*pb.FieldDiff{
+		{FieldPath: "a", ChangeType: pb.ChangeType_CHANGE_TYPE_ADDED, NewValue: "1"},
+		{FieldPath: "b", ChangeType: pb.ChangeType_CHANGE_TYPE_REMOVED, OldValue: "2"},
+		{FieldPath: "c", ChangeType: pb.ChangeType_CHANGE_TYPE_MODIFIED, OldValue: "3", NewValue: "4"},
+	}}, nil
 }
 
 func (s *stubConfigService) ExportConfig(ctx context.Context, _ *pb.ExportConfigRequest) (*pb.ExportConfigResponse, error) {
@@ -774,6 +787,46 @@ func TestAdminConfigTransport_RollbackToVersion_ForwardsAuthMetadata(t *testing.
 	_, _ = tr.RollbackToVersion(context.Background(), "t1", 1, "rollback")
 
 	assertMetadataHeader(t, stub.lastMD, "x-role", "superadmin")
+}
+
+func TestAdminConfigTransport_DiffVersions_ForwardsAuthMetadata(t *testing.T) {
+	stub := &stubConfigService{}
+	conn := newBufconnServer(t, stub, nil, nil)
+	tr := newAdminConfigTransport(t, conn, grpctransport.WithRole("superadmin"))
+
+	_, _ = tr.DiffVersions(context.Background(), "t1", 1, 2)
+
+	assertMetadataHeader(t, stub.lastMD, "x-role", "superadmin")
+}
+
+func TestAdminConfigTransport_DiffVersions_NotFound(t *testing.T) {
+	stub := &stubConfigService{err: status.Error(codes.NotFound, "version not found")}
+	conn := newBufconnServer(t, stub, nil, nil)
+	tr := newAdminConfigTransport(t, conn, grpctransport.WithRole("superadmin"))
+
+	_, err := tr.DiffVersions(context.Background(), "t1", 1, 99)
+	if !errors.Is(err, adminclient.ErrNotFound) {
+		t.Errorf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestAdminConfigTransport_DiffVersions_Success(t *testing.T) {
+	stub := &stubConfigService{}
+	conn := newBufconnServer(t, stub, nil, nil)
+	tr := newAdminConfigTransport(t, conn, grpctransport.WithRole("superadmin"))
+
+	diffs, err := tr.DiffVersions(context.Background(), "t1", 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []adminclient.FieldDiff{
+		{FieldPath: "a", ChangeType: adminclient.ChangeTypeAdded, NewValue: "1"},
+		{FieldPath: "b", ChangeType: adminclient.ChangeTypeRemoved, OldValue: "2"},
+		{FieldPath: "c", ChangeType: adminclient.ChangeTypeModified, OldValue: "3", NewValue: "4"},
+	}
+	if !reflect.DeepEqual(diffs, want) {
+		t.Errorf("diffs = %+v, want %+v", diffs, want)
+	}
 }
 
 func TestAdminConfigTransport_ExportConfig_ForwardsAuthMetadata(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a server-side `DiffVersions` RPC to `ConfigService` that diffs two config versions for a tenant and returns the changed fields (added / removed / modified, with old and new values). Closes the gap where comparing versions required pulling both snapshots client-side.

## Changes
- **Proto:** `rpc DiffVersions(DiffVersionsRequest) returns (DiffVersionsResponse)` (GET `/v1/tenants/{tenant_id}/versions/{from_version}/diff/{to_version}`), with `FieldDiff` + `ChangeType` enum (`ADDED`/`REMOVED`/`MODIFIED`). Regenerated pb.go, gateway, OpenAPI, and the API reference docs.
- **Server** (`internal/config`): `DiffVersions` handler — `ActionRead` auth (mirrors `GetVersion`), validates both versions exist, loads each via the existing `GetFullConfigAtVersion` store method, and computes the diff in a new internal `diffConfigMaps` helper (sorted, mirrors `sdk/tools/diff` logic without importing the SDK).
- **SDK:** `adminclient.Client.DiffConfigVersions(ctx, tenantID, fromVersion, toVersion)` returning `[]FieldDiff` (placed in `adminclient` alongside the other version ops), wired through the `ConfigTransport` interface + grpctransport conversion.

## Test plan
- [x] Server tests: added/removed/modified/unchanged, identical-versions empty diff, nonexistent-version error, auth.
- [x] SDK + transport tests for the new method and conversion.
- [x] `DiffVersions` registered in the e2e role×action auth matrix (required by `TestRPCMatrixCoverage`).
- [x] `make pre-commit` (build/vet/lint/test/coverage all modules) and `make e2e` pass locally.

## Design notes
- SDK home is `adminclient` (where `ListVersions`/`GetVersion`/`RollbackToVersion` live), not `configclient`.
- A field present-but-null at one version is treated as present (`""`), so dropping it reads as `REMOVED`.

Closes #2