### PR TITLE
Fix go install: release-time replace strip + configwatcher deadlock

### DIFF
--- a/docs/adr/ADR-007-strip-replaces-at-release.md
+++ b/docs/adr/ADR-007-strip-replaces-at-release.md
@@ -1,0 +1,90 @@
+# ADR-007: Strip Inter-Module `replace` Directives at Release Time
+
+**Date:** 2026-06-29
+**Status:** Accepted
+**Refines:** [ADR-006](ADR-006-go-module-split.md) — implements its "published versions use normal module paths" intent; does not change the module split or local-dev model.
+**Deciders:** OpenDecree maintainers
+
+## Context
+
+ADR-006 split the repo into multiple Go modules and chose `replace` directives in
+each module's `go.mod` (pointing at the local worktree) as the local-development
+resolution mechanism. It stated that *"published versions use normal module paths and
+semantic version tags"* — but nothing enforced that, and the `replace` directives were
+present in every tagged commit.
+
+Verifying the documented quickstart from a clean machine (issue #990) showed the
+consequence: **the headline install paths are impossible for end users.**
+
+- `go install` refuses any module whose `go.mod` contains `replace` directives:
+
+  > The go.mod file for the module providing named packages contains one or more
+  > replace directives.
+
+  Both `go install .../cmd/server@<ver>` and `go install .../cmd/decree@<ver>` fail for
+  **every** published version (v0.5.0 … v0.12.0-alpha.4), confirmed in a clean
+  `golang:1.25` container.
+
+- The same directives, combined with all versions being `-alpha` pre-releases
+  (`@latest` skips pre-releases), made `go get .../sdk/<m>@latest` resolve to stale
+  releases.
+
+### Why not commit `go.work` instead?
+
+The obvious alternative — drop `replace`, commit a `go.work` for resolution — was
+prototyped and rejected. `replace` resolves locally while preserving each module's
+**own** dependency versions; `go.work` recomputes a single **union** MVS across all
+26 modules, upgrading shared deps for the lightweight SDK modules. That changes what
+every module builds/tests against (no longer what consumers actually get) and, in
+practice, surfaced a flaky deadlock in `configwatcher`'s race tests (~20–40% of runs
+under workspace mode, 0% single-module). Committing `go.work` would push that flake
+into CI. So local development keeps `replace`; the published artifact is fixed instead.
+
+## Decision
+
+Keep `replace` directives in the working tree (`main` is unchanged — CI and local dev
+behave exactly as before). **Strip them only from the tagged release commit**, so
+published modules carry clean `go.mod` files with normal `require` directives.
+
+`scripts/release/strip-replaces.sh` provides the mechanism:
+
+- `strip` — remove internal `replace github.com/opendecree/decree/...` directives from
+  the **published** modules (everything except `examples/`, `e2e`, `chaos`, `stress`,
+  `fixtures/`, which keep theirs).
+- `tidy` — `GOWORK=off go mod tidy` per module, leaf-first, so each module's `go.sum`
+  gains the internal-module hashes the published tag needs. (Under `replace`, those
+  hashes are absent; without them `go install` fails with *"missing go.sum entry"* —
+  the concrete second failure found while validating the fix.)
+- `check` — fail if any published module still has an internal `replace`.
+
+## Release procedure (extends RELEASING.md)
+
+The existing flow already merges a PR bumping every intra-repo `require` to the new
+version before tagging. The strip step is added at tag time, on the release commit
+(not merged back to `main`):
+
+1. Merge the require-version-bump PR to `main` (unchanged).
+2. On the release commit: `strip-replaces.sh strip`.
+3. Tag **leaf-first** (`api`, `sdk/retry`, … `cmd/decree`, root). Before tagging each
+   module, run `strip-replaces.sh tidy <module>` — its intra-repo deps are already
+   published from earlier iterations, so `go mod tidy` resolves and records their
+   hashes. Push tags individually, ≤3 at a time (GitHub's tag-event limit).
+4. `strip-replaces.sh check` must pass on the tagged tree.
+5. Install commands must pin an explicit version (e.g. `@v0.12.0-alpha.5`) until a
+   non-pre-release exists — `@latest` skips pre-releases. Release tagging must also
+   flag pre-releases consistently so GitHub's "Latest" release is correct.
+
+## Consequences
+
+**Positive:**
+- `go install github.com/opendecree/decree/cmd/{server,decree}@<version>` works.
+- `go get github.com/opendecree/decree/sdk/<module>@<version>` works.
+- `main`, CI, and the local-dev workflow are untouched — zero new flakiness, no
+  `go.work` policy change, no churn on every `go.mod`.
+
+**Negative / notes:**
+- The tagged commit diverges from `main` (it has no `replace` directives). It is a
+  release artifact, not merged back.
+- The release runbook gains a strip + per-module tidy step; it must run leaf-first.
+- Takes effect only from the first release tagged this way; tags ≤ v0.12.0-alpha.4
+  remain non-installable.

--- a/scripts/release/strip-replaces.sh
+++ b/scripts/release/strip-replaces.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# strip-replaces.sh — prepare a release commit so published modules are go-installable.
+#
+# WHY: committed `replace github.com/opendecree/decree/...` directives make
+# `go install <module>/cmd/...@<ver>` and `go get <module>@<ver>` impossible —
+# Go refuses any module whose go.mod contains replace directives. The directives
+# exist for local development (see ADR-006); they must NOT appear in a tagged,
+# published commit. See ADR-007.
+#
+# This script does not touch `main`. It runs against the detached release commit
+# (after the require-version bump PR is merged — see RELEASING.md), strips the
+# internal replace directives, and regenerates go.sum via `go mod tidy` so the
+# tagged tree carries the internal-module hashes.
+#
+# Usage:
+#   strip-replaces.sh strip [module ...]   # remove internal replaces (text only; no network)
+#   strip-replaces.sh tidy  [module ...]   # go mod tidy (deps must already be published/tagged)
+#   strip-replaces.sh check [module ...]   # exit non-zero if any module still has internal replaces
+#
+# With no module args, operates on every published module (all modules except the
+# internal-only test/example modules listed in EXCLUDE_RE). `tidy` runs leaf-first,
+# so each module is tidied only after its intra-repo deps are available on the proxy.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Internal-only modules — never published, keep their replace directives.
+EXCLUDE_RE='^(examples/|e2e|chaos|stress|fixtures/)'
+
+# Leaf-first dependency order for `go mod tidy` (deps before dependents).
+LEAF_FIRST_ORDER='api sdk/retry sdk/configclient sdk/configwatcher sdk/adminclient sdk/grpctransport sdk/tools sdk/contrib/envconfig sdk/contrib/koanf sdk/contrib/viper contrib/decree-docs cmd/decree .'
+
+published_modules() {
+  # Every go.mod dir, minus the internal-only modules, emitted leaf-first.
+  local all
+  all="$(find . -name go.mod -printf '%h\n' | sed 's#^\./##' | sort)"
+  for m in $LEAF_FIRST_ORDER; do
+    if printf '%s\n' "$all" | grep -qx "$m" && ! printf '%s\n' "$m" | grep -qE "$EXCLUDE_RE"; then
+      echo "$m"
+    fi
+  done
+}
+
+internal_replace_count() {
+  grep -cE '^replace github.com/opendecree/decree' "$1/go.mod" 2>/dev/null || true
+}
+
+mods() { if [ "$#" -gt 0 ]; then printf '%s\n' "$@"; else published_modules; fi; }
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  strip)
+    while read -r m; do
+      [ -n "$m" ] || continue
+      n="$(internal_replace_count "$m")"
+      if [ "${n:-0}" -gt 0 ]; then
+        sed -i '/^replace github.com\/opendecree\/decree/d' "$m/go.mod"
+        echo "stripped $n internal replace(s): $m/go.mod"
+      fi
+    done < <(mods "$@")
+    ;;
+  tidy)
+    while read -r m; do
+      [ -n "$m" ] || continue
+      echo "go mod tidy: $m"
+      (cd "$m" && GOWORK=off go mod tidy)
+    done < <(mods "$@")
+    ;;
+  check)
+    bad=0
+    while read -r m; do
+      [ -n "$m" ] || continue
+      n="$(internal_replace_count "$m")"
+      if [ "${n:-0}" -gt 0 ]; then
+        echo "FAIL: $m/go.mod still has $n internal replace directive(s)"
+        bad=1
+      fi
+    done < <(mods "$@")
+    if [ "$bad" -eq 0 ]; then echo "OK: no internal replace directives in published modules"; fi
+    exit "$bad"
+    ;;
+  *)
+    echo "usage: strip-replaces.sh {strip|tidy|check} [module ...]" >&2
+    exit 2
+    ;;
+esac

