### PR TITLE
feat(decree-docs): render CEL validation rules in mdx backend

### DIFF
--- a/contrib/decree-docs/mdx/mdx.go
+++ b/contrib/decree-docs/mdx/mdx.go
@@ -6,6 +6,15 @@
 // _category_.json (sidebar label + position) and an index.mdx with that
 // group's fields. The tree drops directly into a Docusaurus docs/ folder.
 //
+// Schema-level cross-field validation rules ([docmodel.Schema.Validations])
+// render as a "## Validations" section on the index page (a rule can
+// reference fields across groups, so there is no single group page to put it
+// on). Each rule's CEL expression renders as an untagged fenced code block —
+// CEL isn't a Prism language, so tagging the fence would invite a wrong
+// language guess and mismatched-keyword highlighting — and its severity
+// (error/warning) renders via the same bracket-label admonition syntax as
+// the deprecation notice below.
+//
 // MDX v3 parses '{' and '<' as the start of a JSX expression or tag, so
 // every piece of schema-sourced text (descriptions, examples, enum values,
 // defaults, patterns, tags) must be neutralized before it reaches the
@@ -71,6 +80,8 @@ func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
 	if s.Info != nil {
 		writeInfo(&b, s.Info)
 	}
+
+	writeValidations(&b, s.Validations)
 
 	fmt.Fprintln(&b, "## Groups")
 	fmt.Fprintln(&b)
