### PR TITLE
decree-docs: add markdown backend (plain and material flavors)

### DIFF
--- a/contrib/decree-docs/README.md
+++ b/contrib/decree-docs/README.md
@@ -4,7 +4,7 @@ A standalone, multi-format documentation generator for decree schemas. It loads 
 
 > **Alpha**: This module is part of the OpenDecree alpha release. The CLI and output formats may change.
 
-> **Status**: in development — this build loads schemas from local YAML files and emits the JSON documentation model. The md/mdx/html backends, server mode, and the config/template system land in upcoming releases.
+> **Status**: in development — this build loads schemas from local YAML files and emits the json and md documentation formats. The mdx/html backends, server mode, and the config/template system land in upcoming releases.
 
 `decree-docs` lives under `contrib/` (standalone tools built on decree), as opposed to `sdk/contrib/` (SDK framework adapters such as viper, koanf, and envconfig). It composes on top of the minimal, zero-dependency `sdk/tools/docgen` library rather than replacing it.
 
@@ -22,6 +22,8 @@ go build -o decree-docs .
 
 ```sh
 decree-docs generate --file decree.schema.yaml --format json
+decree-docs generate --file decree.schema.yaml --format md --flavor material
+decree-docs generate --file decree.schema.yaml --format md --pages multi --out-dir docs/
 decree-docs --help
 decree-docs version
 ```
@@ -64,9 +66,16 @@ Serialization rules (see the `docmodel` package documentation for the authoritat
 - Fields are sorted by path, so output is deterministic.
 - Server-side bookkeeping (schema ID, checksum, published state, timestamps) is excluded: a schema loaded from a file and the same schema fetched from a server produce identical documents.
 
+## The md format
+
+`--format md` renders Markdown from the doc model. `--flavor plain` emits portable CommonMark; `--flavor material` additionally uses the `admonition` and `pymdownx.tabbed` extensions this repo's `mkdocs.yml` already enables — deprecation notices render as a `!!! warning` admonition, and fields with two or more named examples render as content tabs. In both flavors, deprecated/sensitive/read-only/write-once fields get a bold badge line distinct from the type/format meta line; material adds an icon per badge.
+
+`--pages single` (default) renders one page: to stdout, or to `<out-dir>/index.md` with `--out-dir`. `--pages multi` renders an index page plus one page per top-level field-path-prefix group (e.g. `payments.fee` and `payments.retries` both land on `payments.md`) and requires `--out-dir`.
+
 ## Testing
 
 ```sh
 go test ./...
-go test . -run TestGenerate_JSONGolden -update   # rewrite golden files
+go test . -run TestGenerate_JSONGolden -update          # rewrite CLI JSON golden files
+go test ./markdown -run TestRender_Golden -update       # rewrite markdown golden files
 ```

--- a/contrib/decree-docs/generate.go
+++ b/contrib/decree-docs/generate.go
@@ -2,17 +2,28 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
 	"github.com/opendecree/decree/contrib/decree-docs/loader"
+	"github.com/opendecree/decree/contrib/decree-docs/markdown"
 )
 
