### PR TITLE
ci: trim server-image build context to stabilize cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,8 +16,27 @@ site/
 .tools-image-built
 ccs
 
-# Note: e2e/ is NOT excluded — go.work references it and the workspace
-# needs all modules present. Test files won't compile (build tag guarded).
+# Go workspace file — excluded so the image build is deterministically in
+# module mode (CI has no go.work). The root module builds ./cmd/server via
+# go.mod and its single `replace github.com/opendecree/decree/api => ./api`,
+# so no other local module needs to be present in the context.
+go.work
+go.work.sum
+
+# Separate Go modules and non-server assets not needed by `go build ./cmd/server`.
+# Excluding them keeps the `COPY . .` layer stable when they change, so PRs that
+# touch only non-server code hit the cached server build instead of rebuilding.
+cmd/decree/
+sdk/
+contrib/
+chaos/
+stress/
+examples/
+fixtures/
+scripts/
+
+# e2e/ is kept in context (separate module, occasionally referenced by local
+# tooling); it could be excluded too now that go.work is, if desired later.
 
 # Docs (not needed in images)
 docs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
               - 'proto/**'
               - 'db/**'
               - 'build/**'
+              - '.dockerignore'
               - 'Makefile'
               - 'docker-compose*.yml'
               - '.github/workflows/**'


### PR DESCRIPTION
## Summary

Trims the server-image Docker build context so PRs that touch only non-server code stop triggering a full cold server rebuild on the integration critical path.

`build/Dockerfile` does `COPY . . && go build ./cmd/server`; the `COPY` layer busts on **any** context file change. The `Server image` job is bimodal — ~15-26s on cache hit vs ~82-114s on miss — and 5 of 9 recent runs missed, adding ~60-90s to PR walltime whenever non-server files changed.

The root module builds in module mode with a single `replace github.com/opendecree/decree/api => ./api`. Every other top-level dir is a separate Go module (`sdk/*`, `contrib`, `cmd/decree`, `chaos`, `stress`, `examples/*`, `fixtures`) or a non-Go asset (`scripts`) — none compiled by `go build ./cmd/server`. This PR:

- Excludes `go.work` / `go.work.sum` so the image build is deterministically **module-mode** (CI has no `go.work`), removing the only reason those modules had to stay in context.
- Excludes the separate modules + `scripts/` from the build context. `e2e/` is kept (per scope; can be dropped later too).
- Adds `.dockerignore` to the `code` paths-filter so changes to it trigger the image-building jobs (this PR self-validates in CI instead of skipping).

Net: non-server PRs hit the cached server build (~90s → ~20s); zero change to image contents.

## Test plan

- [x] `docker build -f build/Dockerfile .` succeeds with the trimmed context; build context dropped to 5.42 MB.
- [x] **Cache stability proven locally:** a real content change under an *excluded* path (`sdk/`) leaves the `go build` layer **CACHED**; a content change under `internal/version/` **re-runs** it (`DONE 21.4s`). So non-server changes no longer rebuild the server, while server changes still do.
- [x] `python3 yaml.safe_load` on `ci.yml` — clean.
- [ ] CI green (server-image + integration now run here via the `code` filter addition, validating the trimmed context end-to-end).

Closes #982