### PR TITLE
feat: apply schema field defaults on tenant creation

### DIFF
--- a/internal/schema/mock_store_test.go
+++ b/internal/schema/mock_store_test.go
@@ -160,3 +160,8 @@ func (m *mockStore) ListFieldLocks(ctx context.Context, tenantID string, arg Lis
 	args := m.Called(ctx, tenantID, arg)
 	return args.Get(0).([]domain.TenantFieldLock), args.Error(1)
 }
+
+func (m *mockStore) SeedTenantConfig(ctx context.Context, arg SeedTenantConfigParams) error {
+	args := m.Called(ctx, arg)
+	return args.Error(0)
+}

--- a/internal/schema/seed.go
+++ b/internal/schema/seed.go
@@ -1,0 +1,152 @@
+package schema
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/storage/domain"
+	"github.com/opendecree/decree/internal/validation"
+)
+
+// SeedTenantConfigParams describes the initial config to materialize for a
+// freshly created tenant. Values maps field path to the canonical string form
+// of the schema field's default. The store writes these as config version 1.
+type SeedTenantConfigParams struct {
+	TenantID string
+	Actor    string
+	// Values maps field path -> default value (canonical string form).
+	// Must be non-empty; callers skip seeding entirely when there are no defaults.
+	Values map[string]SeedValue
+}
+
+// SeedValue is a single default value plus the checksum of its canonical
+// string form, precomputed so both store implementations agree on the digest.
+type SeedValue struct {
+	Value    string
+	Checksum string
+}
+
+// collectDefaultValues extracts the fields that carry a default_value and
+// returns them keyed by field path, with each default's checksum precomputed.
+// Every default is validated against its field's type and constraints first:
+// schema publish does not validate default_value, so an out-of-range or
+// type-mismatched default would otherwise be silently seeded as invalid config.
+// Returns a nil map when no field has a default (caller then skips seeding).
+func collectDefaultValues(fields []domain.SchemaField) (map[string]SeedValue, error) {
+	var out map[string]SeedValue
+	for _, f := range fields {
+		if f.DefaultValue == nil {
+			continue
+		}
+		if err := validateDefaultValue(f); err != nil {
+			return nil, err
+		}
+		if out == nil {
+			out = make(map[string]SeedValue)
+		}
+		out[f.Path] = SeedValue{
+			Value:    *f.DefaultValue,
+			Checksum: configValueChecksum(*f.DefaultValue),
+		}
+	}
+	return out, nil
+}
+
+// validateDefaultValue checks that a field's default_value is a legal value for
+// the field's type and constraints. It mirrors the per-field validation the
+// config service applies on writes, so a default can never seed a value that a
+// subsequent SetField would reject.
+func validateDefaultValue(f domain.SchemaField) error {
+	if f.DefaultValue == nil {
+		return nil
+	}
+	ft := f.FieldType.ToProto()
+
+	var opts []validation.Option
+	if f.Nullable {
+		opts = append(opts, validation.WithNullable())
+	}
+	if f.Sensitive {
+		opts = append(opts, validation.WithSensitive())
+	}
+	if len(f.Constraints) > 0 {
+		var c pb.FieldConstraints
+		if err := json.Unmarshal(f.Constraints, &c); err != nil {
+			return fmt.Errorf("field %s: invalid stored constraints: %w", f.Path, err)
+		}
+		opts = append(opts, validation.WithConstraints(&c))
+	}
+
+	tv, err := defaultToTypedValue(*f.DefaultValue, f.FieldType)
+	if err != nil {
+		return fmt.Errorf("field %s: invalid default value: %w", f.Path, err)
+	}
+
+	v := validation.NewFieldValidator(f.Path, ft, opts...)
+	if err := v.Validate(tv); err != nil {
+		return fmt.Errorf("invalid default value: %w", err)
+	}
+	return nil
+}
+
+// defaultToTypedValue parses a default's canonical string form into the
+// TypedValue variant for the field type. Unlike the lenient DB-read conversion
+// in the config package, parse failures here are returned as errors so an
+// unparseable default (e.g. "abc" for an integer field) is rejected at tenant
+// creation rather than stored as a zero value.
+func defaultToTypedValue(s string, ft domain.FieldType) (*pb.TypedValue, error) {
+	switch ft {
+	case domain.FieldTypeInteger:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("not an integer: %q", s)
+		}
+		return &pb.TypedValue{Kind: &pb.TypedValue_IntegerValue{IntegerValue: n}}, nil
+	case domain.FieldTypeNumber:
+		n, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("not a number: %q", s)
+		}
+		return &pb.TypedValue{Kind: &pb.TypedValue_NumberValue{NumberValue: n}}, nil
+	case domain.FieldTypeString:
+		return &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: s}}, nil
+	case domain.FieldTypeBool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("not a bool: %q", s)
+		}
+		return &pb.TypedValue{Kind: &pb.TypedValue_BoolValue{BoolValue: b}}, nil
+	case domain.FieldTypeTime:
+		t, err := time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return nil, fmt.Errorf("not an RFC3339 time: %q", s)
+		}
+		return &pb.TypedValue{Kind: &pb.TypedValue_TimeValue{TimeValue: timestamppb.New(t)}}, nil
+	case domain.FieldTypeDuration:
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, fmt.Errorf("not a duration: %q", s)
+		}
+		return &pb.TypedValue{Kind: &pb.TypedValue_DurationValue{DurationValue: durationpb.New(d)}}, nil
+	case domain.FieldTypeURL:
+		return &pb.TypedValue{Kind: &pb.TypedValue_UrlValue{UrlValue: s}}, nil
+	case domain.FieldTypeJSON:
+		return &pb.TypedValue{Kind: &pb.TypedValue_JsonValue{JsonValue: s}}, nil
+	default:
+		return &pb.TypedValue{Kind: &pb.TypedValue_StringValue{StringValue: s}}, nil
+	}
+}
+
+// configValueChecksum computes the checksum for a config value's canonical
+// string form. It must match the config store's scheme (xxHash64, hex) so a
+// seeded value's checksum is indistinguishable from one written via SetField.
+func configValueChecksum(value string) string {
+	return strconv.FormatUint(xxhash.Sum64String(value), 16)
+}

