### PR TITLE
ci(release): install syft + bump requires to v0.12.0-alpha.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,8 @@ jobs:
       # GoReleaser v2 shells out to syft for the SBOM step; it is no longer
       # preinstalled on the GitHub runner image, so install it explicitly.
       - name: Install Syft for SBOM generation
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        # anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
 
       - name: Run goreleaser
         # goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # GoReleaser v2 shells out to syft for the SBOM step; it is no longer
+      # preinstalled on the GitHub runner image, so install it explicitly.
+      - name: Install Syft for SBOM generation
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
       - name: Run goreleaser
         # goreleaser/goreleaser-action@v7
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89

--- a/chaos/go.mod
+++ b/chaos/go.mod
@@ -3,10 +3,10 @@ module github.com/opendecree/decree/chaos
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+	github.com/opendecree/decree/api v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 )
@@ -15,8 +15,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/cmd/decree/go.mod
+++ b/cmd/decree/go.mod
@@ -3,10 +3,10 @@ module github.com/opendecree/decree/cmd/decree
 go 1.24.0
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.2
 	github.com/spf13/cobra v1.10.2
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -17,9 +17,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/contrib/decree-docs/go.mod
+++ b/contrib/decree-docs/go.mod
@@ -3,15 +3,15 @@ module github.com/opendecree/decree/contrib/decree-docs
 go 1.24.0
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.2
 	github.com/spf13/cobra v1.10.2
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -3,10 +3,10 @@ module github.com/opendecree/decree/e2e
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+	github.com/opendecree/decree/api v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
@@ -16,8 +16,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/examples/config-validation/go.mod
+++ b/examples/config-validation/go.mod
@@ -2,7 +2,7 @@ module github.com/opendecree/decree/examples/config-validation
 
 go 1.25
 
-require github.com/opendecree/decree/sdk/tools v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/tools v0.12.0-alpha.2
 
 require (
 	github.com/kr/text v0.2.0 // indirect

--- a/examples/environment-bootstrap/go.mod
+++ b/examples/environment-bootstrap/go.mod
@@ -3,18 +3,18 @@ module github.com/opendecree/decree/examples/environment-bootstrap
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.2
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/examples/feature-flags/go.mod
+++ b/examples/feature-flags/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/feature-flags
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/live-config/go.mod
+++ b/examples/live-config/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/live-config
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/multi-tenant/go.mod
+++ b/examples/multi-tenant/go.mod
@@ -3,16 +3,16 @@ module github.com/opendecree/decree/examples/multi-tenant
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/optimistic-concurrency/go.mod
+++ b/examples/optimistic-concurrency/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/optimistic-concurrency
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/quickstart/go.mod
+++ b/examples/quickstart/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/quickstart
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/schema-lifecycle/go.mod
+++ b/examples/schema-lifecycle/go.mod
@@ -3,16 +3,16 @@ module github.com/opendecree/decree/examples/schema-lifecycle
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/setup/go.mod
+++ b/examples/setup/go.mod
@@ -3,18 +3,18 @@ module github.com/opendecree/decree/examples/setup
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.2
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/cel-go v0.28.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/opendecree/decree/api v0.12.0-alpha.1
+	github.com/opendecree/decree/api v0.12.0-alpha.2
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/redis/go-redis/extra/redisotel/v9 v9.20.1
 	github.com/redis/go-redis/v9 v9.20.1

--- a/sdk/adminclient/go.mod
+++ b/sdk/adminclient/go.mod
@@ -2,6 +2,6 @@ module github.com/opendecree/decree/sdk/adminclient
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2
 
 replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/configclient/go.mod
+++ b/sdk/configclient/go.mod
@@ -2,6 +2,6 @@ module github.com/opendecree/decree/sdk/configclient
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2
 
 replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/configwatcher/go.mod
+++ b/sdk/configwatcher/go.mod
@@ -2,9 +2,9 @@ module github.com/opendecree/decree/sdk/configwatcher
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 
 replace github.com/opendecree/decree/sdk/retry => ../retry
 

--- a/sdk/contrib/envconfig/go.mod
+++ b/sdk/contrib/envconfig/go.mod
@@ -2,9 +2,9 @@ module github.com/opendecree/decree/sdk/contrib/envconfig
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
+require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 
 replace github.com/opendecree/decree/sdk/configclient => ../../../sdk/configclient
 

--- a/sdk/contrib/koanf/go.mod
+++ b/sdk/contrib/koanf/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/knadh/koanf/v2 v2.1.2
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
 )
 
 require (
@@ -12,7 +12,7 @@ require (
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 )
 
 replace github.com/opendecree/decree/sdk/configclient => ../../../sdk/configclient

--- a/sdk/contrib/viper/go.mod
+++ b/sdk/contrib/viper/go.mod
@@ -3,7 +3,7 @@ module github.com/opendecree/decree/sdk/contrib/viper
 go 1.22.0
 
 require (
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
 	github.com/spf13/viper v1.19.0
 )
 
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/sdk/grpctransport/go.mod
+++ b/sdk/grpctransport/go.mod
@@ -3,17 +3,17 @@ module github.com/opendecree/decree/sdk/grpctransport
 go 1.24.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1
+	github.com/opendecree/decree/api v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/sdk/tools/go.mod
+++ b/sdk/tools/go.mod
@@ -5,14 +5,14 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/stress/go.mod
+++ b/stress/go.mod
@@ -13,9 +13,9 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../sdk/grpctransport
 replace github.com/opendecree/decree/sdk/configwatcher => ../sdk/configwatcher
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.1
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.1
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.2
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.2
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 )
@@ -24,9 +24,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.1 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.2 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect


### PR DESCRIPTION
Closes #938

## Summary
- Add a SHA-pinned `anchore/sbom-action/download-syft` step to `release.yml` so GoReleaser's SBOM step works — `syft` is no longer preinstalled on the GitHub runner, which blocked the `v0.12.0-alpha.1` release.
- Bump every inter-module `require` to `v0.12.0-alpha.2`. The `v0.12.0-alpha.1` module tags were never published (its release failed), so siblings must resolve at alpha.2.

## Test plan
- [x] `make build` — server + CLI green
- [x] `make lint-go` — 0 issues, fmt clean
- [x] `go mod tidy` no-op across all 24 modules (readonly-safe)
- [ ] PR CI — full Build / Test / E2E / Examples / Stress / Lint suite
- [ ] Release `v0.12.0-alpha.2` → `release.yml` SBOM step now succeeds with syft

🤖 Generated with [Claude Code](https://claude.com/claude-code)