### PR TITLE
ci: move benchmarks to nightly workflow so check gate doesn't wait

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,58 @@
+# Nightly benchmarks for OpenDecree server + CLI.
+#
+# Split out of ci.yml (issue #970): the bench job was push-to-main only and
+# purely informational (it never blocked anything), yet it sat in the CI
+# `check` alls-green gate's `needs:`, forcing that gate to wait 7-10 min for
+# benchmarks on every push to main. Relocating to a standalone nightly schedule
+# lets the per-push CI gate go green ~2x faster while still tracking benchmark
+# results over time.
+#
+# Runs hot-path and infrastructure benchmarks against main; uploads results as
+# a workflow artifact for tracking over time. Storage (dbstore) and Redis
+# benchmarks are skipped: no DB/Redis services here.
+
+name: Benchmarks
+
+on:
+  schedule:
+    # Nightly at 07:00 UTC.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/go.sum"
+
+      - name: Run benchmarks
+        run: |
+          go test -bench=. -benchmem -run='^$' -benchtime=5s -count=5 \
+            ./internal/authz/ ./internal/cache/ ./internal/pubsub/ ./cmd/server/ \
+            | tee bench.txt
+
+      - name: Compute p50/p95 with benchstat
+        run: |
+          go run golang.org/x/perf/cmd/benchstat@latest bench.txt | tee bench-stats.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-${{ github.sha }}
+          path: |
+            bench.txt
+            bench-stats.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@
 #   - tools job → ghcr.io/<owner>/decree-tools:buildcache
 # ci.yml e2e/examples/stress are read-only consumers.
 # E2E benchmarks moved to release.yml — too slow for per-PR CI.
+# The unit/infra `bench` job lives in bench.yml — it ran push-to-main only and
+# was purely informational, but sat in check.needs and so delayed the alls-green
+# gate 7-10 min on every push. Relocated to a nightly schedule (issue #970).
 
 name: CI
 
@@ -618,48 +621,6 @@ jobs:
       - name: Run chart render tests
         run: ./deploy/helm/decree/tests/template_test.sh
 
-  # Runs hot-path and infrastructure benchmarks; uploads results as a workflow
-  # artifact for tracking over time. Informational — push-to-main only, never
-  # blocks PRs. Storage (dbstore) and Redis benchmarks are skipped: no DB/Redis
-  # services here.
-  bench:
-    name: Benchmarks
-    runs-on: ubuntu-latest
-    needs: changes
-    if: github.event_name == 'push' && needs.changes.outputs.code == 'true'
-    permissions:
-      contents: read
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
-
-      - name: Run benchmarks
-        run: |
-          go test -bench=. -benchmem -run='^$' -benchtime=5s -count=5 \
-            ./internal/authz/ ./internal/cache/ ./internal/pubsub/ ./cmd/server/ \
-            | tee bench.txt
-
-      - name: Compute p50/p95 with benchstat
-        run: |
-          go run golang.org/x/perf/cmd/benchstat@latest bench.txt | tee bench-stats.txt
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
-        with:
-          name: bench-${{ github.sha }}
-          path: |
-            bench.txt
-            bench-stats.txt
-
   # Upgrade safety: runs the previous-release binary against a fresh DB,
   # populates fixture data, applies new migrations, then asserts the new binary
   # can read the old data and accept new writes. Only runs on PRs that touch
@@ -797,7 +758,7 @@ jobs:
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, bench, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only]
+    needs: [lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -806,4 +767,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, bench, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only
+          allowed-skips: lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only


### PR DESCRIPTION
## Summary

The `bench` job ran only on push to main and was purely informational (never blocked anything), yet it sat in the `check` alls-green gate's `needs:`, forcing that gate to wait ~7–10 min for benchmarks on every push to main.

- Moved the benchmark steps verbatim into a new standalone workflow `.github/workflows/bench.yml` — nightly `schedule` (07:00 UTC) + `workflow_dispatch`. Same packages, same `-benchtime=5s -count=5`, same artifact upload; no parameter changes.
- Removed the `bench` job from `ci.yml` and dropped `bench` from the `check` job's `needs` and `allowed-skips`.

Net effect: per-push CI green ~2× faster (measured baseline run had total wall 441s with bench at 409s); benchmark tracking continues nightly.

## Test plan
- [x] `actionlint` (rhysd/actionlint:1.7.12, same `-shellcheck= -pyflakes=` flags as the CI lint gate) over `.github/workflows/` → clean, exit 0
- [x] `make pre-commit` → green (full pipeline; workflow paths count as code)
- [x] Both workflow files parse (`yaml.safe_load`)
- [x] `check.needs` no longer references `bench`; all other jobs unchanged

Closes #970