### PR TITLE
fix(schema): preserve allowed_schemes in seed/dump and YAML codec

### DIFF
--- a/internal/schema/yaml.go
+++ b/internal/schema/yaml.go
@@ -128,6 +128,7 @@ type ConstraintsYAML struct {
 	Pattern          string         `yaml:"pattern,omitempty"`
 	Enum             []string       `yaml:"enum,omitempty"`
 	JSONSchema       string         `yaml:"json_schema,omitempty"`
+	AllowedSchemes   []string       `yaml:"allowed_schemes,omitempty"`
 	Extensions       map[string]any `yaml:",inline"`
 }
 
@@ -445,9 +446,13 @@ func protoConstraintsToYAML(c *pb.FieldConstraints) *ConstraintsYAML {
 	if len(c.EnumValues) > 0 {
 		yc.Enum = c.EnumValues
 	}
+	if len(c.AllowedSchemes) > 0 {
+		yc.AllowedSchemes = c.AllowedSchemes
+	}
 	// Return nil if all fields are zero-valued.
 	if yc.Minimum == nil && yc.Maximum == nil && yc.ExclusiveMinimum == nil && yc.ExclusiveMaximum == nil &&
-		yc.MinLength == nil && yc.MaxLength == nil && yc.Pattern == "" && len(yc.Enum) == 0 && yc.JSONSchema == "" {
+		yc.MinLength == nil && yc.MaxLength == nil && yc.Pattern == "" && len(yc.Enum) == 0 && yc.JSONSchema == "" &&
+		len(yc.AllowedSchemes) == 0 {
 		return nil
 	}
 	return yc
@@ -610,6 +615,9 @@ func yamlConstraintsToProto(yc *ConstraintsYAML) *pb.FieldConstraints {
 	}
 	if len(yc.Enum) > 0 {
 		c.EnumValues = yc.Enum
+	}
+	if len(yc.AllowedSchemes) > 0 {
+		c.AllowedSchemes = yc.AllowedSchemes
 	}
 	if yc.JSONSchema != "" {
 		c.JsonSchema = &yc.JSONSchema

--- a/internal/schema/yaml_test.go
+++ b/internal/schema/yaml_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -559,4 +560,107 @@ func TestConstraintsNilWhenEmpty(t *testing.T) {
 		Fields: []*pb.SchemaField{field},
 	})
 	assert.Nil(t, doc.Fields["x"].Constraints)
+}
+
+// TestYAMLRoundtrip_AllowedSchemes verifies that the allowed_schemes URL
+// constraint survives a full proto → YAML → proto round-trip through the
+// import/export codec. Mirrors the enum handling in TestYAMLRoundtrip.
+func TestYAMLRoundtrip_AllowedSchemes(t *testing.T) {
+	original := &pb.Schema{
+		Name:    "links",
+		Version: 1,
+		Fields: []*pb.SchemaField{
+			{
+				Path: "links.webhook",
+				Type: pb.FieldType_FIELD_TYPE_URL,
+				Constraints: &pb.FieldConstraints{
+					AllowedSchemes: []string{"https", "sftp"},
+				},
+			},
+		},
+	}
+
+	// Proto → YAML: the constraint is emitted under the OAS-style key.
+	doc := schemaToYAML(original)
+	webhook := doc.Fields["links.webhook"]
+	require.NotNil(t, webhook.Constraints)
+	assert.Equal(t, []string{"https", "sftp"}, webhook.Constraints.AllowedSchemes)
+
+	// Marshal → Unmarshal → proto: the value must still be present.
+	data, err := marshalSchemaYAML(doc)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "allowed_schemes")
+
+	parsed, err := unmarshalSchemaYAML(data)
+	require.NoError(t, err)
+
+	fields := yamlToProtoFields(parsed)
+	require.Len(t, fields, 1)
+	assert.Equal(t, []string{"https", "sftp"}, fields[0].Constraints.AllowedSchemes)
+}
+
+// TestProtoConstraintsToYAML_PropertyDrift reflects over every exported field
+// of the proto FieldConstraints message and asserts each one is either copied
+// into ConstraintsYAML by protoConstraintsToYAML or explicitly recorded below
+// as intentionally absent. A constraint added to the proto fails this test
+// until it is mapped in the codec (both directions) or recorded here. Mirrors
+// the drift-guard approach used for the docgen mapping in #912.
+func TestProtoConstraintsToYAML_PropertyDrift(t *testing.T) {
+	// Populate every proto constraint with a distinct non-zero value.
+	in := &pb.FieldConstraints{
+		Min:            ptr(1.0),
+		Max:            ptr(9.0),
+		ExclusiveMin:   ptr(0.5),
+		ExclusiveMax:   ptr(9.5),
+		MinLength:      ptr(int32(2)),
+		MaxLength:      ptr(int32(64)),
+		Regex:          ptr("^https://"),
+		EnumValues:     []string{"a", "b"},
+		JsonSchema:     ptr(`{"type":"string"}`),
+		AllowedSchemes: []string{"https", "sftp"},
+	}
+	out := protoConstraintsToYAML(in)
+	require.NotNil(t, out)
+
+	// notMapped lists proto FieldConstraints fields that intentionally have no
+	// ConstraintsYAML counterpart. All current constraints are mapped, so this
+	// is empty; it documents intent and gives future fields a clear opt-out.
+	notMapped := map[string]bool{}
+
+	// yamlByProto maps each mapped proto field name to the corresponding
+	// ConstraintsYAML field name (they differ for several constraints).
+	yamlByProto := map[string]string{
+		"Min":            "Minimum",
+		"Max":            "Maximum",
+		"ExclusiveMin":   "ExclusiveMinimum",
+		"ExclusiveMax":   "ExclusiveMaximum",
+		"MinLength":      "MinLength",
+		"MaxLength":      "MaxLength",
+		"Regex":          "Pattern",
+		"EnumValues":     "Enum",
+		"JsonSchema":     "JSONSchema",
+		"AllowedSchemes": "AllowedSchemes",
+	}
+
+	iv := reflect.ValueOf(in).Elem()
+	ov := reflect.ValueOf(out).Elem()
+	for i := 0; i < iv.NumField(); i++ {
+		sf := iv.Type().Field(i)
+		// Skip unexported protobuf bookkeeping (state, unknownFields, sizeCache).
+		if sf.PkgPath != "" {
+			continue
+		}
+		name := sf.Name
+		if notMapped[name] {
+			continue
+		}
+		require.Falsef(t, iv.Field(i).IsZero(),
+			"proto FieldConstraints.%s is zero in this test — populate it so the drift check can verify the mapping", name)
+
+		yamlName, ok := yamlByProto[name]
+		require.Truef(t, ok,
+			"proto FieldConstraints.%s has no ConstraintsYAML mapping — map it in protoConstraintsToYAML/yamlConstraintsToProto or record it in notMapped", name)
+		assert.Falsef(t, ov.FieldByName(yamlName).IsZero(),
+			"proto FieldConstraints.%s is dropped by protoConstraintsToYAML", name)
+	}
 }

