### PR TITLE
fix(ci): lint-go now covers all Go modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,17 @@ jobs:
       - name: Go format check
         run: golangci-lint fmt --diff
 
+      - name: Go lint (contrib + SDK modules + CLI)
+        # golangci-lint-action only lints the root module's working directory.
+        # Loop over the same module list used by `make test`/`build`/`vet` so
+        # contrib/decree-docs, the SDK modules, and cmd/decree are covered too.
+        run: |
+          for mod in sdk/retry sdk/configclient sdk/adminclient sdk/configwatcher sdk/grpctransport sdk/tools sdk/contrib/viper sdk/contrib/envconfig sdk/contrib/koanf contrib/decree-docs cmd/decree; do
+            echo "::group::golangci-lint: $mod"
+            (cd "$mod" && golangci-lint run ./... && golangci-lint fmt --diff)
+            echo "::endgroup::"
+          done
+
       - name: Install buf
         run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
         env:

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,12 @@ ui:
 ## lint: Run all linters (Go + protobuf + migrations)
 lint: lint-go lint-proto lint-migrations
 
-## lint-go: Run golangci-lint (linters + formatter)
+## lint-go: Run golangci-lint (linters + formatter) across all modules
 lint-go:
 	golangci-lint run ./...
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && golangci-lint run ./...) || exit 1; done
 	golangci-lint fmt --diff