--- a/sdk/configwatcher/watcher.go
+++ b/sdk/configwatcher/watcher.go
@@ -319,16 +319,19 @@ func (w *Watcher) Close() error {
 	}
 	w.closed = true
 	started := w.started
+	// Capture cancelReady atomically with started. A concurrent Start that
+	// fails its snapshot rolls back and replaces w.cancelReady, closing only
+	// the original channel (see Start's rollback branch). Reading cancelReady
+	// in a separate, later lock section could capture the fresh replacement —
+	// which is never closed — and deadlock the <-ready wait below. This is the
+	// failed-snapshot race that hung TestWatcher_StartCloseConcurrent_SnapshotFails.
+	ready := w.cancelReady
 	w.mu.Unlock()
 
 	if started {
-		// Wait until Start has finished assigning w.cancel. This prevents a
-		// race where Close is called while Start is executing but hasn't yet
-		// stored the cancel function.
-		w.mu.RLock()
-		ready := w.cancelReady
-		w.mu.RUnlock()
-
+		// Wait until Start has finished assigning w.cancel (or rolled back).
+		// This prevents a race where Close runs while Start is executing but
+		// hasn't yet stored the cancel function.
 		if ready != nil {
 			<-ready
 		}


### PR DESCRIPTION
Refs #990 — Stage 1 of the go-install fix. Does **not** close #990; that closes once `v0.12.0-alpha.5` ships with stripped go.mod files and `go install` is verified from a clean machine (Stage 2).

## Summary
- **`go install` / `go get` are broken for every published version.** Committed inter-module `replace` directives make `go install <module>/cmd/...@<ver>` and `go get <module>@<ver>` fail — Go refuses any module whose go.mod has replace directives (confirmed in a clean `golang:1.25` container for server + CLI, all versions ≤ v0.12.0-alpha.4). Fixed at the published artifact, not on `main`: `scripts/release/strip-replaces.sh` removes internal replaces and retidies `go.sum` at tag time, leaving `main`, CI, and local dev untouched (they keep replaces). Rationale + the rejected committed-`go.work` alternative (its union-MVS surfaced the configwatcher flake) are in **ADR-007**.
- **configwatcher deadlock fix (prerequisite).** `Close` latched `started` and `cancelReady` in two separate lock sections; a concurrent failed-snapshot `Start` rollback swapped `cancelReady` in between, leaving `Close` blocked on a channel nothing closes. Captured atomically now. This was intermittently hanging `make pre-commit`/CI to the 10m timeout.

## Test plan
- [x] `make pre-commit` green — build, vet, lint, all-module `-race` tests, coverage thresholds
- [x] configwatcher stress: 1000 race iterations under workspace mode (the worst case, previously ~20–40% hang) — no deadlock
- [x] `strip-replaces.sh` validated in a clean `golang:1.25` container: `check` (fails with replaces) → `strip` → `check` (passes) → `tidy` → `go build ./cmd/server` + CLI OK; internal modules (e2e, examples) keep their replaces
- [ ] `go install ...@v0.12.0-alpha.5` end-to-end — verified at Stage 2 against the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)