### PR TITLE
docs: re-add Coverage badge, Codespaces on its own line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
   <a href="https://github.com/opendecree/decree/releases"><img src="https://img.shields.io/github/v/release/opendecree/decree?include_prereleases" alt="Release"></a>
   <a href="https://pkg.go.dev/github.com/opendecree/decree"><img src="https://pkg.go.dev/badge/github.com/opendecree/decree.svg" alt="Go Reference"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
+  <a href="https://codecov.io/gh/opendecree/decree"><img src="https://codecov.io/gh/opendecree/decree/graph/badge.svg" alt="Coverage"></a>
+</p>
+<p align="center">
   <a href="https://codespaces.new/opendecree/decree"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Follow-up to #902. Restore the Coverage badge (cap raised to 6) as a quality signal.
- Move the "Open in GitHub Codespaces" badge to its own line at the end so it reads as a standalone call-to-action.

## Test plan
- [x] Visual check of remaining badge markup renders correctly