### PR TITLE
build(deps): cap x/net at 1.24-floor tier, bump to v0.50.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,9 @@ updates:
       # grpc 1.81+ requires go 1.25.
       - dependency-name: "google.golang.org/grpc"
         versions: [">=1.81.0"]
+      # x/net 0.51+ requires go 1.25.
+      - dependency-name: "golang.org/x/net"
+        versions: [">=0.51.0"]
 
   # ── Tier: 1.22-floor (SDK core: configclient, adminclient, configwatcher) ─
   # Consumer-facing SDK modules; must stay installable with go 1.22 toolchains.

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.41.0 // indirect
-	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -24,8 +24,8 @@ go.opentelemetry.io/otel/sdk/metric v1.41.0 h1:siZQIYBAUd1rlIWQT2uCxWJxcCO7q3Tri
 go.opentelemetry.io/otel/sdk/metric v1.41.0/go.mod h1:HNBuSvT7ROaGtGI50ArdRLUnvRTRGniSUZbxiWxSO8Y=
 go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
-golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
-golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
+golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=

--- a/sdk/grpctransport/go.mod
+++ b/sdk/grpctransport/go.mod
@@ -14,7 +14,7 @@ require (
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/opendecree/decree/sdk/retry v0.12.0-alpha.5 // indirect
-	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect

--- a/sdk/grpctransport/go.sum
+++ b/sdk/grpctransport/go.sum
@@ -24,8 +24,8 @@ go.opentelemetry.io/otel/sdk/metric v1.41.0 h1:siZQIYBAUd1rlIWQT2uCxWJxcCO7q3Tri
 go.opentelemetry.io/otel/sdk/metric v1.41.0/go.mod h1:HNBuSvT7ROaGtGI50ArdRLUnvRTRGniSUZbxiWxSO8Y=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
-golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
-golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
+golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
+golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.34.0 h1:oL/Qq0Kdaqxa1KbNeMKwQq0reLCCaFtqu2eNuSeNHbk=


### PR DESCRIPTION
## Summary

- `golang.org/x/net` v0.51.0+ declares `go 1.25.0` in its own go.mod, which would force `api` and `sdk/grpctransport` off the Go 1.24 floor if bumped past v0.50.0.
- Dependabot PRs #1001 and #1002 both attempted the 0.55.0 bump and silently dropped the module `go` directive to 1.25.0 as a side effect — closed both in favor of this manual fix.
- Bumps `golang.org/x/net` from v0.49.0 to v0.50.0 (the last version still on go 1.24) in both `api` and `sdk/grpctransport`.
- Adds `golang.org/x/net` to the dependabot ignore list for the 1.24-floor tier, matching the existing `grpc-gateway`/`otel`/`grpc` entries in the same file.

## Test plan

- [x] `go build ./...` clean in root, api, sdk/grpctransport, cmd/decree, e2e, chaos, stress, and every examples/* module
- [x] `go vet -tags e2e|chaos|stress ./...` clean for tagged suites
- [x] `go mod tidy` in every module consuming api/grpctransport via replace directive — no drift
- [x] `make lint-go` — 0 issues
- [x] Confirmed `api/go.mod` and `sdk/grpctransport/go.mod` still declare `go 1.24.0` after the bump

Refs #1001, #1002 (closed dependabot PRs, superseded by this fix)