### PR TITLE
decree-docs: scaffold contrib module and CI wiring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,13 +27,14 @@ updates:
           - minor
           - patch
 
-  # ── Tier: 1.24-floor (api, CLI, grpctransport, tools) ───────────────────
+  # ── Tier: 1.24-floor (api, CLI, grpctransport, tools, decree-docs) ──────
   # Must not cross go 1.25. Ignore any dep that forces the go directive above
   # 1.24, including otel ≥ 1.42 (requires go 1.25) and grpc-gateway ≥ 2.29.
   - package-ecosystem: gomod
     directories:
       - /api
       - /cmd/decree
+      - /contrib/decree-docs
       - /sdk/grpctransport
       - /sdk/tools
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
           cd sdk/contrib/viper && go test ./... -count=1 -coverprofile=../../cov-contrib-viper.out -covermode=atomic & pids+=($!)
           cd sdk/contrib/envconfig && go test ./... -count=1 -coverprofile=../../cov-contrib-envconfig.out -covermode=atomic & pids+=($!)
           cd sdk/contrib/koanf && go test ./... -count=1 -coverprofile=../../cov-contrib-koanf.out -covermode=atomic & pids+=($!)
+          cd contrib/decree-docs && go test ./... -count=1 -coverprofile=../../cov-decree-docs.out -covermode=atomic & pids+=($!)
           cd cmd/decree && go test ./... -count=1 -coverprofile=../../cov-decree.out -covermode=atomic & pids+=($!)
           fail=0
           for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
@@ -274,12 +275,13 @@ jobs:
             --profile sdk/configwatcher=cov-configwatcher.out \
             --profile sdk/grpctransport=cov-grpctransport.out \
             --profile sdk/tools=cov-tools.out \
+            --profile contrib/decree-docs=cov-decree-docs.out \
             --profile cmd/decree=cov-decree.out
 
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage.out
-          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-contrib-envconfig.out cov-contrib-koanf.out cov-decree.out; do
+          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-contrib-envconfig.out cov-contrib-koanf.out cov-decree-docs.out cov-decree.out; do
             [ -f "$f" ] && grep -v "^mode:" "$f" >> coverage.out || true
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ site/
 /decree
 /server
 cmd/decree/decree
+contrib/decree-docs/decree-docs
 
 # Example binaries (compiled in-place by go build / go test -tags=example)
 examples/config-validation/config-validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,14 +97,16 @@ sdk/
 ├── configclient/        # Config read/write SDK (own module)
 ├── adminclient/         # Admin operations SDK (own module)
 ├── configwatcher/       # Live typed values SDK (own module)
-└── tools/               # Power tools: diff, docgen, validate, seed, dump (own module)
+├── tools/               # Power tools: diff, docgen, validate, seed, dump (own module)
+└── contrib/             # SDK framework adapters: viper, koanf, envconfig (own modules)
 
 e2e/                     # End-to-end tests (own module: e2e/go.mod)
 build/                   # Dockerfiles (service + tools)
 deploy/
 ├── helm/                # Helm chart
 └── otel-collector.yaml  # OTel Collector config for local dev
