### PR TITLE
docgen: align online mode field metadata with --file mode

### DIFF
--- a/cmd/decree/docgen.go
+++ b/cmd/decree/docgen.go
@@ -93,16 +93,22 @@ func init() {
 	docgenCmd.Flags().Bool("no-grouping", false, "flat list instead of grouped by prefix")
 }
 
-// adminSchemaToDocgen converts adminclient types to docgen types.
+// adminSchemaToDocgen converts adminclient types to docgen types. It must map
+// every documentation-relevant property the admin client carries so that
+// online mode documents a schema identically to --file mode (#912);
+// TestAdminSchemaToDocgen_PropertyDrift guards the mapping against new
+// adminclient properties.
 func adminSchemaToDocgen(s *adminclient.Schema) docgen.Schema {
 	ds := docgen.Schema{
-		Name:        s.Name,
-		Description: s.Description,
-		Version:     s.Version,
-		Fields:      make([]docgen.Field, len(s.Fields)),
+		Name:               s.Name,
+		Description:        s.Description,
+		Version:            s.Version,
+		VersionDescription: s.VersionDescription,
+		Info:               schemaInfoFromAdmin(s.Info),
+		Fields:             make([]docgen.Field, len(s.Fields)),
 	}
 	for i, f := range s.Fields {
-		ds.Fields[i] = docgen.Field{
+		df := docgen.Field{
 			Path:        f.Path,
 			Type:        string(f.Type),
 			Description: f.Description,
@@ -110,22 +116,63 @@ func adminSchemaToDocgen(s *adminclient.Schema) docgen.Schema {
 			Nullable:    f.Nullable,
 			Deprecated:  f.Deprecated,
 			RedirectTo:  f.RedirectTo,
+			Title:       f.Title,
+			Example:     f.Example,
+			Tags:        f.Tags,
+			Format:      f.Format,
+			ReadOnly:    f.ReadOnly,
+			WriteOnce:   f.WriteOnce,
+			Sensitive:   f.Sensitive,
 		}
-		if f.Constraints != nil {
-			ds.Fields[i].Constraints = &docgen.Constraints{
-				Min:          f.Constraints.Min,
-				Max:          f.Constraints.Max,
-				ExclusiveMin: f.Constraints.ExclusiveMin,
-				ExclusiveMax: f.Constraints.ExclusiveMax,
-				MinLength:    f.Constraints.MinLength,
-				MaxLength:    f.Constraints.MaxLength,
-				Pattern:      f.Constraints.Pattern,
-				Enum:         f.Constraints.Enum,
-				JSONSchema:   f.Constraints.JSONSchema,
+		if len(f.Examples) > 0 {
+			df.Examples = make(map[string]docgen.FieldExample, len(f.Examples))
+			for name, ex := range f.Examples {
+				df.Examples[name] = docgen.FieldExample{Value: ex.Value, Summary: ex.Summary}
 			}
 		}
+		if f.ExternalDocs != nil {
+			df.ExternalDocs = &docgen.ExternalDocs{
+				Description: f.ExternalDocs.Description,
+				URL:         f.ExternalDocs.URL,
+			}
+		}
+		if f.Constraints != nil {
+			df.Constraints = &docgen.Constraints{
+				Min:            f.Constraints.Min,
+				Max:            f.Constraints.Max,
+				ExclusiveMin:   f.Constraints.ExclusiveMin,
+				ExclusiveMax:   f.Constraints.ExclusiveMax,
+				MinLength:      f.Constraints.MinLength,
+				MaxLength:      f.Constraints.MaxLength,
+				Pattern:        f.Constraints.Pattern,
+				Enum:           f.Constraints.Enum,
+				JSONSchema:     f.Constraints.JSONSchema,
+				AllowedSchemes: f.Constraints.AllowedSchemes,
+			}
+		}
+		ds.Fields[i] = df
 	}
 	return ds
+}
+
+// schemaInfoFromAdmin converts the adminclient info metadata to the docgen shape.
+func schemaInfoFromAdmin(info *adminclient.SchemaInfo) *docgen.SchemaInfo {
+	if info == nil {
+		return nil
+	}
+	di := &docgen.SchemaInfo{
+		Title:  info.Title,
+		Author: info.Author,
+		Labels: info.Labels,
+	}
+	if info.Contact != nil {
+		di.Contact = &docgen.SchemaContact{
+			Name:  info.Contact.Name,
+			Email: info.Contact.Email,
+			URL:   info.Contact.URL,
+		}
+	}
+	return di
 }
 
 // schemaFromYAML parses a schema YAML file into a docgen.Schema using the

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -294,6 +294,250 @@ func TestAdminSchemaToDocgen_NoConstraints(t *testing.T) {
 	}
 }
 
+// ptrTo returns a pointer to v.
+func ptrTo[T any](v T) *T { return &v }
+
+// fullAdminSchema returns an adminclient.Schema with every property set to a
+// distinct non-zero value. TestAdminSchemaToDocgen_Metadata and
+// TestAdminSchemaToDocgen_PropertyDrift use it to verify that
+// adminSchemaToDocgen maps the complete admin client surface.
+func fullAdminSchema() *adminclient.Schema {
+	return &adminclient.Schema{
+		ID:                 "schema-uuid",
+		Name:               "payments",
+		Description:        "Payment configuration schema",
+		Version:            3,
+		ParentVersion:      ptrTo(int32(2)),
+		VersionDescription: "Added refund_window field",
+		Checksum:           "abc123",
+		Published:          true,
+		CreatedAt:          time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+		Info: &adminclient.SchemaInfo{
+			Title:  "Payments Configuration",
+			Author: "platform-team",
+			Contact: &adminclient.SchemaContact{
+				Name:  "Pat",
+				Email: "pat@example.com",
+				URL:   "https://example.com/payments-team",
+			},
+			Labels: map[string]string{"team": "platform"},
+		},
+		Fields: []adminclient.Field{
+			{
+				Path:        "payments.webhook",
+				Type:        adminclient.FieldTypeURL,
+				Nullable:    true,
+				Deprecated:  true,
+				RedirectTo:  "payments.callback_url",
+				Default:     "https://example.com/hook",
+				Description: "Webhook endpoint",
+				Title:       "Webhook URL",
+				Example:     "https://example.com/hook-example",
+				Examples: map[string]adminclient.FieldExample{
+					"primary": {Value: "https://hooks.example.com/a", Summary: "Primary endpoint"},
+				},
+				ExternalDocs: &adminclient.ExternalDocs{
+					Description: "Webhook guide",
+					URL:         "https://docs.example.com/webhooks",
+				},
+				Tags:      []string{"billing", "integration"},
+				Format:    "uri",
+				ReadOnly:  true,
+				WriteOnce: true,
+				Sensitive: true,
+				Constraints: &adminclient.FieldConstraints{
+					Min:            ptrTo(1.0),
+					Max:            ptrTo(9.0),
+					ExclusiveMin:   ptrTo(0.5),
+					ExclusiveMax:   ptrTo(9.5),
+					MinLength:      ptrTo(int32(2)),
+					MaxLength:      ptrTo(int32(64)),
+					Pattern:        "^https://",
+					Enum:           []string{"https://a.example.com", "https://b.example.com"},
+					JSONSchema:     `{"type":"string"}`,
+					AllowedSchemes: []string{"https", "sftp"},
+				},
+			},
+		},
+	}
+}
+
+func TestAdminSchemaToDocgen_Metadata(t *testing.T) {
+	got := adminSchemaToDocgen(fullAdminSchema())
+	want := docgen.Schema{
+		Name:               "payments",
+		Description:        "Payment configuration schema",
+		Version:            3,
+		VersionDescription: "Added refund_window field",
+		Info: &docgen.SchemaInfo{
+			Title:  "Payments Configuration",
+			Author: "platform-team",
+			Contact: &docgen.SchemaContact{
+				Name:  "Pat",
+				Email: "pat@example.com",
+				URL:   "https://example.com/payments-team",
+			},
+			Labels: map[string]string{"team": "platform"},
+		},
+		Fields: []docgen.Field{
+			{
+				Path:        "payments.webhook",
+				Type:        "url",
+				Description: "Webhook endpoint",
+				Default:     "https://example.com/hook",
+				Nullable:    true,
+				Deprecated:  true,
+				RedirectTo:  "payments.callback_url",
+				Title:       "Webhook URL",
+				Example:     "https://example.com/hook-example",
+				Examples: map[string]docgen.FieldExample{
+					"primary": {Value: "https://hooks.example.com/a", Summary: "Primary endpoint"},
+				},
+				ExternalDocs: &docgen.ExternalDocs{
+					Description: "Webhook guide",
+					URL:         "https://docs.example.com/webhooks",
+				},
+				Tags:      []string{"billing", "integration"},
+				Format:    "uri",
+				ReadOnly:  true,
+				WriteOnce: true,
+				Sensitive: true,
+				Constraints: &docgen.Constraints{
+					Min:            ptrTo(1.0),
+					Max:            ptrTo(9.0),
+					ExclusiveMin:   ptrTo(0.5),
+					ExclusiveMax:   ptrTo(9.5),
+					MinLength:      ptrTo(int32(2)),
+					MaxLength:      ptrTo(int32(64)),
+					Pattern:        "^https://",
+					Enum:           []string{"https://a.example.com", "https://b.example.com"},
+					JSONSchema:     `{"type":"string"}`,
+					AllowedSchemes: []string{"https", "sftp"},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("adminSchemaToDocgen mismatch:\ngot:  %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestAdminSchemaToDocgen_PropertyDrift reflects over every exported property
+// of the adminclient schema types and asserts each one is either copied into
+// the docgen model by adminSchemaToDocgen or explicitly recorded below as
+// non-documentation metadata. A property added to adminclient fails this test
+// until it is populated in fullAdminSchema and either mapped or recorded.
+func TestAdminSchemaToDocgen_PropertyDrift(t *testing.T) {
+	in := fullAdminSchema()
+	out := adminSchemaToDocgen(in)
+
+	tests := []struct {
+		name  string
+		admin any
+		doc   any
+		// notDocumented lists adminclient properties that deliberately have no
+		// docgen counterpart: server bookkeeping that schema YAML cannot
+		// express, so documenting it would break online/--file parity.
+		notDocumented []string
+	}{
+		{
+			name:          "Schema",
+			admin:         *in,
+			doc:           out,
+			notDocumented: []string{"ID", "ParentVersion", "Checksum", "Published", "CreatedAt"},
+		},
+		{name: "Field", admin: in.Fields[0], doc: out.Fields[0]},
+		{name: "FieldConstraints", admin: *in.Fields[0].Constraints, doc: *out.Fields[0].Constraints},
+		{name: "SchemaInfo", admin: *in.Info, doc: *out.Info},
+		{name: "SchemaContact", admin: *in.Info.Contact, doc: *out.Info.Contact},
+		{name: "FieldExample", admin: in.Fields[0].Examples["primary"], doc: out.Fields[0].Examples["primary"]},
+		{name: "ExternalDocs", admin: *in.Fields[0].ExternalDocs, doc: *out.Fields[0].ExternalDocs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			av := reflect.ValueOf(tt.admin)
+			dv := reflect.ValueOf(tt.doc)
+			skip := make(map[string]bool, len(tt.notDocumented))
+			for _, name := range tt.notDocumented {
+				if _, ok := av.Type().FieldByName(name); !ok {
+					t.Errorf("stale notDocumented entry %q: adminclient.%s has no such property", name, av.Type().Name())
+				}
+				skip[name] = true
+			}
+			for i := 0; i < av.NumField(); i++ {
+				name := av.Type().Field(i).Name
+				if skip[name] {
+					continue
+				}
+				if av.Field(i).IsZero() {
+					t.Errorf("adminclient.%s.%s is zero in fullAdminSchema — populate it so this test can verify the mapping", av.Type().Name(), name)
+					continue
+				}
+				df, ok := dv.Type().FieldByName(name)
+				if !ok {
+					t.Errorf("adminclient.%s.%s has no docgen counterpart — map it in adminSchemaToDocgen or record it in notDocumented", av.Type().Name(), name)
+					continue
+				}
+				if dv.FieldByIndex(df.Index).IsZero() {
+					t.Errorf("adminclient.%s.%s is dropped by adminSchemaToDocgen", av.Type().Name(), name)
+				}
+			}
+		})
+	}
+}
+
+// TestDocgenOnlineFileParity asserts the acceptance criterion of #912: the
+// same schema content produces byte-identical documentation whether it is
+// read from a YAML file or fetched from the server via the admin client.
+func TestDocgenOnlineFileParity(t *testing.T) {
+	fileSchema, err := schemaFromYAML([]byte(metadataSchemaYAML))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The adminclient equivalent of metadataSchemaYAML, as GetSchema would
+	// return it. Field order is reversed to prove output order-independence.
+	online := &adminclient.Schema{
+		Name:               "payments",
+		Version:            3,
+		VersionDescription: "Added refund_window field",
+		Info: &adminclient.SchemaInfo{
+			Title:   "Payments Configuration",
+			Author:  "platform-team",
+			Contact: &adminclient.SchemaContact{Name: "Pat", Email: "pat@example.com"},
+			Labels:  map[string]string{"team": "platform"},
+		},
+		Fields: []adminclient.Field{
+			{
+				Path: "payments.webhook",
+				Type: adminclient.FieldTypeURL,
+				Constraints: &adminclient.FieldConstraints{
+					AllowedSchemes: []string{"https", "sftp"},
+				},
+			},
+			{
+				Path: "payments.fee",
+				Type: adminclient.FieldTypeNumber,
+				Examples: map[string]adminclient.FieldExample{
+					"low":  {Value: "0.01", Summary: "Low rate"},
+					"high": {Value: "0.99"},
+				},
+				ExternalDocs: &adminclient.ExternalDocs{
+					Description: "Fee guide",
+					URL:         "https://docs.example.com/fees",
+				},
+			},
+		},
+	}
+
+	fromFile := docgen.Generate(*fileSchema)
+	fromOnline := docgen.Generate(adminSchemaToDocgen(online))
+	if fromFile != fromOnline {
+		t.Errorf("online and --file modes documented the same schema differently:\n--file:\n%s\nonline:\n%s", fromFile, fromOnline)
+	}
+}
+
 // --- schemaFromYAML ---
 
 func TestSchemaFromYAML(t *testing.T) {

--- a/sdk/adminclient/types.go
+++ b/sdk/adminclient/types.go
@@ -90,6 +90,9 @@ type FieldConstraints struct {
 	Pattern      string
 	Enum         []string
 	JSONSchema   string
+	// AllowedSchemes lists the URI schemes accepted for url-typed fields.
+	// When empty the server defaults to http and https.
+	AllowedSchemes []string
 }
 
 // Tenant represents a tenant assigned to a schema.

--- a/sdk/adminclient/types_test.go
+++ b/sdk/adminclient/types_test.go
@@ -170,15 +170,16 @@ func TestFieldConstraints_AllFields(t *testing.T) {
 	maxLen := int32(255)
 
 	c := FieldConstraints{
-		Min:          &min,
-		Max:          &max,
-		ExclusiveMin: &exMin,
-		ExclusiveMax: &exMax,
-		MinLength:    &minLen,
-		MaxLength:    &maxLen,
-		Pattern:      "^[a-z]+$",
-		Enum:         []string{"a", "b"},
-		JSONSchema:   `{"type":"object"}`,
+		Min:            &min,
+		Max:            &max,
+		ExclusiveMin:   &exMin,
+		ExclusiveMax:   &exMax,
+		MinLength:      &minLen,
+		MaxLength:      &maxLen,
+		Pattern:        "^[a-z]+$",
+		Enum:           []string{"a", "b"},
+		JSONSchema:     `{"type":"object"}`,
+		AllowedSchemes: []string{"https", "sftp"},
 	}
 
 	if c.Min == nil || *c.Min != 0.0 {
@@ -195,6 +196,9 @@ func TestFieldConstraints_AllFields(t *testing.T) {
 	}
 	if got := c.JSONSchema; got != `{"type":"object"}` {
 		t.Errorf("got JSONSchema %v, want %v", got, `{"type":"object"}`)
+	}
+	if len(c.AllowedSchemes) != 2 || c.AllowedSchemes[0] != "https" {
+		t.Errorf("got AllowedSchemes %v, want [https sftp]", c.AllowedSchemes)
 	}
 }
 

--- a/sdk/grpctransport/convert.go
+++ b/sdk/grpctransport/convert.go
@@ -210,7 +210,8 @@ func constraintsFromProto(c *pb.FieldConstraints) *adminclient.FieldConstraints 
 		return nil
 	}
 	fc := &adminclient.FieldConstraints{
-		Enum: c.GetEnumValues(),
+		Enum:           c.GetEnumValues(),
+		AllowedSchemes: c.GetAllowedSchemes(),
 	}
 	if c.Min != nil {
 		v := c.GetMin()
@@ -304,7 +305,8 @@ func constraintsToProto(c *adminclient.FieldConstraints) *pb.FieldConstraints {
 		return nil
 	}
 	fc := &pb.FieldConstraints{
-		EnumValues: c.Enum,
+		EnumValues:     c.Enum,
+		AllowedSchemes: c.AllowedSchemes,
 	}
 	if c.Min != nil {
 		fc.Min = c.Min

--- a/sdk/grpctransport/convert_test.go
+++ b/sdk/grpctransport/convert_test.go
@@ -302,13 +302,14 @@ func TestFieldsRoundTrip_WithConstraints(t *testing.T) {
 			Path: "rate",
 			Type: "number",
 			Constraints: &adminclient.FieldConstraints{
-				Min:        &min,
-				Max:        &max,
-				MinLength:  &minLen,
-				MaxLength:  &maxLen,
-				Enum:       []string{"low", "high"},
-				Pattern:    `^\d+$`,
-				JSONSchema: `{"type":"number"}`,
+				Min:            &min,
+				Max:            &max,
+				MinLength:      &minLen,
+				MaxLength:      &maxLen,
+				Enum:           []string{"low", "high"},
+				Pattern:        `^\d+$`,
+				JSONSchema:     `{"type":"number"}`,
+				AllowedSchemes: []string{"https", "sftp"},
 			},
 		},
 	}
@@ -337,6 +338,9 @@ func TestFieldsRoundTrip_WithConstraints(t *testing.T) {
 	}
 	if c.JSONSchema != `{"type":"number"}` {
 		t.Errorf("JSONSchema: got %q", c.JSONSchema)
+	}
+	if len(c.AllowedSchemes) != 2 || c.AllowedSchemes[0] != "https" || c.AllowedSchemes[1] != "sftp" {
+		t.Errorf("AllowedSchemes: got %v", c.AllowedSchemes)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The same schema documented differently depending on how it was loaded: `adminSchemaToDocgen` dropped Info, Title, Example, Examples, ExternalDocs, Tags, Format, ReadOnly, WriteOnce, Sensitive, VersionDescription, and AllowedSchemes that `--file` mode renders. Online mode now maps the full admin-client surface, structured to read in parallel with `schemaFromYAML`.
- Root-causing the gap surfaced that adminclient itself dropped proto `FieldConstraints.allowed_schemes`; adminclient and grpctransport now carry it both directions.
- A reflection-based drift-guard test walks all seven struct pairs, so a future adminclient field addition fails the test until it is mapped (or explicitly listed as not-documented). Mutation-tested in both failure directions.
- A parity test renders the same schema through both loaders and asserts byte-identical markdown.

## Test plan
- [x] `make test` — all modules pass
- [x] `./scripts/check-coverage.sh` — cmd/decree 87.4% (≥86.1), sdk/adminclient 98.3% (≥97.7); changed grpctransport functions at 100% per `go tool cover -func`
- [x] `make lint-go` clean; `go build`/`go vet` clean in touched modules
- [x] Tagged compile checks: `e2e`, `e2e upgrade`, `stress`, `chaos`, `integration`, `example` across all examples modules

Closes #912