### PR TITLE
release: prepare v0.12.0-alpha.5 (version bump + pinned install docs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,14 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          gh release create "$GITHUB_REF_NAME" \
+          # Mark semver pre-releases (tags containing a hyphen, e.g.
+          # v0.12.0-alpha.5) as pre-releases so GitHub's "Latest" release never
+          # points at an alpha. Stable tags (v1.2.3) create a full release.
+          PRERELEASE_FLAG=""
+          case "$GITHUB_REF_NAME" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" $PRERELEASE_FLAG \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
             --notes-start-tag "${{ steps.prev.outputs.tag }}" \

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Beyond the table, OpenDecree also includes **import/export** of portable YAML sc
 ```bash
 # go install names the server binary "server" after its directory; the canonical
 # name is decree-server, matching the release archives and Docker image.
-go install github.com/opendecree/decree/cmd/server@latest
+go install github.com/opendecree/decree/cmd/server@v0.12.0-alpha.5
 mv "$(go env GOPATH)/bin/server" "$(go env GOPATH)/bin/decree-server"
-go install github.com/opendecree/decree/cmd/decree@latest
+go install github.com/opendecree/decree/cmd/decree@v0.12.0-alpha.5
 
 # Start with in-memory storage — zero dependencies
 INSECURE_LISTEN=1 STORAGE_BACKEND=memory HTTP_PORT=8080 decree-server
@@ -145,7 +145,7 @@ docker compose up -d --wait service
 
 ```bash
 # Go install
-go install github.com/opendecree/decree/cmd/decree@latest
+go install github.com/opendecree/decree/cmd/decree@v0.12.0-alpha.5
 
 # Homebrew (macOS / Linux) — coming in beta
 brew install opendecree/tap/decree
@@ -160,7 +160,7 @@ brew install opendecree/tap/decree
 
 | SDK | Language | Protocol | Status | Version | Install |
 |-----|----------|----------|--------|---------|---------|
-| [decree](sdk/) | ![Go](https://img.shields.io/badge/-Go-00ADD8?logo=go&logoColor=white) | ![gRPC](https://img.shields.io/badge/-gRPC-244c5a?logo=grpc&logoColor=white) | ![alpha](https://img.shields.io/badge/status-alpha-orange) | [![Go release](https://img.shields.io/github/v/release/opendecree/decree?include_prereleases&label=)](https://github.com/opendecree/decree/releases) | `go get github.com/opendecree/decree/sdk/grpctransport@latest` |
+| [decree](sdk/) | ![Go](https://img.shields.io/badge/-Go-00ADD8?logo=go&logoColor=white) | ![gRPC](https://img.shields.io/badge/-gRPC-244c5a?logo=grpc&logoColor=white) | ![alpha](https://img.shields.io/badge/status-alpha-orange) | [![Go release](https://img.shields.io/github/v/release/opendecree/decree?include_prereleases&label=)](https://github.com/opendecree/decree/releases) | `go get github.com/opendecree/decree/sdk/grpctransport@v0.12.0-alpha.5` |
 | [decree-python](https://github.com/opendecree/decree-python) | ![Python](https://img.shields.io/badge/-Python-3776AB?logo=python&logoColor=white) | ![gRPC](https://img.shields.io/badge/-gRPC-244c5a?logo=grpc&logoColor=white) | ![alpha](https://img.shields.io/badge/status-alpha-orange) | [![PyPI](https://img.shields.io/pypi/v/opendecree?label=)](https://pypi.org/project/opendecree/) | `pip install opendecree` |
 | [decree-typescript](https://github.com/opendecree/decree-typescript) | ![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?logo=typescript&logoColor=white) | ![gRPC](https://img.shields.io/badge/-gRPC-244c5a?logo=grpc&logoColor=white) | ![alpha](https://img.shields.io/badge/status-alpha-orange) | [![npm](https://img.shields.io/npm/v/@opendecree/sdk?label=)](https://www.npmjs.com/package/@opendecree/sdk) | `npm install @opendecree/sdk` |
 | [REST API](#rest-api) | Any | ![REST](https://img.shields.io/badge/-REST%2FJSON-0a7ea4?logo=openapiinitiative&logoColor=white) | ![alpha](https://img.shields.io/badge/status-alpha-orange) | — | `curl` |
@@ -182,11 +182,11 @@ fmt.Println(fee.Get()) // always fresh
 ```
 
 ```bash
-go get github.com/opendecree/decree/sdk/grpctransport@latest  # gRPC transport (pulls in configclient, etc.)
-go get github.com/opendecree/decree/sdk/configclient@latest   # core client (no gRPC dependency)
-go get github.com/opendecree/decree/sdk/adminclient@latest    # admin operations
-go get github.com/opendecree/decree/sdk/configwatcher@latest  # live config watcher
-go get github.com/opendecree/decree/sdk/tools@latest          # diff, docgen, validate, seed, dump
+go get github.com/opendecree/decree/sdk/grpctransport@v0.12.0-alpha.5  # gRPC transport (pulls in configclient, etc.)
+go get github.com/opendecree/decree/sdk/configclient@v0.12.0-alpha.5   # core client (no gRPC dependency)
+go get github.com/opendecree/decree/sdk/adminclient@v0.12.0-alpha.5    # admin operations
+go get github.com/opendecree/decree/sdk/configwatcher@v0.12.0-alpha.5  # live config watcher
+go get github.com/opendecree/decree/sdk/tools@v0.12.0-alpha.5          # diff, docgen, validate, seed, dump
 ```
 
 Go API docs on pkg.go.dev:
@@ -252,7 +252,7 @@ cd quickstart && go run .   # run any example
 ## CLI
 
 ```bash
-go install github.com/opendecree/decree/cmd/decree@latest
+go install github.com/opendecree/decree/cmd/decree@v0.12.0-alpha.5
 
 decree schema list
 decree schema import --publish decree.schema.yaml  # import + auto-publish

--- a/chaos/go.mod
+++ b/chaos/go.mod
@@ -3,10 +3,10 @@ module github.com/opendecree/decree/chaos
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+	github.com/opendecree/decree/api v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 )
@@ -15,8 +15,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/cmd/decree/go.mod
+++ b/cmd/decree/go.mod
@@ -4,10 +4,10 @@ go 1.25.7
 
 require (
 	github.com/lib/pq v1.12.3
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.5
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/spf13/cobra v1.10.2
 	google.golang.org/grpc v1.80.0
@@ -20,9 +20,9 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/contrib/decree-docs/go.mod
+++ b/contrib/decree-docs/go.mod
@@ -3,8 +3,8 @@ module github.com/opendecree/decree/contrib/decree-docs
 go 1.24.0
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.5
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -12,7 +12,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect

--- a/docs/cli/guide.md
+++ b/docs/cli/guide.md
@@ -20,7 +20,7 @@ start at [`decree`](decree.md). For the authentication model in depth, see
 ## Installing
 
 ```
-go install github.com/opendecree/decree/cmd/decree@latest
+go install github.com/opendecree/decree/cmd/decree@v0.12.0-alpha.5
 ```
 
 Verify the install and print the version:

--- a/docs/development/checklists.md
+++ b/docs/development/checklists.md
@@ -58,20 +58,34 @@ Standard development workflow checklists.
 
 ## Release Tag Process
 
-1. Tag root + all submodules:
+Published modules carry local-dev `replace` directives on `main`, which make
+`go install`/`go get` impossible. Per
+[ADR-007](../adr/ADR-007-strip-replaces-at-release.md) they are stripped from the
+tagged commit only — `main` is never changed. Follow ADR-007's "Release
+procedure" exactly; the outline:
+
+1. Merge the require-version-bump PR (every intra-repo `require` → new version;
+   README/docs install commands pinned to the new version). `main` keeps its
+   `replace` directives.
+2. On the release commit: `./scripts/release/strip-replaces.sh strip`.
+3. Tag **leaf-first**, in the order below, tidying each module
+   (`strip-replaces.sh tidy <module>`) and pushing it before the next so its
+   intra-repo dependencies resolve from the module proxy. Push **≤3 tags per
+   `git push`** (GitHub drops tag events past 3 in one push). Tag the root
+   `v{X.Y.Z}` **last** — only it matches the `v*` trigger and creates the GitHub
+   release.
    ```
-   git tag -a v{X.Y.Z} -m "v{X.Y.Z}"
-   git tag -a api/v{X.Y.Z} -m "api v{X.Y.Z}"
-   git tag -a sdk/configclient/v{X.Y.Z} -m "sdk/configclient v{X.Y.Z}"
-   git tag -a sdk/adminclient/v{X.Y.Z} -m "sdk/adminclient v{X.Y.Z}"
-   git tag -a sdk/configwatcher/v{X.Y.Z} -m "sdk/configwatcher v{X.Y.Z}"
-   git tag -a sdk/grpctransport/v{X.Y.Z} -m "sdk/grpctransport v{X.Y.Z}"
-   git tag -a sdk/tools/v{X.Y.Z} -m "sdk/tools v{X.Y.Z}"
-   git tag -a cmd/decree/v{X.Y.Z} -m "cmd/decree v{X.Y.Z}"
+   api → sdk/retry → sdk/configclient → sdk/configwatcher → sdk/adminclient →
+   sdk/grpctransport → sdk/tools → sdk/contrib/envconfig → sdk/contrib/koanf →
+   sdk/contrib/viper → contrib/decree-docs → cmd/decree → (root) v{X.Y.Z}
    ```
-2. Push tags: `git push origin --tags`
-3. If release workflow doesn't trigger: `gh workflow run release.yml --ref v{X.Y.Z}`
-4. Monitor: `gh run list --workflow=release.yml --limit 1`
+4. `./scripts/release/strip-replaces.sh check` must pass on the tagged tree.
+5. If the release workflow doesn't trigger: `gh workflow run release.yml --ref v{X.Y.Z}`
+6. Monitor: `gh run list --workflow=release.yml --limit 1`
+
+> The tagged commit intentionally diverges from `main` (no `replace` directives)
+> and is **not** merged back. During alpha, install commands must pin an explicit
+> version (`@v{X.Y.Z}`) — `@latest` skips pre-releases.
 
 ## Post-Release Verification
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ brew install decree
 ### Go install
 
 ```bash
-go install github.com/opendecree/decree/cmd/decree@latest
+go install github.com/opendecree/decree/cmd/decree@v0.12.0-alpha.5
 ```
 
 Set your identity (required for all operations):
@@ -137,7 +137,7 @@ decree config get-all <tenant-id>
 Install the SDK:
 
 ```bash
-go get github.com/opendecree/decree/sdk/configclient@latest
+go get github.com/opendecree/decree/sdk/configclient@v0.12.0-alpha.5
 ```
 
 Read configuration values with typed getters:
@@ -210,7 +210,7 @@ currency, _ := snap.Get(ctx, "payments.currency")
 For long-running services that need to react to config changes in real-time, use the configwatcher SDK:
 
 ```bash
-go get github.com/opendecree/decree/sdk/configwatcher@latest
+go get github.com/opendecree/decree/sdk/configwatcher@v0.12.0-alpha.5
 ```
 
 ```go

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -39,7 +39,7 @@ if err != nil {
 
 Runtime config reads and writes for application code.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/configclient@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/configclient@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/configclient](https://pkg.go.dev/github.com/opendecree/decree/sdk/configclient)
 
 Features: Get, GetAll, GetFields, Set, SetMany, typed getters/setters (GetInt, SetBool, etc.), Snapshot for pinned-version reads, GetForUpdate + Update for optimistic concurrency, null support, opt-in retry with exponential backoff (`WithRetry`).
@@ -48,7 +48,7 @@ Features: Get, GetAll, GetFields, Set, SetMany, typed getters/setters (GetInt, S
 
 Schema, tenant, audit, and config admin operations for tooling and CI/CD.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/adminclient@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/adminclient@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/adminclient](https://pkg.go.dev/github.com/opendecree/decree/sdk/adminclient)
 
 Features: Schema CRUD, publish, import/export (YAML), tenant CRUD, field locks, config versioning, rollback, audit log queries, usage stats.
@@ -57,7 +57,7 @@ Features: Schema CRUD, publish, import/export (YAML), tenant CRUD, field locks, 
 
 Live typed configuration values with automatic subscription and reconnect.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/configwatcher@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/configwatcher@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/configwatcher](https://pkg.go.dev/github.com/opendecree/decree/sdk/configwatcher)
 
 Features: `Value[T]` generic type with `Get()`, `GetWithNull()`, `Changes()` channel. Typed accessors (String, Int, Float, Bool, Duration). Auto-reconnect with exponential backoff. Thread-safe.
@@ -66,7 +66,7 @@ Features: `Value[T]` generic type with `Get()`, `GetWithNull()`, `Changes()` cha
 
 Reusable power tools for config management — importable as Go packages for integration into servers, CI, or custom tooling.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/tools@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/tools@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/tools](https://pkg.go.dev/github.com/opendecree/decree/sdk/tools)
 
 Packages: `diff` (config version diffing), `docgen` (schema → markdown), `validate` (offline YAML validation), `seed` (bootstrap from YAML), `dump` (full tenant backup). Offline tools have zero gRPC/proto dependencies.
@@ -75,7 +75,7 @@ Packages: `diff` (config version diffing), `docgen` (schema → markdown), `vali
 
 gRPC connection management and the gRPC implementation of the `Transport` the clients depend on.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/grpctransport@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/grpctransport@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport](https://pkg.go.dev/github.com/opendecree/decree/sdk/grpctransport)
 
 `Dial(target, ...)` returns a `*grpc.ClientConn` (TLS with system roots by default; `WithInsecure()`, `WithCustomCA()`, and `WithKeepalive()` adjust it). The convenience constructors `NewConfigClient`, `NewAdminClient`, and `NewWatcher` wrap a connection into the matching client. For a custom connection — for example one with interceptors — construct the `*grpc.ClientConn` yourself and pass it to one of those constructors.
@@ -84,7 +84,7 @@ gRPC connection management and the gRPC implementation of the `Transport` the cl
 
 The shared retry policy used by the clients: exponential backoff with optional jitter, applied to transient (retryable) errors. Enable it on a client with that client's `WithRetry` option. The package also exposes `Config`, `IsRetryable`, and backoff helpers for use in custom tooling.
 
-- **Install:** `go get github.com/opendecree/decree/sdk/retry@latest`
+- **Install:** `go get github.com/opendecree/decree/sdk/retry@v0.12.0-alpha.5`
 - **API Reference:** [pkg.go.dev/github.com/opendecree/decree/sdk/retry](https://pkg.go.dev/github.com/opendecree/decree/sdk/retry)
 
 ## OpenTelemetry instrumentation (Go)

--- a/docs/server/deployment.md
+++ b/docs/server/deployment.md
@@ -9,7 +9,7 @@ Run with in-memory storage — zero external dependencies:
 ```bash
 # go install names the server binary "server" after its directory; the canonical
 # name is decree-server, matching the release archives and Docker image.
-go install github.com/opendecree/decree/cmd/server@latest
+go install github.com/opendecree/decree/cmd/server@v0.12.0-alpha.5
 mv "$(go env GOPATH)/bin/server" "$(go env GOPATH)/bin/decree-server"
 STORAGE_BACKEND=memory HTTP_PORT=8080 decree-server
 

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -3,10 +3,10 @@ module github.com/opendecree/decree/e2e
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+	github.com/opendecree/decree/api v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
@@ -16,8 +16,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect

--- a/examples/config-validation/go.mod
+++ b/examples/config-validation/go.mod
@@ -2,7 +2,7 @@ module github.com/opendecree/decree/examples/config-validation
 
 go 1.25
 
-require github.com/opendecree/decree/sdk/tools v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/tools v0.12.0-alpha.5
 
 require (
 	github.com/kr/text v0.2.0 // indirect

--- a/examples/environment-bootstrap/go.mod
+++ b/examples/environment-bootstrap/go.mod
@@ -3,18 +3,18 @@ module github.com/opendecree/decree/examples/environment-bootstrap
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.5
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/examples/feature-flags/go.mod
+++ b/examples/feature-flags/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/feature-flags
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/live-config/go.mod
+++ b/examples/live-config/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/live-config
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/multi-tenant/go.mod
+++ b/examples/multi-tenant/go.mod
@@ -3,16 +3,16 @@ module github.com/opendecree/decree/examples/multi-tenant
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/optimistic-concurrency/go.mod
+++ b/examples/optimistic-concurrency/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/optimistic-concurrency
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/quickstart/go.mod
+++ b/examples/quickstart/go.mod
@@ -2,15 +2,15 @@ module github.com/opendecree/decree/examples/quickstart
 
 go 1.25.0
 
-require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/schema-lifecycle/go.mod
+++ b/examples/schema-lifecycle/go.mod
@@ -3,16 +3,16 @@ module github.com/opendecree/decree/examples/schema-lifecycle
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/examples/setup/go.mod
+++ b/examples/setup/go.mod
@@ -3,18 +3,18 @@ module github.com/opendecree/decree/examples/setup
 go 1.25.0
 
 require (
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/tools v0.12.0-alpha.5
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/cel-go v0.28.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/opendecree/decree/api v0.12.0-alpha.4
+	github.com/opendecree/decree/api v0.12.0-alpha.5
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/redis/go-redis/extra/redisotel/v9 v9.21.0
 	github.com/redis/go-redis/v9 v9.21.0

--- a/sdk/adminclient/go.mod
+++ b/sdk/adminclient/go.mod
@@ -2,6 +2,6 @@ module github.com/opendecree/decree/sdk/adminclient
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5
 
 replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/configclient/go.mod
+++ b/sdk/configclient/go.mod
@@ -2,6 +2,6 @@ module github.com/opendecree/decree/sdk/configclient
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5
 
 replace github.com/opendecree/decree/sdk/retry => ../retry

--- a/sdk/configwatcher/go.mod
+++ b/sdk/configwatcher/go.mod
@@ -2,9 +2,9 @@ module github.com/opendecree/decree/sdk/configwatcher
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 
 replace github.com/opendecree/decree/sdk/retry => ../retry
 

--- a/sdk/contrib/envconfig/go.mod
+++ b/sdk/contrib/envconfig/go.mod
@@ -2,9 +2,9 @@ module github.com/opendecree/decree/sdk/contrib/envconfig
 
 go 1.22.0
 
-require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
+require github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
 
-require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+require github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 
 replace github.com/opendecree/decree/sdk/configclient => ../../../sdk/configclient
 

--- a/sdk/contrib/koanf/go.mod
+++ b/sdk/contrib/koanf/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/knadh/koanf/v2 v2.1.2
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
 )
 
 require (
@@ -12,7 +12,7 @@ require (
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 )
 
 replace github.com/opendecree/decree/sdk/configclient => ../../../sdk/configclient

--- a/sdk/contrib/viper/go.mod
+++ b/sdk/contrib/viper/go.mod
@@ -3,7 +3,7 @@ module github.com/opendecree/decree/sdk/contrib/viper
 go 1.22.0
 
 require (
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
 	github.com/spf13/viper v1.19.0
 )
 
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/sdk/grpctransport/go.mod
+++ b/sdk/grpctransport/go.mod
@@ -3,17 +3,17 @@ module github.com/opendecree/decree/sdk/grpctransport
 go 1.24.0
 
 require (
-	github.com/opendecree/decree/api v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4
+	github.com/opendecree/decree/api v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/sdk/tools/go.mod
+++ b/sdk/tools/go.mod
@@ -5,14 +5,14 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/kr/pretty v0.3.1 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/stress/go.mod
+++ b/stress/go.mod
@@ -13,9 +13,9 @@ replace github.com/opendecree/decree/sdk/grpctransport => ../sdk/grpctransport
 replace github.com/opendecree/decree/sdk/configwatcher => ../sdk/configwatcher
 
 require (
-	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.4
-	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.4
+	github.com/opendecree/decree/sdk/adminclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/configclient v0.12.0-alpha.5
+	github.com/opendecree/decree/sdk/grpctransport v0.12.0-alpha.5
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
 )
@@ -24,9 +24,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/opendecree/decree/api v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.4 // indirect
-	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.4 // indirect
+	github.com/opendecree/decree/api v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/configwatcher v0.12.0-alpha.5 // indirect
+	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	golang.org/x/net v0.51.0 // indirect


### PR DESCRIPTION
## Summary
- Reversible prep for the `v0.12.0-alpha.5` release (Stage 2 of #990). The tag/strip step follows in a separate, manual run — this PR changes only `main`.
- Bumps every intra-repo `require` from `v0.12.0-alpha.4` to `v0.12.0-alpha.5` across all 23 modules.
- Pins the README and docs `go install` / `go get` commands to `@v0.12.0-alpha.5`. Per ADR-007, `@latest` skips pre-releases and resolves to a stale, non-installable version, so alpha install commands must pin an explicit version.
- `release.yml`: marks hyphenated semver tags (e.g. `v0.12.0-alpha.5`) as GitHub pre-releases, so the "Latest" release stops pointing at an old alpha.
- `checklists.md`: replaces the stale Release Tag Process (8 tags, no strip step) with the ADR-007 procedure — leaf-first tagging, root tag last, ≤3 tags per push.

`main` keeps its `replace` directives; they are stripped only at the tagged release commit (ADR-007), which is not merged back.

## Test plan
- [x] `go build ./...` (root) and `cd cmd/decree && go build ./...` both compile against the bumped requires (replaces resolve locally; no `go.sum` churn, no fetch of the unpublished tag).
- [x] No stray `@latest` left on `github.com/opendecree/decree` install commands; `golang.org/x/...@latest` tool installs and the `?include_prereleases` badge untouched.
- [ ] CI green.

Refs #990 — this PR is the prep only. Tracking issue #990 stays open; it is wrapped up separately after the tags are pushed and a clean-machine `go install @v0.12.0-alpha.5` check passes.