### PR TITLE
feat(decree-docs): add mdx backend for Docusaurus

### DIFF
--- a/contrib/decree-docs/README.md
+++ b/contrib/decree-docs/README.md
@@ -4,7 +4,7 @@ A standalone, multi-format documentation generator for decree schemas. It loads 
 
 > **Alpha**: This module is part of the OpenDecree alpha release. The CLI and output formats may change.
 
-> **Status**: in development — this build loads schemas from local YAML files and emits the json, md, and html documentation formats. The mdx backend, server mode, and the config/template system land in upcoming releases.
+> **Status**: in development — this build loads schemas from local YAML files and emits the json, md, mdx, and html documentation formats. Server mode and the config/template system land in upcoming releases.
 
 `decree-docs` lives under `contrib/` (standalone tools built on decree), as opposed to `sdk/contrib/` (SDK framework adapters such as viper, koanf, and envconfig). It composes on top of the minimal, zero-dependency `sdk/tools/docgen` library rather than replacing it.
 
@@ -26,6 +26,7 @@ decree-docs generate --file decree.schema.yaml --format md --flavor material
 decree-docs generate --file decree.schema.yaml --format md --pages multi --out-dir docs/
 decree-docs generate --file decree.schema.yaml --format html --theme dark
 decree-docs generate --file decree.schema.yaml --format html --css brand.css --out-dir docs/
+decree-docs generate --file decree.schema.yaml --format mdx --out-dir docs/
 decree-docs --help
 decree-docs version
 ```
@@ -84,6 +85,16 @@ The page anatomy (left nav grouped by field-path prefix, content pane of per-fie
 
 `--format html` always renders to a single file: stdout, or `<out-dir>/index.html` with `--out-dir`.
 
+## The mdx format
+
+`--format mdx` renders a Docusaurus-compatible doc tree: an `index.mdx` overview page, plus one category folder per top-level field-path-prefix group, each holding a `_category_.json` (sidebar label and position) and an `index.mdx` with that group's fields. Drop the tree directly into a Docusaurus `docs/` folder. `--out-dir` is required — there is no single-file/stdout mode, since the format only makes sense as a directory tree.
+
+MDX v3 parses `{` and `<` as the start of a JSX expression or tag, so every piece of schema-sourced text (descriptions, examples, enum values, defaults, patterns, tags) is neutralized before it reaches the output: prose is backslash-escaped (also defanging `<!--` HTML-comment sequences), and values that are naturally code-like (examples, defaults, enum members, patterns) are wrapped in backticks as a code span instead, which MDX reads as literal text. Deprecated fields render as a `:::caution[Deprecated]` admonition; sensitive/nullable/read-only/write-once fields get a badge line under the field heading.
+
+```sh
+decree-docs generate --file decree.schema.yaml --format mdx --out-dir docs/
+```
+
 ## Testing
 
 ```sh
@@ -91,4 +102,5 @@ go test ./...
 go test . -run TestGenerate_JSONGolden -update          # rewrite CLI JSON golden files
 go test ./markdown -run TestRender_Golden -update       # rewrite markdown golden files
 go test ./html -run TestRender_Golden -update           # rewrite html golden files
+go test ./mdx -run TestRender_Golden -update            # rewrite mdx golden files
 ```

--- a/contrib/decree-docs/generate.go
+++ b/contrib/decree-docs/generate.go
@@ -14,11 +14,11 @@ import (
 	"github.com/opendecree/decree/contrib/decree-docs/html"
 	"github.com/opendecree/decree/contrib/decree-docs/loader"
 	"github.com/opendecree/decree/contrib/decree-docs/markdown"
+	"github.com/opendecree/decree/contrib/decree-docs/mdx"
 )
 
-// docFormats lists the formats generate can emit. The mdx backend lands in
-// an upcoming release (#917).
-var docFormats = []string{"json", "md", "html"}
+// docFormats lists the formats generate can emit.
+var docFormats = []string{"json", "md", "html", "mdx"}
 
 // mdFlavors lists the --flavor values valid with --format md.
 var mdFlavors = []string{string(markdown.Plain), string(markdown.Material)}
@@ -53,7 +53,12 @@ external assets, no network requests) to stdout or to <out-dir>/index.html
 with --out-dir. --theme selects a built-in color scheme (light, dark, or
 auto, which follows the reader's OS preference). --css <file> appends the
 file's contents in a trailing CSS cascade layer, so user overrides take
-precedence over the built-in theme without needing !important.`,
+precedence over the built-in theme without needing !important.
+
+The mdx format renders a Docusaurus-compatible doc tree to <out-dir>: an
+index.mdx overview page, plus one category folder per top-level field group,
+each with a _category_.json (sidebar label and position) and an index.mdx.
+--out-dir is required. Drop the tree into a Docusaurus docs/ folder.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runGenerate,
 }
@@ -107,6 +112,8 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return runGenerateMD(cmd, doc)
 	case "html":
 		return runGenerateHTML(cmd, doc)
+	case "mdx":
+		return runGenerateMDX(cmd, doc)
 	default:
 		return doc.EncodeJSON(cmd.OutOrStdout())
 	}