-// docFormats lists the formats generate can emit. The md, mdx, and html
-// backends land in upcoming releases (#915-#917).
-var docFormats = []string{"json"}
+// docFormats lists the formats generate can emit. The mdx and html backends
+// land in upcoming releases (#916-#917).
+var docFormats = []string{"json", "md"}
+
+// mdFlavors lists the --flavor values valid with --format md.
+var mdFlavors = []string{string(markdown.Plain), string(markdown.Material)}
+
+// mdPageModes lists the --pages values valid with --format md.
+var mdPageModes = []string{string(markdown.SinglePage), string(markdown.MultiPage)}
 
 var generateCmd = &cobra.Command{
 	Use:   "generate [schema-id]",
@@ -25,7 +36,13 @@ upcoming release (#918); --file and schema-id are mutually exclusive.
 
 The json format emits the complete documentation model: a stable JSON
 document, versioned by its docModelVersion root marker, that third-party
-renderers can build on.`,
+renderers can build on.
+
+The md format renders Markdown. --flavor plain emits portable CommonMark;
+--flavor material additionally uses the MkDocs Material admonition and
+content-tab extensions. --pages single (default) renders one page to
+stdout (or to <out-dir>/index.md with --out-dir); --pages multi renders an
+index page plus one page per top-level field group and requires --out-dir.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runGenerate,
 }
@@ -33,8 +50,17 @@ renderers can build on.`,
 func init() {
 	generateCmd.Flags().String("file", "", "schema YAML file (offline mode)")
 	generateCmd.Flags().String("format", "json", "output format: "+strings.Join(docFormats, ", "))
+	generateCmd.Flags().String("flavor", string(markdown.Plain), "md flavor: "+strings.Join(mdFlavors, ", "))
+	generateCmd.Flags().String("pages", string(markdown.SinglePage), "md page mode: "+strings.Join(mdPageModes, ", "))
+	generateCmd.Flags().String("out-dir", "", "output directory (required when md rendering produces multiple pages)")
 	_ = generateCmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return docFormats, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = generateCmd.RegisterFlagCompletionFunc("flavor", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return mdFlavors, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = generateCmd.RegisterFlagCompletionFunc("pages", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return mdPageModes, cobra.ShellCompDirectiveNoFileComp
 	})
 	rootCmd.AddCommand(generateCmd)
 }
@@ -59,6 +85,47 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// Only json today; this switch grows with the md/mdx/html backends.
+
+	if format == "md" {
+		return runGenerateMD(cmd, doc)
+	}
 	return doc.EncodeJSON(cmd.OutOrStdout())
+}
+
+func runGenerateMD(cmd *cobra.Command, doc *docmodel.Document) error {
+	flavorFlag, _ := cmd.Flags().GetString("flavor")
+	if !slices.Contains(mdFlavors, flavorFlag) {
+		return fmt.Errorf("unknown flavor %q (valid flavors: %s)", flavorFlag, strings.Join(mdFlavors, ", "))
+	}
+	pagesFlag, _ := cmd.Flags().GetString("pages")
+	if !slices.Contains(mdPageModes, pagesFlag) {
+		return fmt.Errorf("unknown pages mode %q (valid modes: %s)", pagesFlag, strings.Join(mdPageModes, ", "))
+	}
+	outDir, _ := cmd.Flags().GetString("out-dir")
+
+	pages, err := markdown.Render(doc, markdown.Options{
+		Flavor: markdown.Flavor(flavorFlag),
+		Pages:  markdown.PageMode(pagesFlag),
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(pages) == 1 && outDir == "" {
+		_, err := io.WriteString(cmd.OutOrStdout(), pages[0].Content)
+		return err
+	}
+	if outDir == "" {
+		return fmt.Errorf("--out-dir is required for multi-page md output")
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create out-dir: %w", err)
+	}
+	for _, p := range pages {
+		path := filepath.Join(outDir, p.Name+".md")
+		if err := os.WriteFile(path, []byte(p.Content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return nil
 }

--- a/contrib/decree-docs/generate_test.go
+++ b/contrib/decree-docs/generate_test.go
@@ -23,6 +23,9 @@ func resetGenerateCmd(t *testing.T) {
 	t.Cleanup(func() {
 		_ = generateCmd.Flags().Set("file", "")
 		_ = generateCmd.Flags().Set("format", "json")
+		_ = generateCmd.Flags().Set("flavor", "plain")
+		_ = generateCmd.Flags().Set("pages", "single")
+		_ = generateCmd.Flags().Set("out-dir", "")
 	})
 }
 
@@ -154,6 +157,141 @@ func TestGenerate_FileNotFound(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "read schema file") {
 		t.Errorf("expected read error, got %q", stderr)
+	}
+}
+
+func TestGenerate_FlavorFlagCompletion(t *testing.T) {
+	complete, ok := generateCmd.GetFlagCompletionFunc("flavor")
+	if !ok {
+		t.Fatal("expected a completion function for --flavor")
+	}
+	values, _ := complete(generateCmd, nil, "")
+	if !slices.Equal(values, mdFlavors) {
+		t.Errorf("got completions %v, want %v", values, mdFlavors)
+	}
+}
+
+func TestGenerate_PagesFlagCompletion(t *testing.T) {
+	complete, ok := generateCmd.GetFlagCompletionFunc("pages")
+	if !ok {
+		t.Fatal("expected a completion function for --pages")
+	}
+	values, _ := complete(generateCmd, nil, "")
+	if !slices.Equal(values, mdPageModes) {
+		t.Errorf("got completions %v, want %v", values, mdPageModes)
+	}
+}
+
+func TestGenerate_MD_SinglePageGoesToStdout(t *testing.T) {
+	code, stdout, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "md")
+	if code != 0 {
+		t.Fatalf("got exit code %d, want 0 (stderr: %s)", code, stderr)
+	}
+	if !strings.HasPrefix(stdout, "# minimal\n\n") {
+		t.Errorf("expected stdout to start with the schema heading, got %q", stdout)
+	}
+}
+
+func TestGenerate_MD_UnknownFlavor(t *testing.T) {
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "md", "--flavor", "fancy")
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, `unknown flavor "fancy"`) || !strings.Contains(stderr, "valid flavors: plain, material") {
+		t.Errorf("expected unknown-flavor error, got %q", stderr)
+	}
+}
+
+func TestGenerate_MD_UnknownPageMode(t *testing.T) {
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "md", "--pages", "weekly")
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, `unknown pages mode "weekly"`) || !strings.Contains(stderr, "valid modes: single, multi") {
+		t.Errorf("expected unknown-pages error, got %q", stderr)
+	}
+}
+
+func TestGenerate_MD_MultiPageRequiresOutDir(t *testing.T) {
+	code, stdout, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/full.schema.yaml", "--format", "md", "--pages", "multi")
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "--out-dir is required") {
+		t.Errorf("expected out-dir-required error, got %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestGenerate_MD_MultiPageWritesFiles(t *testing.T) {
+	outDir := t.TempDir()
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/full.schema.yaml", "--format", "md", "--pages", "multi", "--out-dir", outDir)
+	if code != 0 {
+		t.Fatalf("got exit code %d, want 0 (stderr: %s)", code, stderr)
+	}
+	for _, name := range []string{"index.md", "payments.md"} {
+		path := filepath.Join(outDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("expected %s to be written: %v", path, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("expected %s to be non-empty", path)
+		}
+	}
+}
+
+func TestGenerate_MD_OutDirNotADirectory(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(outDir, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/full.schema.yaml", "--format", "md", "--pages", "multi", "--out-dir", outDir)
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "create out-dir") {
+		t.Errorf("expected create-out-dir error, got %q", stderr)
+	}
+}
+
+func TestGenerate_MD_WriteFileError(t *testing.T) {
+	outDir := t.TempDir()
+	// index.md as a directory makes the write to that path fail.
+	if err := os.Mkdir(filepath.Join(outDir, "index.md"), 0o755); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/full.schema.yaml", "--format", "md", "--pages", "multi", "--out-dir", outDir)
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "write") {
+		t.Errorf("expected write error, got %q", stderr)
+	}
+}
+
+func TestGenerate_MD_SinglePageWithOutDirWritesIndexFile(t *testing.T) {
+	outDir := t.TempDir()
+	code, stdout, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "md", "--out-dir", outDir)
+	if code != 0 {
+		t.Fatalf("got exit code %d, want 0 (stderr: %s)", code, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout when writing to --out-dir, got %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "index.md")); err != nil {
+		t.Errorf("expected index.md to be written: %v", err)
 	}
 }
 