@@ -307,6 +318,44 @@ func jsxStyle(css string) string {
 // MDX/JSX-adjacent span rather than a code span.
 func monoHeading(path string) string {
 	return fmt.Sprintf(`<span style={{fontFamily: "var(--ifm-font-family-monospace)"}}>%s</span>`, escapeText(path))
+}
+
+// writeValidations renders the schema's cross-field CEL validation rules on
+// the index page (not per-group), since a rule may reference fields across
+// groups. Each rule renders as a list entry: the CEL expression as an
+// untagged fenced code block (CEL isn't a Prism language, so an untagged
+// fence avoids a wrong language guess and mismatched-keyword highlighting),
+// followed by the severity-distinguished message. Mirrors the md backend's
+// writeValidations/writeValidationMessage.
+func writeValidations(b *strings.Builder, validations []docmodel.Validation) {
+	if len(validations) == 0 {
+		return
+	}
+	fmt.Fprintln(b, "## Validations")
+	fmt.Fprintln(b)
+	for _, v := range validations {
+		fmt.Fprintln(b, "```")
+		fmt.Fprintln(b, v.Rule)
+		fmt.Fprintln(b, "```")
+		fmt.Fprintln(b)
+		writeValidationMessage(b, v)
+	}
+}
+
+// writeValidationMessage renders a validation's message with its severity
+// distinguished via the same bracket-label admonition mechanism
+// writeDeprecationNotice uses: ":::danger[Error]" for error severity,
+// ":::caution[Warning]" for warning (and the default, in case Severity is
+// unset or holds an unrecognized value).
+func writeValidationMessage(b *strings.Builder, v docmodel.Validation) {
+	admonition, label := "caution", "Warning"
+	if v.Severity == "error" {
+		admonition, label = "danger", "Error"
+	}
+	fmt.Fprintf(b, ":::%s[%s]\n", admonition, label)
+	fmt.Fprintf(b, "%s\n", escapeText(v.Message))
+	fmt.Fprintln(b, ":::")
+	fmt.Fprintln(b)
 }
 
 func writeDeprecationNotice(b *strings.Builder, f docmodel.Field) {

--- a/contrib/decree-docs/mdx/mdx_test.go
+++ b/contrib/decree-docs/mdx/mdx_test.go
@@ -291,28 +291,133 @@ func TestRender_MultipleFieldsInGroup(t *testing.T) {
 	}
 }
 
-// TestRender_Validations_Ignored documents current scope: mdx.go does not
-// render Schema.Validations (tracked separately as #960). Render must not
-// crash or otherwise choke on a schema that sets it; the field is simply
-// absent from output.
-func TestRender_Validations_Ignored(t *testing.T) {
+// TestRender_Validations_Golden pins rendering of schema-level CEL
+// validation rules (added in #960): one error-severity and one
+// warning-severity rule, to exercise the severity distinction.
+func TestRender_Validations_Golden(t *testing.T) {
 	doc := docmodel.New(docmodel.Schema{
 		Name: "payments",
 		Fields: []docmodel.Field{
 			{Path: "payments.fee", Type: "number"},
+			{Path: "payments.retries", Type: "integer"},
 		},
 		Validations: []docmodel.Validation{
-			{Rule: "self.payments.fee > 0", Message: "Fee must be positive.", Severity: "error"},
+			{
+				Rule:     "self.payments.fee < self.payments.retries",
+				Message:  "Fee rate must be less than the retry count.",
+				Severity: "error",
+			},
+			{
+				Rule:     `self.payments.webhook.startsWith("https://")`,
+				Message:  "Webhook URLs should use https.",
+				Severity: "warning",
+			},
+		},
+	})
+
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var index string
+	for _, p := range pages {
+		if p.Path == "index.mdx" {
+			index = p.Content
+		}
+	}
+	if index == "" {
+		t.Fatal("expected an index.mdx page")
+	}
+
+	const golden = "testdata/validations-index.golden.mdx"
+	if *update {
+		if err := os.WriteFile(golden, []byte(index), 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if index != string(want) {
+		t.Errorf("index page does not match %s:\ngot:\n%s\nwant:\n%s", golden, index, want)
+	}
+}
+
+// TestRender_NoValidations ensures schemas with no validations render no
+// "## Validations" section.
+func TestRender_NoValidations(t *testing.T) {
+	doc, err := loader.FromFile("../testdata/minimal.schema.yaml")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, p := range pages {
+		if strings.Contains(p.Content, "Validations") {
+			t.Errorf("unexpected Validations section in page %q:\n%s", p.Path, p.Content)
+		}
+	}
+}
+
+// TestRender_Validations_OnIndexNotGroup ensures validations render on the
+// top-level index page, not on any group page, since a rule can reference
+// fields in more than one group.
+func TestRender_Validations_OnIndexNotGroup(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "payments",
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+			{Path: "beta.value", Type: "string"},
+		},
+		Validations: []docmodel.Validation{
+			{Rule: "self.alpha.value != self.beta.value", Message: "alpha and beta must differ.", Severity: "error"},
+		},
+	})
+
+	pages, err := Render(doc)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	var index, alpha string
+	for _, p := range pages {
+		switch p.Path {
+		case "index.mdx":
+			index = p.Content
+		case "alpha/index.mdx":
+			alpha = p.Content
+		}
+	}
+	if !strings.Contains(index, "## Validations") {
+		t.Errorf("expected Validations section on index page, got:\n%s", index)
+	}
+	if strings.Contains(alpha, "Validations") {
+		t.Errorf("unexpected Validations section on group page, got:\n%s", alpha)
+	}
+}
+
+// TestRender_Validations_DefaultSeverity ensures an unset/unrecognized
+// Severity falls back to the warning admonition, mirroring how
+// writeDeprecationNotice falls back to generic text when optional data is
+// missing.
+func TestRender_Validations_DefaultSeverity(t *testing.T) {
+	doc := docmodel.New(docmodel.Schema{
+		Name: "edge",
+		Fields: []docmodel.Field{
+			{Path: "alpha.value", Type: "string"},
+		},
+		Validations: []docmodel.Validation{
+			{Rule: "self.alpha.value != \"\"", Message: "alpha.value must not be empty."},
 		},
 	})
 	pages, err := Render(doc)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
-	for _, p := range pages {
-		if strings.Contains(p.Content, "Validations") || strings.Contains(p.Content, "self.payments.fee") {
-			t.Errorf("did not expect Validations content to be rendered (tracked separately as #960), got in %q:\n%s", p.Path, p.Content)
-		}
+	if !strings.Contains(pages[0].Content, ":::caution[Warning]\n") {
+		t.Errorf("expected default-severity validation to render as a warning admonition, got:\n%s", pages[0].Content)
 	}
 }
 

--- a/contrib/decree-docs/mdx/testdata/validations-index.golden.mdx
+++ b/contrib/decree-docs/mdx/testdata/validations-index.golden.mdx
@@ -1,0 +1,29 @@
+---
+id: "index"
+title: "payments"
+sidebar_label: "Overview"
+sidebar_position: 0
+---
+
+## Validations
+
+```
+self.payments.fee < self.payments.retries
+```
+
+:::danger[Error]
+Fee rate must be less than the retry count.
+:::
+
+```
+self.payments.webhook.startsWith("https://")
+```
+
+:::caution[Warning]
+Webhook URLs should use https.
+:::
+
+## Groups
+
+- [payments](./payments/index) — 2 fields
+


### PR DESCRIPTION
## Summary
- The mdx backend had no way to render the schema-level CEL validation rules added to the doc model in #957.
- Renders a "## Validations" section on the top-level index.mdx (a rule can span groups, so it doesn't belong on a group page). Rule expressions render as untagged fenced code blocks; severity uses Docusaurus bracket-label admonitions (`:::danger[Error]` / `:::caution[Warning]`), the same mechanism already used for deprecation notices in this backend.

## Test plan
- `go build ./...` and `go test ./...` pass in `contrib/decree-docs`.
- New golden fixture for a schema with an error- and a warning-severity rule, plus tests confirming validations render on the index page (not group pages) and that an unset/unrecognized severity falls back to a warning admonition.
- Screenshot-verified against a real Docusaurus v3 static build (headless Chrome) — admonitions render correctly (red/error, amber/warning), code fences are plain with no leaked syntax.
- `gofmt -l` clean; `golangci-lint run ./...` clean.

Closes #960