### PR TITLE
ci: build server image once and pull it in integration/upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,24 @@
 # CI pipeline for OpenDecree server, SDKs, and CLI.
 #
-# Jobs: changes ──┬── tools → integration (e2e|examples|stress) ──────→ check (alls-green gate)
-#                 ├── lint, docs ──────────────────────────────────────────────┘
+# Jobs: changes ──┬── tools, server-image → integration (e2e|examples|stress) ─→ check (alls-green gate)
+#                 ├──                      → upgrade ───────────────────────────┤
+#                 ├── lint, docs ──────────────────────────────────────────────┤
 #                 └── test, sdk-compat, govulncheck, deps-review ──────────────┘
 #
 # The changes job runs dorny/paths-filter; code jobs skip on docs-only PRs;
 # the docs job additionally skips unless proto/CLI/mkdocs files changed.
 #
-# The tools job builds/caches the Docker image used by e2e, examples, and
-# stress, with a registry-backed buildx cache (:buildcache tag) so unchanged
-# layers are pulled from ghcr and only modified layers rebuild.
+# The tools job builds/caches the decree-tools Docker image (goose/migrate),
+# and the server-image job builds the decree server image ONCE and pushes it to
+# ghcr by digest. Both use a registry-backed buildx cache (:buildcache tag) so
+# unchanged layers are pulled from ghcr and only modified layers rebuild. The
+# integration legs (e2e/examples/stress) and the upgrade job then just `docker
+# pull` the prebuilt server image instead of rebuilding it once per leg.
 #
 # Security posture (issue #8):
 #   - Workflow-level permissions default to `contents: read` — jobs opt into more.
-#   - Only `tools` has `packages: write` (pushes the tools image); consumers get
-#     `packages: read` to pull.
+#   - Only `tools` and `server-image` have `packages: write` (they push the
+#     tools and server images); consumers get `packages: read` to pull.
 #   - All actions/checkout steps use `persist-credentials: false` so the
 #     GITHUB_TOKEN isn't left in .git/config for later steps.
 #   - `deps-review` blocks PRs that add dependencies with known high-severity
@@ -23,12 +27,15 @@
 #
 # The check job aggregates all results for branch protection (skipped jobs allowed).
 #
-# Cache budget: all Docker layer caches live on ghcr.io as `:buildcache` tags on
+# Cache budget: Docker layer caches live on ghcr.io as `:buildcache` tags on
 # their respective image repos (no 10GB GHA cache limit). Writers:
 #   - main.yml  → ghcr.io/<owner>/decree:buildcache, decree-cli:buildcache
 #   - release.yml → same refs (shared with main.yml, mode=max)
 #   - tools job → ghcr.io/<owner>/decree-tools:buildcache
-# ci.yml e2e/examples/stress are read-only consumers.
+#   - server-image job → reads ghcr.io/<owner>/decree:buildcache (main.yml is
+#     the canonical writer) and writes the shared `server-build` GHA scope.
+# ci.yml integration (e2e/examples/stress) and upgrade are read-only consumers:
+# they `docker pull` the prebuilt server image and no longer build it.
 # E2E benchmarks moved to release.yml — too slow for per-PR CI.
 # The unit/infra `bench` job lives in bench.yml — it ran push-to-main only and
 # was purely informational, but sat in check.needs and so delayed the alls-green
@@ -52,6 +59,7 @@ permissions:
 
 env:
   TOOLS_IMAGE: ghcr.io/${{ github.repository_owner }}/decree-tools
+  SERVER_IMAGE: ghcr.io/${{ github.repository_owner }}/decree
 
 jobs:
   # Detects which paths changed so downstream jobs can skip on docs-only PRs.
@@ -180,6 +188,52 @@ jobs:
 
     outputs:
       image: ${{ env.TOOLS_IMAGE }}:${{ steps.hash.outputs.tag }}
