### PR TITLE
docs: trim README badges to highest-signal set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@
   <a href="https://github.com/opendecree/decree/actions/workflows/ci.yml"><img src="https://github.com/opendecree/decree/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/opendecree/decree/releases"><img src="https://img.shields.io/github/v/release/opendecree/decree?include_prereleases" alt="Release"></a>
   <a href="https://pkg.go.dev/github.com/opendecree/decree"><img src="https://pkg.go.dev/badge/github.com/opendecree/decree.svg" alt="Go Reference"></a>
-  <a href="https://goreportcard.com/report/github.com/opendecree/decree"><img src="https://goreportcard.com/badge/github.com/opendecree/decree" alt="Go Report Card"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
-  <a href="https://www.repostatus.org/#active"><img src="https://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active"></a>
-  <a href="https://codecov.io/gh/opendecree/decree"><img src="https://codecov.io/gh/opendecree/decree/graph/badge.svg" alt="Coverage"></a>
   <a href="https://codespaces.new/opendecree/decree"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Reduce header badges to the 5 highest-signal: CI, Release, Go Reference, License, Codespaces.
- Drop Go Report Card, repostatus "Active" badge, and Coverage badge — the Alpha banner already covers status, and these clutter the top of the README without aiding adoption decisions.

## Test plan
- [x] Visual check of remaining badge markup renders correctly