--- a/sdk/tools/dump/dump.go
+++ b/sdk/tools/dump/dump.go
@@ -200,5 +200,8 @@ func convertConstraints(c *adminclient.FieldConstraints) *seed.ConstraintsDef {
 	if len(c.Enum) > 0 {
 		cd.Enum = c.Enum
 	}
+	if len(c.AllowedSchemes) > 0 {
+		cd.AllowedSchemes = c.AllowedSchemes
+	}
 	return cd
 }

--- a/sdk/tools/dump/dump_test.go
+++ b/sdk/tools/dump/dump_test.go
@@ -370,15 +370,16 @@ func TestConvertConstraints(t *testing.T) {
 	maxLen := int32(50)
 
 	c := &adminclient.FieldConstraints{
-		Min:          &min,
-		Max:          &max,
-		ExclusiveMin: &exMin,
-		ExclusiveMax: &exMax,
-		MinLength:    &minLen,
-		MaxLength:    &maxLen,
-		Pattern:      "^[a-z]+$",
-		Enum:         []string{"a", "b"},
-		JSONSchema:   `{"type":"object"}`,
+		Min:            &min,
+		Max:            &max,
+		ExclusiveMin:   &exMin,
+		ExclusiveMax:   &exMax,
+		MinLength:      &minLen,
+		MaxLength:      &maxLen,
+		Pattern:        "^[a-z]+$",
+		Enum:           []string{"a", "b"},
+		JSONSchema:     `{"type":"object"}`,
+		AllowedSchemes: []string{"https", "sftp"},
 	}
 
 	cd := convertConstraints(c)
@@ -399,6 +400,9 @@ func TestConvertConstraints(t *testing.T) {
 	}
 	if cd.JSONSchema != `{"type":"object"}` {
 		t.Errorf("jsonSchema = %q", cd.JSONSchema)
+	}
+	if got := cd.AllowedSchemes; len(got) != 2 || got[0] != "https" || got[1] != "sftp" {
+		t.Errorf("allowedSchemes = %v, want [https sftp]", got)
 	}
 }
 

