### PR TITLE
docs: use banner image in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/opendecree/decree/main/assets/logo.png" alt="OpenDecree" width="150">
+  <img src="https://raw.githubusercontent.com/opendecree/decree/main/assets/opendecree_banner.png" alt="OpenDecree — Define once. Typed Everywhere." width="100%">
 </p>
-
-<h1 align="center">OpenDecree</h1>
 
 <p align="center">
   <a href="https://github.com/opendecree/decree/actions/workflows/ci.yml"><img src="https://github.com/opendecree/decree/actions/workflows/ci.yml/badge.svg" alt="CI"></a>


### PR DESCRIPTION
## Summary
- Replace the small header logo with the full-width `opendecree_banner.png` hero, which carries the OpenDecree wordmark and the "Define once. Typed Everywhere." tagline.
- Drop the now-redundant centered `<h1>` — the banner provides the title.
- Sharpens the first impression for the alpha launch, since the README is the de-facto landing page.

## Test plan
- [x] Banner resolves from `raw.githubusercontent.com/.../assets/opendecree_banner.png` (already on `main`).
- [x] Badges, taglines, alpha note, and demo GIF below the hero are unchanged.
- [x] Docs-only change — no code affected.

_No linked issue — docs-only._