+
+  # Builds the server image ONCE and pushes it to ghcr by digest, so the
+  # integration matrix (e2e/examples/stress) and the upgrade job each pull a
+  # single prebuilt image instead of rebuilding it 4×. Runs parallel to `tools`
+  # (both gated only on `changes`). Uses the same two-tier cache as before:
+  # the registry :buildcache (read-only; main.yml is the canonical writer) plus
+  # the shared GHA scope. Pushing by digest avoids tag churn on ghcr.
+  server-image:
+    name: Server image
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push server image by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: build/Dockerfile
+          cache-from: |
+            type=registry,ref=${{ env.SERVER_IMAGE }}:buildcache
+            type=gha,scope=server-build
+          cache-to: type=gha,scope=server-build,mode=max
+          outputs: type=image,name=${{ env.SERVER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+    outputs:
+      image: ${{ env.SERVER_IMAGE }}@${{ steps.build.outputs.digest }}
 
   # Runs golangci-lint against Go code and buf lint/breaking against protos.
   # buf is installed via go install (no Docker image needed), so this job runs
@@ -405,12 +459,12 @@ jobs:
           fi
 
   # E2E, examples, and stress share identical setup (checkout, Go, Docker,
-  # tools image, server image prebuild). Collapsed into one matrix job to
-  # eliminate the 3× YAML duplication. Legs run in parallel by default.
+  # pull tools image, pull prebuilt server image). Collapsed into one matrix job
+  # to eliminate the 3× YAML duplication. Legs run in parallel by default.
   integration:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    needs: [tools, changes]
+    needs: [tools, server-image, changes]
     if: needs.changes.outputs.code == 'true'
     permissions:
       contents: read
@@ -448,28 +502,8 @@ jobs:
       - name: Pull tools image
         run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
-
-      - name: Pre-build server image with layer cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: build/Dockerfile
-          load: true
-          tags: decree-service
-          # Two-tier cache:
-          #   - registry buildcache (read-only; main.yml is canonical writer)
-          #     supplies stable layers like base image + go mod download.
-          #   - GHA cache (read/write, shared scope) carries warm layers
-          #     forward from previous PR runs without round-tripping ghcr.
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
-            type=gha,scope=server-build
-          cache-to: type=gha,scope=server-build,mode=max
+      - name: Pull server image
+        run: docker pull "${{ needs.server-image.outputs.image }}"
 
       - name: Run ${{ matrix.name }}
         run: |
@@ -488,6 +522,7 @@ jobs:
           esac
         env:
           TOOLS_IMAGE: ${{ needs.tools.outputs.image }}
+          SERVICE_IMAGE: ${{ needs.server-image.outputs.image }}
 
   # Runs Postgres integration tests using testcontainers-go. Docker is
   # available on ubuntu-latest runners; no server image or tools image required.
@@ -628,7 +663,7 @@ jobs:
   upgrade:
     name: Upgrade test
     runs-on: ubuntu-latest
-    needs: [tools, changes]
+    needs: [tools, server-image, changes]
     if: needs.changes.outputs.migrations == 'true'
     permissions:
       contents: read
@@ -657,29 +692,14 @@ jobs:
       - name: Pull tools image
         run: docker pull "${{ needs.tools.outputs.image }}" && docker tag "${{ needs.tools.outputs.image }}" decree-tools
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
-
-      - name: Pre-build server image with layer cache
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: build/Dockerfile
-          load: true
-          tags: decree-service
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ github.repository_owner }}/decree:buildcache
-            type=gha,scope=server-build
-          cache-to: type=gha,scope=server-build,mode=max
+      - name: Pull server image
+        run: docker pull "${{ needs.server-image.outputs.image }}"
 
       - name: Run upgrade test
         run: ./scripts/run-upgrade-test.sh
         env:
           TOOLS_IMAGE: decree-tools
-          SERVICE_IMAGE: decree-service
+          SERVICE_IMAGE: ${{ needs.server-image.outputs.image }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Posts a synthetic codecov/patch:success status when no Go code changed so


### PR DESCRIPTION
## Summary

The server Docker image was built **4× per run** — once in each of the three `integration` legs (e2e/examples/stress) via the "Pre-build server image with layer cache" step, plus a fourth time in the `upgrade` job.

- New `server-image` job builds the server image **once** and pushes it to ghcr **by digest** (mirrors the `tools` job and main.yml's push-by-digest pattern). Runs parallel to `tools`, gated on `changes`. Same two-tier cache (registry `decree:buildcache` read-only + shared `server-build` GHA scope).
- `integration` and `upgrade` now `docker pull` the prebuilt image and pass it through `SERVICE_IMAGE`. Compose's `service` (`image: ${SERVICE_IMAGE:-decree-server}`) resolves to the already-pulled ref and does not build — same mechanism already used for the tools image via `TOOLS_IMAGE`.
- Dropped the now-unused "Set up Docker Buildx" + "Pre-build server image" steps from both consumers.

Removes 3 redundant builds + 4 buildx-container setups per run and the concurrent `server-build` cache contention; shrinks the `changes→server-image→E2E` critical path.

## Test plan
- [x] `actionlint` (rhysd/actionlint:1.7.12, CI gate flags) → exit 0
- [x] `make pre-commit` → green
- [x] `yaml.safe_load` parses ci.yml
- [x] Verified `scripts/run-upgrade-test.sh` consumes `SERVICE_IMAGE` as a plain `docker run` ref (line 156), so the digest ref works without editing the script
- [ ] **Full validation is the CI run on this PR** — the integration/upgrade GitHub-Actions jobs cannot run locally

Closes #971