### PR TITLE
ci: split test job into parallel internal and modules jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,10 +314,12 @@ jobs:
       - name: Proto lint + breaking
         run: buf lint && buf breaking --against ".git#branch=main"
 
-  # Builds the server + CLI, runs unit, SDK, and CLI tests in parallel, then
-  # enforces the coverage ratchet defined in coverage-thresholds.json.
-  test:
-    name: Test
+  # Runs the unit tests under the race detector with coverage, then enforces
+  # the internal-module coverage ratchet. Split from the SDK/CLI/tools tests
+  # (test-modules) so the two heavy sequential steps run on separate runners
+  # concurrently. -race coverage of internal/ is preserved here unchanged.
+  test-internal:
+    name: Test (internal)
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.code == 'true'
@@ -336,6 +338,37 @@ jobs:
 
       - name: Unit tests
         run: go test ./internal/... -race -count=1 -coverprofile=coverage-internal.out -covermode=atomic
+
+      - name: Coverage ratchet
+        run: ./scripts/check-coverage.sh --profiles-only --profile internal=coverage-internal.out
+
+      - name: Upload coverage to Codecov
+        # codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          files: coverage-internal.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Runs the SDK, CLI, and tools module tests in parallel, then enforces the
+  # coverage ratchet for those modules. Split from test-internal so it runs on
+  # a separate runner concurrently with the race-enabled unit tests.
+  test-modules:
+    name: Test (modules)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: "**/go.sum"
 
       - name: SDK + CLI + tools tests
         run: |
@@ -356,8 +389,7 @@ jobs:
 
       - name: Coverage ratchet
         run: |
-          ./scripts/check-coverage.sh \
-            --profile internal=coverage-internal.out \
+          ./scripts/check-coverage.sh --profiles-only \
             --profile sdk/configclient=cov-configclient.out \
             --profile sdk/adminclient=cov-adminclient.out \
             --profile sdk/configwatcher=cov-configwatcher.out \
@@ -369,7 +401,7 @@ jobs:
       - name: Merge coverage profiles
         run: |
           echo "mode: atomic" > coverage.out
-          for f in coverage-internal.out cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-contrib-envconfig.out cov-contrib-koanf.out cov-decree-docs.out cov-decree.out; do
+          for f in cov-configclient.out cov-adminclient.out cov-configwatcher.out cov-grpctransport.out cov-tools.out cov-contrib-viper.out cov-contrib-envconfig.out cov-contrib-koanf.out cov-decree-docs.out cov-decree.out; do
             [ -f "$f" ] && grep -v "^mode:" "$f" >> coverage.out || true
           done
 
@@ -794,7 +826,7 @@ jobs:
   check:
     name: CI check
     if: always()
-    needs: [lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only]
+    needs: [lint, test-internal, test-modules, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, meta-schemas, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -803,4 +835,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: lint, test, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only
+          allowed-skips: lint, test-internal, test-modules, sdk-compat, docs, integration, pg-integration, govulncheck, deps-review, helm, upgrade, codecov-skip, codecov-skip-grpctransport, codecov-skip-ci-only

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -4,11 +4,14 @@
 # Usage:
 #   ./scripts/check-coverage.sh                            # Run tests + check thresholds
 #   ./scripts/check-coverage.sh --profile mod=path ...    # Check using pre-computed profiles
+#   ./scripts/check-coverage.sh --profiles-only --profile mod=path ...  # Check ONLY supplied profiles
 #   ./scripts/check-coverage.sh --update                   # Update thresholds (always runs tests)
 #
 # --profile can be repeated once per module. Paths are relative to the
 # directory from which the script is invoked (typically the repo root).
-# Modules with no --profile arg fall back to running go test.
+# Modules with no --profile arg fall back to running go test, unless
+# --profiles-only is set, in which case they are skipped (lets CI split the
+# ratchet across parallel jobs, each validating only the profiles it produced).
 set -euo pipefail
 
 THRESHOLDS_FILE="coverage-thresholds.json"
@@ -58,12 +61,17 @@ declare -A FAIL_LOGS
 
 # Parse arguments.
 UPDATE=false
+PROFILES_ONLY=false
 declare -A PROFILES=()
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --update)
       UPDATE=true
+      shift
+      ;;
+    --profiles-only)
+      PROFILES_ONLY=true
       shift
       ;;
     --profile)
@@ -207,6 +215,10 @@ print_fail_logs() {
 for module in "${!MODULES[@]}"; do
   if [ "$UPDATE" = false ] && [ -n "${PROFILES[$module]:-}" ]; then
     read_coverage "$module" "${MODULE_DIRS[$module]}" "${PROFILES[$module]}"
+  elif [ "$UPDATE" = false ] && [ "$PROFILES_ONLY" = true ]; then
+    # No profile supplied and --profiles-only set: skip this module rather than
+    # running its tests. Another (parallel) invocation validates it.
+    continue
   else
     run_coverage "$module" "${MODULE_DIRS[$module]}" "${MODULES[$module]}"
   fi
@@ -247,7 +259,8 @@ fi
 # Check mode: compare against thresholds.
 failed=0
 for module in $(echo "${!MODULES[@]}" | tr ' ' '\n' | sort); do
-  current=${COVERAGES[$module]}
+  current=${COVERAGES[$module]:-}
+  [ -z "$current" ] && continue  # skipped under --profiles-only
   threshold=$(get_threshold "$module")
   if [ "$current" = "FAIL" ]; then
     printf "%-25s %7s   ✗ TESTS FAILED (%s)\n" "$module" "--" "${FAIL_REASONS[$module]}"


### PR DESCRIPTION
## Summary

Splits the single `test` job into two parallel jobs so its two heavy, previously-sequential steps run on separate runners concurrently:

- **`test-internal`** — `go test ./internal/... -race` (race-detector coverage of `internal/` preserved unchanged).
- **`test-modules`** — the SDK / CLI / tools coverage fan-out.

`test` was the sole PR critical-path pole at ~147s (internal `-race` 77s + module fan-out 54s, run back-to-back on one runner). Running them on separate runners drops the job's wall time toward ~90s and the PR critical path from ~154s to ~103s (new pole: integration E2E).

Adds a `--profiles-only` flag to `scripts/check-coverage.sh` so each job ratchets only the profiles it produced. Without it the script falls back to running `go test` for any ratcheted module lacking a `--profile`, which would re-run the *other* job's suites and negate the split. Together the two jobs still validate every ratcheted module exactly once.

The `check` alls-green gate's `needs:` and `allowed-skips:` are updated to reference both new job names in place of `test`.

## Test plan

- [x] `bash -n` + `python3 yaml.safe_load` on the workflow — both clean.
- [x] Generated real coverage profiles, then ran both ratchet commands with `--profiles-only`: `test-internal` validates only `internal` (0.23s, no test re-run); `test-modules` validates the 6 module keys with no `internal` re-run (0.88s). Both report all thresholds met.
- [x] Default `check-coverage.sh` path (no flag) is unchanged — the skip branch is gated off unless `--profiles-only` is passed.
- [ ] CI green on this PR (the split runs here; confirms coverage gate + alls-green wiring).

Closes #979