--- a/contrib/decree-docs/main.go
+++ b/contrib/decree-docs/main.go
@@ -41,8 +41,8 @@ decree schemas. It loads schemas from local files or from a running decree
 server and renders them as json, md, mdx, or html, with built-in themes,
 CSS style injection, and a template override system.
 
-This build loads schemas from local YAML files and emits the JSON
-documentation model; the md/mdx/html backends and server mode land in
+This build loads schemas from local YAML files and emits the json and md
+documentation formats; the mdx/html backends and server mode land in
 upcoming releases.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/contrib/decree-docs/markdown/markdown.go
+++ b/contrib/decree-docs/markdown/markdown.go
@@ -1,0 +1,383 @@
+// Package markdown renders a decree-docs documentation model
+// ([docmodel.Document]) as Markdown.
+//
+// Two flavors are supported. "plain" emits portable CommonMark. "material"
+// emits Markdown that additionally relies on the MkDocs Material extensions
+// this repo's mkdocs.yml already enables: admonition blocks for deprecation
+// notices, and pymdownx.tabbed content tabs for fields with two or more
+// named examples. In both flavors, field flags (deprecated, sensitive,
+// read-only, write-once) render as a bold badge line distinct from the
+// field's type/format meta line; material adds an icon per badge.
+//
+// Two page modes are supported. [SinglePage] renders the whole schema as one
+// page. [MultiPage] renders an index page plus one page per top-level
+// path-prefix group (the same grouping sdk/tools/docgen uses for "##"
+// sections), each holding the fields under that group.
+package markdown
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+)
+
+// Flavor selects the Markdown dialect Render emits.
+type Flavor string
+
+const (
+	// Plain emits portable CommonMark.
+	Plain Flavor = "plain"
+	// Material emits Markdown using MkDocs Material's admonition and
+	// content-tab extensions.
+	Material Flavor = "material"
+)
+
+// PageMode selects how Render splits the document into pages.
+type PageMode string
+
+const (
+	// SinglePage renders the whole schema as one page.
+	SinglePage PageMode = "single"
+	// MultiPage renders an index page plus one page per path-prefix group.
+	MultiPage PageMode = "multi"
+)
+
+// Options configures Render.
+type Options struct {
+	Flavor Flavor
+	Pages  PageMode
+}
+
+// Page is one rendered Markdown page.
+type Page struct {
+	// Name is the page's logical name: "index" for the single page or the
+	// multi-page index, and the path-prefix group name for each multi-page
+	// group page. Callers writing to disk join it with ".md".
+	Name    string
+	Content string
+}
+
+// Render renders doc as one or more Markdown pages per opts.
+func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
+	if opts.Flavor != Plain && opts.Flavor != Material {
+		return nil, fmt.Errorf("unknown flavor %q (valid flavors: %s, %s)", opts.Flavor, Plain, Material)
+	}
+
+	groups := groupByPrefix(doc.Schema.Fields)
+
+	switch opts.Pages {
+	case SinglePage, "":
+		var b strings.Builder
+		writeHeader(&b, doc.Schema)
+		for _, g := range groups {
+			fmt.Fprintf(&b, "## %s\n\n", g.prefix)
+			for _, f := range g.fields {
+				writeField(&b, f, opts.Flavor)
+			}
+		}
+		return []Page{{Name: "index", Content: b.String()}}, nil
+	case MultiPage:
+		pages := []Page{indexPage(doc.Schema, groups)}
+		for _, g := range groups {
+			var b strings.Builder
+			fmt.Fprintf(&b, "# %s\n\n", g.prefix)
+			for _, f := range g.fields {
+				writeField(&b, f, opts.Flavor)
+			}
+			pages = append(pages, Page{Name: g.prefix, Content: b.String()})
+		}
+		return pages, nil
+	default:
+		return nil, fmt.Errorf("unknown pages mode %q (valid modes: %s, %s)", opts.Pages, SinglePage, MultiPage)
+	}
+}
+
+func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
+	var b strings.Builder
+	writeHeader(&b, s)
+	fmt.Fprintln(&b, "## Groups")
+	fmt.Fprintln(&b)
+	for _, g := range groups {
+		noun := "fields"
+		if len(g.fields) == 1 {
+			noun = "field"
+		}
+		fmt.Fprintf(&b, "- [%s](%s.md) — %d %s\n", g.prefix, g.prefix, len(g.fields), noun)
+	}
+	fmt.Fprintln(&b)
+	return Page{Name: "index", Content: b.String()}
+}
+
+func writeHeader(b *strings.Builder, s docmodel.Schema) {
+	title := s.Name
+	if s.Info != nil && s.Info.Title != "" {
+		title = s.Info.Title
+	}
+	fmt.Fprintf(b, "# %s\n\n", title)
+	if s.Description != "" {
+		fmt.Fprintf(b, "%s\n\n", s.Description)
+	}
+	if s.Version > 0 {
+		if s.VersionDescription != "" {
+			fmt.Fprintf(b, "**Version:** %d — %s\n\n", s.Version, s.VersionDescription)
+		} else {
+			fmt.Fprintf(b, "**Version:** %d\n\n", s.Version)
+		}
+	}
+	if s.Info != nil {
+		writeInfo(b, s.Info)
+	}
+}
+
+func writeInfo(b *strings.Builder, info *docmodel.Info) {
+	if info.Author != "" {
+		fmt.Fprintf(b, "**Author:** %s\n\n", info.Author)
+	}
+	if c := info.Contact; c != nil {
+		switch {
+		case c.Email != "":
+			fmt.Fprintf(b, "**Contact:** %s <%s>\n\n", c.Name, c.Email)
+		case c.URL != "":
+			fmt.Fprintf(b, "**Contact:** [%s](%s)\n\n", c.Name, c.URL)
+		case c.Name != "":
+			fmt.Fprintf(b, "**Contact:** %s\n\n", c.Name)
+		}
+	}
+	if len(info.Labels) > 0 {
+		labels := make([]string, 0, len(info.Labels))
+		for k, v := range info.Labels {
+			labels = append(labels, fmt.Sprintf("`%s: %s`", k, v))
+		}
+		sort.Strings(labels)
+		fmt.Fprintf(b, "**Labels:** %s\n\n", strings.Join(labels, ", "))
+	}
+}
+
+// --- Grouping ---
+
+type fieldGroup struct {
+	prefix string
+	fields []docmodel.Field
+}
+
+// groupByPrefix groups fields by their top-level path prefix. fields is
+// assumed sorted by path (docmodel guarantees this), so the first occurrence
+// of each prefix establishes deterministic group order.
+func groupByPrefix(fields []docmodel.Field) []fieldGroup {
+	var groups []fieldGroup
+	index := make(map[string]int)
+	for _, f := range fields {
+		prefix := f.Path
+		if i := strings.IndexByte(f.Path, '.'); i > 0 {
+			prefix = f.Path[:i]
+		}
+		if i, ok := index[prefix]; ok {
+			groups[i].fields = append(groups[i].fields, f)
+		} else {
+			index[prefix] = len(groups)
+			groups = append(groups, fieldGroup{prefix: prefix, fields: []docmodel.Field{f}})
+		}
+	}
+	return groups
+}
+
+// --- Fields ---
+
+func writeField(b *strings.Builder, f docmodel.Field, flavor Flavor) {
+	if f.Title != "" {
+		fmt.Fprintf(b, "### %s (`%s`)\n\n", f.Title, f.Path)
+	} else {
+		fmt.Fprintf(b, "### `%s`\n\n", f.Path)
+	}
+
+	fmt.Fprintf(b, "%s\n\n", fieldMeta(f))
+	if line := badgeLine(f, flavor); line != "" {
+		fmt.Fprintf(b, "%s\n\n", line)
+	}
+
+	if f.Deprecated {
+		writeDeprecationNotice(b, f, flavor)
+	}
+
+	if f.Description != "" {
+		fmt.Fprintf(b, "%s\n\n", f.Description)
+	}
+
+	writeExamples(b, f, flavor)
+
+	if f.ExternalDocs != nil && f.ExternalDocs.URL != "" {
+		if f.ExternalDocs.Description != "" {
+			fmt.Fprintf(b, "**See also:** [%s](%s)\n\n", f.ExternalDocs.Description, f.ExternalDocs.URL)
+		} else {
+			fmt.Fprintf(b, "**See also:** %s\n\n", f.ExternalDocs.URL)
+		}
+	}
+
+	if f.Constraints != nil {
+		writeConstraints(b, f.Constraints)
+	}
+}
+
+// fieldMeta renders a field's type and non-flag metadata as a single italic
+// line, e.g. "*type: `string` · format: email · default: `prod`*". Flags
+// (deprecated, sensitive, read-only, write-once) render separately as
+// badges; see badgeLine.
+func fieldMeta(f docmodel.Field) string {
+	parts := []string{fmt.Sprintf("type: `%s`", f.Type)}
+	if f.Format != "" {
+		parts = append(parts, fmt.Sprintf("format: %s", f.Format))
+	}
+	if f.Nullable {
+		parts = append(parts, "nullable")
+	}
+	if f.Default != "" {
+		parts = append(parts, fmt.Sprintf("default: `%s`", f.Default))
+	}
+	if len(f.Tags) > 0 {
+		parts = append(parts, fmt.Sprintf("tags: %s", strings.Join(f.Tags, ", ")))
+	}
+	return "*" + strings.Join(parts, " · ") + "*"
+}
+
+type badge struct {
+	icon, label string
+}
+
+// badgeLine renders deprecated/sensitive/read-only/write-once as a bold
+// badge line, visually distinct from the italic meta line. Material adds an
+// icon per badge.
+func badgeLine(f docmodel.Field, flavor Flavor) string {
+	var badges []badge
+	if f.Deprecated {
+		badges = append(badges, badge{"⚠️", "Deprecated"})
+	}
+	if f.Sensitive {
+		badges = append(badges, badge{"🔒", "Sensitive"})
+	}
+	if f.ReadOnly {
+		badges = append(badges, badge{"👁", "Read-only"})
+	}
+	if f.WriteOnce {
+		badges = append(badges, badge{"🔏", "Write-once"})
+	}
+	if len(badges) == 0 {
+		return ""
+	}
+	parts := make([]string, len(badges))
+	for i, bd := range badges {
+		if flavor == Material {
+			parts[i] = fmt.Sprintf("**%s %s**", bd.icon, bd.label)
+		} else {
+			parts[i] = fmt.Sprintf("**%s**", bd.label)
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func writeDeprecationNotice(b *strings.Builder, f docmodel.Field, flavor Flavor) {
+	body := "This field should no longer be used."
+	if f.RedirectTo != "" {
+		body = fmt.Sprintf("Use `%s` instead.", f.RedirectTo)
+	}
+	if flavor == Material {
+		fmt.Fprintln(b, `!!! warning "Deprecated"`)
+		fmt.Fprintf(b, "    %s\n\n", body)
+		return
+	}
+	fmt.Fprintf(b, "> **Deprecated** — %s\n\n", body)
+}
+
+func writeExamples(b *strings.Builder, f docmodel.Field, flavor Flavor) {
+	if f.Example != "" {
+		fmt.Fprintf(b, "**Example:** `%s`\n\n", f.Example)
+	}
+	if len(f.Examples) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(f.Examples))
+	for name := range f.Examples {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if flavor == Material && len(names) >= 2 {
+		fmt.Fprintln(b, "**Examples:**")
+		fmt.Fprintln(b)
+		for _, name := range names {
+			ex := f.Examples[name]
+			fmt.Fprintf(b, "=== %q\n\n", name)
+			fmt.Fprintf(b, "    **Value:** `%s`\n", ex.Value)
+			if ex.Summary != "" {
+				fmt.Fprintf(b, "\n    %s\n", ex.Summary)
+			}
+			fmt.Fprintln(b)
+		}
+		return
+	}
+
+	fmt.Fprintln(b, "**Examples:**")
+	for _, name := range names {
+		ex := f.Examples[name]
+		if ex.Summary != "" {
+			fmt.Fprintf(b, "- **%s:** `%s` — %s\n", name, ex.Value, ex.Summary)
+		} else {
+			fmt.Fprintf(b, "- **%s:** `%s`\n", name, ex.Value)
+		}
+	}
+	fmt.Fprintln(b)
+}
+
+func writeConstraints(b *strings.Builder, c *docmodel.Constraints) {
+	var lines []string
+	if c.Minimum != nil {
+		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Minimum)))
+	}
+	if c.Maximum != nil {
+		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Maximum)))
+	}
+	if c.ExclusiveMinimum != nil {
+		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMinimum)))
+	}
+	if c.ExclusiveMaximum != nil {
+		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMaximum)))
+	}
+	if c.MinLength != nil {
+		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
+	}
+	if c.MaxLength != nil {
+		lines = append(lines, fmt.Sprintf("Max length: %d", *c.MaxLength))
+	}
+	if c.Pattern != "" {
+		lines = append(lines, fmt.Sprintf("Pattern: `%s`", c.Pattern))
+	}
+	if len(c.Enum) > 0 {
+		lines = append(lines, fmt.Sprintf("Enum: %s", strings.Join(c.Enum, ", ")))
+	}
+	if c.JSONSchema != "" {
+		lines = append(lines, "JSON Schema: (see schema definition)")
+	}
+	if len(c.AllowedSchemes) > 0 {
+		lines = append(lines, fmt.Sprintf("Allowed schemes: %s", strings.Join(c.AllowedSchemes, ", ")))
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintln(b, "**Constraints:**")
+	for _, l := range lines {
+		fmt.Fprintf(b, "- %s\n", l)
+	}
+	fmt.Fprintln(b)
+}
+
+// formatFloat formats f for display, omitting the decimal point when the
+// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
+func formatFloat(f float64) string {
+	if f == float64(int64(f)) {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}

--- a/contrib/decree-docs/markdown/markdown_test.go
+++ b/contrib/decree-docs/markdown/markdown_test.go
@@ -1,0 +1,255 @@
+package markdown
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+	"github.com/opendecree/decree/contrib/decree-docs/loader"
+)
+
+// -update rewrites the golden files from current output:
+//
+//	go test . -run TestRender_Golden -update
+var update = flag.Bool("update", false, "rewrite golden files")
+
+// TestRender_Golden pins the rendered output for every flavor x page mode
+// combination against the full fixture, which exercises every documented
+// schema and field property.
+func TestRender_Golden(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/full.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		opts   Options
+		golden map[string]string // page name -> golden file path
+	}{
+		{
+			name: "plain single",
+			opts: Options{Flavor: Plain, Pages: SinglePage},
+			golden: map[string]string{
+				"index": "testdata/plain-single.golden.md",
+			},
+		},
+		{
+			name: "material single",
+			opts: Options{Flavor: Material, Pages: SinglePage},
+			golden: map[string]string{
+				"index": "testdata/material-single.golden.md",
+			},
+		},
+		{
+			name: "plain multi",
+			opts: Options{Flavor: Plain, Pages: MultiPage},
+			golden: map[string]string{
+				"index":    "testdata/plain-multi-index.golden.md",
+				"payments": "testdata/plain-multi-payments.golden.md",
+			},
+		},
+		{
+			name: "material multi",
+			opts: Options{Flavor: Material, Pages: MultiPage},
+			golden: map[string]string{
+				"index":    "testdata/material-multi-index.golden.md",
+				"payments": "testdata/material-multi-payments.golden.md",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pages, err := Render(doc, tt.opts)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if len(pages) != len(tt.golden) {
+				t.Fatalf("got %d pages, want %d", len(pages), len(tt.golden))
+			}
+			for _, p := range pages {
+				golden, ok := tt.golden[p.Name]
+				if !ok {
+					t.Fatalf("unexpected page %q", p.Name)
+				}
+				if *update {
+					if err := os.WriteFile(golden, []byte(p.Content), 0o644); err != nil {
+						t.Fatalf("update golden: %v", err)
+					}
+				}
+				want, err := os.ReadFile(golden)
+				if err != nil {
+					t.Fatalf("read golden: %v", err)
+				}
+				if p.Content != string(want) {
+					t.Errorf("page %q does not match %s:\ngot:\n%s\nwant:\n%s", p.Name, golden, p.Content, want)
+				}
+			}
+		})
+	}
+}
+
+// TestRender_MinimalSchema pins behavior on a schema with no flags, no
+// examples, and no constraints: no badge line, no deprecation notice, no
+// examples/constraints sections should be emitted.
+func TestRender_MinimalSchema(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	for _, flavor := range []Flavor{Plain, Material} {
+		t.Run(string(flavor), func(t *testing.T) {
+			pages, err := Render(doc, Options{Flavor: flavor, Pages: SinglePage})
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			content := pages[0].Content
+			for _, unwanted := range []string{"Deprecated", "Sensitive", "Read-only", "Write-once", "Example", "Constraints"} {
+				if strings.Contains(content, unwanted) {
+					t.Errorf("unexpected %q in minimal output:\n%s", unwanted, content)
+				}
+			}
+		})
+	}
+}
+
+// TestRender_EdgeCases exercises branches the full/minimal fixtures don't
+// reach: a bare version (no versionDescription), a contact with only a URL
+// or only a name, an externalDocs block with no description, a non-nil but
+// empty constraints block, a fractional constraint value, and a multi-page
+// group with exactly one field (singular "field" in the index).
+func TestRender_EdgeCases(t *testing.T) {
+	half := 0.5
+	doc := docmodel.New(docmodel.Schema{
+		Name:    "edge",
+		Version: 2,
+		Info: &docmodel.Info{
+			Contact: &docmodel.Contact{Name: "Sam", URL: "https://example.com/sam"},
+		},
+		Fields: []docmodel.Field{
+			{
+				Path:         "alpha.value",
+				Type:         "string",
+				ExternalDocs: &docmodel.ExternalDocs{URL: "https://example.com/alpha"},
+				Constraints:  &docmodel.Constraints{},
+			},
+			{
+				Path:        "beta.value",
+				Type:        "number",
+				Constraints: &docmodel.Constraints{Minimum: &half},
+			},
+		},
+	})
+
+	pages, err := Render(doc, Options{Flavor: Plain, Pages: MultiPage})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	index := pages[0]
+	if !strings.Contains(index.Content, "**Version:** 2\n") {
+		t.Errorf("expected bare version line, got:\n%s", index.Content)
+	}
+	if !strings.Contains(index.Content, "**Contact:** [Sam](https://example.com/sam)") {
+		t.Errorf("expected URL-only contact line, got:\n%s", index.Content)
+	}
+	if !strings.Contains(index.Content, "- [alpha](alpha.md) — 1 field\n") {
+		t.Errorf("expected singular 'field' for a one-field group, got:\n%s", index.Content)
+	}
+
+	var alpha, beta string
+	for _, p := range pages {
+		switch p.Name {
+		case "alpha":
+			alpha = p.Content
+		case "beta":
+			beta = p.Content
+		}
+	}
+	if !strings.Contains(alpha, "**See also:** https://example.com/alpha\n") {
+		t.Errorf("expected description-less externalDocs line, got:\n%s", alpha)
+	}
+	if strings.Contains(alpha, "Constraints") {
+		t.Errorf("expected empty constraints block to render nothing, got:\n%s", alpha)
+	}
+	if !strings.Contains(beta, "Minimum: 0.5\n") {
+		t.Errorf("expected fractional minimum, got:\n%s", beta)
+	}
+}
+
+func TestRender_NameOnlyContact(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Info: &docmodel.Info{Contact: &docmodel.Contact{Name: "Sam"}},
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+		},
+	})
+	pages, err := Render(doc, Options{Flavor: Plain, Pages: SinglePage})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(pages[0].Content, "**Contact:** Sam\n") {
+		t.Errorf("expected name-only contact line, got:\n%s", pages[0].Content)
+	}
+}
+
+func TestRender_UnknownFlavor(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	if _, err := Render(doc, Options{Flavor: "fancy", Pages: SinglePage}); err == nil {
+		t.Error("expected error for unknown flavor, got nil")
+	}
+}
+
+func TestRender_UnknownPageMode(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	if _, err := Render(doc, Options{Flavor: Plain, Pages: "weekly"}); err == nil {
+		t.Error("expected error for unknown page mode, got nil")
+	}
+}
+
+func TestRender_MultiPage_GroupsByPrefix(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/full.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	pages, err := Render(doc, Options{Flavor: Plain, Pages: MultiPage})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	names := make([]string, 0, len(pages))
+	for _, p := range pages {
+		names = append(names, p.Name)
+	}
+	want := []string{"index", "payments"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Errorf("got pages %v, want %v", names, want)
+	}
+}
+
+func TestRender_MultiPage_IndexLinksToGroupPages(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/full.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	pages, err := Render(doc, Options{Flavor: Plain, Pages: MultiPage})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	index := pages[0]
+	if index.Name != "index" {
+		t.Fatalf("got first page %q, want index", index.Name)
+	}
+	if !strings.Contains(index.Content, "(payments.md)") {
+		t.Errorf("expected index to link to payments.md, got:\n%s", index.Content)
+	}
+}