@@ -181,6 +188,28 @@ func runGenerateHTML(cmd *cobra.Command, doc *docmodel.Document) error {
 	path := filepath.Join(outDir, "index.html")
 	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+func runGenerateMDX(cmd *cobra.Command, doc *docmodel.Document) error {
+	outDir, _ := cmd.Flags().GetString("out-dir")
+	if outDir == "" {
+		return fmt.Errorf("--out-dir is required for mdx output")
+	}
+
+	pages, err := mdx.Render(doc)
+	if err != nil {
+		return err
+	}
+	for _, p := range pages {
+		path := filepath.Join(outDir, p.Path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(p.Content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
 	}
 	return nil
 }

--- a/contrib/decree-docs/generate_test.go
+++ b/contrib/decree-docs/generate_test.go
@@ -402,6 +402,74 @@ func TestGenerate_HTML_WriteFileError(t *testing.T) {
 	}
 }
 
+func TestGenerate_MDX_RequiresOutDir(t *testing.T) {
+	code, stdout, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "mdx")
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "--out-dir is required") {
+		t.Errorf("expected out-dir-required error, got %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout, got %q", stdout)
+	}
+}
+
+func TestGenerate_MDX_WritesTree(t *testing.T) {
+	outDir := t.TempDir()
+	code, stdout, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/full.schema.yaml", "--format", "mdx", "--out-dir", outDir)
+	if code != 0 {
+		t.Fatalf("got exit code %d, want 0 (stderr: %s)", code, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("expected empty stdout when writing to --out-dir, got %q", stdout)
+	}
+	for _, name := range []string{"index.mdx", "payments/_category_.json", "payments/index.mdx"} {
+		path := filepath.Join(outDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("expected %s to be written: %v", path, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("expected %s to be non-empty", path)
+		}
+	}
+}
+
+func TestGenerate_MDX_OutDirNotADirectory(t *testing.T) {
+	outDir := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(outDir, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "mdx", "--out-dir", filepath.Join(outDir, "docs"))
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "create") {
+		t.Errorf("expected create error, got %q", stderr)
+	}
+}
+
+func TestGenerate_MDX_WriteFileError(t *testing.T) {
+	outDir := t.TempDir()
+	// index.mdx as a directory makes the write to that path fail.
+	if err := os.Mkdir(filepath.Join(outDir, "index.mdx"), 0o755); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+	code, _, stderr := runGenerateCLI(t,
+		"generate", "--file", "testdata/minimal.schema.yaml", "--format", "mdx", "--out-dir", outDir)
+	if code != 1 {
+		t.Errorf("got exit code %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "write") {
+		t.Errorf("expected write error, got %q", stderr)
+	}
+}
+
 func TestGenerate_InvalidSchema(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bad.yaml")
 	if err := os.WriteFile(path, []byte("name: no-spec-version\n"), 0o600); err != nil {

--- a/contrib/decree-docs/mdx/mdx.go
+++ b/contrib/decree-docs/mdx/mdx.go
@@ -1,0 +1,482 @@
+// Package mdx renders a decree-docs documentation model
+// ([docmodel.Document]) as Docusaurus-compatible MDX.
+//
+// Render emits a doc tree, not a single file: an index.mdx overview page,
+// plus one category folder per top-level path-prefix group, each holding a
+// _category_.json (sidebar label + position) and an index.mdx with that
+// group's fields. The tree drops directly into a Docusaurus docs/ folder.
+//
+// MDX v3 parses '{' and '<' as the start of a JSX expression or tag, so
+// every piece of schema-sourced text (descriptions, examples, enum values,
+// defaults, patterns, tags) must be neutralized before it reaches the
+// output: prose runs through [escapeText], which backslash-escapes '{',
+// '<', '`', and '\' (escaping '<' also defangs "<!--" HTML-comment
+// sequences); values that are naturally code-like run through [codeSpan]
+// instead, which wraps them in backticks — a code span's content is read as
+// literal text and not reparsed as MDX, the standard escaping technique for
+// this class of generator.
+package mdx
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+)
+
+// Page is one file in the rendered MDX tree.
+type Page struct {
+	// Path is the file's path relative to the output root, e.g.
+	// "index.mdx" or "auth/_category_.json".
+	Path string
+	// Content is the file's contents.
+	Content string
+}
+
+// Render renders doc as a Docusaurus MDX doc tree.
+func Render(doc *docmodel.Document) ([]Page, error) {
+	groups := groupByPrefix(doc.Schema.Fields)
+
+	pages := make([]Page, 0, 1+2*len(groups))
+	pages = append(pages, indexPage(doc.Schema, groups))
+	for i, g := range groups {
+		position := i + 1
+		pages = append(pages, categoryFile(g.prefix, position))
+		pages = append(pages, groupPage(g))
+	}
+	return pages, nil
+}
+
+func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
+	title := s.Name
+	if s.Info != nil && s.Info.Title != "" {
+		title = s.Info.Title
+	}
+
+	var b strings.Builder
+	writeFrontmatter(&b, "index", title, "Overview", 0)
+
+	if s.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", escapeText(s.Description))
+	}
+	if s.Version > 0 {
+		if s.VersionDescription != "" {
+			fmt.Fprintf(&b, "**Version:** %d — %s\n\n", s.Version, escapeText(s.VersionDescription))
+		} else {
+			fmt.Fprintf(&b, "**Version:** %d\n\n", s.Version)
+		}
+	}
+	if s.Info != nil {
+		writeInfo(&b, s.Info)
+	}
+
+	fmt.Fprintln(&b, "## Groups")
+	fmt.Fprintln(&b)
+	for _, g := range groups {
+		noun := "fields"
+		if len(g.fields) == 1 {
+			noun = "field"
+		}
+		fmt.Fprintf(&b, "- [%s](./%s/index) — %d %s\n", escapeText(g.prefix), g.prefix, len(g.fields), noun)
+	}
+	fmt.Fprintln(&b)
+
+	return Page{Path: "index.mdx", Content: b.String()}
+}
+
+func writeInfo(b *strings.Builder, info *docmodel.Info) {
+	if info.Author != "" {
+		fmt.Fprintf(b, "**Author:** %s\n\n", escapeText(info.Author))
+	}
+	if c := info.Contact; c != nil {
+		switch {
+		case c.Email != "":
+			fmt.Fprintf(b, "**Contact:** [%s](mailto:%s)\n\n", escapeText(c.Name), c.Email)
+		case c.URL != "":
+			fmt.Fprintf(b, "**Contact:** [%s](%s)\n\n", escapeText(c.Name), c.URL)
+		case c.Name != "":
+			fmt.Fprintf(b, "**Contact:** %s\n\n", escapeText(c.Name))
+		}
+	}
+	if len(info.Labels) > 0 {
+		labels := make([]string, 0, len(info.Labels))
+		for k, v := range info.Labels {
+			labels = append(labels, codeSpan(fmt.Sprintf("%s: %s", k, v)))
+		}
+		sort.Strings(labels)
+		fmt.Fprintf(b, "**Labels:** %s\n\n", strings.Join(labels, ", "))
+	}
+}
+
+func categoryFile(prefix string, position int) Page {
+	label := jsonString(prefix)
+	content := fmt.Sprintf("{\n  \"label\": %s,\n  \"position\": %d\n}\n", label, position)
+	return Page{Path: prefix + "/_category_.json", Content: content}
+}
+
+func groupPage(g fieldGroup) Page {
+	var b strings.Builder
+	writeFrontmatter(&b, "index", g.prefix, g.prefix, 1)
+	for i, f := range g.fields {
+		if i > 0 {
+			fmt.Fprintln(&b, "---")
+			fmt.Fprintln(&b)
+		}
+		writeField(&b, f)
+	}
+	return Page{Path: g.prefix + "/index.mdx", Content: b.String()}
+}
+
+func writeFrontmatter(b *strings.Builder, id, title, sidebarLabel string, position int) {
+	fmt.Fprintln(b, "---")
+	fmt.Fprintf(b, "id: %s\n", yamlQuote(id))
+	fmt.Fprintf(b, "title: %s\n", yamlQuote(title))
+	fmt.Fprintf(b, "sidebar_label: %s\n", yamlQuote(sidebarLabel))
+	fmt.Fprintf(b, "sidebar_position: %d\n", position)
+	fmt.Fprintln(b, "---")
+	fmt.Fprintln(b)
+}
+
+// --- Grouping ---
+
+type fieldGroup struct {
+	prefix string
+	fields []docmodel.Field
+}
+
+// groupByPrefix groups fields by their top-level path prefix. fields is
+// assumed sorted by path (docmodel guarantees this), so the first occurrence
+// of each prefix establishes deterministic group order.
+func groupByPrefix(fields []docmodel.Field) []fieldGroup {
+	var groups []fieldGroup
+	index := make(map[string]int)
+	for _, f := range fields {
+		prefix := f.Path
+		if i := strings.IndexByte(f.Path, '.'); i > 0 {
+			prefix = f.Path[:i]
+		}
+		if i, ok := index[prefix]; ok {
+			groups[i].fields = append(groups[i].fields, f)
+		} else {
+			index[prefix] = len(groups)
+			groups = append(groups, fieldGroup{prefix: prefix, fields: []docmodel.Field{f}})
+		}
+	}
+	return groups
+}
+
+// --- Fields ---
+
+func writeField(b *strings.Builder, f docmodel.Field) {
+	// The heading is always the bare path, never "Title (path)" — a mixed
+	// format makes the right-hand TOC wrap unevenly and gives the page two
+	// different scanning rhythms. Title (when set) becomes a line under the
+	// heading instead, so the data isn't lost.
+	fmt.Fprintf(b, "### %s\n", monoHeading(f.Path))
+	if f.Title != "" {
+		fmt.Fprintf(b, "%s\n", escapeText(f.Title))
+	}
+
+	// nameBadges render on their own line directly under the heading, not
+	// inside it — Docusaurus's right-hand TOC pulls its labels straight from
+	// the heading's rendered content, so any HTML embedded in the "###" line
+	// itself leaks into the sidebar too.
+	var nameBadges []string
+	if f.Nullable {
+		nameBadges = append(nameBadges, pill("Nullable", "outline"))
+	}
+	if f.ReadOnly {
+		nameBadges = append(nameBadges, pill("Read-only", "outline"))
+	}
+	if f.WriteOnce {
+		nameBadges = append(nameBadges, pill("Write-once", "info"))
+	}
+	if f.Sensitive {
+		nameBadges = append(nameBadges, pill("Sensitive", "danger"))
+	}
+	if len(nameBadges) > 0 {
+		fmt.Fprintf(b, "%s\n", strings.Join(nameBadges, " "))
+	}
+	fmt.Fprintln(b)
+
+	if f.Description != "" {
+		fmt.Fprintf(b, "%s\n\n", escapeText(f.Description))
+	}
+
+	fmt.Fprintf(b, "%s\n\n", fieldMeta(f))
+
+	if f.Deprecated {
+		writeDeprecationNotice(b, f)
+	}
+
+	writeExamples(b, f)
+
+	if f.ExternalDocs != nil && f.ExternalDocs.URL != "" {
+		if f.ExternalDocs.Description != "" {
+			fmt.Fprintf(b, "**See also:** [%s](%s)\n\n", escapeText(f.ExternalDocs.Description), f.ExternalDocs.URL)
+		} else {
+			fmt.Fprintf(b, "**See also:** %s\n\n", f.ExternalDocs.URL)
+		}
+	}
+
+	if f.Constraints != nil {
+		writeConstraints(b, f.Constraints)
+	}
+}
+
+// fieldMeta renders a field's type and remaining metadata as a single
+// upright (non-italic) line — italic monospace fights itself legibly, and
+// upright with monospace value chips is the convention API references like
+// Stripe and Prisma use. type is a plain code chip, not a pill — it
+// identifies the field rather than flagging a state, so it doesn't need a
+// color. The nullable/read-only/write-once/sensitive flags sit next to the
+// field name instead (see writeField) and deprecated gets its own
+// admonition (see writeDeprecationNotice).
+func fieldMeta(f docmodel.Field) string {
+	parts := []string{fmt.Sprintf("type %s", codeSpan(f.Type))}
+	if f.Format != "" {
+		parts = append(parts, fmt.Sprintf("format %s", codeSpan(f.Format)))
+	}
+	if f.Default != "" {
+		parts = append(parts, fmt.Sprintf("default %s", codeSpan(f.Default)))
+	}
+	if len(f.Tags) > 0 {
+		tags := make([]string, len(f.Tags))
+		for i, t := range f.Tags {
+			tags[i] = codeSpan(t)
+		}
+		parts = append(parts, fmt.Sprintf("tags %s", strings.Join(tags, " ")))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// pillTitles holds the tooltip text (HTML title attribute) shown on hover
+// for each fixed pill label.
+var pillTitles = map[string]string{
+	"Nullable":   "Accepts a null value",
+	"Read-only":  "Clients cannot write this field",
+	"Write-once": "Can only be set once; immutable after that",
+	"Sensitive":  "Value is not displayed in clear text",
+}
+
+// pill renders a colored badge. label is always one of this package's own
+// fixed strings, never schema-sourced text, so it needs no escaping. The
+// HTML title attribute gives a native hover tooltip with no extra JS or
+// component.
+//
+// variant "outline" is a muted low-emphasis style for flags that are just
+// FYI properties (nullable, read-only), not states worth alarm — it's a
+// custom inline style rather than Infima's badge--secondary class, because
+// badge--secondary renders as a near-white solid fill in dark mode, making
+// the least urgent flag the loudest thing on the card. The inline style
+// uses Infima's emphasis CSS variables so it still adapts to the host
+// site's light/dark theme. Other variants use Infima's built-in
+// badge--<variant> classes — the same CSS Docusaurus already ships
+// globally — since those colors (danger/info/...) are semantically fixed
+// regardless of the site's brand color, unlike badge--primary/secondary.
+func pill(label, variant string) string {
+	if variant == "outline" {
+		style := "background:transparent;border:1px solid var(--ifm-color-emphasis-400);" +
+			"color:var(--ifm-color-emphasis-700);border-radius:var(--ifm-badge-border-radius,0.4rem);" +
+			"padding:0.2em 0.6em;font-size:0.75em;font-weight:700"
+		return fmt.Sprintf(`<span style={{%s}} title="%s">%s</span>`, jsxStyle(style), pillTitles[label], label)
+	}
+	return fmt.Sprintf(`<span className="badge badge--%s" title="%s">%s</span>`, variant, pillTitles[label], label)
+}
+
+// jsxStyle converts a CSS declaration string ("a:b;c:d") into a JSX object
+// literal body ('"a": "b", "c": "d"') for use in a style={{...}} attribute —
+// MDX/JSX requires style as an object, not a CSS string like plain HTML.
+func jsxStyle(css string) string {
+	decls := strings.Split(strings.TrimSuffix(css, ";"), ";")
+	pairs := make([]string, 0, len(decls))
+	for _, d := range decls {
+		k, v, _ := strings.Cut(d, ":")
+		pairs = append(pairs, fmt.Sprintf(`"%s": "%s"`, strings.TrimSpace(k), strings.TrimSpace(v)))
+	}
+	return strings.Join(pairs, ", ")
+}
+
+// monoHeading renders a field path as bold monospace text without the
+// <code> chip background a markdown backtick span would give it — a
+// heading shouldn't look like a code block, it should read as a heading
+// first. path is always schema-controlled (never free-form prose), but
+// still passed through escapeText defensively since it ends up inside an
+// MDX/JSX-adjacent span rather than a code span.
+func monoHeading(path string) string {
+	return fmt.Sprintf(`<span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>%s</span>`, escapeText(path))
+}
+
+func writeDeprecationNotice(b *strings.Builder, f docmodel.Field) {
+	body := "This field should no longer be used."
+	if f.RedirectTo != "" {
+		body = fmt.Sprintf("Use %s instead.", codeSpan(f.RedirectTo))
+	}
+	fmt.Fprintln(b, ":::caution[Deprecated]")
+	fmt.Fprintln(b, body)
+	fmt.Fprintln(b, ":::")
+	fmt.Fprintln(b)
+}
+
+// writeExamples renders f.Example and f.Examples as a single "Examples:"
+// list — keeping them as two separate blocks (a singular "Example:" right
+// above a plural "Examples:") reads like a duplication bug rather than two
+// distinct pieces of data.
+func writeExamples(b *strings.Builder, f docmodel.Field) {
+	if f.Example == "" && len(f.Examples) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(f.Examples))
+	for name := range f.Examples {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Fprintln(b, "**Examples:**")
+	if f.Example != "" {
+		fmt.Fprintf(b, "- %s\n", codeSpan(f.Example))
+	}
+	for _, name := range names {
+		ex := f.Examples[name]
+		if ex.Summary != "" {
+			fmt.Fprintf(b, "- **%s:** %s — %s\n", escapeText(name), codeSpan(ex.Value), escapeText(ex.Summary))
+		} else {
+			fmt.Fprintf(b, "- **%s:** %s\n", escapeText(name), codeSpan(ex.Value))
+		}
+	}
+	fmt.Fprintln(b)
+}
+
+func writeConstraints(b *strings.Builder, c *docmodel.Constraints) {
+	var lines []string
+	if c.Minimum != nil {
+		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Minimum)))
+	}
+	if c.Maximum != nil {
+		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Maximum)))
+	}
+	if c.ExclusiveMinimum != nil {
+		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMinimum)))
+	}
+	if c.ExclusiveMaximum != nil {
+		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMaximum)))
+	}
+	if c.MinLength != nil {
+		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
+	}
+	if c.MaxLength != nil {
+		lines = append(lines, fmt.Sprintf("Max length: %d", *c.MaxLength))
+	}
+	if c.Pattern != "" {
+		lines = append(lines, fmt.Sprintf("Pattern: %s", codeSpan(c.Pattern)))
+	}
+	if len(c.Enum) > 0 {
+		enum := make([]string, len(c.Enum))
+		for i, v := range c.Enum {
+			enum[i] = codeSpan(v)
+		}
+		lines = append(lines, fmt.Sprintf("Enum: %s", strings.Join(enum, ", ")))
+	}
+	if c.JSONSchema != "" {
+		lines = append(lines, "JSON Schema: (see schema definition)")
+	}
+	if len(c.AllowedSchemes) > 0 {
+		schemes := make([]string, len(c.AllowedSchemes))
+		for i, s := range c.AllowedSchemes {
+			schemes[i] = codeSpan(s)
+		}
+		lines = append(lines, fmt.Sprintf("Allowed schemes: %s", strings.Join(schemes, ", ")))
+	}
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintln(b, "**Constraints:**")
+	for _, l := range lines {
+		fmt.Fprintf(b, "- %s\n", l)
+	}
+	fmt.Fprintln(b)
+}
+
+// formatFloat formats f for display, omitting the decimal point when the
+// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
+func formatFloat(f float64) string {
+	if f == float64(int64(f)) {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// --- Escaping ---
+
+// escapeText backslash-escapes the characters MDX v3 treats specially in
+// prose: '<' and '{' open JSX tags/expressions, '`' opens a code span, and
+// '\' is the escape character itself. Escaping '<' also defangs "<!--"
+// HTML-comment sequences, since a comment can't open without an unescaped
+// '<'.
+func escapeText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\\', '<', '{', '`':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// codeSpan wraps s in backticks, widening the delimiter when s itself
+// contains a run of backticks (CommonMark code span rules). Code span
+// content is read as literal text, not reparsed as MDX, so this is the
+// preferred way to render schema-sourced values that are naturally
+// code-like (examples, defaults, enum members, patterns).
+func codeSpan(s string) string {
+	longest, run := 0, 0
+	for _, r := range s {
+		if r == '`' {
+			run++
+			if run > longest {
+				longest = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	delim := strings.Repeat("`", longest+1)
+	if s == "" || strings.HasPrefix(s, "`") || strings.HasSuffix(s, "`") {
+		return delim + " " + s + " " + delim
+	}
+	return delim + s + delim
+}
+
+// yamlQuote double-quotes s for use as a YAML frontmatter scalar value,
+// escaping backslashes, double quotes, and newlines.
+func yamlQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return `"` + s + `"`
+}
+
+// jsonString renders s as a JSON string literal for _category_.json.
+func jsonString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/contrib/decree-docs/mdx/mdx_test.go
+++ b/contrib/decree-docs/mdx/mdx_test.go
@@ -1,0 +1,472 @@
+package mdx
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+	"github.com/opendecree/decree/contrib/decree-docs/loader"
+)
+
+// -update rewrites the golden files from current output:
+//
+//	go test . -run TestRender_Golden -update
+var update = flag.Bool("update", false, "rewrite golden files")
+
+// TestRender_Golden pins the rendered output for the full fixture, which
+// exercises every documented schema and field property, across every page
+// the renderer emits: the index plus one category folder per top-level
+// field-path-prefix group.
+func TestRender_Golden(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/full.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	golden := map[string]string{
+		"index.mdx":                "testdata/full-index.golden.mdx",
+		"payments/_category_.json": "testdata/full-payments-category.golden.json",
+		"payments/index.mdx":       "testdata/full-payments-index.golden.mdx",
+	}
+	if len(pages) != len(golden) {
+		t.Fatalf("got %d pages, want %d", len(pages), len(golden))
+	}
+	for _, p := range pages {
+		path, ok := golden[p.Path]
+		if !ok {
+			t.Fatalf("unexpected page %q", p.Path)
+		}
+		if *update {
+			if err := os.WriteFile(path, []byte(p.Content), 0o644); err != nil {
+				t.Fatalf("update golden: %v", err)
+			}
+		}
+		want, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read golden: %v", err)
+		}
+		if p.Content != string(want) {
+			t.Errorf("page %q does not match %s:\ngot:\n%s\nwant:\n%s", p.Path, path, p.Content, want)
+		}
+	}
+}
+
+// TestRender_MinimalSchema pins behavior on a schema with no flags, no
+// examples, and no constraints: no badges, no deprecation admonition, no
+// examples/constraints sections should be emitted.
+func TestRender_MinimalSchema(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var content string
+	for _, p := range pages {
+		content += p.Content
+	}
+	for _, unwanted := range []string{"Deprecated", "Sensitive", "Read-only", "Write-once", "Nullable", "Examples", "Constraints", ":::caution"} {
+		if strings.Contains(content, unwanted) {
+			t.Errorf("unexpected %q in minimal output:\n%s", unwanted, content)
+		}
+	}
+}
+
+// TestRender_CategoryFiles ensures every top-level field-path-prefix group
+// gets a _category_.json with a label and a 1-based sidebar position, and
+// that the index page is not itself treated as a group.
+func TestRender_CategoryFiles(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/full.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var found bool
+	for _, p := range pages {
+		if p.Path == "payments/_category_.json" {
+			found = true
+			if !strings.Contains(p.Content, `"label": "payments"`) {
+				t.Errorf("expected label in category file, got:\n%s", p.Content)
+			}
+			if !strings.Contains(p.Content, `"position": 1`) {
+				t.Errorf("expected position 1 for the only group, got:\n%s", p.Content)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a payments/_category_.json page")
+	}
+}
+
+// TestRender_EdgeCases exercises branches the full/minimal fixtures don't
+// reach: a bare version (no versionDescription), a contact with only a URL
+// or only a name, an externalDocs block with no description, a non-nil but
+// empty constraints block, a fractional constraint value, a multi-group
+// schema, and a single-field group (singular "field" in the index).
+func TestRender_EdgeCases(t *testing.T) {
+	half := 0.5
+	doc := docmodel.New(docmodel.Schema{
+		Name:    "edge",
+		Version: 2,
+		Info: &docmodel.Info{
+			Contact: &docmodel.Contact{Name: "Sam", URL: "https://example.com/sam"},
+		},
+		Fields: []docmodel.Field{
+			{
+				Path:         "alpha.value",
+				Type:         "string",
+				ExternalDocs: &docmodel.ExternalDocs{URL: "https://example.com/alpha"},
+				Constraints:  &docmodel.Constraints{},
+			},
+			{
+				Path:        "beta.value",
+				Type:        "number",
+				Constraints: &docmodel.Constraints{Minimum: &half},
+			},
+		},
+	})
+
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	var index, alpha, beta string
+	for _, p := range pages {
+		switch p.Path {
+		case "index.mdx":
+			index = p.Content
+		case "alpha/index.mdx":
+			alpha = p.Content
+		case "beta/index.mdx":
+			beta = p.Content
+		}
+	}
+
+	if !strings.Contains(index, "**Version:** 2\n") {
+		t.Errorf("expected bare version line, got:\n%s", index)
+	}
+	if !strings.Contains(index, "**Contact:** [Sam](https://example.com/sam)") {
+		t.Errorf("expected URL-only contact line, got:\n%s", index)
+	}
+	if !strings.Contains(index, "- [alpha](./alpha/index) — 1 field\n") {
+		t.Errorf("expected singular 'field' for a one-field group, got:\n%s", index)
+	}
+	if !strings.Contains(index, "- [beta](./beta/index) — 1 field\n") {
+		t.Errorf("expected beta group link, got:\n%s", index)
+	}
+
+	if alpha == "" {
+		t.Fatal("expected an alpha/index.mdx page")
+	}
+	if !strings.Contains(alpha, "**See also:** https://example.com/alpha\n") {
+		t.Errorf("expected description-less externalDocs line, got:\n%s", alpha)
+	}
+	if strings.Contains(alpha, "Constraints") {
+		t.Errorf("expected empty constraints block to render nothing, got:\n%s", alpha)
+	}
+
+	if beta == "" {
+		t.Fatal("expected a beta/index.mdx page")
+	}
+	if !strings.Contains(beta, "Minimum: 0.5\n") {
+		t.Errorf("expected fractional minimum, got:\n%s", beta)
+	}
+}
+
+func TestRender_NameOnlyContact(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Info: &docmodel.Info{Contact: &docmodel.Contact{Name: "Sam"}},
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(pages[0].Content, "**Contact:** Sam\n") {
+		t.Errorf("expected name-only contact line, got:\n%s", pages[0].Content)
+	}
+}
+
+func TestRender_EmailContact(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Info: &docmodel.Info{Contact: &docmodel.Contact{Name: "Sam", Email: "sam@example.com"}},
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !strings.Contains(pages[0].Content, "**Contact:** [Sam](mailto:sam@example.com)\n") {
+		t.Errorf("expected email contact line, got:\n%s", pages[0].Content)
+	}
+}
+
+func TestRender_InfoLabels(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Info: &docmodel.Info{
+			Author: "platform-team",
+			Labels: map[string]string{"tier": "critical", "team": "platform"},
+		},
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	content := pages[0].Content
+	if !strings.Contains(content, "**Author:** platform-team\n") {
+		t.Errorf("expected author line, got:\n%s", content)
+	}
+	if !strings.Contains(content, "**Labels:** `team: platform`, `tier: critical`\n") {
+		t.Errorf("expected sorted label chips, got:\n%s", content)
+	}
+}
+
+// TestRender_DeprecatedWithoutRedirect ensures the deprecation admonition
+// falls back to generic text when RedirectTo is empty.
+func TestRender_DeprecatedWithoutRedirect(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string", Deprecated: true},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var all string
+	for _, p := range pages {
+		all += p.Content
+	}
+	if !strings.Contains(all, ":::caution[Deprecated]\nThis field should no longer be used.\n:::\n") {
+		t.Errorf("expected generic deprecation admonition, got:\n%s", all)
+	}
+}
+
+// TestRender_MultipleFieldsInGroup ensures fields within the same group are
+// separated by a horizontal rule.
+func TestRender_MultipleFieldsInGroup(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Fields: []docmodel.Field{
+			{Path: "alpha.one", Type: "string"},
+			{Path: "alpha.two", Type: "string"},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var alpha string
+	for _, p := range pages {
+		if p.Path == "alpha/index.mdx" {
+			alpha = p.Content
+		}
+	}
+	if !strings.Contains(alpha, "---\n") {
+		t.Errorf("expected a horizontal rule between fields, got:\n%s", alpha)
+	}
+}
+
+// TestRender_Validations_Ignored documents current scope: mdx.go does not
+// render Schema.Validations (tracked separately as #960). Render must not
+// crash or otherwise choke on a schema that sets it; the field is simply
+// absent from output.
+func TestRender_Validations_Ignored(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "payments",
+		Fields: []docmodel.Field{
+			{Path: "payments.fee", Type: "number"},
+		},
+		Validations: []docmodel.Validation{
+			{Rule: "self.payments.fee > 0", Message: "Fee must be positive.", Severity: "error"},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, p := range pages {
+		if strings.Contains(p.Content, "Validations") || strings.Contains(p.Content, "self.payments.fee") {
+			t.Errorf("did not expect Validations content to be rendered (tracked separately as #960), got in %q:\n%s", p.Path, p.Content)
+		}
+	}
+}
+
+// --- Escaping edge cases ---
+//
+// MDX v3 parses '{' and '<' as JSX, so these tests pin escapeText and
+// codeSpan's behavior directly, at the unit level, rather than only through
+// golden-file output — that way the exact character-by-character escaping
+// is locked down independent of surrounding prose.
+
+func TestEscapeText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain text", "hello world", "hello world"},
+		{"literal brace", "a {b} c", `a \{b} c`},
+		{"literal angle bracket", "a < b > c", `a \< b > c`},
+		{"backtick", "use `code`", "use \\`code\\`"},
+		{"backslash", `a\b`, `a\\b`},
+		{"html comment", "a <!-- comment --> b", `a \<!-- comment --> b`},
+		{"jsx-like tag", "<Foo bar={baz} />", `\<Foo bar=\{baz} />`},
+		{"multiple braces", "{{nested}}", `\{\{nested}}`},
+		{"mixed all specials", "<{`" + `\` + "}>", "\\<\\{\\`\\\\}>"},
+		{"angle then bang dash dash", "<!--", `\<!--`},
+		{"only backslash", `\`, `\\`},
+		{"unicode passthrough", "café résumé", "café résumé"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := escapeText(tt.in)
+			if got != tt.want {
+				t.Errorf("escapeText(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodeSpan(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "`  `"},
+		{"plain", "hello", "`hello`"},
+		{"contains jsx-like text", "<Foo/>", "`<Foo/>`"},
+		{"contains braces", "{value}", "`{value}`"},
+		{"single backtick", "a`b", "``a`b``"},
+		{"leading backtick", "`abc", "`` `abc ``"},
+		{"trailing backtick", "abc`", "`` abc` ``"},
+		{"double backtick run", "a``b", "```a``b```"},
+		{"only backticks", "```", "```` ``` ````"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := codeSpan(tt.in)
+			if got != tt.want {
+				t.Errorf("codeSpan(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJSONString pins jsonString's JSON-literal escaping: double quotes and
+// backslashes are backslash-escaped, embedded newlines become the two-char
+// "\n" escape (category labels come from field path prefixes, but the
+// function itself makes no such assumption), and plain text passes through.
+func TestJSONString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "payments", `"payments"`},
+		{"double quote", `say "hi"`, `"say \"hi\""`},
+		{"backslash", `a\b`, `"a\\b"`},
+		{"newline", "a\nb", `"a\nb"`},
+		{"empty", "", `""`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := jsonString(tt.in)
+			if got != tt.want {
+				t.Errorf("jsonString(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRender_EscapesSchemaText ensures schema-sourced text that looks like
+// JSX/markup survives a full Render call escaped, not interpreted, since
+// descriptions/titles/examples are untrusted relative to the renderer. This
+// is the integration-level companion to TestEscapeText/TestCodeSpan.
+func TestRender_EscapesSchemaText(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name:        "edge",
+		Description: "Uses {braces} and <tags> and `backticks` and <!-- comments -->.",
+		Fields: []docmodel.Field{
+			{
+				Path:        "alpha.value",
+				Type:        "string",
+				Title:       "<Title/>",
+				Description: "A {curly} <b>bold</b> description with a backtick ` and a <!-- sneaky comment -->.",
+				Default:     "<{default}>",
+				Example:     "<{example}>",
+				Examples: map[string]docmodel.Example{
+					"sample": {Value: "<{ex}>", Summary: "a <summary> with {braces}"},
+				},
+				Constraints: &docmodel.Constraints{
+					Pattern: "^<{[a-z]+}>$",
+					Enum:    []string{"<a>", "{b}"},
+				},
+			},
+		},
+	})
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var all string
+	for _, p := range pages {
+		all += p.Content
+	}
+
+	// No *unescaped* JSX-triggering construct should survive: every literal
+	// '<' or '{' that came from prose (escapeText) must be preceded by a
+	// backslash. Check for the unescaped form specifically — "\<tags>"
+	// legitimately contains "<tags>" as a substring, so the assertion must
+	// anchor on the character immediately before '<' or '{' not being '\'.
+	forbidden := []string{
+		"<tags>",
+		"<b>bold</b>",
+		"<!-- sneaky comment -->",
+		"<!-- comments -->",
+	}
+	for _, f := range forbidden {
+		if idx := strings.Index(all, f); idx >= 0 && (idx == 0 || all[idx-1] != '\\') {
+			t.Errorf("unescaped %q leaked into output:\n%s", f, all)
+		}
+	}
+	// escapeText'd description text: only '\', '<', '{', and '`' are
+	// backslashed; '}' and '>' are left as-is (escaping '<' is sufficient
+	// to defang "<!--", since a comment can't open without an unescaped
+	// '<', and a bare '}'/'>' with no preceding unescaped opener is inert).
+	wantDescription := "Uses \\{braces} and \\<tags> and \\`backticks\\` and \\<!-- comments -->."
+	if !strings.Contains(all, wantDescription) {
+		t.Errorf("expected escaped schema-level description, got:\n%s", all)
+	}
+	// codeSpan'd values (default/example/enum) keep their raw braces/angle
+	// brackets literally, but fenced in backticks so MDX reads them as text.
+	if !strings.Contains(all, "default `<{default}>`") {
+		t.Errorf("expected code-spanned default, got:\n%s", all)
+	}
+}

