### PR TITLE
build(go): bump to 1.25.12 to fix GO-2026-5856

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,7 +646,7 @@ jobs:
         # golang/govulncheck-action@v1
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
         with:
-          go-version-input: "1.25.11"
+          go-version-input: "1.25.12"
           work-dir: .
 
   # Validates every checked-in *.decree.schema.yaml and *.decree.config.yaml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendecree/decree
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/MicahParks/keyfunc/v3 v3.8.0


### PR DESCRIPTION
## Summary

- govulncheck's required CI gate fails on every open PR because go.mod (and the govulncheck-action's `go-version-input` pin in ci.yml) are pinned to go1.25.11, which has GO-2026-5856 (crypto/tls Encrypted Client Hello privacy leak). Fixed upstream in go1.25.12.
- This is independent of any PR's actual diff, so it's currently blocking the entire dependabot merge queue.

## Test plan

- [x] `go build ./...` passes on go1.25.12
- [x] `make lint-go` clean (golangci-lint run + fmt --diff)
- [ ] CI govulncheck gate goes green on this PR