### PR TITLE
docs: add WIP project status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://github.com/opendecree/decree/releases"><img src="https://img.shields.io/github/v/release/opendecree/decree?include_prereleases" alt="Release"></a>
   <a href="https://pkg.go.dev/github.com/opendecree/decree"><img src="https://pkg.go.dev/badge/github.com/opendecree/decree.svg" alt="Go Reference"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a>
+  <a href="https://www.repostatus.org/#wip"><img src="https://www.repostatus.org/badges/latest/wip.svg" alt="Project Status: WIP"></a>
   <a href="https://codecov.io/gh/opendecree/decree"><img src="https://codecov.io/gh/opendecree/decree/graph/badge.svg" alt="Coverage"></a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Summary

- Adds a `repostatus` **WIP** badge to the README, matching the Python, TypeScript, demos, and UI READMEs.
- Final piece of the cross-repo docs consistency sweep (#906). The issue assumed `decree` showed an "active" badge — in fact it had **no** repostatus badge at all. Since every OpenDecree repo is alpha, WIP is the honest, consistent signal across the org.

## Sibling PRs (same sweep)

- opendecree/decree-python#145 — correct the stale server-version floor (`>=0.3.0` → `>=0.8.0`) in constant, tests, README, docs
- opendecree/decree-typescript#129 — collapse the duplicated Requirements section
- opendecree/decree-ui#83 — add the same WIP badge

## Test plan

- [x] Markdown/HTML-only change; badge renders via repostatus.org
- [x] No code, tests, or generated files touched

Refs #906

> Note: using `Refs` (not `Closes`) so #906 stays open until all four PRs merge; it will be closed manually once the sweep lands.