### PR TITLE
chore: fix pre-release doc inaccuracies and allowlist test fixture

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# gitleaks configuration for OpenDecree.
+#
+# Extends the upstream default ruleset (so all built-in secret detectors stay
+# active) and only adds allowlist entries for intentional, non-secret fixtures.
+title = "OpenDecree"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Intentional fake secrets used in tests, not real credentials"
+# The sensitive-field redaction e2e test (regression for decree#215) hard-codes a
+# placeholder token to assert it is redacted on every read path. It is not a real
+# secret. Allowlisted by path + value so historical commits scan clean too.
+paths = ['''e2e/security_test\.go''']
+regexes = ['''s3cr3t-t0k3n-abc123''']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ modify specs → generate code → test → lint → build → deploy → e2e te
 
 1. **Protobuf** — edit `.proto` files under `proto/centralconfig/v1/`, then run `make generate`
 2. **SQL queries** — edit `.sql` files under `db/queries/`, then run `make generate`
-3. **Migrations** — edit `db/migrations/001_initial_schema.sql` (pre-production, single migration)
+3. **Migrations** — edit `db/migrations/00001_baseline.sql` (pre-production, single squashed migration)
 
 Generated code is **checked into git** — `go build` works immediately after cloning. Run `make generate` after modifying proto or SQL specs.
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The entire gRPC API is also available as REST/JSON (via grpc-gateway). Set `HTTP
 
 ```bash
 # Version check
-curl http://localhost:8080/v1/version
+curl http://localhost:8080/v1/server/info
 
 # List schemas
 curl -H "x-subject: admin" http://localhost:8080/v1/schemas
@@ -386,7 +386,7 @@ JWT is **opt-in**. By default, the service uses metadata-based auth:
 
 Without JWT, pass identity via gRPC metadata headers:
 - `x-subject` (required) — actor identity
-- `x-role` — `superadmin` (default), `admin`, or `user`
+- `x-role` — `superadmin`, `admin`, or `user`; omitted defaults to `user` (least privilege)
 - `x-tenant-id` — required for non-superadmin roles
 
 ### Observability (all opt-in)


### PR DESCRIPTION
## Summary

Fixes found while running the **Before Release Tag** checklist ahead of `v0.12.0-alpha.5`.

- **Add `.gitleaks.toml`** — the sensitive-field redaction e2e test (decree#215) hard-codes a placeholder token, which gitleaks reports as a generic API key. Extend the default ruleset with an allowlist for that fixture so the secret scan is clean across full git history. (Gitleaks is a manual release-checklist step, not wired into CI — which is why this sat undetected.)
- **README** — the metadata `x-role` default is `user` (least privilege), not `superadmin`; superadmin only applies when `DECREE_INSECURE_DEFAULT_SUPERADMIN=1` is set. The REST version check is `GET /v1/server/info`, not `/v1/version` (which 404s).
- **CONTRIBUTING** — the single squashed migration is `00001_baseline.sql`, not the stale `001_initial_schema.sql`.

## Test plan

- [x] `gitleaks git .` with the new config — 581 commits scanned, **no leaks found**.
- [x] Smoke test (rebuilt image, `STORAGE_BACKEND=memory INSECURE_LISTEN=1`): `/v1/server/info` returns version + features; `/v1/version` returns 404.
- [x] Confirmed `00001_baseline.sql` is the only file in `db/migrations/`.
- [x] pre-commit safety scan clean (docs + config only, no Go changes).