### PR TITLE
feat(decree-docs): render CEL validation rules in md backend

### DIFF
--- a/contrib/decree-docs/markdown/markdown.go
+++ b/contrib/decree-docs/markdown/markdown.go
@@ -4,15 +4,24 @@
 // Two flavors are supported. "plain" emits portable CommonMark. "material"
 // emits Markdown that additionally relies on the MkDocs Material extensions
 // this repo's mkdocs.yml already enables: admonition blocks for deprecation
-// notices, and pymdownx.tabbed content tabs for fields with two or more
-// named examples. In both flavors, field flags (deprecated, sensitive,
-// read-only, write-once) render as a bold badge line distinct from the
-// field's type/format meta line; material adds an icon per badge.
+// notices and validation severity, and pymdownx.tabbed content tabs for
+// fields with two or more named examples. In both flavors, field flags
+// (deprecated, sensitive, read-only, write-once) render as a bold badge line
+// distinct from the field's type/format meta line; material adds an icon
+// per badge.
 //
 // Two page modes are supported. [SinglePage] renders the whole schema as one
 // page. [MultiPage] renders an index page plus one page per top-level
 // path-prefix group (the same grouping sdk/tools/docgen uses for "##"
 // sections), each holding the fields under that group.
+//
+// Schema-level cross-field validation rules ([docmodel.Schema.Validations])
+// render as a "## Validations" section on the single page (right after the
+// header) or on the multi-page index (since a rule can span multiple
+// groups). Each rule's CEL expression renders as an untagged fenced code
+// block — CEL isn't a Prism/standard-highlighter language, so tagging the
+// fence would invite a wrong language guess and mismatched-keyword
+// highlighting.
 package markdown
 
 import (
@@ -72,6 +81,7 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 	case SinglePage, "":
 		var b strings.Builder
 		writeHeader(&b, doc.Schema)
+		writeValidations(&b, doc.Schema.Validations, opts.Flavor)
 		for _, g := range groups {
 			fmt.Fprintf(&b, "## %s\n\n", g.prefix)
 			for _, f := range g.fields {
@@ -80,7 +90,7 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 		}
 		return []Page{{Name: "index", Content: b.String()}}, nil
 	case MultiPage:
-		pages := []Page{indexPage(doc.Schema, groups)}
+		pages := []Page{indexPage(doc.Schema, groups, opts.Flavor)}
 		for _, g := range groups {
 			var b strings.Builder
 			fmt.Fprintf(&b, "# %s\n\n", g.prefix)
@@ -95,9 +105,10 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 	}
 }
 
-func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
+func indexPage(s docmodel.Schema, groups []fieldGroup, flavor Flavor) Page {
 	var b strings.Builder
 	writeHeader(&b, s)
+	writeValidations(&b, s.Validations, flavor)
 	fmt.Fprintln(&b, "## Groups")
 	fmt.Fprintln(&b)
 	for _, g := range groups {
@@ -288,6 +299,47 @@ func writeDeprecationNotice(b *strings.Builder, f docmodel.Field, flavor Flavor)
 		return
 	}
 	fmt.Fprintf(b, "> **Deprecated** — %s\n\n", body)
+}
+
+// writeValidations renders the schema's cross-field CEL validation rules as
+// a list, one entry per rule: the rule expression as a fenced code block
+// (deliberately untagged — CEL isn't a Prism/standard-highlighter language,
+// so an untagged fence avoids mismatched-keyword highlighting from a wrong
+// language guess) followed by the human-readable message. Severity is
+// distinguished using the same admonition/blockquote treatment as
+// writeDeprecationNotice: material gets a `!!!` admonition (error or
+// warning), plain gets a bold-prefixed blockquote.
+func writeValidations(b *strings.Builder, validations []docmodel.Validation, flavor Flavor) {
+	if len(validations) == 0 {
+		return
+	}
+	fmt.Fprintln(b, "## Validations")
+	fmt.Fprintln(b)
+	for _, v := range validations {
+		fmt.Fprintln(b, "```")
+		fmt.Fprintln(b, v.Rule)
+		fmt.Fprintln(b, "```")
+		fmt.Fprintln(b)
+		writeValidationMessage(b, v, flavor)
+	}
+}
+
+// writeValidationMessage renders a validation's message with its severity
+// visually distinguished, mirroring writeDeprecationNotice's admonition
+// (material) / blockquote (plain) pattern.
+func writeValidationMessage(b *strings.Builder, v docmodel.Validation, flavor Flavor) {
+	label := "Warning"
+	admonition := "warning"
+	if v.Severity == "error" {
+		label = "Error"
+		admonition = "error"
+	}
+	if flavor == Material {
+		fmt.Fprintf(b, "!!! %s %q\n", admonition, label)
+		fmt.Fprintf(b, "    %s\n\n", v.Message)
+		return
+	}
+	fmt.Fprintf(b, "> **%s** — %s\n\n", label, v.Message)
 }
 
 func writeExamples(b *strings.Builder, f docmodel.Field, flavor Flavor) {

--- a/contrib/decree-docs/markdown/markdown_test.go
+++ b/contrib/decree-docs/markdown/markdown_test.go
@@ -180,6 +180,118 @@ func TestRender_EdgeCases(t *testing.T) {
 	}
 }
 
+// TestRender_Validations_Golden pins rendering of schema-level CEL
+// validation rules (added in #958): both flavors, with one error-severity
+// and one warning-severity rule to exercise the severity distinction.
+func TestRender_Validations_Golden(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "payments",
+		Fields: []docmodel.Field{
+			{Path: "payments.fee", Type: "number"},
+			{Path: "payments.retries", Type: "integer"},
+		},
+		Validations: []docmodel.Validation{
+			{
+				Rule:     "self.payments.fee < self.payments.retries",
+				Message:  "Fee rate must be less than the retry count.",
+				Severity: "error",
+			},
+			{
+				Rule:     `self.payments.webhook.startsWith("https://")`,
+				Message:  "Webhook URLs should use https.",
+				Severity: "warning",
+			},
+		},
+	})
+
+	tests := []struct {
+		name   string
+		flavor Flavor
+		golden string
+	}{
+		{name: "plain", flavor: Plain, golden: "testdata/validations-plain.golden.md"},
+		{name: "material", flavor: Material, golden: "testdata/validations-material.golden.md"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pages, err := Render(doc, Options{Flavor: tt.flavor, Pages: SinglePage})
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			content := pages[0].Content
+			if *update {
+				if err := os.WriteFile(tt.golden, []byte(content), 0o644); err != nil {
+					t.Fatalf("update golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(tt.golden)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			if content != string(want) {
+				t.Errorf("content does not match %s:\ngot:\n%s\nwant:\n%s", tt.golden, content, want)
+			}
+		})
+	}
+}
+
+// TestRender_NoValidations ensures schemas with no validations render no
+// "## Validations" section, in both single- and multi-page modes.
+func TestRender_NoValidations(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	for _, pages := range []PageMode{SinglePage, MultiPage} {
+		rendered, err := Render(doc, Options{Flavor: Plain, Pages: pages})
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		for _, p := range rendered {
+			if strings.Contains(p.Content, "Validations") {
+				t.Errorf("unexpected Validations section in page %q:\n%s", p.Name, p.Content)
+			}
+		}
+	}
+}
+
+// TestRender_Validations_MultiPageIndex ensures validations render on the
+// multi-page index (not on a group page), since a rule can span fields in
+// more than one group.
+func TestRender_Validations_MultiPageIndex(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "payments",
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+			{Path: "beta.value", Type: "string"},
+		},
+		Validations: []docmodel.Validation{
+			{Rule: "self.alpha.value != self.beta.value", Message: "alpha and beta must differ.", Severity: "error"},
+		},
+	})
+
+	pages, err := Render(doc, Options{Flavor: Plain, Pages: MultiPage})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var index, alpha string
+	for _, p := range pages {
+		switch p.Name {
+		case "index":
+			index = p.Content
+		case "alpha":
+			alpha = p.Content
+		}
+	}
+	if !strings.Contains(index, "## Validations") {
+		t.Errorf("expected Validations section on index page, got:\n%s", index)
+	}
+	if strings.Contains(alpha, "Validations") {
+		t.Errorf("unexpected Validations section on group page, got:\n%s", alpha)
+	}
+}
+
 func TestRender_NameOnlyContact(t *testing.T) {
 	doc := docmodel.New(docmodel.Schema{
 		Name: "edge",

--- a/contrib/decree-docs/markdown/testdata/validations-material.golden.md
+++ b/contrib/decree-docs/markdown/testdata/validations-material.golden.md
@@ -1,0 +1,28 @@
+# payments
+
+## Validations
+
+```
+self.payments.fee < self.payments.retries
+```
+
+!!! error "Error"
+    Fee rate must be less than the retry count.
+
+```
+self.payments.webhook.startsWith("https://")
+```
+
+!!! warning "Warning"
+    Webhook URLs should use https.
+
+## payments
+
+### `payments.fee`
+
+*type: `number`*
+
+### `payments.retries`
+
+*type: `integer`*
+

--- a/contrib/decree-docs/markdown/testdata/validations-plain.golden.md
+++ b/contrib/decree-docs/markdown/testdata/validations-plain.golden.md
@@ -1,0 +1,26 @@
+# payments
+
+## Validations
+
+```
+self.payments.fee < self.payments.retries
+```
+
+> **Error** — Fee rate must be less than the retry count.
+
+```
+self.payments.webhook.startsWith("https://")
+```
+
+> **Warning** — Webhook URLs should use https.
+
+## payments
+
+### `payments.fee`
+
+*type: `number`*
+
+### `payments.retries`
+
+*type: `integer`*
+


### PR DESCRIPTION
## Summary
- The md backend had no way to render the schema-level CEL validation rules added to the doc model in #957.
- Renders a "## Validations" section (single page: after the header; multi-page: on the index, since a rule can span groups). Each rule's expression is an untagged fenced code block (CEL isn't a Prism language, so an untagged fence avoids a wrong language guess); severity is distinguished using the existing deprecation-notice admonition/blockquote pattern (material/plain).

## Test plan
- `go build ./...` and `go test ./...` pass in `contrib/decree-docs`.
- New golden files (plain + material) for a schema with an error- and a warning-severity rule.
- Tests confirm no Validations section renders when there are none, and multi-page validations land on the index page only.
- `gofmt -l` clean; `golangci-lint run ./markdown/...` clean.

Closes #958