--- a/contrib/decree-docs/markdown/testdata/material-multi-index.golden.md
+++ b/contrib/decree-docs/markdown/testdata/material-multi-index.golden.md
@@ -1,0 +1,16 @@
+# Payments Configuration
+
+Payment processing configuration.
+
+**Version:** 3 — Added refund window and webhook controls.
+
+**Author:** platform-team
+
+**Contact:** Pat <pat@example.com>
+
+**Labels:** `team: platform`, `tier: critical`
+
+## Groups
+
+- [payments](payments.md) — 10 fields
+

--- a/contrib/decree-docs/markdown/testdata/material-multi-payments.golden.md
+++ b/contrib/decree-docs/markdown/testdata/material-multi-payments.golden.md
@@ -1,0 +1,109 @@
+# payments
+
+### `payments.api_key`
+
+*type: `string` · format: password*
+
+**🔒 Sensitive** · **🔏 Write-once**
+
+Gateway API key.
+
+### `payments.cutoff`
+
+*type: `time` · nullable*
+
+Daily settlement cutoff.
+
+### Payments Enabled (`payments.enabled`)
+
+*type: `bool` · default: `true`*
+
+Master switch for payment processing.
+
+### `payments.environment`
+
+*type: `string`*
+
+**👁 Read-only**
+
+Deployment environment label.
+
+**Constraints:**
+- Min length: 2
+- Max length: 32
+- Pattern: `^[a-z][a-z0-9-]*$`
+
+### `payments.fee`
+
+*type: `number` · nullable · default: `0.01` · tags: billing, rates*
+
+Per-transaction fee rate.
+
+**Example:** `0.02`
+
+**Examples:**
+
+=== "high"
+
+    **Value:** `0.99`
+
+=== "low"
+
+    **Value:** `0.01`
+
+    Promotional rate
+
+**See also:** [Fee guide](https://docs.example.com/fees)
+
+**Constraints:**
+- Minimum: 0
+- Maximum: 1
+
+### `payments.metadata`
+
+*type: `json`*
+
+Free-form gateway metadata.
+
+**Constraints:**
+- JSON Schema: (see schema definition)
+
+### `payments.mode`
+
+*type: `string` · default: `test`*
+
+**⚠️ Deprecated**
+
+!!! warning "Deprecated"
+    Use `payments.environment` instead.
+
+Processing mode.
+
+**Constraints:**
+- Enum: live, test
+
+### `payments.refund_window`
+
+*type: `duration` · default: `72h`*
+
+Window during which refunds are accepted.
+
+### `payments.retries`
+
+*type: `integer` · default: `3`*
+
+Delivery attempts per webhook event.
+
+**Constraints:**
+- Exclusive minimum: 0
+- Exclusive maximum: 10
+
+### Webhook URL (`payments.webhook`)
+
+*type: `url`*
+
+Endpoint receiving payment events.
+
+**Constraints:**
+- Allowed schemes: https, sftp
+

--- a/contrib/decree-docs/markdown/testdata/material-single.golden.md
+++ b/contrib/decree-docs/markdown/testdata/material-single.golden.md
@@ -1,0 +1,121 @@
+# Payments Configuration
+
+Payment processing configuration.
+
+**Version:** 3 — Added refund window and webhook controls.
+
+**Author:** platform-team
+
+**Contact:** Pat <pat@example.com>
+
+**Labels:** `team: platform`, `tier: critical`
+
+## payments
+
+### `payments.api_key`
+
+*type: `string` · format: password*
+
+**🔒 Sensitive** · **🔏 Write-once**
+
+Gateway API key.
+
+### `payments.cutoff`
+
+*type: `time` · nullable*
+
+Daily settlement cutoff.
+
+### Payments Enabled (`payments.enabled`)
+
+*type: `bool` · default: `true`*
+
+Master switch for payment processing.
+
+### `payments.environment`
+
+*type: `string`*
+
+**👁 Read-only**
+
+Deployment environment label.
+
+**Constraints:**
+- Min length: 2
+- Max length: 32
+- Pattern: `^[a-z][a-z0-9-]*$`
+
+### `payments.fee`
+
+*type: `number` · nullable · default: `0.01` · tags: billing, rates*
+
+Per-transaction fee rate.
+
+**Example:** `0.02`
+
+**Examples:**
+
+=== "high"
+
+    **Value:** `0.99`
+
+=== "low"
+
+    **Value:** `0.01`
+
+    Promotional rate
+
+**See also:** [Fee guide](https://docs.example.com/fees)
+
+**Constraints:**
+- Minimum: 0
+- Maximum: 1
+
+### `payments.metadata`
+
+*type: `json`*
+
+Free-form gateway metadata.
+
+**Constraints:**
+- JSON Schema: (see schema definition)
+
+### `payments.mode`
+
+*type: `string` · default: `test`*
+
+**⚠️ Deprecated**
+
+!!! warning "Deprecated"
+    Use `payments.environment` instead.
+
+Processing mode.
+
+**Constraints:**
+- Enum: live, test
+
+### `payments.refund_window`
+
+*type: `duration` · default: `72h`*
+
+Window during which refunds are accepted.
+
+### `payments.retries`
+
+*type: `integer` · default: `3`*
+
+Delivery attempts per webhook event.
+
+**Constraints:**
+- Exclusive minimum: 0
+- Exclusive maximum: 10
+
+### Webhook URL (`payments.webhook`)
+
+*type: `url`*
+
+Endpoint receiving payment events.
+
+**Constraints:**
+- Allowed schemes: https, sftp
+

--- a/contrib/decree-docs/markdown/testdata/plain-multi-index.golden.md
+++ b/contrib/decree-docs/markdown/testdata/plain-multi-index.golden.md
@@ -1,0 +1,16 @@
+# Payments Configuration
+
+Payment processing configuration.
+
+**Version:** 3 — Added refund window and webhook controls.
+
+**Author:** platform-team
+
+**Contact:** Pat <pat@example.com>
+
+**Labels:** `team: platform`, `tier: critical`
+
+## Groups
+
+- [payments](payments.md) — 10 fields
+

--- a/contrib/decree-docs/markdown/testdata/plain-multi-payments.golden.md
+++ b/contrib/decree-docs/markdown/testdata/plain-multi-payments.golden.md
@@ -1,0 +1,100 @@
+# payments
+
+### `payments.api_key`
+
+*type: `string` · format: password*
+
+**Sensitive** · **Write-once**
+
+Gateway API key.
+
+### `payments.cutoff`
+
+*type: `time` · nullable*
+
+Daily settlement cutoff.
+
+### Payments Enabled (`payments.enabled`)
+
+*type: `bool` · default: `true`*
+
+Master switch for payment processing.
+
+### `payments.environment`
+
+*type: `string`*
+
+**Read-only**
+
+Deployment environment label.
+
+**Constraints:**
+- Min length: 2
+- Max length: 32
+- Pattern: `^[a-z][a-z0-9-]*$`
+
+### `payments.fee`
+
+*type: `number` · nullable · default: `0.01` · tags: billing, rates*
+
+Per-transaction fee rate.
+
+**Example:** `0.02`
+
+**Examples:**
+- **high:** `0.99`
+- **low:** `0.01` — Promotional rate
+
+**See also:** [Fee guide](https://docs.example.com/fees)
+
+**Constraints:**
+- Minimum: 0
+- Maximum: 1
+
+### `payments.metadata`
+
+*type: `json`*
+
+Free-form gateway metadata.
+
+**Constraints:**
+- JSON Schema: (see schema definition)
+
+### `payments.mode`
+
+*type: `string` · default: `test`*
+
+**Deprecated**
+
+> **Deprecated** — Use `payments.environment` instead.
+
+Processing mode.
+
+**Constraints:**
+- Enum: live, test
+
+### `payments.refund_window`
+
+*type: `duration` · default: `72h`*
+
+Window during which refunds are accepted.
+
+### `payments.retries`
+
+*type: `integer` · default: `3`*
+
+Delivery attempts per webhook event.
+
+**Constraints:**
+- Exclusive minimum: 0
+- Exclusive maximum: 10
+
+### Webhook URL (`payments.webhook`)
+
+*type: `url`*
+
+Endpoint receiving payment events.
+
+**Constraints:**
+- Allowed schemes: https, sftp
+

--- a/contrib/decree-docs/markdown/testdata/plain-single.golden.md
+++ b/contrib/decree-docs/markdown/testdata/plain-single.golden.md
@@ -1,0 +1,112 @@
+# Payments Configuration
+
+Payment processing configuration.
+
+**Version:** 3 — Added refund window and webhook controls.
+
+**Author:** platform-team
+
+**Contact:** Pat <pat@example.com>
+
+**Labels:** `team: platform`, `tier: critical`
+
+## payments
+
+### `payments.api_key`
+
+*type: `string` · format: password*
+
+**Sensitive** · **Write-once**
+
+Gateway API key.
+
+### `payments.cutoff`
+
+*type: `time` · nullable*
+
+Daily settlement cutoff.
+
+### Payments Enabled (`payments.enabled`)
+
+*type: `bool` · default: `true`*
+
+Master switch for payment processing.
+
+### `payments.environment`
+
+*type: `string`*
+
+**Read-only**
+
+Deployment environment label.
+
+**Constraints:**
+- Min length: 2
+- Max length: 32
+- Pattern: `^[a-z][a-z0-9-]*$`
+
+### `payments.fee`
+
+*type: `number` · nullable · default: `0.01` · tags: billing, rates*
+
+Per-transaction fee rate.
+
+**Example:** `0.02`
+
+**Examples:**
+- **high:** `0.99`
+- **low:** `0.01` — Promotional rate
+
+**See also:** [Fee guide](https://docs.example.com/fees)
+
+**Constraints:**
+- Minimum: 0
+- Maximum: 1
+
+### `payments.metadata`
+
+*type: `json`*
+
+Free-form gateway metadata.
+
+**Constraints:**
+- JSON Schema: (see schema definition)
+
+### `payments.mode`
+
+*type: `string` · default: `test`*
+
+**Deprecated**
+
+> **Deprecated** — Use `payments.environment` instead.
+
+Processing mode.
+
+**Constraints:**
+- Enum: live, test
+
+### `payments.refund_window`
+
+*type: `duration` · default: `72h`*
+
+Window during which refunds are accepted.
+
+### `payments.retries`
+
+*type: `integer` · default: `3`*
+
+Delivery attempts per webhook event.
+
+**Constraints:**
+- Exclusive minimum: 0
+- Exclusive maximum: 10
+
+### Webhook URL (`payments.webhook`)
+
+*type: `url`*
+
+Endpoint receiving payment events.
+
+**Constraints:**
+- Allowed schemes: https, sftp
+


### PR DESCRIPTION
## Summary

- Adds `--format md` to `decree-docs generate`, the first non-JSON rendering backend, alongside the existing JSON doc model output.
- `--flavor plain` emits portable CommonMark; `--flavor material` uses the `admonition` and `pymdownx.tabbed` MkDocs Material extensions this repo's `mkdocs.yml` already enables (deprecation notices as admonitions, fields with two or more named examples as content tabs).
- Deprecated, sensitive, read-only, and write-once fields render as a bold badge line distinct from the type/format meta line, so they're visually identifiable at a glance; material adds an icon per badge.
- `--pages single` (default) renders one page; `--pages multi` renders an index page plus one page per top-level field-path-prefix group, mirroring the grouping `sdk/tools/docgen` already uses.

## Test plan

- [x] Golden-file tests cover all four flavor x page-mode combinations against the full fixture schema.
- [x] Edge-case tests cover branches the fixtures don't otherwise reach (bare version, contact variants, description-less externalDocs, empty constraints, fractional constraint values, singular-field groups).
- [x] CLI tests cover flag validation (unknown flavor/pages), stdout vs `--out-dir` routing, and `--out-dir` error paths.
- [x] `make pre-commit` passes; `contrib/decree-docs` coverage is 99.4% (threshold 99.0%).
- [x] `/before-pr` checklist passes (docs regen, proto lint, env-var check).

Closes #915