### PR TITLE
ci: fix decree-cli image build (per-Dockerfile dockerignore)

### DIFF
--- a/build/Dockerfile.decree.dockerignore
+++ b/build/Dockerfile.decree.dockerignore
@@ -1,0 +1,59 @@
+# Build-context ignore specific to build/Dockerfile.decree (the decree CLI image).
+#
+# BuildKit uses a Dockerfile-specific ignore file (<dockerfile-path>.dockerignore)
+# in preference to the root .dockerignore when one exists, and does NOT merge the
+# two. The root .dockerignore excludes cmd/decree/ and sdk/ to keep the SERVER
+# image's `COPY . .` layer cache-stable (commit ba94c76). But the CLI image is
+# built FROM those modules, so excluding them starved its COPYs and broke the
+# build ("/sdk/tools/go.mod: not found"). This file re-includes cmd/decree/ and
+# sdk/ by omitting those two excludes; everything else mirrors the root ignore.
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# CI/IDE
+.github/
+.claude/
+.idea/
+.vscode/
+
+# Build artifacts
+bin/
+dist/
+site/
+.tools-image-built
+ccs
+
+# Go workspace file — excluded so the build is deterministically in module mode
+# (CI has no go.work; the CLI builds cmd/decree as a standalone module).
+go.work
+go.work.sum
+
+# Separate modules / assets the CLI build does NOT compile. cmd/decree/ and sdk/
+# are intentionally NOT excluded here — the CLI image is built from them.
+contrib/
+chaos/
+stress/
+examples/
+fixtures/
+scripts/
+
+# Docs (not needed in images)
+docs/
+mkdocs.yml
+schemas/
+*.md
+LICENSE
+
+# Deploy configs (not needed inside images)
+deploy/
+
+# Environment & secrets
+.env
+.env.*
+
+# Temporary
+tmp/
+*.log


### PR DESCRIPTION
## Summary
- The `Main` workflow's `decree-cli` image build has failed on every push to `main` since `ba94c76` (2026-06-24), so no `decree-cli:main` image has published in five days.
- Root cause: `ba94c76` added `cmd/decree/` and `sdk/` to the root `.dockerignore` to keep the server image's `COPY . .` layer cache-stable. But `.dockerignore` applies to every build that shares the context, and the `decree-cli` image (`build/Dockerfile.decree`) is built from those modules — so its `COPY` steps resolved to nothing and the build failed with `"/sdk/tools/go.mod": not found`.
- `ci.yml` only builds the tools and server images (never `decree-cli`), which is why pull-request CI stayed green and the breakage only surfaced on `main`. `release.yml` builds `decree-cli` from the same context, so a release would have failed the same way.

## Fix
- Add `build/Dockerfile.decree.dockerignore`. BuildKit prefers a Dockerfile-specific ignore file over the root `.dockerignore` (the two are not merged), so the CLI build regains `cmd/decree/` + `sdk/` while the server build keeps the root ignore byte-for-byte.

## Test plan
- [x] `docker build -f build/Dockerfile.decree .` — succeeds; `decree version` runs in the resulting image.
- [x] `docker build -f build/Dockerfile .` (server) — still builds against the unchanged root `.dockerignore`.
- [ ] Post-merge: the `Main` workflow's `Build decree-cli` jobs go green (this workflow only runs on push to `main`, so PR CI does not exercise it).

Refs #990 — also unblocks the alpha.5 release, since `release.yml` publishes the `decree-cli` image from the same build context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)