### PR TITLE
fix(build): copy sdk/retry go.mod in CLI Dockerfile

### DIFF
--- a/build/Dockerfile.decree
+++ b/build/Dockerfile.decree
@@ -9,6 +9,7 @@ WORKDIR /app
 # copies go.sum only when it exists without failing.
 COPY cmd/decree/go.mod cmd/decree/go.su[m] ./cmd/decree/
 COPY api/go.mod api/go.su[m] ./api/
+COPY sdk/retry/go.mod sdk/retry/go.su[m] ./sdk/retry/
 COPY sdk/adminclient/go.mod sdk/adminclient/go.su[m] ./sdk/adminclient/
 COPY sdk/configclient/go.mod sdk/configclient/go.su[m] ./sdk/configclient/
 COPY sdk/configwatcher/go.mod sdk/configwatcher/go.su[m] ./sdk/configwatcher/


### PR DESCRIPTION
## Summary
- `cmd/decree/go.mod` has `replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry`, but `build/Dockerfile.decree` never copied `sdk/retry/go.mod` into the build context.
- `go mod download` failed resolving the replace target, breaking the CLI Docker build (linux/amd64 + arm64) on every push to main since the `sdk/retry` module was introduced.

## Test plan
- [x] `docker build -f build/Dockerfile.decree --target builder .` succeeds locally (previously failed at the `go mod download` step)