### PR TITLE
ci: install buf from pinned release binary instead of go install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,9 +299,17 @@ jobs:
           done
 
       - name: Install buf
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
         env:
-          GOTOOLCHAIN: auto
+          BUF_VERSION: v1.66.1
+          # sha256 of buf-Linux-x86_64 from the official v1.66.1 release (sha256.txt).
+          BUF_SHA256: ef835cb38ed973849f68e0e6a88153cb2168507e09eecbec43a2ada2f6a698be
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64" -o "$HOME/.local/bin/buf"
+          echo "${BUF_SHA256}  $HOME/.local/bin/buf" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/buf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/buf" --version
 
       - name: Proto lint + breaking
         run: buf lint && buf breaking --against ".git#branch=main"
@@ -434,9 +442,17 @@ jobs:
           cache-dependency-path: "**/go.sum"
 
       - name: Install buf
-        run: go install github.com/bufbuild/buf/cmd/buf@v1.66.1
         env:
-          GOTOOLCHAIN: auto
+          BUF_VERSION: v1.66.1
+          # sha256 of buf-Linux-x86_64 from the official v1.66.1 release (sha256.txt).
+          BUF_SHA256: ef835cb38ed973849f68e0e6a88153cb2168507e09eecbec43a2ada2f6a698be
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64" -o "$HOME/.local/bin/buf"
+          echo "${BUF_SHA256}  $HOME/.local/bin/buf" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/buf"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/buf" --version
 
       - name: Install protoc-gen-doc
         run: go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1


### PR DESCRIPTION
## Summary

The `lint` and `docs` jobs installed buf with `go install github.com/bufbuild/buf/cmd/buf@v1.66.1`, which **compiles buf from source** on every run (~20–40s each). Lint is the current CI critical-path job (after #970/#971), so this directly cuts walltime.

- Both `Install buf` steps now download the pinned **prebuilt** `buf-Linux-x86_64` v1.66.1 binary and verify it against a hardcoded sha256 (`ef835cb…698be`, from the official release `sha256.txt`), then put it on `$GITHUB_PATH`.
- Version stays pinned at v1.66.1 (matches CLAUDE.md). `protoc-gen-doc` and `build/Dockerfile.tools` untouched.

Keeps the supply-chain pin posture: the binary is checksum-verified, and no new `uses:` action is introduced (`check-supply-chain-pins.sh` passes).

## Test plan
- [x] Checksum sanity-check: downloaded the real v1.66.1 binary, `sha256sum -c` → OK
- [x] `./scripts/check-supply-chain-pins.sh` → `supply-chain pins OK`
- [x] `actionlint` (CI-gate flags) → exit 0
- [x] `make pre-commit` → green
- [x] `lint` job exercises the new install on this PR; `docs` job skips (no proto/CLI/mkdocs change) but its step is identical

Closes #973