--- a/contrib/decree-docs/mdx/testdata/full-index.golden.mdx
+++ b/contrib/decree-docs/mdx/testdata/full-index.golden.mdx
@@ -1,0 +1,21 @@
+---
+id: "index"
+title: "Payments Configuration"
+sidebar_label: "Overview"
+sidebar_position: 0
+---
+
+Payment processing configuration.
+
+**Version:** 3 — Added refund window and webhook controls.
+
+**Author:** platform-team
+
+**Contact:** [Pat](mailto:pat@example.com)
+
+**Labels:** `team: platform`, `tier: critical`
+
+## Groups
+
+- [payments](./payments/index) — 10 fields
+

--- a/contrib/decree-docs/mdx/testdata/full-payments-category.golden.json
+++ b/contrib/decree-docs/mdx/testdata/full-payments-category.golden.json
@@ -1,0 +1,4 @@
+{
+  "label": "payments",
+  "position": 1
+}

--- a/contrib/decree-docs/mdx/testdata/full-payments-index.golden.mdx
+++ b/contrib/decree-docs/mdx/testdata/full-payments-index.golden.mdx
@@ -1,0 +1,124 @@
+---
+id: "index"
+title: "payments"
+sidebar_label: "payments"
+sidebar_position: 1
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.api_key</span>
+<span className="badge badge--info" title="Can only be set once; immutable after that">Write-once</span> <span className="badge badge--danger" title="Value is not displayed in clear text">Sensitive</span>
+
+Gateway API key.
+
+type `string` · format `password`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.cutoff</span>
+<span style={{"background": "transparent", "border": "1px solid var(--ifm-color-emphasis-400)", "color": "var(--ifm-color-emphasis-700)", "border-radius": "var(--ifm-badge-border-radius,0.4rem)", "padding": "0.2em 0.6em", "font-size": "0.75em", "font-weight": "700"}} title="Accepts a null value">Nullable</span>
+
+Daily settlement cutoff.
+
+type `time`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.enabled</span>
+Payments Enabled
+
+Master switch for payment processing.
+
+type `bool` · default `true`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.environment</span>
+<span style={{"background": "transparent", "border": "1px solid var(--ifm-color-emphasis-400)", "color": "var(--ifm-color-emphasis-700)", "border-radius": "var(--ifm-badge-border-radius,0.4rem)", "padding": "0.2em 0.6em", "font-size": "0.75em", "font-weight": "700"}} title="Clients cannot write this field">Read-only</span>
+
+Deployment environment label.
+
+type `string`
+
+**Constraints:**
+- Min length: 2
+- Max length: 32
+- Pattern: `^[a-z][a-z0-9-]*$`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.fee</span>
+<span style={{"background": "transparent", "border": "1px solid var(--ifm-color-emphasis-400)", "color": "var(--ifm-color-emphasis-700)", "border-radius": "var(--ifm-badge-border-radius,0.4rem)", "padding": "0.2em 0.6em", "font-size": "0.75em", "font-weight": "700"}} title="Accepts a null value">Nullable</span>
+
+Per-transaction fee rate.
+
+type `number` · default `0.01` · tags `billing` `rates`
+
+**Examples:**
+- `0.02`
+- **high:** `0.99`
+- **low:** `0.01` — Promotional rate
+
+**See also:** [Fee guide](https://docs.example.com/fees)
+
+**Constraints:**
+- Minimum: 0
+- Maximum: 1
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.metadata</span>
+
+Free-form gateway metadata.
+
+type `json`
+
+**Constraints:**
+- JSON Schema: (see schema definition)
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.mode</span>
+
+Processing mode.
+
+type `string` · default `test`
+
+:::caution[Deprecated]
+Use `payments.environment` instead.
+:::
+
+**Constraints:**
+- Enum: `live`, `test`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.refund_window</span>
+
+Window during which refunds are accepted.
+
+type `duration` · default `72h`
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.retries</span>
+
+Delivery attempts per webhook event.
+
+type `integer` · default `3`
+
+**Constraints:**
+- Exclusive minimum: 0
+- Exclusive maximum: 10
+
+---
+
+### <span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>payments.webhook</span>
+Webhook URL
+
+Endpoint receiving payment events.
+
+type `url`
+
+**Constraints:**
+- Allowed schemes: `https`, `sftp`
+

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
   "cmd/decree": 86.1,
-  "contrib/decree-docs": 99.1,
+  "contrib/decree-docs": 99.3,
   "internal": 88.5,
   "sdk/adminclient": 97.7,
   "sdk/configclient": 87.1,


### PR DESCRIPTION
## Summary
- decree-docs had json/md/html backends but no Docusaurus-compatible output, blocking embedding generated docs directly into a Docusaurus docs/ site.
- Adds the mdx backend: renders a doc tree (index.mdx overview + one category folder per top-level field-path-prefix group, each with _category_.json + index.mdx) that drops directly into a Docusaurus docs/ folder. Wired into the CLI as `--format mdx` (requires `--out-dir`).
- All schema-sourced text passes through escaping helpers since MDX v3 parses `{`/`<` as JSX — verified against a real Docusaurus build during design iteration, which caught a contact-email autolink bug and a v2-vs-v3 admonition syntax bug (Docusaurus v3 requires the bracket-label `:::type[Title]` form).

## Test plan
- `go build ./...` and `go test ./...` pass in `contrib/decree-docs`.
- Golden-file tests (multi-group schema, deprecated fields, sensitive/nullable/read-only/write-once pills, examples, constraints, external docs links).
- Dedicated escaping edge-case suite covering `{`, `<`, backtick, backslash, and `<!--` HTML-comment sequences.
- `mdx` package itself at 100% coverage; `contrib/decree-docs` aggregate ratcheted 99.1% → 99.3% in coverage-thresholds.json.
- Visually verified rendering against a real Docusaurus v3 static build (headless Chrome screenshots) through multiple design-iteration rounds.
- README updated with usage example and golden-update instructions.
- `gofmt -l` clean; `golangci-lint run ./...` clean.

Closes #917