### PR TITLE
docs: publish a path-to-1.0 ROADMAP and link it from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 <p align="center"><em>Typed business configuration: the layer between feature flags and infrastructure config.</em></p>
 
 > **Alpha Software** — OpenDecree is under active development. APIs, proto definitions, configuration formats, and behavior may change without notice between versions. Not recommended for production use yet.
+>
+> See the **[Roadmap](ROADMAP.md)** for what is stable today and the path to a 1.0 stable release.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/opendecree/decree/main/assets/demo.gif" alt="OpenDecree quickstart demo: schema → config → watch" width="800">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,59 +1,61 @@
 # OpenDecree Roadmap
 
-> **Status:** Alpha — everything subject to change.
-> See [Ideas discussions](https://github.com/opendecree/decree/discussions/categories/ideas) for raw feature exploration.
+> **Alpha software.** APIs, proto definitions, configuration formats, and behavior may change between versions. Not recommended for production use yet.
 
-## Current priorities
+This roadmap is the honest counterpart to that warning: what you can already build on, what is still moving, and the milestones between here and a stable **1.0**. It stays high-level on purpose — milestones, not dated promises — so it remains accurate as work lands.
 
-### 1. Quick wins & cleanup
+For live status, see the [GitHub milestones](https://github.com/opendecree/decree/milestones) and the [project board](https://github.com/orgs/opendecree/projects/1). Raw feature ideas live in [Discussions → Ideas](https://github.com/opendecree/decree/discussions/categories/ideas).
 
-- [x] GHA bumps across all repos ([#50](https://github.com/opendecree/decree/issues/50), [decree-python#1](https://github.com/opendecree/decree-python/issues/1), [decree-typescript#1](https://github.com/opendecree/decree-typescript/issues/1), [decree-ui#1](https://github.com/opendecree/decree-ui/issues/1))
-- [x] Community health files ([#43](https://github.com/opendecree/decree/issues/43), [#44](https://github.com/opendecree/decree/issues/44), [#47](https://github.com/opendecree/decree/issues/47), [#48](https://github.com/opendecree/decree/issues/48), [#49](https://github.com/opendecree/decree/issues/49))
-- [ ] Coding guidelines doc ([#52](https://github.com/opendecree/decree/issues/52))
+## Where we are
 
-### 2. SDK Lightweight ✅
+Releases are in the **0.x alpha** series ([latest release](https://github.com/opendecree/decree/releases/latest)). The core service and its data model have already been through a [security review](https://github.com/opendecree/decree/issues/26), [stress testing](https://github.com/opendecree/decree/issues/27), and a beta-readiness audit. What stands between alpha and 1.0 is API stabilization, ecosystem breadth, and a public launch — **not** a core re-architecture. The foundation you build on today is what we expect to carry forward.
 
-- [x] Remove testify from SDK modules ([#40](https://github.com/opendecree/decree/issues/40))
-- [x] SDK transport interface: decouple from gRPC ([#41](https://github.com/opendecree/decree/issues/41))
-- [x] Lower SDK minimum Go version ([#42](https://github.com/opendecree/decree/issues/42))
+## Stable vs. in flux
 
-### 3. Hardening ✅
+Alpha means we reserve the right to break anything — but in practice these surfaces are not equally settled. Use this as a guide to where churn is likely:
 
-- [x] Usage stats recording ([#12](https://github.com/opendecree/decree/issues/12))
-- [x] Cursor-based pagination ([#13](https://github.com/opendecree/decree/issues/13))
-- [x] Security review ([#26](https://github.com/opendecree/decree/issues/26))
-- [x] Stress testing phases 1–3 ([#27](https://github.com/opendecree/decree/issues/27), [#28](https://github.com/opendecree/decree/issues/28), [#29](https://github.com/opendecree/decree/issues/29))
+| Surface | Maturity |
+|---------|----------|
+| Core type system — `TypedValue`: integer, number, string, bool, time, duration, url, json | **Stable** |
+| gRPC API — SchemaService, ConfigService, AuditService | **Stable** |
+| Multi-tenancy & RBAC — roles, tenant scoping, field-level locking | **Stable** |
+| Audit trail & versioning — full history, rollback to any version | **Stable** |
+| Storage / cache / pub-sub backends — Postgres, Redis, in-memory (behind Go interfaces) | **Stable** |
+| REST/JSON gateway (grpc-gateway) | **Stable** |
+| Auth — metadata headers (default), JWT/JWKS (opt-in) | **Stable** |
+| SDKs — Go, Python, TypeScript | **Settling** |
+| Admin GUI (decree-ui) | **Settling** |
+| Observability — OpenTelemetry (opt-in) | **Settling** |
+| Externally-managed fields, validation webhooks, SDK code generation | **Planned** |
 
-### 4. Go-to-Market
+What the labels mean:
 
-- [x] README rewrite ([#31](https://github.com/opendecree/decree/issues/31))
-- [x] Visual assets: terminal GIF, screenshots, comparison table ([#32](https://github.com/opendecree/decree/issues/32), [#33](https://github.com/opendecree/decree/issues/33), [#34](https://github.com/opendecree/decree/issues/34), [#35](https://github.com/opendecree/decree/issues/35))
-- [ ] Blog posts ([#36](https://github.com/opendecree/decree/issues/36), [#37](https://github.com/opendecree/decree/issues/37))
-- [ ] Community: awesome-go, awesome-selfhosted ([#38](https://github.com/opendecree/decree/issues/38))
-- [ ] 48-hour launch plan ([#39](https://github.com/opendecree/decree/issues/39))
+- **Stable** — the shape is settled. Changes are expected to be additive, and any breaking change will be called out in the release notes.
+- **Settling** — works today, but expect minor ergonomic changes. SDK surfaces track the proto; OTel span/metric names may still shift.
+- **Planned** — not yet implemented. These will add proto and may shift adjacent APIs ([externally-managed fields #78](https://github.com/opendecree/decree/issues/78), [validation webhooks #77](https://github.com/opendecree/decree/issues/77), [SDK codegen #19](https://github.com/opendecree/decree/issues/19)).
 
-### 5. Ecosystem
+## Path to 1.0
 
-- [ ] Contrib integrations: viper, koanf, envconfig ([#14](https://github.com/opendecree/decree/issues/14), [#15](https://github.com/opendecree/decree/issues/15), [#16](https://github.com/opendecree/decree/issues/16))
-- [ ] ConfigWatcher: write-through, field groups ([#17](https://github.com/opendecree/decree/issues/17), [#18](https://github.com/opendecree/decree/issues/18))
-- [ ] SDK code generation ([#19](https://github.com/opendecree/decree/issues/19))
-- [ ] Distribution: Homebrew ([#20](https://github.com/opendecree/decree/issues/20))
-- [ ] Observability: Grafana dashboard, Prometheus alerts ([#21](https://github.com/opendecree/decree/issues/21), [#22](https://github.com/opendecree/decree/issues/22))
+High-level milestones, roughly in order. Live status lives on the [GitHub milestones](https://github.com/opendecree/decree/milestones) page — this list deliberately avoids dates.
 
-### 6. Admin GUI ✅
+**Done**
 
-- [x] Phase 8: Embed in Go binary ([#24](https://github.com/opendecree/decree/issues/24))
-- [x] Phase 9: Polish + release ([#25](https://github.com/opendecree/decree/issues/25))
+- **Hardening** — usage stats, cursor pagination, security review, stress testing.
+- **Admin GUI** — embedded in the server binary and released.
+- **Lightweight SDKs** — testify dropped, transport decoupled from gRPC, lower Go floor.
 
-## Wishlist / exploration
+**In progress**
 
-Raw ideas live in [GitHub Discussions → Ideas](https://github.com/opendecree/decree/discussions/categories/ideas). See the [refinement checklist](https://github.com/opendecree/decree/discussions/55) for how ideas graduate to issues.
+- **Beta Readiness** — findings from the beta-readiness audit across server, storage, tests, and the Go SDK. Nearly complete; remaining work is documentation polish.
 
-## Backlog (unmilestoned)
+**Toward 1.0**
 
-- Webhook notifications ([#1](https://github.com/opendecree/decree/issues/1))
-- Config diffing API ([#2](https://github.com/opendecree/decree/issues/2))
-- Schema migration assistant ([#3](https://github.com/opendecree/decree/issues/3))
-- Multi-environment promotion ([#4](https://github.com/opendecree/decree/issues/4))
-- Config templates ([#5](https://github.com/opendecree/decree/issues/5))
-- Architecture Decision Records ([#6](https://github.com/opendecree/decree/issues/6))
+- **Go-to-Market** — README/docs rewrite (done), blog posts, and a public launch.
+- **Ecosystem** — contrib integrations (viper, koanf, envconfig), SDK code generation, validation webhooks, externally-managed fields, distribution (Homebrew), observability templates (Grafana/Prometheus).
+- **API stability commitment** — once the **Settling** and **Planned** surfaces above land, freeze the proto/API, document the backward-compatibility guarantees, and drop the alpha label.
+
+**What 1.0 means:** a documented backward-compatibility promise across the gRPC/proto API and the SDK surfaces, and removal of the alpha warning. We are not there yet — but the stable surfaces above are the parts we already intend to honor.
+
+## Backlog & ideas
+
+Unmilestoned candidates live in the [issue backlog](https://github.com/opendecree/decree/issues); raw ideas live in [Discussions → Ideas](https://github.com/opendecree/decree/discussions/categories/ideas). See the [refinement checklist](https://github.com/opendecree/decree/discussions/55) for how an idea graduates to a tracked issue.


### PR DESCRIPTION
## Summary

- Replaces the old `ROADMAP.md` — an internal milestone checklist of issue links, unlinked from any README and going stale on every issue close — with a **path-to-1.0 document** aimed at evaluators weighing whether to build on alpha software.
- Adds a **stable vs. in-flux** maturity table separating mature surfaces (core type system, gRPC API, multi-tenancy, audit/versioning, storage backends) from settling ones (SDKs, Admin GUI, OTel) and planned ones (externally-managed fields, validation webhooks, SDK codegen).
- Defines what a **1.0 stable release** will mean: a documented backward-compatibility promise and removal of the alpha label.
- Links the roadmap from the README's alpha callout so the runway is visible **alongside** the warning. The alpha warning text itself is unchanged.

## Test plan

- [x] `pre-commit` docs-only safety scan — clean
- [x] Alpha warning text in `README.md` verified unchanged (link appended, not edited)
- [x] Roadmap links resolve: milestones, project board, discussions, issue backlog

## Notes

The acceptance criteria also require a link from the **org profile README**, which lives in `opendecree/.github`. That one-line change ships as a companion PR in that repo.

Closes #905