--- a/sdk/tools/seed/seed.go
+++ b/sdk/tools/seed/seed.go
@@ -108,6 +108,7 @@ type ConstraintsDef struct {
 	Pattern          string   `yaml:"pattern,omitempty"`
 	Enum             []string `yaml:"enum,omitempty"`
 	JSONSchema       string   `yaml:"json_schema,omitempty"`
+	AllowedSchemes   []string `yaml:"allowed_schemes,omitempty"`
 }
 
 // TenantDef defines the tenant to create or reuse.

--- a/sdk/tools/seed/seed_test.go
+++ b/sdk/tools/seed/seed_test.go
@@ -298,6 +298,75 @@ tenant:
 	}
 }
 
+// TestParseFile_AllowedSchemes verifies the allowed_schemes URL constraint is
+// parsed into ConstraintsDef. Mirrors the enum assertion above.
+func TestParseFile_AllowedSchemes(t *testing.T) {
+	data := `spec_version: "v1"
+schema:
+  name: constrained
+  fields:
+    webhook:
+      type: url
+      constraints:
+        allowed_schemes: [https, sftp]
+tenant:
+  name: t
+`
+	f, err := ParseFile([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	webhook := f.Schema.Fields["webhook"]
+	if webhook.Constraints == nil {
+		t.Fatal("webhook constraints is nil")
+	}
+	if got := webhook.Constraints.AllowedSchemes; len(got) != 2 || got[0] != "https" || got[1] != "sftp" {
+		t.Errorf("webhook allowed_schemes: %v, want [https sftp]", got)
+	}
+}
+
+// TestMarshal_AllowedSchemesRoundTrip mirrors the dump → seed round-trip: a
+// ConstraintsDef carrying allowed_schemes is marshaled to YAML and re-parsed,
+// and the value must survive both directions. This guards the dump/seed path
+// from the drop described in #927.
+func TestMarshal_AllowedSchemesRoundTrip(t *testing.T) {
+	schemes := []string{"https", "sftp"}
+	original := &File{
+		SpecVersion: "v1",
+		Schema: SchemaDef{
+			Name: "links",
+			Fields: map[string]FieldDef{
+				"webhook": {
+					Type:        "url",
+					Constraints: &ConstraintsDef{AllowedSchemes: schemes},
+				},
+			},
+		},
+		Tenant: TenantDef{Name: "t"},
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "allowed_schemes") {
+		t.Fatalf("marshaled YAML missing allowed_schemes:\n%s", data)
+	}
+
+	reparsed, err := ParseFile(data)
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nYAML:\n%s", err, data)
+	}
+	c := reparsed.Schema.Fields["webhook"].Constraints
+	if c == nil {
+		t.Fatal("round-trip dropped constraints entirely")
+	}
+	if got := c.AllowedSchemes; len(got) != 2 || got[0] != "https" || got[1] != "sftp" {
+		t.Errorf("round-trip allowed_schemes: %v, want %v", got, schemes)
+	}
+}
+
 // --- Run tests with mocks ---
 
 func TestRun_NewSchemaNewTenantWithConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- `FieldConstraints.allowed_schemes` was silently dropped on the seed/dump and server YAML codec round-trips while only gRPC `CreateSchema`/`UpdateSchema` preserved it. This closes a constraint-fidelity gap ahead of the alpha release.
- Adds the field to `seed.ConstraintsDef` and `dump.convertConstraints`, and maps it in both directions of the server YAML codec (`protoConstraintsToYAML` / `yamlConstraintsToProto`).
- Adds a reflection-based drift guard so any future proto `FieldConstraints` field left unmapped by the YAML codec fails CI.

## Test plan
- Round-trip tests for both paths (seed/dump and YAML codec) assert the constraint survives in both directions, including that marshaled YAML actually contains `allowed_schemes`.
- Drift guard verified to fail when the codec mapping is removed.
- `make test` and `make lint-go` pass; coverage thresholds met (internal 91.4%, sdk/tools 97.1%).

Closes #927