### PR TITLE
refactor(decree-docs): share render helpers across backends

### DIFF
--- a/contrib/decree-docs/html/html.go
+++ b/contrib/decree-docs/html/html.go
@@ -17,11 +17,10 @@ package html
 import (
 	"fmt"
 	"html/template"
-	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+	"github.com/opendecree/decree/contrib/decree-docs/internal/render"
 )
 
 // Theme selects the built-in color scheme baked into the document.
@@ -58,9 +57,9 @@ func Render(doc *docmodel.Document, opts Options) (string, error) {
 		return "", fmt.Errorf("unknown theme %q (valid themes: %s, %s, %s)", theme, Light, Dark, Auto)
 	}
 
-	groups := groupByPrefix(doc.Schema.Fields)
+	groups := render.GroupByPrefix(doc.Schema.Fields)
 	page := pageView{
-		Title:       schemaTitle(doc.Schema),
+		Title:       render.Title(doc.Schema),
 		Sub:         schemaSubtitle(doc.Schema),
 		Groups:      make([]groupView, 0, len(groups)),
 		CSS:         template.CSS(buildCSS(theme, opts.CSS)),
@@ -69,8 +68,8 @@ func Render(doc *docmodel.Document, opts Options) (string, error) {
 		Validations: newValidationViews(doc.Schema.Validations),
 	}
 	for _, g := range groups {
-		gv := groupView{Prefix: g.prefix}
-		for _, f := range g.fields {
+		gv := groupView{Prefix: g.Prefix}
+		for _, f := range g.Fields {
 			gv.Fields = append(gv.Fields, newFieldView(f))
 		}
 		page.Groups = append(page.Groups, gv)
@@ -81,13 +80,6 @@ func Render(doc *docmodel.Document, opts Options) (string, error) {
 		return "", fmt.Errorf("render html: %w", err)
 	}
 	return b.String(), nil
-}
-
-func schemaTitle(s docmodel.Schema) string {
-	if s.Info != nil && s.Info.Title != "" {
-		return s.Info.Title
-	}
-	return s.Name
 }
 
 func schemaSubtitle(s docmodel.Schema) string {
@@ -107,34 +99,6 @@ func countTypes(fields []docmodel.Field) int {
 		seen[f.Type] = struct{}{}
 	}
 	return len(seen)
-}
-
-// --- Grouping ---
-
-type fieldGroup struct {
-	prefix string
-	fields []docmodel.Field
-}
-
-// groupByPrefix groups fields by their top-level path prefix. fields is
-// assumed sorted by path (docmodel guarantees this), so the first
-// occurrence of each prefix establishes deterministic group order.
-func groupByPrefix(fields []docmodel.Field) []fieldGroup {
-	var groups []fieldGroup
-	index := make(map[string]int)
-	for _, f := range fields {
-		prefix := f.Path
-		if i := strings.IndexByte(f.Path, '.'); i > 0 {
-			prefix = f.Path[:i]
-		}
-		if i, ok := index[prefix]; ok {
-			groups[i].fields = append(groups[i].fields, f)
-		} else {
-			index[prefix] = len(groups)
-			groups = append(groups, fieldGroup{prefix: prefix, fields: []docmodel.Field{f}})
-		}
-	}
-	return groups
 }
 
 // --- View model ---
@@ -183,10 +147,7 @@ func newValidationViews(validations []docmodel.Validation) []validationView {
 	}
 	out := make([]validationView, 0, len(validations))
 	for _, v := range validations {
-		severity, label := "warning", "Warning"
-		if v.Severity == "error" {
-			severity, label = "error", "Error"
-		}
+		severity, label := render.Severity(v.Severity)
 		out = append(out, validationView{
 			Rule:     v.Rule,
 			Message:  v.Message,
@@ -226,16 +187,9 @@ func newFieldView(f docmodel.Field) fieldView {
 	if f.Example != "" {
 		fv.Examples = append(fv.Examples, exampleView{Value: f.Example})
 	}
-	if len(f.Examples) > 0 {
-		names := make([]string, 0, len(f.Examples))
-		for name := range f.Examples {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		for _, name := range names {
-			ex := f.Examples[name]
-			fv.Examples = append(fv.Examples, exampleView{Name: name, Value: ex.Value, Summary: ex.Summary})
-		}
+	for _, name := range render.SortedExampleNames(f) {
+		ex := f.Examples[name]
+		fv.Examples = append(fv.Examples, exampleView{Name: name, Value: ex.Value, Summary: ex.Summary})
 	}
 
 	fv.Constraints = constraintLines(f.Constraints)
@@ -243,48 +197,17 @@ func newFieldView(f docmodel.Field) fieldView {
 }
 
 func constraintLines(c *docmodel.Constraints) []string {
-	if c == nil {
+	cs := render.Constraints(c)
+	if len(cs) == 0 {
 		return nil
 	}
-	var lines []string
-	if c.Minimum != nil {
-		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Minimum)))
-	}
-	if c.Maximum != nil {
-		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Maximum)))
-	}
-	if c.ExclusiveMinimum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMinimum)))
-	}
-	if c.ExclusiveMaximum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMaximum)))
-	}
-	if c.MinLength != nil {
-		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
-	}
-	if c.MaxLength != nil {
-		lines = append(lines, fmt.Sprintf("Max length: %d", *c.MaxLength))
-	}
-	if c.Pattern != "" {
-		lines = append(lines, fmt.Sprintf("Pattern: %s", c.Pattern))
-	}
-	if len(c.Enum) > 0 {
-		lines = append(lines, fmt.Sprintf("Enum: %s", strings.Join(c.Enum, ", ")))
-	}
-	if c.JSONSchema != "" {
-		lines = append(lines, "JSON Schema: (see schema definition)")
-	}
-	if len(c.AllowedSchemes) > 0 {
-		lines = append(lines, fmt.Sprintf("Allowed schemes: %s", strings.Join(c.AllowedSchemes, ", ")))
+	lines := make([]string, len(cs))
+	for i, k := range cs {
+		if k.Kind == render.ListConstraint {
+			lines[i] = fmt.Sprintf("%s: %s", k.Label, strings.Join(k.Values, ", "))
+		} else {
+			lines[i] = fmt.Sprintf("%s: %s", k.Label, k.Value)
+		}
 	}
 	return lines
-}
-
-// formatFloat formats f for display, omitting the decimal point when the
-// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
-func formatFloat(f float64) string {
-	if f == float64(int64(f)) {
-		return strconv.FormatInt(int64(f), 10)
-	}
-	return strconv.FormatFloat(f, 'g', -1, 64)
 }