-contrib/                 # Third-party integrations (future: viper, koanf)
+contrib/
+└── decree-docs/         # Standalone schema docs generator (own module)
 ```
 
 ### Module Layout

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 SERVER_LDFLAGS := -X github.com/opendecree/decree/internal/version.Version=$(GIT_VERSION) -X github.com/opendecree/decree/internal/version.Commit=$(GIT_COMMIT)
 CLI_LDFLAGS := -X main.cliVersion=$(GIT_VERSION) -X main.cliCommit=$(GIT_COMMIT)
 
-# Module list for multi-module operations.
+# Module lists for multi-module operations.
 SDK_MODULES := sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/viper sdk/contrib/envconfig sdk/contrib/koanf
+CONTRIB_MODULES := contrib/decree-docs
 
 .PHONY: all generate generate-proto generate-sqlc deps test lint lint-go lint-proto lint-migrations build image ui migrate e2e e2e-jwt examples bench bench-e2e stress chaos docs docs-api docs-cli docs-man docs-serve docs-deploy pre-commit clean tools help demo-gif validate-meta-schemas
 
@@ -92,12 +93,12 @@ lint-proto: $(TOOLS_SENTINEL)
 ## deps: Download Go module dependencies across all modules
 deps:
 	go mod download ./...
-	@for mod in api $(SDK_MODULES) cmd/decree; do (cd $$mod && go mod download ./...) || exit 1; done
+	@for mod in api $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && go mod download ./...) || exit 1; done
 
 ## test: Run unit tests across all modules
 test:
 	go test ./... -race -count=1
-	@for mod in $(SDK_MODULES) cmd/decree; do (cd $$mod && go test ./... -race -count=1) || exit 1; done
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && go test ./... -race -count=1) || exit 1; done
 
 ## validate-meta-schemas: Validate canonical schema/config YAMLs against the v0.1.0 meta-schemas
 validate-meta-schemas:
@@ -107,10 +108,10 @@ validate-meta-schemas:
 pre-commit:
 	@echo "=== Build ==="
 	go build ./...
-	@for mod in $(SDK_MODULES) cmd/decree; do (cd $$mod && go build ./...) || exit 1; done
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && go build ./...) || exit 1; done
 	@echo "=== Vet ==="
 	go vet ./...
-	@for mod in $(SDK_MODULES) cmd/decree; do (cd $$mod && go vet ./...) || exit 1; done
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && go vet ./...) || exit 1; done
 	@echo "=== Format ==="
 	@unformatted=$$(gofumpt -l .); \
 	if [ -n "$$unformatted" ]; then \
@@ -121,7 +122,7 @@ pre-commit:
 	golangci-lint run ./...
 	@echo "=== Test ==="
 	go test ./... -race -count=1
-	@for mod in $(SDK_MODULES) cmd/decree; do (cd $$mod && go test ./... -race -count=1) || exit 1; done
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && go test ./... -race -count=1) || exit 1; done
 	@echo "=== Coverage ==="
 	./scripts/check-coverage.sh
 	@echo ""

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,16 @@
+# contrib
+
+Standalone tools built on top of decree. Each subdirectory is its own Go module, developed and versioned independently of the server and SDK modules.
+
+> **Alpha**: These modules are part of the OpenDecree alpha release. The APIs may change.
+
+## Scope: `contrib/` vs `sdk/contrib/`
+
+- **`contrib/` (this directory)** hosts standalone tools — complete programs with their own CLIs that consume decree schemas or a running decree server (e.g. `decree-docs`).
+- **[`sdk/contrib/`](../sdk/contrib/)** hosts SDK framework adapters — libraries that plug the Go SDK into third-party configuration frameworks (viper, koanf, envconfig).
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| [`decree-docs`](decree-docs/) | Multi-format documentation generator for decree schemas |

--- a/contrib/decree-docs/README.md
+++ b/contrib/decree-docs/README.md
@@ -1,0 +1,26 @@
+# decree-docs
+
+A standalone, multi-format documentation generator for decree schemas. It loads schemas from local files or from a running decree server and renders them as `json`, `md`, `mdx`, or `html`, with built-in themes, CSS style injection, and a template override system.
+
+> **Alpha**: This module is part of the OpenDecree alpha release. The CLI and output formats may change.
+
+> **Status**: scaffold — this build ships the command skeleton and version information only. The loaders and format backends land in upcoming releases.
+
+`decree-docs` lives under `contrib/` (standalone tools built on decree), as opposed to `sdk/contrib/` (SDK framework adapters such as viper, koanf, and envconfig). It composes on top of the minimal, zero-dependency `sdk/tools/docgen` library rather than replacing it.
+
+## Build
+
+The module is not tagged for release yet; build it from a checkout:
+
+```sh
+git clone https://github.com/opendecree/decree
+cd decree/contrib/decree-docs
+go build -o decree-docs .
+```
+
+## Usage
+
+```sh
+decree-docs --help
+decree-docs version
+```

--- a/contrib/decree-docs/cli_test.go
+++ b/contrib/decree-docs/cli_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// resetRootCmd restores rootCmd I/O and args after a test so that global state
+// mutations do not leak between tests.
+func resetRootCmd(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+}
+
+// --- Command structure ---
+
+func TestRootCommand_HasVersionSubcommand(t *testing.T) {
+	names := make([]string, 0, len(rootCmd.Commands()))
+	for _, cmd := range rootCmd.Commands() {
+		names = append(names, cmd.Name())
+	}
+	if !slices.Contains(names, "version") {
+		t.Errorf("missing subcommand: version (got %v)", names)
+	}
+}
+
+func TestRootCmd_SilenceUsage(t *testing.T) {
+	if !rootCmd.SilenceUsage {
+		t.Error("expected rootCmd.SilenceUsage = true, got false")
+	}
+}
+
+func TestRootCmd_SilenceErrors(t *testing.T) {
+	if !rootCmd.SilenceErrors {
+		t.Error("expected rootCmd.SilenceErrors = true, got false")
+	}
+}
+
+// --- Exit codes ---
+
+func TestRun_Help_ExitsZero(t *testing.T) {
+	resetRootCmd(t)
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	if code := run([]string{"--help"}); code != 0 {
+		t.Errorf("got exit code %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "decree-docs") {
+		t.Errorf("expected help output to mention decree-docs, got %q", stdout.String())
+	}
+}
+
+func TestRun_NoArgs_ShowsHelp(t *testing.T) {
+	resetRootCmd(t)
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	if code := run([]string{}); code != 0 {
+		t.Errorf("got exit code %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "Usage:") {
+		t.Errorf("expected bare invocation to print help, got %q", stdout.String())
+	}
+}
+
+func TestRun_VersionCommand_ExitsZero(t *testing.T) {
+	resetRootCmd(t)
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	if code := run([]string{"version"}); code != 0 {
+		t.Errorf("got exit code %d, want 0", code)
+	}
+	want := "decree-docs " + version
+	if !strings.Contains(stdout.String(), want) {
+		t.Errorf("expected version output to contain %q, got %q", want, stdout.String())
+	}
+}
+
+func TestRun_UnknownCommand_ExitsNonZeroWithError(t *testing.T) {
+	resetRootCmd(t)
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	if code := run([]string{"definitely-not-a-command"}); code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "Error:") {
+		t.Errorf("expected error message on stderr, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected empty stdout on unknown command, got %q", stdout.String())
+	}
+}

--- a/contrib/decree-docs/go.mod
+++ b/contrib/decree-docs/go.mod
@@ -1,0 +1,20 @@
+module github.com/opendecree/decree/contrib/decree-docs
+
+go 1.24.0
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)
+
+// Intra-repo dependencies build against the working tree (pattern shared with
+// sdk/contrib and cmd/decree). decree-docs grows require directives for
+// sdk/tools and sdk/adminclient when the loaders land; the replaces are inert
+// until then.
+replace github.com/opendecree/decree/sdk/tools => ../../sdk/tools
+
+replace github.com/opendecree/decree/sdk/adminclient => ../../sdk/adminclient
+
+replace github.com/opendecree/decree/sdk/retry => ../../sdk/retry

--- a/contrib/decree-docs/go.sum
+++ b/contrib/decree-docs/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/contrib/decree-docs/main.go
+++ b/contrib/decree-docs/main.go
@@ -1,0 +1,48 @@
+// Command decree-docs generates documentation from decree schemas.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+// run executes the root command with the given arguments and returns the
+// process exit code. Split from main so tests can drive the CLI in-process.
+func run(args []string) int {
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	rootCmd.SetArgs(args)
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		_, _ = fmt.Fprintf(rootCmd.ErrOrStderr(), "Error: %s\n", err)
+		return 1
+	}
+	return 0
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "decree-docs",
+	Short: "Generate documentation from decree schemas",
+	Long: `decree-docs is a standalone, multi-format documentation generator for
+decree schemas. It loads schemas from local files or from a running decree
+server and renders them as json, md, mdx, or html, with built-in themes,
+CSS style injection, and a template override system.
+
+This build ships the command skeleton and version information only; the
+loaders and format backends land in upcoming releases.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}