+	@for mod in $(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree; do (cd $$mod && golangci-lint fmt --diff) || exit 1; done
 
 ## lint-migrations: Check migrations for blocking CREATE INDEX (requires CONCURRENTLY or suppression annotation)
 lint-migrations:

--- a/cmd/decree/audit.go
+++ b/cmd/decree/audit.go
@@ -160,11 +160,11 @@ var auditUnusedCmd = &cobra.Command{
 // non-nil error when breaks are found so that the CLI exits non-zero.
 func printVerifyResult(w io.Writer, result adminclient.VerifyChainResult) error {
 	if result.OK {
-		fmt.Fprintf(w, "OK — %d entries, chain intact\n", result.Total)
+		_, _ = fmt.Fprintf(w, "OK — %d entries, chain intact\n", result.Total)
 		return nil
 	}
 
-	fmt.Fprintf(w, "FAIL — %d breaks in %d entries\n", len(result.Breaks), result.Total)
+	_, _ = fmt.Fprintf(w, "FAIL — %d breaks in %d entries\n", len(result.Breaks), result.Total)
 	rows := tableRows([]string{"POSITION", "ENTRY_ID", "GOT", "WANT"})
 	for _, b := range result.Breaks {
 		got := b.Got

--- a/cmd/decree/cli_test.go
+++ b/cmd/decree/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"slices"
@@ -376,8 +377,8 @@ func TestMain_PrintsErrorBeforeExit(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected child process to exit non-zero, got nil error")
 	}
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
 	}
 	if got := exitErr.ExitCode(); got != 1 {

--- a/cmd/decree/connect_test.go
+++ b/cmd/decree/connect_test.go
@@ -27,7 +27,7 @@ func TestDialServer_TLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dialServer (TLS path) unexpected error: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TestDialServer_TLS_NoWarning verifies that no warning is printed to stderr
@@ -53,7 +53,7 @@ func TestDialServer_TLS_NoWarning(t *testing.T) {
 	t.Cleanup(func() { os.Stderr = origStderr })
 
 	conn, dialErr := dialServer()
-	w.Close()
+	_ = w.Close()
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck
@@ -61,7 +61,7 @@ func TestDialServer_TLS_NoWarning(t *testing.T) {
 	if dialErr != nil {
 		t.Fatalf("dialServer (TLS path) unexpected error: %v", dialErr)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	if buf.Len() != 0 {
 		t.Errorf("expected no stderr output on TLS path, got: %q", buf.String())
@@ -85,7 +85,7 @@ func TestDialServer_Insecure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dialServer (insecure path) unexpected error: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TestDialServer_Insecure_PrintsWarning verifies that a warning is printed to
@@ -111,7 +111,7 @@ func TestDialServer_Insecure_PrintsWarning(t *testing.T) {
 	t.Cleanup(func() { os.Stderr = origStderr })
 
 	conn, dialErr := dialServer()
-	w.Close()
+	_ = w.Close()
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck
@@ -119,7 +119,7 @@ func TestDialServer_Insecure_PrintsWarning(t *testing.T) {
 	if dialErr != nil {
 		t.Fatalf("dialServer (insecure path) unexpected error: %v", dialErr)
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	got := buf.String()
 	if !strings.Contains(got, "Warning") {
@@ -162,7 +162,7 @@ func TestResolveToken_TokenFile(t *testing.T) {
 		t.Fatalf("create temp: %v", err)
 	}
 	f.WriteString("  file-token\n") //nolint:errcheck
-	f.Close()
+	_ = f.Close()
 
 	flagToken = "ignored"
 	flagTokenFile = f.Name()

--- a/cmd/decree/gendocs.go
+++ b/cmd/decree/gendocs.go
@@ -39,11 +39,7 @@ var genDocsCmd = &cobra.Command{
 			return fmt.Sprintf("---\ntitle: %s\n---\n\n", title)
 		}
 
-		linkHandler := func(name string) string {
-			return strings.ToLower(name)
-		}
-
-		if err := doc.GenMarkdownTreeCustom(rootCmd, outDir, prepender, linkHandler); err != nil {
+		if err := doc.GenMarkdownTreeCustom(rootCmd, outDir, prepender, strings.ToLower); err != nil {
 			return fmt.Errorf("generate docs: %w", err)
 		}
 

--- a/cmd/decree/helpers_test.go
+++ b/cmd/decree/helpers_test.go
@@ -62,7 +62,7 @@ func TestPrintOutput_JSON(t *testing.T) {
 	t.Cleanup(func() { os.Stdout = origStdout })
 
 	err := printOutput(map[string]string{"k": "v"})
-	w.Close()
+	_ = w.Close()
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck
@@ -86,7 +86,7 @@ func TestPrintOutput_YAML(t *testing.T) {
 	t.Cleanup(func() { os.Stdout = origStdout })
 
 	err := printOutput(map[string]string{"k": "v"})
-	w.Close()
+	_ = w.Close()
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck
@@ -110,7 +110,7 @@ func TestPrintOutput_Table(t *testing.T) {
 	t.Cleanup(func() { os.Stdout = origStdout })
 
 	err := printOutput([][]string{{"HEADER"}, {"row"}})
-	w.Close()
+	_ = w.Close()
 
 	var buf bytes.Buffer
 	io.Copy(&buf, r) //nolint:errcheck

--- a/cmd/decree/main.go
+++ b/cmd/decree/main.go
@@ -25,6 +25,14 @@ var (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+// run executes the root command and returns the process exit code. Splitting
+// this out from main keeps the signal-context defer (stop()) and any future
+// deferred cleanup running before the process exits — os.Exit in main itself
+// would skip them (gocritic: exitAfterDefer).
+func run() int {
 	ctx, stop := signal.NotifyContext(
 		context.Background(),
 		syscall.SIGINT,
@@ -34,8 +42,9 @@ func main() {
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 var rootCmd = &cobra.Command{
@@ -56,12 +65,12 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		defer conn.Close()
-		fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for server %s (timeout %s)...\n", flagServer, timeout)
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for server %s (timeout %s)...\n", flagServer, timeout)
 		if err := waitForServer(cmd.Context(), conn, timeout); err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "Server ready.\n")
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Server ready.\n")
 		return nil
 	},
 }

--- a/cmd/decree/output.go
+++ b/cmd/decree/output.go
@@ -67,7 +67,7 @@ func printTable(w io.Writer, data any) error {
 // printStatus writes a human-readable status message to cmd.ErrOrStderr() so
 // that it never pollutes the machine-readable stdout stream.
 func printStatus(cmd *cobra.Command, format string, args ...any) {
-	fmt.Fprintf(cmd.ErrOrStderr(), format, args...)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), format, args...)
 }
 
 // tableRows is a helper to build table data with headers.

--- a/cmd/decree/wait_test.go
+++ b/cmd/decree/wait_test.go
@@ -22,7 +22,7 @@ func TestWaitForServer_Healthy(t *testing.T) {
 	hs := health.NewServer()
 	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	healthpb.RegisterHealthServer(srv, hs)
-	go srv.Serve(lis)
+	go func() { _ = srv.Serve(lis) }()
 	defer srv.Stop()
 
 	conn, err := grpc.NewClient(lis.Addr().String(),
@@ -31,7 +31,7 @@ func TestWaitForServer_Healthy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	if err := waitForServer(context.Background(), conn, 5*time.Second); err != nil {
 		t.Fatalf("expected healthy server, got: %v", err)
@@ -46,7 +46,7 @@ func TestWaitForServer_Timeout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	err = waitForServer(context.Background(), conn, 2*time.Second)
 	if err == nil {
@@ -62,7 +62,7 @@ func TestWaitForServer_ParentCancel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately

--- a/sdk/adminclient/audit.go
+++ b/sdk/adminclient/audit.go
@@ -288,44 +288,45 @@ func computeClientHash(previousHash string, e *AuditEntry) string {
 	h := sha256.New()
 	if e.ChainEpoch == 0 {
 		// Epoch 0: structural fields only (legacy, backward compat).
-		fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d",
+		// hash.Hash.Write/Fprintf never return an error per the hash.Hash contract.
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d",
 			previousHash, e.ID, e.TenantID, e.Actor, e.Action, e.ObjectKind, e.CreatedAt.UnixNano())
 		return hex.EncodeToString(h.Sum(nil))
 	}
 	// Epoch 1+: structural fields followed by payload fields.
 	// Mirrors internal/audit.ComputeEntryHash epoch-1 logic exactly.
-	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d\x00",
+	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%d\x00",
 		previousHash, e.ID, e.TenantID, e.Actor, e.Action, e.ObjectKind, e.CreatedAt.UnixNano())
 	writeNullableStr(h, e.FieldPath)
 	writeNullableStr(h, e.OldValue)
 	writeNullableStr(h, e.NewValue)
 	writeNullableI32(h, e.ConfigVersion)
 	if len(e.Metadata) == 0 {
-		h.Write([]byte{0x00})
+		_, _ = h.Write([]byte{0x00})
 	} else {
 		// Metadata is hashed as sorted JSON to produce a deterministic encoding
 		// that matches the server's encoding of the JSONB bytes.
-		h.Write([]byte{0x01})
+		_, _ = h.Write([]byte{0x01})
 		b, _ := marshalSortedJSON(e.Metadata)
-		fmt.Fprint(h, hex.EncodeToString(b))
+		_, _ = fmt.Fprint(h, hex.EncodeToString(b))
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 
 func writeNullableStr(h interface{ Write([]byte) (int, error) }, s string) {
 	if s == "" {
-		h.Write([]byte{0x00})
+		_, _ = h.Write([]byte{0x00})
 	} else {
-		h.Write([]byte{0x01})
-		fmt.Fprintf(h, "%s\x00", s)
+		_, _ = h.Write([]byte{0x01})
+		_, _ = fmt.Fprintf(h, "%s\x00", s)
 	}
 }
 
 func writeNullableI32(h interface{ Write([]byte) (int, error) }, v *int32) {
 	if v == nil {
-		h.Write([]byte{0x00})
+		_, _ = h.Write([]byte{0x00})
 	} else {
-		fmt.Fprintf(h, "\x01%d\x00", *v)
+		_, _ = fmt.Fprintf(h, "\x01%d\x00", *v)
 	}
 }
 

--- a/sdk/adminclient/coverage_test.go
+++ b/sdk/adminclient/coverage_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 // TestRetry_ContextAlreadyCancelledBeforeBackoff covers the ctx.Err() != nil fast-path
@@ -80,7 +82,7 @@ func TestRetry_ContextCancelledDuringBackoff(t *testing.T) {
 // TestBackoffDuration_WithJitter covers the jitter branch in backoffDuration.
 func TestBackoffDuration_WithJitter(t *testing.T) {
 	// With jitter enabled the result must be in [0, backoff) where backoff = 100ms at attempt 0.
-	d := backoffDuration(0, 100*time.Millisecond, 5*time.Second, true)
+	d := sdkretry.BackoffDuration(0, 100*time.Millisecond, 5*time.Second, true)
 	if d < 0 || d >= 100*time.Millisecond {
 		t.Errorf("jittered backoff %v out of expected range [0, 100ms)", d)
 	}
@@ -88,7 +90,7 @@ func TestBackoffDuration_WithJitter(t *testing.T) {
 	// Run several times to confirm it's not always zero (probabilistic, but 0 has P=1/1e9).
 	nonZero := false
 	for range 20 {
-		if backoffDuration(0, 100*time.Millisecond, 5*time.Second, true) > 0 {
+		if sdkretry.BackoffDuration(0, 100*time.Millisecond, 5*time.Second, true) > 0 {
 			nonZero = true
 			break
 		}

--- a/sdk/adminclient/example_test.go
+++ b/sdk/adminclient/example_test.go
@@ -222,8 +222,8 @@ func ExampleWithAuditTenant() {
 		fmt.Println("error:", err)
 		return
 	}
-	fmt.Println(len(entries) >= 0)
-	// Output: true
+	fmt.Println("queried", len(entries), "entries without error")
+	// Output: queried 0 entries without error
 }
 
 func ExampleClient_QueryWriteLog() {
@@ -238,8 +238,8 @@ func ExampleClient_QueryWriteLog() {
 		fmt.Println("error:", err)
 		return
 	}
-	fmt.Println(len(entries) >= 0)
-	// Output: true
+	fmt.Println("queried", len(entries), "entries without error")
+	// Output: queried 0 entries without error
 }
 
 func ExampleClient_VerifyChain() {

--- a/sdk/adminclient/retry.go
+++ b/sdk/adminclient/retry.go
@@ -2,7 +2,6 @@ package adminclient
 
 import (
 	"context"
-	"time"
 
 	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
@@ -15,10 +14,4 @@ type RetryConfig = sdkretry.Config
 // Only idempotent operations (reads: List*, Get*) should be wrapped with retry.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
 	return sdkretry.Run(ctx, c.opts.retryEnabled, c.opts.retry, fn)
-}
-
-// backoffDuration computes exponential backoff with optional jitter.
-// Exposed for tests.
-func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
-	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
 }

--- a/sdk/adminclient/retry_test.go
+++ b/sdk/adminclient/retry_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 func TestRetry_NoRetryByDefault(t *testing.T) {
@@ -238,22 +240,22 @@ func TestRetryableError_Unwrap(t *testing.T) {
 }
 
 func TestBackoffDuration(t *testing.T) {
-	b0 := backoffDuration(0, 100*time.Millisecond, 5*time.Second, false)
+	b0 := sdkretry.BackoffDuration(0, 100*time.Millisecond, 5*time.Second, false)
 	if b0 != 100*time.Millisecond {
 		t.Errorf("got %v, want %v", b0, 100*time.Millisecond)
 	}
 
-	b1 := backoffDuration(1, 100*time.Millisecond, 5*time.Second, false)
+	b1 := sdkretry.BackoffDuration(1, 100*time.Millisecond, 5*time.Second, false)
 	if b1 != 200*time.Millisecond {
 		t.Errorf("got %v, want %v", b1, 200*time.Millisecond)
 	}
 
-	b2 := backoffDuration(2, 100*time.Millisecond, 5*time.Second, false)
+	b2 := sdkretry.BackoffDuration(2, 100*time.Millisecond, 5*time.Second, false)
 	if b2 != 400*time.Millisecond {
 		t.Errorf("got %v, want %v", b2, 400*time.Millisecond)
 	}
 
-	b10 := backoffDuration(10, 100*time.Millisecond, 5*time.Second, false)
+	b10 := sdkretry.BackoffDuration(10, 100*time.Millisecond, 5*time.Second, false)
 	if b10 != 5*time.Second {
 		t.Errorf("got %v, want %v", b10, 5*time.Second)
 	}

--- a/sdk/configclient/retry.go
+++ b/sdk/configclient/retry.go
@@ -2,7 +2,6 @@ package configclient
 
 import (
 	"context"
-	"time"
 
 	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
@@ -23,10 +22,4 @@ func WithRetry(cfg RetryConfig) Option {
 // retry executes fn with retries if retry is enabled. Otherwise calls fn once.
 func retry[T any](ctx context.Context, c *Client, fn func(ctx context.Context) (T, error)) (T, error) {
 	return sdkretry.Run(ctx, c.opts.retryEnabled, c.opts.retry, fn)
-}
-
-// backoffDuration computes exponential backoff with optional jitter.
-// Exposed for tests.
-func backoffDuration(attempt int, initial, max time.Duration, jitter bool) time.Duration {
-	return sdkretry.BackoffDuration(attempt, initial, max, jitter)
 }

--- a/sdk/configclient/retry_test.go
+++ b/sdk/configclient/retry_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	sdkretry "github.com/opendecree/decree/sdk/retry"
 )
 
 func TestRetry_NoRetryByDefault(t *testing.T) {
@@ -169,29 +171,29 @@ func TestRetryConfig_PreservesCustomValues(t *testing.T) {
 }
 
 func TestBackoffDuration(t *testing.T) {
-	b0 := backoffDuration(0, 100*time.Millisecond, 5*time.Second, false)
+	b0 := sdkretry.BackoffDuration(0, 100*time.Millisecond, 5*time.Second, false)
 	if b0 != 100*time.Millisecond {
 		t.Errorf("got %v, want %v", b0, 100*time.Millisecond)
 	}
 
-	b1 := backoffDuration(1, 100*time.Millisecond, 5*time.Second, false)
+	b1 := sdkretry.BackoffDuration(1, 100*time.Millisecond, 5*time.Second, false)
 	if b1 != 200*time.Millisecond {
 		t.Errorf("got %v, want %v", b1, 200*time.Millisecond)
 	}
 
-	b2 := backoffDuration(2, 100*time.Millisecond, 5*time.Second, false)
+	b2 := sdkretry.BackoffDuration(2, 100*time.Millisecond, 5*time.Second, false)
 	if b2 != 400*time.Millisecond {
 		t.Errorf("got %v, want %v", b2, 400*time.Millisecond)
 	}
 
-	b10 := backoffDuration(10, 100*time.Millisecond, 5*time.Second, false)
+	b10 := sdkretry.BackoffDuration(10, 100*time.Millisecond, 5*time.Second, false)
 	if b10 != 5*time.Second {
 		t.Errorf("got %v, want %v", b10, 5*time.Second)
 	}
 }
 
 func TestBackoffDuration_WithJitter(t *testing.T) {
-	b := backoffDuration(2, 100*time.Millisecond, 5*time.Second, true)
+	b := sdkretry.BackoffDuration(2, 100*time.Millisecond, 5*time.Second, true)
 	if b >= 400*time.Millisecond {
 		t.Errorf("got %v, want < %v", b, 400*time.Millisecond)
 	}

--- a/sdk/configclient/typed_test.go
+++ b/sdk/configclient/typed_test.go
@@ -383,7 +383,7 @@ func TestRetryableError(t *testing.T) {
 	if re.Error() != "unavailable" {
 		t.Errorf("Error(): got %v, want unavailable", re.Error())
 	}
-	if re.Unwrap() != inner {
+	if !errors.Is(re.Unwrap(), inner) {
 		t.Errorf("Unwrap(): got %v, want %v", re.Unwrap(), inner)
 	}
 }

--- a/sdk/configwatcher/fieldgroups_test.go
+++ b/sdk/configwatcher/fieldgroups_test.go
@@ -44,7 +44,7 @@ func TestNewGroup_FillAllTypes(t *testing.T) {
 	if err := w.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	var cfg Config
 	if err := g.Fill(&cfg); err != nil {

--- a/sdk/configwatcher/watcher_test.go
+++ b/sdk/configwatcher/watcher_test.go
@@ -3,6 +3,7 @@ package configwatcher
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -318,27 +319,27 @@ func TestWatcher_RegisterAfterStart(t *testing.T) {
 	if errAfter == nil {
 		t.Fatal("expected ErrStarted, got nil")
 	}
-	if errAfter != ErrStarted {
+	if !errors.Is(errAfter, ErrStarted) {
 		t.Errorf("got %v, want ErrStarted", errAfter)
 	}
 
 	// Verify all typed methods return ErrStarted after Start.
-	if _, e := w.Int("x", 0); e != ErrStarted {
+	if _, e := w.Int("x", 0); !errors.Is(e, ErrStarted) {
 		t.Errorf("Int: got %v, want ErrStarted", e)
 	}
-	if _, e := w.Float("x", 0); e != ErrStarted {
+	if _, e := w.Float("x", 0); !errors.Is(e, ErrStarted) {
 		t.Errorf("Float: got %v, want ErrStarted", e)
 	}
-	if _, e := w.Bool("x", false); e != ErrStarted {
+	if _, e := w.Bool("x", false); !errors.Is(e, ErrStarted) {
 		t.Errorf("Bool: got %v, want ErrStarted", e)
 	}
-	if _, e := w.Duration("x", 0); e != ErrStarted {
+	if _, e := w.Duration("x", 0); !errors.Is(e, ErrStarted) {
 		t.Errorf("Duration: got %v, want ErrStarted", e)
 	}
-	if _, e := w.Time("x", time.Time{}); e != ErrStarted {
+	if _, e := w.Time("x", time.Time{}); !errors.Is(e, ErrStarted) {
 		t.Errorf("Time: got %v, want ErrStarted", e)
 	}
-	if _, e := w.Raw("x", ""); e != ErrStarted {
+	if _, e := w.Raw("x", ""); !errors.Is(e, ErrStarted) {
 		t.Errorf("Raw: got %v, want ErrStarted", e)
 	}
 
@@ -1417,7 +1418,7 @@ func TestWatcher_StartAfterClose(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected ErrClosed from Start after Close, got nil")
 	}
-	if err != ErrClosed {
+	if !errors.Is(err, ErrClosed) {
 		t.Errorf("got %v, want ErrClosed", err)
 	}
 

--- a/sdk/configwatcher/write_test.go
+++ b/sdk/configwatcher/write_test.go
@@ -44,7 +44,7 @@ func TestSetString_WritesAndUpdatesLocal(t *testing.T) {
 	if err := w.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	if err := w.SetString(context.Background(), "app.env", "production"); err != nil {
 		t.Fatalf("SetString: %v", err)
@@ -84,7 +84,7 @@ func TestSetString_TransportError(t *testing.T) {
 	if err := w.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	err := w.SetString(context.Background(), "app.env", "production")
 	if err == nil {
@@ -112,7 +112,7 @@ func TestSetBool_WriteThroughOptions(t *testing.T) {
 	if err := w.Start(context.Background()); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	defer w.Close()
+	defer func() { _ = w.Close() }()
 
 	if err := w.SetBool(context.Background(), "app.debug", true,
 		WithDescription("enable debug"),

--- a/sdk/grpctransport/applyauth_test.go
+++ b/sdk/grpctransport/applyauth_test.go
@@ -152,10 +152,6 @@ func TestApplyAuth_TokenSource_TakesPrecedenceOverBearerToken(t *testing.T) {
 		t.Fatalf("expected 1 call option, got %d", len(callOpts))
 	}
 	// Verify the credential resolves the tokenSource token (not the static one).
-	// Extract the PerRPCCredentials from the call option by casting via interface.
-	type perRPCOption interface {
-		GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error)
-	}
 	// The call option wraps credentials; test it indirectly by verifying only
 	// one call option is returned (correct path taken).
 	_ = callOpts[0]

--- a/sdk/grpctransport/auth_test.go
+++ b/sdk/grpctransport/auth_test.go
@@ -98,7 +98,7 @@ func TestInsecureConn_WithBearerToken_RPCRejected(t *testing.T) {
 	srv := grpc.NewServer()
 	pb.RegisterConfigServiceServer(srv, &pb.UnimplementedConfigServiceServer{})
 	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(func() { srv.Stop(); lis.Close() })
+	t.Cleanup(func() { srv.Stop(); _ = lis.Close() })
 
 	// Dial with insecure credentials (no TLS).
 	clientConn, err := grpc.NewClient(
@@ -111,7 +111,7 @@ func TestInsecureConn_WithBearerToken_RPCRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
-	t.Cleanup(func() { clientConn.Close() })
+	t.Cleanup(func() { _ = clientConn.Close() })
 
 	transport, err := grpctransport.NewConfigTransport(clientConn,
 		grpctransport.WithBearerToken("super-secret-jwt"),

--- a/sdk/grpctransport/dial_test.go
+++ b/sdk/grpctransport/dial_test.go
@@ -15,7 +15,7 @@ func TestDial_DefaultTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TODO: There is no test that verifies WithInsecure yields a plaintext
@@ -28,7 +28,7 @@ func TestDial_WithInsecure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 func TestDial_WithCustomCA(t *testing.T) {
@@ -37,7 +37,7 @@ func TestDial_WithCustomCA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TestDial_DefaultKeepalive verifies that Dial succeeds with the default
@@ -49,7 +49,7 @@ func TestDial_DefaultKeepalive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial with default keepalive failed: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TestDial_WithKeepalive verifies that WithKeepalive overrides the defaults
@@ -67,7 +67,7 @@ func TestDial_WithKeepalive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial with custom keepalive failed: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 }
 
 // TestDefaultKeepaliveParams verifies the exported default values match the

--- a/sdk/grpctransport/errors_test.go
+++ b/sdk/grpctransport/errors_test.go
@@ -125,7 +125,7 @@ func TestMapConfigError_RetryableWrapsOriginalError(t *testing.T) {
 	if !errors.As(err, &re) {
 		t.Fatalf("got %v, want *RetryableError", err)
 	}
-	if re.Err != orig {
+	if !errors.Is(re.Err, orig) {
 		t.Errorf("RetryableError.Err = %v, want original gRPC error", re.Err)
 	}
 }
@@ -133,7 +133,7 @@ func TestMapConfigError_RetryableWrapsOriginalError(t *testing.T) {
 func TestMapConfigError_NonGRPC_PassThrough(t *testing.T) {
 	orig := errors.New("some non-grpc error")
 	err := mapConfigError(orig)
-	if err != orig {
+	if !errors.Is(err, orig) {
 		t.Errorf("got %v, want original error passed through", err)
 	}
 }
@@ -141,7 +141,7 @@ func TestMapConfigError_NonGRPC_PassThrough(t *testing.T) {
 func TestMapConfigError_Default_PassThrough(t *testing.T) {
 	orig := status.Error(codes.Internal, "internal")
 	err := mapConfigError(orig)
-	if err != orig {
+	if !errors.Is(err, orig) {
 		t.Errorf("got %v, want original gRPC error passed through for default code", err)
 	}
 }
@@ -213,7 +213,7 @@ func TestMapAdminError_RetryableWrapsOriginalError(t *testing.T) {
 	if !errors.As(err, &re) {
 		t.Fatalf("got %v, want *RetryableError", err)
 	}
-	if re.Err != orig {
+	if !errors.Is(re.Err, orig) {
 		t.Errorf("RetryableError.Err = %v, want original gRPC error", re.Err)
 	}
 }
@@ -221,7 +221,7 @@ func TestMapAdminError_RetryableWrapsOriginalError(t *testing.T) {
 func TestMapAdminError_NonGRPC_PassThrough(t *testing.T) {
 	orig := errors.New("some non-grpc error")
 	err := mapAdminError(orig)
-	if err != orig {
+	if !errors.Is(err, orig) {
 		t.Errorf("got %v, want original error passed through", err)
 	}
 }
@@ -229,7 +229,7 @@ func TestMapAdminError_NonGRPC_PassThrough(t *testing.T) {
 func TestMapAdminError_Default_PassThrough(t *testing.T) {
 	orig := status.Error(codes.Internal, "internal")
 	err := mapAdminError(orig)
-	if err != orig {
+	if !errors.Is(err, orig) {
 		t.Errorf("got %v, want original gRPC error passed through for default code", err)
 	}
 }

--- a/sdk/grpctransport/example_test.go
+++ b/sdk/grpctransport/example_test.go
@@ -13,7 +13,7 @@ func ExampleDial() {
 		fmt.Println("error:", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	fmt.Println("ok")
 	// Output: ok
 }
@@ -25,7 +25,7 @@ func ExampleDial_insecure() {
 		fmt.Println("error:", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	fmt.Println("ok")
 	// Output: ok
 }
@@ -36,7 +36,7 @@ func ExampleNewConfigClient() {
 		fmt.Println("error:", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, err = grpctransport.NewConfigClient(conn,
 		grpctransport.WithSubject("myapp"),
@@ -56,7 +56,7 @@ func ExampleNewAdminClient() {
 		fmt.Println("error:", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, err = grpctransport.NewAdminClient(conn,
 		grpctransport.WithSubject("admin"),
@@ -76,7 +76,7 @@ func ExampleNewWatcher() {
 		fmt.Println("error:", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	_, err = grpctransport.NewWatcher(conn, "tenant-uuid",
 		grpctransport.WithSubject("myapp"),

--- a/sdk/grpctransport/server_transport_test.go
+++ b/sdk/grpctransport/server_transport_test.go
@@ -44,7 +44,7 @@ func newServerTransportWithStub(t *testing.T, stub pb.ServerServiceServer) *grpc
 	srv := grpc.NewServer()
 	pb.RegisterServerServiceServer(srv, stub)
 	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(func() { srv.Stop(); lis.Close() })
+	t.Cleanup(func() { srv.Stop(); _ = lis.Close() })
 
 	cc, err := grpc.NewClient(
 		"passthrough:///bufconn",
@@ -56,7 +56,7 @@ func newServerTransportWithStub(t *testing.T, stub pb.ServerServiceServer) *grpc
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
-	t.Cleanup(func() { cc.Close() })
+	t.Cleanup(func() { _ = cc.Close() })
 
 	return grpctransport.NewServerTransport(cc)
 }

--- a/sdk/grpctransport/transport_test.go
+++ b/sdk/grpctransport/transport_test.go
@@ -52,7 +52,7 @@ func newBufconnServer(
 		pb.RegisterAuditServiceServer(srv, auditSvc)
 	}
 	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(func() { srv.Stop(); lis.Close() })
+	t.Cleanup(func() { srv.Stop(); _ = lis.Close() })
 
 	cc, err := grpc.NewClient(
 		"passthrough:///bufconn",
@@ -64,7 +64,7 @@ func newBufconnServer(
 	if err != nil {
 		t.Fatalf("grpc.NewClient: %v", err)
 	}
-	t.Cleanup(func() { cc.Close() })
+	t.Cleanup(func() { _ = cc.Close() })
 	return cc
 }
 
@@ -1581,7 +1581,7 @@ func TestDial_WithInsecure_Succeeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
-	cc.Close()
+	_ = cc.Close()
 }
 
 func TestDefaultKeepalive_HasExpectedDefaults(t *testing.T) {

--- a/sdk/tools/docgen/docgen.go
+++ b/sdk/tools/docgen/docgen.go
@@ -217,16 +217,17 @@ func writeSchemaInfo(b *strings.Builder, info *SchemaInfo) {
 		fmt.Fprintf(b, "**Author:** %s\n\n", info.Author)
 	}
 	if info.Contact != nil {
-		if info.Contact.Email != "" {
+		switch {
+		case info.Contact.Email != "":
 			fmt.Fprintf(b, "**Contact:** %s <%s>\n\n", info.Contact.Name, info.Contact.Email)
-		} else if info.Contact.URL != "" {
+		case info.Contact.URL != "":
 			fmt.Fprintf(b, "**Contact:** [%s](%s)\n\n", info.Contact.Name, info.Contact.URL)
-		} else if info.Contact.Name != "" {
+		case info.Contact.Name != "":
 			fmt.Fprintf(b, "**Contact:** %s\n\n", info.Contact.Name)
 		}
 	}
 	if len(info.Labels) > 0 {
-		var labels []string
+		labels := make([]string, 0, len(info.Labels))
 		for k, v := range info.Labels {
 			labels = append(labels, fmt.Sprintf("`%s: %s`", k, v))
 		}

--- a/sdk/tools/validate/validate.go
+++ b/sdk/tools/validate/validate.go
@@ -136,33 +136,33 @@ func Strict() Option {
 	return func(o *options) { o.strict = true }
 }
 
-// --- Result ---
+// --- ResultError ---
 
-// Violation describes a single validation error.
-type Violation struct {
+// ViolationError describes a single validation error.
+type ViolationError struct {
 	FieldPath string
 	Message   string
 }
 
-func (v Violation) Error() string {
+func (v ViolationError) Error() string {
 	if v.FieldPath != "" {
 		return fmt.Sprintf("%s: %s", v.FieldPath, v.Message)
 	}
 	return v.Message
 }
 
-// Result holds all validation violations.
-type Result struct {
-	Violations []Violation
+// ResultError holds all validation violations.
+type ResultError struct {
+	Violations []ViolationError
 }
 
 // IsValid returns true if there are no violations.
-func (r *Result) IsValid() bool {
+func (r *ResultError) IsValid() bool {
 	return len(r.Violations) == 0
 }
 
 // Error returns a multi-line summary of all violations.
-func (r *Result) Error() string {
+func (r *ResultError) Error() string {
 	if r.IsValid() {
 		return ""
 	}
@@ -176,8 +176,8 @@ func (r *Result) Error() string {
 	return b.String()
 }
 
-func (r *Result) add(fieldPath, msg string) {
-	r.Violations = append(r.Violations, Violation{FieldPath: fieldPath, Message: msg})
+func (r *ResultError) add(fieldPath, msg string) {
+	r.Violations = append(r.Violations, ViolationError{FieldPath: fieldPath, Message: msg})
 }
 
 // --- Public API ---
@@ -214,7 +214,7 @@ func ParseSchema(data []byte) (*SchemaFile, error) {
 			if err != nil {
 				return nil, fmt.Errorf("field %s: invalid default: %w", path, err)
 			}
-			r := &Result{}
+			r := &ResultError{}
 			validateValue(r, path, dv, f)
 			if !r.IsValid() {
 				return nil, fmt.Errorf("field %s: default %q violates constraints: %s", path, f.Default, r.Error())
@@ -241,7 +241,7 @@ func ParseConfig(data []byte) (*ConfigFile, error) {
 
 // Validate checks a config file against a schema file.
 // Both are provided as raw YAML bytes.
-func Validate(schemaYAML, configYAML []byte, opts ...Option) (*Result, error) {
+func Validate(schemaYAML, configYAML []byte, opts ...Option) (*ResultError, error) {
 	schema, err := ParseSchema(schemaYAML)
 	if err != nil {
 		return nil, fmt.Errorf("schema: %w", err)
@@ -255,13 +255,13 @@ func Validate(schemaYAML, configYAML []byte, opts ...Option) (*Result, error) {
 }
 
 // ValidateParsed checks a parsed config against a parsed schema.
-func ValidateParsed(schema *SchemaFile, config *ConfigFile, opts ...Option) *Result {
+func ValidateParsed(schema *SchemaFile, config *ConfigFile, opts ...Option) *ResultError {
 	var o options
 	for _, opt := range opts {
 		opt(&o)
 	}
 
-	result := &Result{}
+	result := &ResultError{}
 
 	// Sort paths for deterministic output.
 	configPaths := sortedKeys(config.Values)
@@ -282,7 +282,7 @@ func ValidateParsed(schema *SchemaFile, config *ConfigFile, opts ...Option) *Res
 }
 
 // ValidateFiles is a convenience that reads files from disk.
-func ValidateFiles(schemaPath, configPath string, opts ...Option) (*Result, error) {
+func ValidateFiles(schemaPath, configPath string, opts ...Option) (*ResultError, error) {
 	schemaData, err := os.ReadFile(schemaPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading schema file: %w", err)
@@ -296,7 +296,7 @@ func ValidateFiles(schemaPath, configPath string, opts ...Option) (*Result, erro
 
 // --- Validation logic ---
 
-func validateValue(result *Result, path string, value any, fd FieldDef) {
+func validateValue(result *ResultError, path string, value any, fd FieldDef) {
 	if value == nil {
 		if !fd.Nullable {
 			result.add(path, "null value for non-nullable field")
@@ -338,7 +338,7 @@ func validateValue(result *Result, path string, value any, fd FieldDef) {
 	}
 }
 
-func validateInteger(result *Result, path string, value any, c *ConstraintsDef) bool {
+func validateInteger(result *ResultError, path string, value any, c *ConstraintsDef) bool {
 	var n float64
 	switch v := value.(type) {
 	case int:
@@ -365,7 +365,7 @@ func validateInteger(result *Result, path string, value any, c *ConstraintsDef) 
 	return true
 }
 
-func validateNumber(result *Result, path string, value any, c *ConstraintsDef) bool {
+func validateNumber(result *ResultError, path string, value any, c *ConstraintsDef) bool {
 	var n float64
 	switch v := value.(type) {
 	case int:
@@ -392,7 +392,7 @@ func validateNumber(result *Result, path string, value any, c *ConstraintsDef) b
 	return true
 }
 
-func validateString(result *Result, path string, value any, c *ConstraintsDef) bool {
+func validateString(result *ResultError, path string, value any, c *ConstraintsDef) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected string, got %T", value))
@@ -418,7 +418,7 @@ func validateString(result *Result, path string, value any, c *ConstraintsDef) b
 	return true
 }
 
-func validateBool(result *Result, path string, value any) bool {
+func validateBool(result *ResultError, path string, value any) bool {
 	if _, ok := value.(bool); !ok {
 		result.add(path, fmt.Sprintf("expected bool, got %T", value))
 		return false
@@ -426,7 +426,7 @@ func validateBool(result *Result, path string, value any) bool {
 	return true
 }
 
-func validateStringType(result *Result, path string, value any, typeName string) bool {
+func validateStringType(result *ResultError, path string, value any, typeName string) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected %s (string), got %T", typeName, value))
@@ -440,7 +440,7 @@ func validateStringType(result *Result, path string, value any, typeName string)
 	return true
 }
 
-func validateDuration(result *Result, path string, value any, _ *ConstraintsDef) bool {
+func validateDuration(result *ResultError, path string, value any, _ *ConstraintsDef) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected duration (string), got %T", value))
@@ -454,7 +454,7 @@ func validateDuration(result *Result, path string, value any, _ *ConstraintsDef)
 	return true
 }
 
-func validateURL(result *Result, path string, value any, c *ConstraintsDef) bool {
+func validateURL(result *ResultError, path string, value any, c *ConstraintsDef) bool {
 	s, ok := value.(string)
 	if !ok {
 		result.add(path, fmt.Sprintf("expected url (string), got %T", value))
@@ -479,7 +479,7 @@ func validateURL(result *Result, path string, value any, c *ConstraintsDef) bool
 	return true
 }
 
-func validateJSON(result *Result, path string, value any, c *ConstraintsDef) {
+func validateJSON(result *ResultError, path string, value any, c *ConstraintsDef) {
 	var jsonStr string
 	switch v := value.(type) {
 	case string:
@@ -529,7 +529,7 @@ func validateJSON(result *Result, path string, value any, c *ConstraintsDef) {
 	}
 }
 
-func validateEnum(result *Result, path string, value any, enum []string) {
+func validateEnum(result *ResultError, path string, value any, enum []string) {
 	s := stringifyForEnum(value)
 	for _, e := range enum {
 		if s == e {
@@ -539,7 +539,7 @@ func validateEnum(result *Result, path string, value any, enum []string) {
 	result.add(path, fmt.Sprintf("value %q is not in enum %v", s, enum))
 }
 
-func validateNumericConstraints(result *Result, path string, n float64, c *ConstraintsDef) {
+func validateNumericConstraints(result *ResultError, path string, n float64, c *ConstraintsDef) {
 	if c.Minimum != nil && n < *c.Minimum {
 		result.add(path, fmt.Sprintf("value %s is less than minimum %s", format.Float(n), format.Float(*c.Minimum)))
 	}

--- a/sdk/tools/validate/validate_test.go
+++ b/sdk/tools/validate/validate_test.go
@@ -1000,12 +1000,12 @@ values: {}`},
 }
 
 func TestResult_Error(t *testing.T) {
-	r := &Result{}
+	r := &ResultError{}
 	if r.Error() != "" {
 		t.Error("expected empty error for valid result")
 	}
 
-	r.Violations = []Violation{
+	r.Violations = []ViolationError{
 		{FieldPath: "a", Message: "bad"},
 		{FieldPath: "b", Message: "worse"},
 	}
@@ -1016,7 +1016,7 @@ func TestResult_Error(t *testing.T) {
 }
 
 func TestViolation_Error_NoField(t *testing.T) {
-	v := Violation{Message: "global error"}
+	v := ViolationError{Message: "global error"}
 	if v.Error() != "global error" {
 		t.Errorf("unexpected: %q", v.Error())
 	}
@@ -1024,7 +1024,7 @@ func TestViolation_Error_NoField(t *testing.T) {
 
 // --- Helpers ---
 
-func assertViolation(t *testing.T, result *Result, field, msgSubstr string) {
+func assertViolation(t *testing.T, result *ResultError, field, msgSubstr string) {
 	t.Helper()
 	if result.IsValid() {
 		t.Fatalf("expected violation for %s containing %q, got valid", field, msgSubstr)


### PR DESCRIPTION
## Summary
- `lint-go` ran golangci-lint against the root module only — `contrib/decree-docs`, all `SDK_MODULES`, and `cmd/decree` were never linted (in the Makefile target or in CI's `lint` job, which called golangci-lint-action directly).
- `lint-go` now loops over `$(SDK_MODULES) $(CONTRIB_MODULES) cmd/decree` the same way `test`/`build`/`vet` already do; added a matching per-module loop step to the CI lint job.
- Running the fixed lint-go surfaced a real, pre-existing violation backlog across `sdk/configclient`, `sdk/adminclient`, `sdk/configwatcher`, `sdk/grpctransport`, `sdk/tools`, and `cmd/decree` (unchecked error returns, sentinel comparisons that should use `errors.Is`, an unused helper, two exported types renamed to satisfy `errname`, and an `os.Exit`-skips-defer bug in `cmd/decree`'s `main`). All fixed; behavior is unchanged except `cmd/decree`'s signal-context cleanup now actually runs before exit.

## Test plan
- [x] `make lint-go` — 0 issues across root + all SDK modules + contrib/decree-docs + cmd/decree
- [x] `make pre-commit` — build, vet, fmt, lint, test, coverage all green
- [x] Verified the gap closes: introduced a temporary unused-variable violation in `contrib/decree-docs/generate.go`, confirmed `make lint-go` failed on it, reverted

Closes #952