### PR TITLE
fix(ci): move CodeQL Go-skip-on-PR logic out of job-level if

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,18 @@ jobs:
       - name: Check supply-chain pins
         run: ./scripts/check-supply-chain-pins.sh
 
+      - name: Lint workflow files
+        # rhysd/actionlint:1.7.12 — catches invalid workflow syntax (e.g. a
+        # context used somewhere it isn't available) before it reaches GitHub,
+        # where such errors silently produce zero jobs instead of a clear
+        # failure. See #931. shellcheck/pyflakes are disabled here: they lint
+        # the shell/Python embedded in `run:` steps, a different and much
+        # noisier concern than workflow-file validity — out of scope for this
+        # gate.
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color -shellcheck= -pyflakes=
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,9 +32,6 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Go autobuild takes ~5 min; skip it on PRs — govulncheck covers per-PR vuln
-    # scanning. Actions and Python are fast (< 1 min) and still run on PRs.
-    if: matrix.language != 'go' || github.event_name != 'pull_request'
     permissions:
       security-events: write
       packages: read
@@ -44,6 +41,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Go autobuild takes ~5 min; skip it on PRs — govulncheck covers per-PR
+        # vuln scanning. Actions and Python are fast (< 1 min) and still run on
+        # PRs. `matrix` is not available in `jobs.<job_id>.if`, so the language
+        # list is selected here instead, per event.
+        language: ${{ github.event_name == 'pull_request' && fromJSON('["actions","python"]') || fromJSON('["actions","go","python"]') }}
         include:
           - language: actions
             build-mode: none

--- a/scripts/check-supply-chain-pins.sh
+++ b/scripts/check-supply-chain-pins.sh
@@ -2,7 +2,8 @@
 # check-supply-chain-pins.sh — Enforce supply-chain pinning policy.
 #
 # 1. Every `uses:` line in .github/workflows/*.yml that references a
-#    non-trusted action must pin to a 40-char commit SHA.
+#    non-trusted action must pin to a 40-char commit SHA (GitHub Actions) or
+#    a `sha256:<64-hex>` digest (raw `docker://` image refs).
 #    Trusted orgs (allowed to pin by tag): actions, github, docker.
 # 2. Every `FROM` line in build/* must pin to an `@sha256:<digest>`.
 #
@@ -34,13 +35,16 @@ while IFS= read -r line; do
   ref="${ref#"${ref%%[![:space:]]*}"}"
   # Skip local workflow refs
   [[ "$ref" == ./* ]] && continue
+  # Strip the docker:// scheme (raw image ref) before org matching/SHA check
+  bare_ref="${ref#docker://}"
   # Trusted orgs may continue to pin by tag
-  case "$ref" in
+  case "$bare_ref" in
     actions/*|github/*|docker/*|opendecree/*) continue ;;
   esac
-  # Ref must look like owner/repo[/path]@<sha>
-  sha="${ref##*@}"
-  if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+  # Ref must look like owner/repo[/path]@<sha> (GitHub Actions, 40-hex commit
+  # SHA) or owner/repo@sha256:<64-hex> (docker:// image ref, content digest)
+  sha="${bare_ref##*@}"
+  if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]] && [[ ! "$sha" =~ ^sha256:[0-9a-f]{64}$ ]]; then
     echo "non-trusted action not SHA-pinned: $file_loc:$lineno: $ref" >&2
     fail=1
   fi


### PR DESCRIPTION
## Summary
- CodeQL has failed every run since #518 — the job-level `if: matrix.language != 'go' || ...` references the `matrix` context, which isn't valid in `jobs.<job_id>.if`, invalidating the entire workflow file (zero jobs created, listed by path not name).
- Fixed by moving the Go-skip-on-PR logic into the `strategy.matrix.language` expression itself: PRs get `["actions","python"]`, push/schedule get `["actions","go","python"]`. Preserves #518's original intent.
- Added an actionlint step (pinned by sha256 digest) to the lint job in `ci.yml` so an invalid workflow file fails fast next time — this caught the original bug immediately when tested against the old file.
- Extended `scripts/check-supply-chain-pins.sh` to recognize sha256 digest pins on `docker://` refs, since the new actionlint step uses one.

## Test plan
- [x] `actionlint` confirms the old codeql.yml fails with the documented `matrix` context error, and the new one passes.
- [x] YAML syntax validated via `yaml.safe_load` on both modified workflow files.
- [x] `check-supply-chain-pins.sh` passes with the new pin.
- [ ] CI green on this PR (push trigger via merge, PR trigger via this PR, schedule trigger to be confirmed post-merge).

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)