--- a/contrib/decree-docs/smoke_test.go
+++ b/contrib/decree-docs/smoke_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSmoke_BinaryBuildsAndRuns is the CLI smoke test: the binary builds, and
+// both `decree-docs --help` and `decree-docs version` exit 0.
+func TestSmoke_BinaryBuildsAndRuns(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go binary not in PATH: %v", err)
+	}
+
+	bin := filepath.Join(t.TempDir(), "decree-docs")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	for _, args := range [][]string{{"--help"}, {"version"}} {
+		name := strings.Join(args, " ")
+		t.Run(name, func(t *testing.T) {
+			out, err := exec.Command(bin, args...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("decree-docs %s failed: %v\n%s", name, err, out)
+			}
+			if !strings.Contains(string(out), "decree-docs") {
+				t.Errorf("expected output of %q to mention decree-docs, got %q", name, out)
+			}
+		})
+	}
+}

--- a/contrib/decree-docs/version.go
+++ b/contrib/decree-docs/version.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Set at build time via ldflags.
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the decree-docs version",
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "decree-docs %s (commit %s)\n", version, commit)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,5 +1,6 @@
 {
   "cmd/decree": 86.1,
+  "contrib/decree-docs": 88.8,
   "internal": 88.5,
   "sdk/adminclient": 97.7,
   "sdk/configclient": 87.1,

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -11,7 +11,7 @@ Six Go SDK packages, each an independent module. Full API reference is hosted on
 - **`grpctransport`** — gRPC connection management and the `Transport` the clients run on.
 - **`retry`** — the shared retry policy (exponential backoff) used by the clients.
 
-The `contrib/` directory additionally holds optional configuration-loader integrations (`envconfig`, `koanf`, `viper`).
+The `sdk/contrib/` directory additionally holds optional configuration-loader integrations (`envconfig`, `koanf`, `viper`).
 
 ## Connecting
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -37,6 +37,7 @@ declare -A MODULES=(
   ["sdk/adminclient"]="./..."
   ["sdk/configwatcher"]="./..."
   ["sdk/tools"]="./..."
+  ["contrib/decree-docs"]="./..."
   ["cmd/decree"]="./..."
 )
 
@@ -47,6 +48,7 @@ declare -A MODULE_DIRS=(
   ["sdk/adminclient"]="sdk/adminclient"
   ["sdk/configwatcher"]="sdk/configwatcher"
   ["sdk/tools"]="sdk/tools"
+  ["contrib/decree-docs"]="contrib/decree-docs"
   ["cmd/decree"]="cmd/decree"
 )
 


### PR DESCRIPTION
## Summary
- First brick of the decree-docs tool (epic #921): a standalone `contrib/decree-docs` module so the full-featured docs generator can grow without weighing down the zero-dependency `sdk/tools/docgen` core.
- Skeleton only — cobra root command, `version` subcommand with the same ldflags mechanism as `cmd/decree`, and a testable `run()` seam; loaders and output formats arrive in #914–#920.
- Establishes the namespace split in `contrib/README.md`: top-level `contrib/` hosts standalone tools, `sdk/contrib/` hosts SDK framework adapters; stale module-inventory lines in CONTRIBUTING.md and docs/sdk.md fixed to match.
- Fully wired: Makefile module loops, ci.yml per-module tests + coverage merge, check-coverage.sh ratchet (88.8 floor, 88.9 measured), dependabot 1.24 tier. Inert replace directives follow the sdk/contrib/viper pattern; requires arrive with #914's loaders.

## Test plan
- [x] `make test` — all modules pass, including the new one
- [x] `./scripts/check-coverage.sh` — contrib/decree-docs 88.9% (≥88.8), all modules green
- [x] `make lint-go` clean; `gofumpt`/`go build`/`go vet` clean in the new module
- [x] Smoke test (automated): binary builds, `--help` and `version` exit 0
- [x] In-process CLI tests: help text, version output, unknown-command error path

Closes #913