--- a/internal/schema/seed_test.go
+++ b/internal/schema/seed_test.go
@@ -1,0 +1,231 @@
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/opendecree/decree/api/centralconfig/v1"
+	"github.com/opendecree/decree/internal/storage/domain"
+)
+
+// publishedSchemaWithFields seeds the memory store with a schema, a published
+// version 1, and the given fields, returning the schema ID. It drives the same
+// service entry points a real caller would, so the resulting version carries a
+// proper ID and the fields are stored under it.
+func publishedSchemaWithFields(t *testing.T, svc *Service, name string, fields []*pb.SchemaField) string {
+	t.Helper()
+	ctx := superadminCtx()
+
+	resp, err := svc.CreateSchema(ctx, &pb.CreateSchemaRequest{Name: name, Fields: fields})
+	require.NoError(t, err)
+	_, err = svc.PublishSchema(ctx, &pb.PublishSchemaRequest{Id: resp.Schema.Id, Version: 1})
+	require.NoError(t, err)
+	return resp.Schema.Id
+}
+
+func strptr(s string) *string { return &s }
+
+func TestCreateTenant_SeedsSchemaDefaults(t *testing.T) {
+	store := NewMemoryStore()
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	// Two fields carry defaults; one does not.
+	schemaID := publishedSchemaWithFields(t, svc, "with-defaults", []*pb.SchemaField{
+		{Path: "a.retries", Type: pb.FieldType_FIELD_TYPE_INT, DefaultValue: strptr("3")},
+		{Path: "a.enabled", Type: pb.FieldType_FIELD_TYPE_BOOL, DefaultValue: strptr("true")},
+		{Path: "a.label", Type: pb.FieldType_FIELD_TYPE_STRING}, // no default
+	})
+
+	tenantResp, err := svc.CreateTenant(ctx, &pb.CreateTenantRequest{
+		Name:          "acme",
+		SchemaId:      schemaID,
+		SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+	tenantID := tenantResp.Tenant.Id
+
+	// Exactly one config version (version 1) seeded for this tenant.
+	versions := store.ConfigVersionsForTenant(tenantID)
+	require.Len(t, versions, 1)
+	assert.Equal(t, int32(1), versions[0].Version)
+
+	// Values contain exactly the two defaults; the field without a default is unset.
+	values := store.ConfigValuesForTenant(tenantID)
+	assert.Equal(t, map[string]string{
+		"a.retries": "3",
+		"a.enabled": "true",
+	}, values)
+	_, hasLabel := values["a.label"]
+	assert.False(t, hasLabel, "field without a default must remain unset")
+}
+
+func TestCreateTenant_NoDefaults_NoSeededVersion(t *testing.T) {
+	store := NewMemoryStore()
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	schemaID := publishedSchemaWithFields(t, svc, "no-defaults", []*pb.SchemaField{
+		{Path: "x.host", Type: pb.FieldType_FIELD_TYPE_STRING},
+		{Path: "x.port", Type: pb.FieldType_FIELD_TYPE_INT},
+	})
+
+	tenantResp, err := svc.CreateTenant(ctx, &pb.CreateTenantRequest{
+		Name:          "globex",
+		SchemaId:      schemaID,
+		SchemaVersion: 1,
+	})
+	require.NoError(t, err)
+
+	// No defaults → no version 1 is created (unchanged pre-defaults behavior).
+	versions := store.ConfigVersionsForTenant(tenantResp.Tenant.Id)
+	assert.Empty(t, versions)
+	assert.Empty(t, store.ConfigValuesForTenant(tenantResp.Tenant.Id))
+}
+
+func TestCreateTenant_InvalidDefault_Rejected(t *testing.T) {
+	store := NewMemoryStore()
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	// Default "abc" is not a valid integer → tenant creation must fail and seed nothing.
+	schemaID := publishedSchemaWithFields(t, svc, "bad-default", []*pb.SchemaField{
+		{Path: "n.count", Type: pb.FieldType_FIELD_TYPE_INT, DefaultValue: strptr("abc")},
+	})
+
+	_, err := svc.CreateTenant(ctx, &pb.CreateTenantRequest{
+		Name:          "initech",
+		SchemaId:      schemaID,
+		SchemaVersion: 1,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	// No tenant row and no config should have been committed.
+	_, getErr := store.GetTenantByName(ctx, "initech")
+	assert.ErrorIs(t, getErr, domain.ErrNotFound)
+}
+
+func TestCreateTenant_DefaultViolatingConstraint_Rejected(t *testing.T) {
+	store := NewMemoryStore()
+	svc := NewService(store, WithLogger(testLogger))
+	ctx := superadminCtx()
+
+	// minimum=1, default=0 → constraint violation rejected at tenant creation.
+	min := float64(1)
+	schemaID := publishedSchemaWithFields(t, svc, "constrained-default", []*pb.SchemaField{
+		{
+			Path:         "n.count",
+			Type:         pb.FieldType_FIELD_TYPE_INT,
+			Constraints:  &pb.FieldConstraints{Min: &min},
+			DefaultValue: strptr("0"),
+		},
+	})
+
+	_, err := svc.CreateTenant(ctx, &pb.CreateTenantRequest{
+		Name:          "umbrella",
+		SchemaId:      schemaID,
+		SchemaVersion: 1,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// --- focused unit coverage for the default-collection helper ---
+
+func TestCollectDefaultValues(t *testing.T) {
+	min := float64(1)
+	cJSON, err := json.Marshal(&pb.FieldConstraints{Min: &min})
+	require.NoError(t, err)
+
+	t.Run("collects only fields with defaults and checksums them", func(t *testing.T) {
+		out, err := collectDefaultValues([]domain.SchemaField{
+			{Path: "a", FieldType: domain.FieldTypeInteger, DefaultValue: strptr("5")},
+			{Path: "b", FieldType: domain.FieldTypeString}, // no default
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, "5", out["a"].Value)
+		assert.Equal(t, configValueChecksum("5"), out["a"].Checksum)
+	})
+
+	t.Run("nil when no field has a default", func(t *testing.T) {
+		out, err := collectDefaultValues([]domain.SchemaField{
+			{Path: "a", FieldType: domain.FieldTypeInteger},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, out)
+	})
+
+	t.Run("rejects unparseable default", func(t *testing.T) {
+		_, err := collectDefaultValues([]domain.SchemaField{
+			{Path: "a", FieldType: domain.FieldTypeInteger, DefaultValue: strptr("notnum")},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects constraint-violating default", func(t *testing.T) {
+		_, err := collectDefaultValues([]domain.SchemaField{
+			{Path: "a", FieldType: domain.FieldTypeInteger, Constraints: cJSON, DefaultValue: strptr("0")},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("nullable string default is valid", func(t *testing.T) {
+		out, err := collectDefaultValues([]domain.SchemaField{
+			{Path: "a", FieldType: domain.FieldTypeString, Nullable: true, DefaultValue: strptr("hi")},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "hi", out["a"].Value)
+	})
+}
+
+func TestDefaultToTypedValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		ft      domain.FieldType
+		wantErr bool
+	}{
+		{"int ok", "42", domain.FieldTypeInteger, false},
+		{"int bad", "x", domain.FieldTypeInteger, true},
+		{"number ok", "1.5", domain.FieldTypeNumber, false},
+		{"number bad", "x", domain.FieldTypeNumber, true},
+		{"bool ok", "true", domain.FieldTypeBool, false},
+		{"bool bad", "yes", domain.FieldTypeBool, true},
+		{"string ok", "hi", domain.FieldTypeString, false},
+		{"time ok", "2024-01-02T03:04:05Z", domain.FieldTypeTime, false},
+		{"time bad", "nope", domain.FieldTypeTime, true},
+		{"duration ok", "5s", domain.FieldTypeDuration, false},
+		{"duration bad", "5", domain.FieldTypeDuration, true},
+		{"url passthrough", "https://x", domain.FieldTypeURL, false},
+		{"json passthrough", "{}", domain.FieldTypeJSON, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := defaultToTypedValue(tc.in, tc.ft)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMemoryStore_SeedTenantConfig_EmptyIsNoop(t *testing.T) {
+	store := NewMemoryStore()
+	err := store.SeedTenantConfig(context.Background(), SeedTenantConfigParams{
+		TenantID: testTenantID,
+		Actor:    "tester",
+		Values:   nil,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, store.ConfigVersionsForTenant(testTenantID))
+}

--- a/internal/schema/service.go
+++ b/internal/schema/service.go
@@ -542,6 +542,21 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 		return nil, status.Error(codes.FailedPrecondition, "schema version must be published before assigning to a tenant")
 	}
 
+	// Materialize the schema's per-field defaults so the new tenant starts with
+	// them as config version 1. Defaults are validated here because schema
+	// publish does not validate default_value (it only checks that constraints
+	// match the field type) — see collectDefaultValues / validateDefaultValue.
+	// Fields without a default are left unset; a schema with no defaults seeds
+	// nothing, preserving the pre-defaults behavior (no version 1 is created).
+	fields, err := s.store.GetSchemaFields(ctx, version.ID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to load schema fields")
+	}
+	defaults, err := collectDefaultValues(fields)
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
+
 	actor := s.getActor(ctx)
 	var tenant domain.Tenant
 
@@ -557,6 +572,18 @@ func (s *Service) CreateTenant(ctx context.Context, req *pb.CreateTenantRequest)
 				return status.Error(codes.AlreadyExists, "tenant with this name already exists")
 			}
 			return err
+		}
+		// Seed defaults in the same tx so the tenant and its initial config
+		// commit together. SeedTenantConfig is a no-op when there are no
+		// defaults, so no empty version is written in that case.
+		if len(defaults) > 0 {
+			if err := tx.SeedTenantConfig(ctx, SeedTenantConfigParams{
+				TenantID: tenant.ID,
+				Actor:    actor,
+				Values:   defaults,
+			}); err != nil {
+				return err
+			}
 		}
 		meta, _ := json.Marshal(map[string]any{"name": req.Name, "schema_id": req.SchemaId, "schema_version": req.SchemaVersion})
 		return tx.InsertAuditWriteLog(ctx, InsertAuditWriteLogParams{

--- a/internal/schema/service_test.go
+++ b/internal/schema/service_test.go
@@ -223,6 +223,8 @@ func TestCreateTenant_Success(t *testing.T) {
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
 		Return(domain.SchemaVersion{Published: true}, nil)
+	store.On("GetSchemaFields", ctx, mock.AnythingOfType("string")).
+		Return([]domain.SchemaField{}, nil)
 	store.On("CreateTenant", ctx, mock.AnythingOfType("schema.CreateTenantParams")).
 		Return(domain.Tenant{ID: testTenantID, Name: "test-tenant", SchemaID: testSchemaID, SchemaVersion: 1}, nil)
 
@@ -244,6 +246,8 @@ func TestCreateTenant_AlreadyExists(t *testing.T) {
 
 	store.On("GetSchemaVersion", ctx, GetSchemaVersionParams{SchemaID: testSchemaID, Version: 1}).
 		Return(domain.SchemaVersion{Published: true}, nil)
+	store.On("GetSchemaFields", ctx, mock.AnythingOfType("string")).
+		Return([]domain.SchemaField{}, nil)
 	store.On("CreateTenant", ctx, mock.AnythingOfType("schema.CreateTenantParams")).
 		Return(domain.Tenant{}, domain.ErrAlreadyExists)
 

--- a/internal/schema/store.go
+++ b/internal/schema/store.go
@@ -197,4 +197,13 @@ type Store interface {
 	DeleteFieldLock(ctx context.Context, arg DeleteFieldLockParams) error
 	GetFieldLocks(ctx context.Context, tenantID string) ([]domain.TenantFieldLock, error)
 	ListFieldLocks(ctx context.Context, tenantID string, arg ListFieldLocksParams) ([]domain.TenantFieldLock, error)
+
+	// SeedTenantConfig writes a tenant's initial config (version 1) from the
+	// schema's field defaults. It creates one config_versions row plus one
+	// config_values row per default, mirroring the config store's write
+	// semantics (version + value + checksum). Intended to be called inside
+	// RunInTx alongside CreateTenant so seeding is atomic with tenant creation.
+	// arg.Values must be non-empty — callers skip the call entirely when the
+	// schema defines no defaults, so no empty version 1 is ever created.
+	SeedTenantConfig(ctx context.Context, arg SeedTenantConfigParams) error
 }

--- a/internal/schema/store_memory.go
+++ b/internal/schema/store_memory.go
@@ -23,6 +23,8 @@ type MemoryStore struct {
 	schemaFields   map[string][]domain.SchemaField     // schemaVersionID → []SchemaField
 	tenants        map[string]domain.Tenant            // id → Tenant
 	fieldLocks     map[string][]domain.TenantFieldLock // tenantID → []TenantFieldLock
+	configVersions map[string]domain.ConfigVersion     // configVersionID → ConfigVersion
+	configValues   map[string][]domain.ConfigValue     // configVersionID → []ConfigValue
 	auditLog       []domain.AuditWriteLog
 }
 
@@ -34,6 +36,8 @@ func NewMemoryStore() *MemoryStore {
 		schemaFields:   make(map[string][]domain.SchemaField),
 		tenants:        make(map[string]domain.Tenant),
 		fieldLocks:     make(map[string][]domain.TenantFieldLock),
+		configVersions: make(map[string]domain.ConfigVersion),
+		configValues:   make(map[string][]domain.ConfigValue),
 	}
 }
 
@@ -63,6 +67,8 @@ func (m *MemoryStore) clone() *MemoryStore {
 		schemaFields:   make(map[string][]domain.SchemaField, len(m.schemaFields)),
 		tenants:        make(map[string]domain.Tenant, len(m.tenants)),
 		fieldLocks:     make(map[string][]domain.TenantFieldLock, len(m.fieldLocks)),
+		configVersions: make(map[string]domain.ConfigVersion, len(m.configVersions)),
+		configValues:   make(map[string][]domain.ConfigValue, len(m.configValues)),
 		auditLog:       make([]domain.AuditWriteLog, len(m.auditLog)),
 	}
 	for k, v := range m.schemas {
@@ -84,6 +90,14 @@ func (m *MemoryStore) clone() *MemoryStore {
 		copy(cp, ls)
 		tmp.fieldLocks[k] = cp
 	}
+	for k, v := range m.configVersions {
+		tmp.configVersions[k] = v
+	}
+	for k, vs := range m.configValues {
+		cp := make([]domain.ConfigValue, len(vs))
+		copy(cp, vs)
+		tmp.configValues[k] = cp
+	}
 	copy(tmp.auditLog, m.auditLog)
 	return tmp
 }
@@ -98,6 +112,8 @@ func (m *MemoryStore) mergeFrom(src *MemoryStore) {
 	m.schemaFields = src.schemaFields
 	m.tenants = src.tenants
 	m.fieldLocks = src.fieldLocks
+	m.configVersions = src.configVersions
+	m.configValues = src.configValues
 	m.auditLog = src.auditLog
 }
 
@@ -596,6 +612,79 @@ func (m *MemoryStore) ListFieldLocks(_ context.Context, tenantID string, arg Lis
 	all := make([]domain.TenantFieldLock, len(locks))
 	copy(all, locks)
 	return paginate(all, int(arg.Offset), int(arg.Limit)), nil
+}
+
+// --- Tenant config seeding ---
+
+// SeedTenantConfig writes the tenant's version-1 config from schema defaults,
+// mirroring the PG store: one config version plus one value per default. A nil
+// or empty Values map is a no-op so no empty version 1 is created.
+func (m *MemoryStore) SeedTenantConfig(_ context.Context, arg SeedTenantConfigParams) error {
+	if len(arg.Values) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cvID := m.nextID()
+	desc := "Initial config from schema defaults"
+	m.configVersions[cvID] = domain.ConfigVersion{
+		ID:          cvID,
+		TenantID:    arg.TenantID,
+		Version:     1,
+		Description: &desc,
+		CreatedBy:   arg.Actor,
+		CreatedAt:   time.Now(),
+	}
+	values := make([]domain.ConfigValue, 0, len(arg.Values))
+	for path, v := range arg.Values {
+		value := v.Value
+		checksum := v.Checksum
+		values = append(values, domain.ConfigValue{
+			ConfigVersionID: cvID,
+			FieldPath:       path,
+			Value:           &value,
+			Checksum:        &checksum,
+		})
+	}
+	m.configValues[cvID] = values
+	return nil
+}
+
+// ConfigVersionsForTenant returns the config versions seeded for a tenant.
+// Test helper: the schema store does not otherwise expose config reads.
+func (m *MemoryStore) ConfigVersionsForTenant(tenantID string) []domain.ConfigVersion {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []domain.ConfigVersion
+	for _, cv := range m.configVersions {
+		if cv.TenantID == tenantID {
+			out = append(out, cv)
+		}
+	}
+	return out
+}
+
+// ConfigValuesForTenant returns field path -> value for the tenant's seeded
+// config, collapsing across versions (only version 1 is ever seeded here).
+// Test helper.
+func (m *MemoryStore) ConfigValuesForTenant(tenantID string) map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make(map[string]string)
+	for _, cv := range m.configVersions {
+		if cv.TenantID != tenantID {
+			continue
+		}
+		for _, v := range m.configValues[cv.ID] {
+			if v.Value != nil {
+				out[v.FieldPath] = *v.Value
+			}
+		}
+	}
+	return out
 }
 
 // paginate applies offset and limit to a sorted slice.

--- a/internal/schema/store_pg.go
+++ b/internal/schema/store_pg.go
@@ -713,6 +713,50 @@ func (s *PGStore) ListFieldLocks(ctx context.Context, tenantID string, arg ListF
 	return result, nil
 }
 
+// --- Tenant config seeding ---
+
+const seedConfigValueSQL = `INSERT INTO config_values (config_version_id, field_path, value, checksum, description) VALUES ($1, $2, $3, $4, NULL)`
+
+// SeedTenantConfig materializes the schema's field defaults as the tenant's
+// version-1 config. It reuses the same physical rows the config service writes
+// (config_versions + config_values) on the tx-bound query handle, so when this
+// runs inside the CreateTenant transaction the seed commits atomically with the
+// tenant row (or rolls back with it).
+func (s *PGStore) SeedTenantConfig(ctx context.Context, arg SeedTenantConfigParams) error {
+	if len(arg.Values) == 0 {
+		return nil
+	}
+	tenantUUID, err := pgconv.StringToUUID(arg.TenantID)
+	if err != nil {
+		return err
+	}
+
+	cv, err := s.write.CreateConfigVersion(ctx, dbstore.CreateConfigVersionParams{
+		TenantID:    tenantUUID,
+		Version:     1,
+		Description: ptrString("Initial config from schema defaults"),
+		CreatedBy:   arg.Actor,
+	})
+	if err != nil {
+		return fmt.Errorf("seed config version: %w", err)
+	}
+
+	batch := &pgx.Batch{}
+	for path, v := range arg.Values {
+		value := v.Value
+		checksum := v.Checksum
+		batch.Queue(seedConfigValueSQL, cv.ID, path, value, checksum)
+	}
+	br := s.batcher().SendBatch(ctx, batch)
+	defer func() { _ = br.Close() }()
+	for range arg.Values {
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("seed config value: %w", err)
+		}
+	}
+	return br.Close()
+}
+
 // --- DB → domain conversion helpers ---
 
 func schemaFromDB(r dbstore.Schema) domain.Schema {

--- a/internal/schema/store_pg_integration_test.go
+++ b/internal/schema/store_pg_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -237,6 +238,81 @@ func TestSchemaPGStore(t *testing.T) {
 		require.NoError(t, store.DeleteTenant(ctx, tenant.ID))
 		_, err = store.GetTenantByID(ctx, tenant.ID)
 		require.Error(t, err)
+	})
+
+	t.Run("SeedTenantConfig", func(t *testing.T) {
+		sch, err := store.CreateSchema(ctx, CreateSchemaParams{
+			Name: fmt.Sprintf("schema-seed-%s", t.Name()),
+		})
+		require.NoError(t, err)
+
+		sv, err := store.CreateSchemaVersion(ctx, CreateSchemaVersionParams{
+			SchemaID: sch.ID,
+			Version:  1,
+			Checksum: "seed",
+		})
+		require.NoError(t, err)
+
+		tenant, err := store.CreateTenant(ctx, CreateTenantParams{
+			Name:          fmt.Sprintf("tenant-seed-%s", t.Name()),
+			SchemaID:      sch.ID,
+			SchemaVersion: sv.Version,
+		})
+		require.NoError(t, err)
+
+		err = store.SeedTenantConfig(ctx, SeedTenantConfigParams{
+			TenantID: tenant.ID,
+			Actor:    "seeder",
+			Values: map[string]SeedValue{
+				"app.retries": {Value: "3", Checksum: configValueChecksum("3")},
+				"app.enabled": {Value: "true", Checksum: configValueChecksum("true")},
+			},
+		})
+		require.NoError(t, err)
+
+		// The seeded version + values land in the real config tables. Read them
+		// back with raw SQL (the config store cannot be imported here — it
+		// imports this package — so a direct query proves the rows exist).
+		tenantUUID, err := pgconv.StringToUUID(tenant.ID)
+		require.NoError(t, err)
+
+		var version int32
+		var createdBy string
+		var cvID pgtype.UUID
+		require.NoError(t, pool.QueryRow(ctx,
+			"SELECT id, version, created_by FROM config_versions WHERE tenant_id = $1", tenantUUID,
+		).Scan(&cvID, &version, &createdBy))
+		assert.Equal(t, int32(1), version)
+		assert.Equal(t, "seeder", createdBy)
+
+		valRows, err := pool.Query(ctx,
+			"SELECT field_path, value, checksum FROM config_values WHERE config_version_id = $1", cvID)
+		require.NoError(t, err)
+		defer valRows.Close()
+		got := make(map[string]string)
+		for valRows.Next() {
+			var path, value, checksum string
+			require.NoError(t, valRows.Scan(&path, &value, &checksum))
+			got[path] = value
+			assert.Equal(t, configValueChecksum(value), checksum, "stored checksum must match value")
+		}
+		require.NoError(t, valRows.Err())
+		assert.Equal(t, map[string]string{"app.retries": "3", "app.enabled": "true"}, got)
+
+		// Empty seed is a no-op even against a real DB: no version row is written.
+		t2, err := store.CreateTenant(ctx, CreateTenantParams{
+			Name:          fmt.Sprintf("tenant-seed-empty-%s", t.Name()),
+			SchemaID:      sch.ID,
+			SchemaVersion: sv.Version,
+		})
+		require.NoError(t, err)
+		require.NoError(t, store.SeedTenantConfig(ctx, SeedTenantConfigParams{TenantID: t2.ID, Actor: "seeder"}))
+		t2UUID, err := pgconv.StringToUUID(t2.ID)
+		require.NoError(t, err)
+		var n int
+		require.NoError(t, pool.QueryRow(ctx,
+			"SELECT count(*) FROM config_versions WHERE tenant_id = $1", t2UUID).Scan(&n))
+		assert.Equal(t, 0, n)
 	})
 
 	t.Run("FieldLocks", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `SchemaField.default_value` was already stored end-to-end but never applied — defaults were dead data. This materializes a schema's field defaults as a tenant's initial config (version 1) when the tenant is created.

## Changes
- `internal/schema` `CreateTenant`: before the transaction, load the assigned schema version's fields and collect those with a non-nil `default_value`, validating each against its type/constraints (publish does **not** validate defaults, so this is enforced at tenant creation — an invalid default fails creation with `FailedPrecondition`). Inside the existing `RunInTx`, after the tenant row is created, seed the defaults as config version 1 — atomic with the tenant (rolls back together).
- New `Store.SeedTenantConfig` (pg + memory) writes a `config_versions` row + `config_values` rows, reusing the config store's checksum scheme. The schema and config PG stores share the same tx, so no cross-store refactor was needed.
- A schema with no defaults seeds nothing (no empty version 1) — behavior is identical to before for such tenants.

## Test plan
- [x] `internal/schema` unit + table tests: default collection/validation, typed conversion, memory seed, empty-is-no-op.
- [x] `make integration-test` (testcontainers PG): `TestSchemaPGStore/SeedTenantConfig` validates the real seed SQL.
- [x] `make pre-commit`: build/vet/lint/test/coverage all modules (`internal` 91.4% ≥ 88.5%).

## Design notes
- Seeding is transactional (no atomicity gap) since both stores share the tx.
- The seed writes the config version/values but not per-field `set_field` audit entries — the `create_tenant` audit entry already records the event; kept minimal to avoid entangling the audit hash chain in tenant creation.

Closes #5