--- a/contrib/decree-docs/internal/render/render.go
+++ b/contrib/decree-docs/internal/render/render.go
@@ -1,0 +1,160 @@
+// Package render holds the format-agnostic derivations the html, markdown,
+// and mdx backends share. Each backend keeps its own syntax (HTML templates,
+// CommonMark, MDX/JSX); what lives here is the logic that has no format in it
+// at all: how fields group into sections, how a schema's display title is
+// chosen, how a validation severity normalizes, the canonical order and
+// labels of constraint lines, and numeric formatting. Centralizing these
+// keeps the three backends from drifting — e.g. adding a constraint kind is a
+// single edit here, not three parallel ones.
+package render
+
+import (
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+)
+
+// Group is a set of fields sharing a top-level path prefix.
+type Group struct {
+	Prefix string
+	Fields []docmodel.Field
+}
+
+// GroupByPrefix groups fields by their top-level path prefix. fields is
+// assumed sorted by path (docmodel guarantees this), so the first occurrence
+// of each prefix establishes deterministic group order.
+func GroupByPrefix(fields []docmodel.Field) []Group {
+	var groups []Group
+	index := make(map[string]int)
+	for _, f := range fields {
+		prefix := f.Path
+		if i := strings.IndexByte(f.Path, '.'); i > 0 {
+			prefix = f.Path[:i]
+		}
+		if i, ok := index[prefix]; ok {
+			groups[i].Fields = append(groups[i].Fields, f)
+		} else {
+			index[prefix] = len(groups)
+			groups = append(groups, Group{Prefix: prefix, Fields: []docmodel.Field{f}})
+		}
+	}
+	return groups
+}
+
+// Title is the schema's display title: the info title when set, otherwise the
+// schema slug.
+func Title(s docmodel.Schema) string {
+	if s.Info != nil && s.Info.Title != "" {
+		return s.Info.Title
+	}
+	return s.Name
+}
+
+// Severity normalizes a validation rule's severity to its canonical key
+// ("error" or "warning") and human label ("Error" or "Warning"). Any value
+// other than "error" is treated as a warning, so the default is well-defined
+// when Severity is unset or unrecognized. Backends map the canonical key onto
+// their own admonition vocabulary (e.g. mdx renders "error" as "danger").
+func Severity(s string) (key, label string) {
+	if s == "error" {
+		return "error", "Error"
+	}
+	return "warning", "Warning"
+}
+
+// SortedExampleNames returns the keys of f.Examples in sorted order, the
+// deterministic iteration order every backend renders named examples in.
+func SortedExampleNames(f docmodel.Field) []string {
+	if len(f.Examples) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(f.Examples))
+	for name := range f.Examples {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// ConstraintKind tells a backend how to format a constraint line's value.
+type ConstraintKind int
+
+const (
+	// ScalarConstraint carries a plain Value (a number, length, or note).
+	ScalarConstraint ConstraintKind = iota
+	// CodeConstraint carries a single code-like Value (a regex pattern) that
+	// backends may wrap in a code span.
+	CodeConstraint
+	// ListConstraint carries Values (enum members, URI schemes) that backends
+	// join, optionally wrapping each member.
+	ListConstraint
+)
+
+// Constraint is one rendered constraint line: a fixed Label plus a value
+// carried in Value (scalar/code) or Values (list), tagged by Kind so each
+// backend can format it in its own syntax.
+type Constraint struct {
+	Label  string
+	Value  string
+	Values []string
+	Kind   ConstraintKind
+}
+
+// Constraints flattens c into the canonical ordered list of constraint lines
+// shared by every backend. Numeric bounds run through FormatFloat; the order
+// and labels here are the single source of truth, so a new constraint is
+// added once. Returns nil when c is nil or carries no rules.
+func Constraints(c *docmodel.Constraints) []Constraint {
+	if c == nil {
+		return nil
+	}
+	var out []Constraint
+	scalar := func(label, value string) {
+		out = append(out, Constraint{Label: label, Value: value})
+	}
+	if c.Minimum != nil {
+		scalar("Minimum", FormatFloat(*c.Minimum))
+	}
+	if c.Maximum != nil {
+		scalar("Maximum", FormatFloat(*c.Maximum))
+	}
+	if c.ExclusiveMinimum != nil {
+		scalar("Exclusive minimum", FormatFloat(*c.ExclusiveMinimum))
+	}
+	if c.ExclusiveMaximum != nil {
+		scalar("Exclusive maximum", FormatFloat(*c.ExclusiveMaximum))
+	}
+	if c.MinLength != nil {
+		scalar("Min length", strconv.FormatInt(int64(*c.MinLength), 10))
+	}
+	if c.MaxLength != nil {
+		scalar("Max length", strconv.FormatInt(int64(*c.MaxLength), 10))
+	}
+	if c.Pattern != "" {
+		out = append(out, Constraint{Label: "Pattern", Value: c.Pattern, Kind: CodeConstraint})
+	}
+	if len(c.Enum) > 0 {
+		out = append(out, Constraint{Label: "Enum", Values: c.Enum, Kind: ListConstraint})
+	}
+	if c.JSONSchema != "" {
+		scalar("JSON Schema", "(see schema definition)")
+	}
+	if len(c.AllowedSchemes) > 0 {
+		out = append(out, Constraint{Label: "Allowed schemes", Values: c.AllowedSchemes, Kind: ListConstraint})
+	}
+	return out
+}
+
+// FormatFloat formats f for display, omitting the decimal point when the
+// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5"). The range guard
+// keeps the int64 conversion in bounds; whole numbers too large for int64
+// fall through to the general format rather than overflowing the cast.
+func FormatFloat(f float64) string {
+	if f == math.Trunc(f) && f >= math.MinInt64 && f <= math.MaxInt64 {
+		return strconv.FormatInt(int64(f), 10)
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}

--- a/contrib/decree-docs/internal/render/render_test.go
+++ b/contrib/decree-docs/internal/render/render_test.go
@@ -1,0 +1,164 @@
+package render
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestGroupByPrefix(t *testing.T) {
+	// Input is sorted by path, as docmodel guarantees. A top-level field
+	// whose path has no dot forms its own single-field group; first
+	// occurrence of each prefix fixes group order.
+	fields := []docmodel.Field{
+		{Path: "auth"},
+		{Path: "auth.token"},
+		{Path: "payments.fee"},
+		{Path: "payments.limit"},
+		{Path: "region"},
+	}
+	got := GroupByPrefix(fields)
+
+	wantPrefixes := []string{"auth", "payments", "region"}
+	if len(got) != len(wantPrefixes) {
+		t.Fatalf("got %d groups, want %d: %+v", len(got), len(wantPrefixes), got)
+	}
+	for i, w := range wantPrefixes {
+		if got[i].Prefix != w {
+			t.Errorf("group %d prefix = %q, want %q", i, got[i].Prefix, w)
+		}
+	}
+	if len(got[0].Fields) != 2 || len(got[1].Fields) != 2 || len(got[2].Fields) != 1 {
+		t.Errorf("group field counts = %d/%d/%d, want 2/2/1",
+			len(got[0].Fields), len(got[1].Fields), len(got[2].Fields))
+	}
+}
+
+func TestGroupByPrefix_Empty(t *testing.T) {
+	if got := GroupByPrefix(nil); got != nil {
+		t.Errorf("GroupByPrefix(nil) = %+v, want nil", got)
+	}
+}
+
+func TestTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		in   docmodel.Schema
+		want string
+	}{
+		{"no info falls back to name", docmodel.Schema{Name: "payments"}, "payments"},
+		{"info title wins", docmodel.Schema{Name: "payments", Info: &docmodel.Info{Title: "Payments API"}}, "Payments API"},
+		{"empty info title falls back", docmodel.Schema{Name: "payments", Info: &docmodel.Info{Author: "x"}}, "payments"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Title(tt.in); got != tt.want {
+				t.Errorf("Title() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeverity(t *testing.T) {
+	tests := []struct {
+		in        string
+		wantKey   string
+		wantLabel string
+	}{
+		{"error", "error", "Error"},
+		{"warning", "warning", "Warning"},
+		{"", "warning", "Warning"},
+		{"bogus", "warning", "Warning"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			key, label := Severity(tt.in)
+			if key != tt.wantKey || label != tt.wantLabel {
+				t.Errorf("Severity(%q) = (%q, %q), want (%q, %q)", tt.in, key, label, tt.wantKey, tt.wantLabel)
+			}
+		})
+	}
+}
+
+func TestSortedExampleNames(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := SortedExampleNames(docmodel.Field{}); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+	t.Run("sorted", func(t *testing.T) {
+		f := docmodel.Field{Examples: map[string]docmodel.Example{
+			"zulu": {}, "alpha": {}, "mike": {},
+		}}
+		got := SortedExampleNames(f)
+		want := []string{"alpha", "mike", "zulu"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestConstraints_Nil(t *testing.T) {
+	if got := Constraints(nil); got != nil {
+		t.Errorf("Constraints(nil) = %+v, want nil", got)
+	}
+	if got := Constraints(&docmodel.Constraints{}); got != nil {
+		t.Errorf("Constraints(empty) = %+v, want nil", got)
+	}
+}
+
+func TestConstraints_OrderAndKinds(t *testing.T) {
+	c := &docmodel.Constraints{
+		Minimum:          ptr(1.0),
+		Maximum:          ptr(10.5),
+		ExclusiveMinimum: ptr(0.0),
+		ExclusiveMaximum: ptr(11.0),
+		MinLength:        ptr(int32(2)),
+		MaxLength:        ptr(int32(8)),
+		Pattern:          "^x$",
+		Enum:             []string{"a", "b"},
+		JSONSchema:       "{}",
+		AllowedSchemes:   []string{"https"},
+	}
+	got := Constraints(c)
+
+	want := []Constraint{
+		{Label: "Minimum", Value: "1", Kind: ScalarConstraint},
+		{Label: "Maximum", Value: "10.5", Kind: ScalarConstraint},
+		{Label: "Exclusive minimum", Value: "0", Kind: ScalarConstraint},
+		{Label: "Exclusive maximum", Value: "11", Kind: ScalarConstraint},
+		{Label: "Min length", Value: "2", Kind: ScalarConstraint},
+		{Label: "Max length", Value: "8", Kind: ScalarConstraint},
+		{Label: "Pattern", Value: "^x$", Kind: CodeConstraint},
+		{Label: "Enum", Values: []string{"a", "b"}, Kind: ListConstraint},
+		{Label: "JSON Schema", Value: "(see schema definition)", Kind: ScalarConstraint},
+		{Label: "Allowed schemes", Values: []string{"https"}, Kind: ListConstraint},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Constraints() mismatch:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestFormatFloat(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want string
+	}{
+		{1.0, "1"},
+		{1.5, "1.5"},
+		{-2.0, "-2"},
+		{0, "0"},
+		{3.14, "3.14"},
+		{1e19, "1e+19"}, // whole but beyond int64 range: takes the general path, no overflow
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := FormatFloat(tt.in); got != tt.want {
+				t.Errorf("FormatFloat(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/contrib/decree-docs/main.go
+++ b/contrib/decree-docs/main.go
@@ -41,9 +41,9 @@ decree schemas. It loads schemas from local files or from a running decree
 server and renders them as json, md, mdx, or html, with built-in themes,
 CSS style injection, and a template override system.
 
-This build loads schemas from local YAML files and emits the json, md, and
-html documentation formats; the mdx backend and server mode land in
-upcoming releases.`,
+This build loads schemas from local YAML files and emits the json, md, mdx,
+and html documentation formats; server mode and the config/template system
+land in upcoming releases.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }

--- a/contrib/decree-docs/markdown/markdown.go
+++ b/contrib/decree-docs/markdown/markdown.go
@@ -27,10 +27,10 @@ package markdown
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+	"github.com/opendecree/decree/contrib/decree-docs/internal/render"
 )
 
 // Flavor selects the Markdown dialect Render emits.
@@ -75,7 +75,7 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 		return nil, fmt.Errorf("unknown flavor %q (valid flavors: %s, %s)", opts.Flavor, Plain, Material)
 	}
 
-	groups := groupByPrefix(doc.Schema.Fields)
+	groups := render.GroupByPrefix(doc.Schema.Fields)
 
 	switch opts.Pages {
 	case SinglePage, "":
@@ -83,8 +83,8 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 		writeHeader(&b, doc.Schema)
 		writeValidations(&b, doc.Schema.Validations, opts.Flavor)
 		for _, g := range groups {
-			fmt.Fprintf(&b, "## %s\n\n", g.prefix)
-			for _, f := range g.fields {
+			fmt.Fprintf(&b, "## %s\n\n", g.Prefix)
+			for _, f := range g.Fields {
 				writeField(&b, f, opts.Flavor)
 			}
 		}
@@ -93,11 +93,11 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 		pages := []Page{indexPage(doc.Schema, groups, opts.Flavor)}
 		for _, g := range groups {
 			var b strings.Builder
-			fmt.Fprintf(&b, "# %s\n\n", g.prefix)
-			for _, f := range g.fields {
+			fmt.Fprintf(&b, "# %s\n\n", g.Prefix)
+			for _, f := range g.Fields {
 				writeField(&b, f, opts.Flavor)
 			}
-			pages = append(pages, Page{Name: g.prefix, Content: b.String()})
+			pages = append(pages, Page{Name: g.Prefix, Content: b.String()})
 		}
 		return pages, nil
 	default:
@@ -105,7 +105,7 @@ func Render(doc *docmodel.Document, opts Options) ([]Page, error) {
 	}
 }
 
-func indexPage(s docmodel.Schema, groups []fieldGroup, flavor Flavor) Page {
+func indexPage(s docmodel.Schema, groups []render.Group, flavor Flavor) Page {
 	var b strings.Builder
 	writeHeader(&b, s)
 	writeValidations(&b, s.Validations, flavor)
@@ -113,21 +113,17 @@ func indexPage(s docmodel.Schema, groups []fieldGroup, flavor Flavor) Page {
 	fmt.Fprintln(&b)
 	for _, g := range groups {
 		noun := "fields"
-		if len(g.fields) == 1 {
+		if len(g.Fields) == 1 {
 			noun = "field"
 		}
-		fmt.Fprintf(&b, "- [%s](%s.md) — %d %s\n", g.prefix, g.prefix, len(g.fields), noun)
+		fmt.Fprintf(&b, "- [%s](%s.md) — %d %s\n", g.Prefix, g.Prefix, len(g.Fields), noun)
 	}
 	fmt.Fprintln(&b)
 	return Page{Name: "index", Content: b.String()}
 }
 
 func writeHeader(b *strings.Builder, s docmodel.Schema) {
-	title := s.Name
-	if s.Info != nil && s.Info.Title != "" {
-		title = s.Info.Title
-	}
-	fmt.Fprintf(b, "# %s\n\n", title)
+	fmt.Fprintf(b, "# %s\n\n", render.Title(s))
 	if s.Description != "" {
 		fmt.Fprintf(b, "%s\n\n", s.Description)
 	}
@@ -165,34 +161,6 @@ func writeInfo(b *strings.Builder, info *docmodel.Info) {
 		sort.Strings(labels)
 		fmt.Fprintf(b, "**Labels:** %s\n\n", strings.Join(labels, ", "))
 	}
-}
-
-// --- Grouping ---
-
-type fieldGroup struct {
-	prefix string
-	fields []docmodel.Field
-}
-
-// groupByPrefix groups fields by their top-level path prefix. fields is
-// assumed sorted by path (docmodel guarantees this), so the first occurrence
-// of each prefix establishes deterministic group order.
-func groupByPrefix(fields []docmodel.Field) []fieldGroup {
-	var groups []fieldGroup
-	index := make(map[string]int)
-	for _, f := range fields {
-		prefix := f.Path
-		if i := strings.IndexByte(f.Path, '.'); i > 0 {
-			prefix = f.Path[:i]
-		}
-		if i, ok := index[prefix]; ok {
-			groups[i].fields = append(groups[i].fields, f)
-		} else {
-			index[prefix] = len(groups)
-			groups = append(groups, fieldGroup{prefix: prefix, fields: []docmodel.Field{f}})
-		}
-	}
-	return groups
 }
 
 // --- Fields ---
@@ -326,14 +294,10 @@ func writeValidations(b *strings.Builder, validations []docmodel.Validation, fla
 
 // writeValidationMessage renders a validation's message with its severity
 // visually distinguished, mirroring writeDeprecationNotice's admonition
-// (material) / blockquote (plain) pattern.
+// (material) / blockquote (plain) pattern. The canonical severity key from
+// [render.Severity] doubles as the material admonition type.
 func writeValidationMessage(b *strings.Builder, v docmodel.Validation, flavor Flavor) {
-	label := "Warning"
-	admonition := "warning"
-	if v.Severity == "error" {
-		label = "Error"
-		admonition = "error"
-	}
+	admonition, label := render.Severity(v.Severity)
 	if flavor == Material {
 		fmt.Fprintf(b, "!!! %s %q\n", admonition, label)
 		fmt.Fprintf(b, "    %s\n\n", v.Message)
@@ -350,11 +314,7 @@ func writeExamples(b *strings.Builder, f docmodel.Field, flavor Flavor) {
 		return
 	}
 
-	names := make([]string, 0, len(f.Examples))
-	for name := range f.Examples {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := render.SortedExampleNames(f)
 
 	if flavor == Material && len(names) >= 2 {
 		fmt.Fprintln(b, "**Examples:**")
@@ -384,52 +344,27 @@ func writeExamples(b *strings.Builder, f docmodel.Field, flavor Flavor) {
 }
 
 func writeConstraints(b *strings.Builder, c *docmodel.Constraints) {
-	var lines []string
-	if c.Minimum != nil {
-		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Minimum)))
-	}
-	if c.Maximum != nil {
-		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Maximum)))
-	}
-	if c.ExclusiveMinimum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMinimum)))
-	}
-	if c.ExclusiveMaximum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMaximum)))
-	}
-	if c.MinLength != nil {
-		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
-	}
-	if c.MaxLength != nil {
-		lines = append(lines, fmt.Sprintf("Max length: %d", *c.MaxLength))
-	}
-	if c.Pattern != "" {
-		lines = append(lines, fmt.Sprintf("Pattern: `%s`", c.Pattern))
-	}
-	if len(c.Enum) > 0 {
-		lines = append(lines, fmt.Sprintf("Enum: %s", strings.Join(c.Enum, ", ")))
-	}
-	if c.JSONSchema != "" {
-		lines = append(lines, "JSON Schema: (see schema definition)")
-	}
-	if len(c.AllowedSchemes) > 0 {
-		lines = append(lines, fmt.Sprintf("Allowed schemes: %s", strings.Join(c.AllowedSchemes, ", ")))
-	}
+	lines := render.Constraints(c)
 	if len(lines) == 0 {
 		return
 	}
 	fmt.Fprintln(b, "**Constraints:**")
-	for _, l := range lines {
-		fmt.Fprintf(b, "- %s\n", l)
+	for _, k := range lines {
+		fmt.Fprintf(b, "- %s: %s\n", k.Label, constraintValue(k))
 	}
 	fmt.Fprintln(b)
 }
 
-// formatFloat formats f for display, omitting the decimal point when the
-// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
-func formatFloat(f float64) string {
-	if f == float64(int64(f)) {
-		return strconv.FormatInt(int64(f), 10)
+// constraintValue formats a constraint value for Markdown: a regex pattern
+// renders as a code span, list values join with commas, and scalars render
+// verbatim.
+func constraintValue(k render.Constraint) string {
+	switch k.Kind {
+	case render.CodeConstraint:
+		return fmt.Sprintf("`%s`", k.Value)
+	case render.ListConstraint:
+		return strings.Join(k.Values, ", ")
+	default:
+		return k.Value
 	}
-	return strconv.FormatFloat(f, 'g', -1, 64)
 }

--- a/contrib/decree-docs/mdx/mdx.go
+++ b/contrib/decree-docs/mdx/mdx.go
@@ -29,10 +29,10 @@ package mdx
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/opendecree/decree/contrib/decree-docs/docmodel"
+	"github.com/opendecree/decree/contrib/decree-docs/internal/render"
 )
 
 // Page is one file in the rendered MDX tree.
@@ -46,26 +46,21 @@ type Page struct {
 
 // Render renders doc as a Docusaurus MDX doc tree.
 func Render(doc *docmodel.Document) ([]Page, error) {
-	groups := groupByPrefix(doc.Schema.Fields)
+	groups := render.GroupByPrefix(doc.Schema.Fields)
 
 	pages := make([]Page, 0, 1+2*len(groups))
 	pages = append(pages, indexPage(doc.Schema, groups))
 	for i, g := range groups {
 		position := i + 1
-		pages = append(pages, categoryFile(g.prefix, position))
+		pages = append(pages, categoryFile(g.Prefix, position))
 		pages = append(pages, groupPage(g))
 	}
 	return pages, nil
 }
 
-func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
-	title := s.Name
-	if s.Info != nil && s.Info.Title != "" {
-		title = s.Info.Title
-	}
-
+func indexPage(s docmodel.Schema, groups []render.Group) Page {
 	var b strings.Builder
-	writeFrontmatter(&b, "index", title, "Overview", 0)
+	writeFrontmatter(&b, "index", render.Title(s), "Overview", 0)
 
 	if s.Description != "" {
 		fmt.Fprintf(&b, "%s\n\n", escapeText(s.Description))
@@ -87,10 +82,10 @@ func indexPage(s docmodel.Schema, groups []fieldGroup) Page {
 	fmt.Fprintln(&b)
 	for _, g := range groups {
 		noun := "fields"
-		if len(g.fields) == 1 {
+		if len(g.Fields) == 1 {
 			noun = "field"
 		}
-		fmt.Fprintf(&b, "- [%s](./%s/index) — %d %s\n", escapeText(g.prefix), g.prefix, len(g.fields), noun)
+		fmt.Fprintf(&b, "- [%s](./%s/index) — %d %s\n", escapeText(g.Prefix), g.Prefix, len(g.Fields), noun)
 	}
 	fmt.Fprintln(&b)
 
@@ -127,17 +122,17 @@ func categoryFile(prefix string, position int) Page {
 	return Page{Path: prefix + "/_category_.json", Content: content}
 }
 
-func groupPage(g fieldGroup) Page {
+func groupPage(g render.Group) Page {
 	var b strings.Builder
-	writeFrontmatter(&b, "index", g.prefix, g.prefix, 1)
-	for i, f := range g.fields {
+	writeFrontmatter(&b, "index", g.Prefix, g.Prefix, 1)
+	for i, f := range g.Fields {
 		if i > 0 {
 			fmt.Fprintln(&b, "---")
 			fmt.Fprintln(&b)
 		}
 		writeField(&b, f)
 	}
-	return Page{Path: g.prefix + "/index.mdx", Content: b.String()}
+	return Page{Path: g.Prefix + "/index.mdx", Content: b.String()}
 }
 
 func writeFrontmatter(b *strings.Builder, id, title, sidebarLabel string, position int) {
@@ -148,34 +143,6 @@ func writeFrontmatter(b *strings.Builder, id, title, sidebarLabel string, positi
 	fmt.Fprintf(b, "sidebar_position: %d\n", position)
 	fmt.Fprintln(b, "---")
 	fmt.Fprintln(b)
-}
-
-// --- Grouping ---
-
-type fieldGroup struct {
-	prefix string
-	fields []docmodel.Field
-}
-
-// groupByPrefix groups fields by their top-level path prefix. fields is
-// assumed sorted by path (docmodel guarantees this), so the first occurrence
-// of each prefix establishes deterministic group order.
-func groupByPrefix(fields []docmodel.Field) []fieldGroup {
-	var groups []fieldGroup
-	index := make(map[string]int)
-	for _, f := range fields {
-		prefix := f.Path
-		if i := strings.IndexByte(f.Path, '.'); i > 0 {
-			prefix = f.Path[:i]
-		}
-		if i, ok := index[prefix]; ok {
-			groups[i].fields = append(groups[i].fields, f)
-		} else {
-			index[prefix] = len(groups)
-			groups = append(groups, fieldGroup{prefix: prefix, fields: []docmodel.Field{f}})
-		}
-	}
-	return groups
 }
 
 // --- Fields ---
@@ -346,11 +313,14 @@ func writeValidations(b *strings.Builder, validations []docmodel.Validation) {
 // distinguished via the same bracket-label admonition mechanism
 // writeDeprecationNotice uses: ":::danger[Error]" for error severity,
 // ":::caution[Warning]" for warning (and the default, in case Severity is
-// unset or holds an unrecognized value).
+// unset or holds an unrecognized value). The canonical key from
+// [render.Severity] selects the admonition; mdx maps error onto Docusaurus's
+// "danger" and warning onto "caution".
 func writeValidationMessage(b *strings.Builder, v docmodel.Validation) {
-	admonition, label := "caution", "Warning"
-	if v.Severity == "error" {
-		admonition, label = "danger", "Error"
+	key, label := render.Severity(v.Severity)
+	admonition := "caution"
+	if key == "error" {
+		admonition = "danger"
 	}
 	fmt.Fprintf(b, ":::%s[%s]\n", admonition, label)
 	fmt.Fprintf(b, "%s\n", escapeText(v.Message))
@@ -378,11 +348,7 @@ func writeExamples(b *strings.Builder, f docmodel.Field) {
 		return
 	}
 
-	names := make([]string, 0, len(f.Examples))
-	for name := range f.Examples {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := render.SortedExampleNames(f)
 
 	fmt.Fprintln(b, "**Examples:**")
 	if f.Example != "" {
@@ -400,62 +366,34 @@ func writeExamples(b *strings.Builder, f docmodel.Field) {
 }
 
 func writeConstraints(b *strings.Builder, c *docmodel.Constraints) {
-	var lines []string
-	if c.Minimum != nil {
-		lines = append(lines, fmt.Sprintf("Minimum: %s", formatFloat(*c.Minimum)))
-	}
-	if c.Maximum != nil {
-		lines = append(lines, fmt.Sprintf("Maximum: %s", formatFloat(*c.Maximum)))
-	}
-	if c.ExclusiveMinimum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive minimum: %s", formatFloat(*c.ExclusiveMinimum)))
-	}
-	if c.ExclusiveMaximum != nil {
-		lines = append(lines, fmt.Sprintf("Exclusive maximum: %s", formatFloat(*c.ExclusiveMaximum)))
-	}
-	if c.MinLength != nil {
-		lines = append(lines, fmt.Sprintf("Min length: %d", *c.MinLength))
-	}
-	if c.MaxLength != nil {
-		lines = append(lines, fmt.Sprintf("Max length: %d", *c.MaxLength))
-	}
-	if c.Pattern != "" {
-		lines = append(lines, fmt.Sprintf("Pattern: %s", codeSpan(c.Pattern)))
-	}
-	if len(c.Enum) > 0 {
-		enum := make([]string, len(c.Enum))
-		for i, v := range c.Enum {
-			enum[i] = codeSpan(v)
-		}
-		lines = append(lines, fmt.Sprintf("Enum: %s", strings.Join(enum, ", ")))
-	}
-	if c.JSONSchema != "" {
-		lines = append(lines, "JSON Schema: (see schema definition)")
-	}
-	if len(c.AllowedSchemes) > 0 {
-		schemes := make([]string, len(c.AllowedSchemes))
-		for i, s := range c.AllowedSchemes {
-			schemes[i] = codeSpan(s)
-		}
-		lines = append(lines, fmt.Sprintf("Allowed schemes: %s", strings.Join(schemes, ", ")))
-	}
+	lines := render.Constraints(c)
 	if len(lines) == 0 {
 		return
 	}
 	fmt.Fprintln(b, "**Constraints:**")
-	for _, l := range lines {
-		fmt.Fprintf(b, "- %s\n", l)
+	for _, k := range lines {
+		fmt.Fprintf(b, "- %s: %s\n", k.Label, constraintValue(k))
 	}
 	fmt.Fprintln(b)
 }
 
-// formatFloat formats f for display, omitting the decimal point when the
-// value is a whole number (e.g. 1.0 -> "1", 1.5 -> "1.5").
-func formatFloat(f float64) string {
-	if f == float64(int64(f)) {
-		return strconv.FormatInt(int64(f), 10)
+// constraintValue formats a constraint value for MDX: regex patterns and
+// every list member run through codeSpan, since enum members and patterns
+// are schema-sourced and may contain MDX-special characters. Scalars are
+// numeric or fixed notes and render verbatim.
+func constraintValue(k render.Constraint) string {
+	switch k.Kind {
+	case render.CodeConstraint:
+		return codeSpan(k.Value)
+	case render.ListConstraint:
+		parts := make([]string, len(k.Values))
+		for i, v := range k.Values {
+			parts[i] = codeSpan(v)
+		}
+		return strings.Join(parts, ", ")
+	default:
+		return k.Value
 	}
-	return strconv.FormatFloat(f, 'g', -1, 64)
 }
 
 // --- Escaping ---

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
   "cmd/decree": 86.1,
-  "contrib/decree-docs": 99.3,
+  "contrib/decree-docs": 99.2,
   "internal": 88.5,
   "sdk/adminclient": 97.7,
   "sdk/configclient": 87.1,


### PR DESCRIPTION
## Summary

- The `html`, `markdown`, and `mdx` backends each re-implemented the same
  format-agnostic logic by copy-paste — field grouping by path prefix,
  whole-number float formatting, schema title resolution, validation
  severity normalization, sorted example ordering, and the canonical order
  and labels of constraint lines. This consolidates them into a new
  `internal/render` package so the three backends share one source of truth
  and cannot drift; each backend keeps only its own output syntax.
- Output is unchanged: constraint lines flow through `render.Constraints`
  (ordered, kind-tagged entries) and each backend still formats values in
  its own dialect, so every golden file is untouched.
- Fixes the root command help, which still claimed the `mdx` backend was
  unimplemented after it shipped.

## Test plan

- `make pre-commit` green: build, vet, gofmt, golangci-lint (0 issues),
  full test suite, coverage, safety scan.
- All golden tests pass with **zero** golden-file changes — proves the
  refactor is byte-for-byte output-preserving across html/markdown/mdx.
- New `internal/render` package covered 100% via direct table tests.

## Notes

- `contrib/decree-docs` coverage threshold drops 99.3 → 99.2. This is not a
  quality regression: consolidating ~2/3 of the duplicated (fully covered)
  helper lines into one copy mechanically reweights the unchanged,
  unreachable defensive branches (pre-validated `Render` error paths,
  `main`). No test or covered behavior was lost.